### PR TITLE
fix: ObjectStateView failing for IP address

### DIFF
--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -49,7 +49,11 @@ class ObjectStateView(views.APIView):
 
         """
         if "'ipam.models.ip.ipaddress'" in object_type_model:
-            return "interface", "interface__device", "interface__device__site"
+            return (
+                "assigned_object",
+                "assigned_object__device",
+                "assigned_object__device__site",
+            )
         if "'dcim.models.device_components.interface'" in object_type_model:
             return "device", "device__site"
         if "'dcim.models.devices.device'" in object_type_model:

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -127,9 +127,15 @@ class ObjectStateView(views.APIView):
             },
         )
 
-        if len(serializer.data) > 0:
-            return Response(serializer.data[0])
-        return Response({})
+        try:
+            if len(serializer.data) > 0:
+                return Response(serializer.data[0])
+            return Response({})
+        except AttributeError as e:
+            return Response(
+                {"errors": [f"Serializer error: {e.args[0]}"]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
     def _additional_attributes_query_filter(self):
         """Get the additional attributes query filter."""

--- a/netbox_diode_plugin/tests/test_object_state.py
+++ b/netbox_diode_plugin/tests/test_object_state.py
@@ -289,7 +289,31 @@ class ObjectStateTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_common_user_with_permissions_get_device_state(self):
+    def test_common_user_with_permissions_get_ip_state_using_id(self):
+        """Test searching for ip using id."""
+        query_parameters = {
+            "id": self.ip_addresses[0].id,
+            "object_type": "ipam.ipaddress",
+        }
+
+        response = self.client.get(self.url, query_parameters, **self.user_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(response.json().get("object_type"), "ipam.ipaddress")
+        self.assertEqual(
+            response.json().get("object").get("address"),
+            self.ip_addresses[0].address.__str__(),
+        )
+        self.assertEqual(
+            response.json()
+            .get("object")
+            .get("assigned_object")
+            .get("interface")
+            .get("name"),
+            self.interfaces[0].name,
+        )
+
+    def test_common_user_with_permissions_get_device_state_using_q_objects(self):
         """Test searching for device using q parameter."""
         query_parameters = {
             "q": self.devices[0].name,
@@ -308,7 +332,7 @@ class ObjectStateTestCase(APITestCase):
             response.json().get("object").get("site").get("name"), self.sites[0].name
         )
 
-    def test_common_user_with_permissions_get_interface_state(self):
+    def test_common_user_with_permissions_get_interface_state_using_q_objects(self):
         """Test searching for interface using q parameter."""
         query_parameters = {
             "q": self.interfaces[0].name,
@@ -329,7 +353,7 @@ class ObjectStateTestCase(APITestCase):
             self.devices[0].name,
         )
 
-    def test_common_user_with_permissions_get_ip_state(self):
+    def test_common_user_with_permissions_get_ip_state_using_q_objects(self):
         """Test searching for ip using q parameter."""
         query_parameters = {
             "q": self.ip_addresses[0].address.__str__(),
@@ -340,5 +364,18 @@ class ObjectStateTestCase(APITestCase):
         }
 
         response = self.client.get(self.url, query_parameters, **self.user_header)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("Site 223", response.json())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(response.json().get("object_type"), "ipam.ipaddress")
+        self.assertEqual(
+            response.json().get("object").get("address"),
+            self.ip_addresses[0].address.__str__(),
+        )
+        self.assertEqual(
+            response.json()
+            .get("object")
+            .get("assigned_object")
+            .get("interface")
+            .get("name"),
+            self.interfaces[0].name,
+        )

--- a/netbox_diode_plugin/tests/test_object_state.py
+++ b/netbox_diode_plugin/tests/test_object_state.py
@@ -300,6 +300,14 @@ class ObjectStateTestCase(APITestCase):
         response = self.client.get(self.url, query_parameters, **self.user_header)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        self.assertEqual(response.json().get("object_type"), "dcim.device")
+        self.assertEqual(
+            response.json().get("object").get("name"), self.devices[0].name
+        )
+        self.assertEqual(
+            response.json().get("object").get("site").get("name"), self.sites[0].name
+        )
+
     def test_common_user_with_permissions_get_interface_state(self):
         """Test searching for interface using q parameter."""
         query_parameters = {
@@ -312,10 +320,19 @@ class ObjectStateTestCase(APITestCase):
         response = self.client.get(self.url, query_parameters, **self.user_header)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        self.assertEqual(response.json().get("object_type"), "dcim.interface")
+        self.assertEqual(
+            response.json().get("object").get("name"), self.interfaces[0].name
+        )
+        self.assertEqual(
+            response.json().get("object").get("device").get("name"),
+            self.devices[0].name,
+        )
+
     def test_common_user_with_permissions_get_ip_state(self):
         """Test searching for ip using q parameter."""
         query_parameters = {
-            "q": self.ip_addresses[0].address.ip,
+            "q": self.ip_addresses[0].address.__str__(),
             "object_type": "ipam.ipaddress",
             "interface": self.interfaces[0].id,
             "interface__device": self.devices[0].id,
@@ -323,4 +340,5 @@ class ObjectStateTestCase(APITestCase):
         }
 
         response = self.client.get(self.url, query_parameters, **self.user_header)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Site 223", response.json())


### PR DESCRIPTION
- Fix ipaddress args for queryset.prefetch_related
- Add proper unit tests to cover this scneario
- Add exception handling in serializer to avoid silent failure