### PR TITLE
feat: add DiodeVMInterfaceSerializer

### DIFF
--- a/netbox_diode_plugin/api/serializers.py
+++ b/netbox_diode_plugin/api/serializers.py
@@ -23,6 +23,7 @@ from virtualization.api.serializers import (
     ClusterGroupSerializer,
     ClusterSerializer,
     ClusterTypeSerializer,
+    VMInterfaceSerializer,
     VirtualDiskSerializer,
     VirtualMachineSerializer,
 )
@@ -327,3 +328,14 @@ class DiodeVirtualDiskSerializer(VirtualDiskSerializer):
 
         model = VirtualDiskSerializer.Meta.model
         fields = VirtualDiskSerializer.Meta.fields
+
+class DiodeVMInterfaceSerializer(VMInterfaceSerializer):
+    """Diode VM Interface Serializer."""
+
+    virtual_machine = DiodeVirtualMachineSerializer()
+
+    class Meta:
+        """Meta class."""
+
+        model = VMInterfaceSerializer.Meta.model
+        fields = VMInterfaceSerializer.Meta.fields


### PR DESCRIPTION
This is to include full virtual machine (nested) object required for reconciliation, missed in https://github.com/netboxlabs/diode-netbox-plugin/pull/19