### PR TITLE
feat: plugin configuration improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ PLUGINS = [
 ]
 ```
 
+Also in your `configuration.py` file, add `netbox_diode_plugin`to the `PLUGINS_CONFIG` dictionary, e.g.:
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_diode_plugin": {
+        "diode_target": "grpc://localhost:8080/diode", # The Diode gRPC target for communication with Diode server, default: "grpc://localhost:8080/diode"
+        "disallow_diode_target_override": True, # Disallow the Diode target to be overridden by the user, default: False
+    }
+}
+```
+
 Restart NetBox services to load the plugin:
 
 ```

--- a/docker/netbox/configuration/plugins.py
+++ b/docker/netbox/configuration/plugins.py
@@ -6,8 +6,9 @@
 
 PLUGINS = ["netbox_diode_plugin"]
 
-# PLUGINS_CONFIG = {
-#     "netbox_diode_plugin": {
-#
-#     }
-# }
+PLUGINS_CONFIG = {
+    "netbox_diode_plugin": {
+        "diode_target": "grpc://localhost:8080/diode", # The Diode gRPC target for communication with Diode server, default: "grpc://localhost:8080/diode"
+        "disallow_diode_target_override": False, # Disallow the Diode target to be overridden by the user, default: False
+    }
+}

--- a/netbox_diode_plugin/forms.py
+++ b/netbox_diode_plugin/forms.py
@@ -1,7 +1,7 @@
 # !/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
 """Diode NetBox Plugin - Forms."""
-
+from django.conf import settings as netbox_settings
 from netbox.forms import NetBoxModelForm
 from utilities.forms.rendering import FieldSet
 
@@ -24,3 +24,17 @@ class SettingsForm(NetBoxModelForm):
 
         model = Setting
         fields = ("diode_target",)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the form."""
+        super().__init__(*args, **kwargs)
+
+        disallow_diode_target_override = netbox_settings.PLUGINS_CONFIG.get(
+            "netbox_diode_plugin", {}
+        ).get("disallow_diode_target_override", False)
+
+        if disallow_diode_target_override:
+            self.fields["diode_target"].disabled = True
+            self.fields["diode_target"].help_text = (
+                "This field is not allowed to be overridden."
+            )

--- a/netbox_diode_plugin/migrations/0002_setting.py
+++ b/netbox_diode_plugin/migrations/0002_setting.py
@@ -3,13 +3,19 @@
 """Diode Netbox Plugin - Database migrations."""
 
 import utilities.json
+from django.conf import settings as netbox_settings
 from django.db import migrations, models
 
 
 def create_settings_entity(apps, schema_editor):
     """Create a Setting entity."""
     Setting = apps.get_model("netbox_diode_plugin", "Setting")
-    Setting.objects.create(diode_target="grpc://localhost:8080/diode")
+
+    diode_target = netbox_settings.PLUGINS_CONFIG.get(
+        "netbox_diode_plugin", {}
+    ).get("diode_target", "grpc://localhost:8080/diode")
+
+    Setting.objects.create(diode_target=diode_target)
 
 
 class Migration(migrations.Migration):

--- a/netbox_diode_plugin/tests/test_forms.py
+++ b/netbox_diode_plugin/tests/test_forms.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""Diode NetBox Plugin - Tests."""
+from unittest import mock
+
+from django.test import TestCase
+
+from netbox_diode_plugin.forms import SettingsForm
+from netbox_diode_plugin.models import Setting
+
+
+class SettingsFormTestCase(TestCase):
+    """Test case for the SettingsForm."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.setting = Setting.objects.create(diode_target="grpc://localhost:8080/diode")
+
+    def test_form_initialization_with_override_allowed(self):
+        """Test form initialization when override is allowed."""
+        with mock.patch("netbox_diode_plugin.forms.netbox_settings") as mock_settings:
+            mock_settings.PLUGINS_CONFIG = {
+                "netbox_diode_plugin": {
+                    "disallow_diode_target_override": False
+                }
+            }
+            form = SettingsForm(instance=self.setting)
+            self.assertFalse(form.fields["diode_target"].disabled)
+            self.assertNotIn("This field is not allowed to be overridden.", form.fields["diode_target"].help_text)
+
+    def test_form_initialization_with_override_disallowed(self):
+        """Test form initialization when override is disallowed."""
+        with mock.patch("netbox_diode_plugin.forms.netbox_settings") as mock_settings:
+            mock_settings.PLUGINS_CONFIG = {
+                "netbox_diode_plugin": {
+                    "disallow_diode_target_override": True
+                }
+            }
+            form = SettingsForm(instance=self.setting)
+            self.assertTrue(form.fields["diode_target"].disabled)
+            self.assertEqual("This field is not allowed to be overridden.", form.fields["diode_target"].help_text)


### PR DESCRIPTION
- configure diode target and disallow its override via NetBox UI with `PLUGINS_CONFIG`, e.g.:
```
PLUGINS_CONFIG = {
    "netbox_diode_plugin": {
        "diode_target": "grpc://localhost:8080/diode", # The Diode gRPC target for communication with Diode server, default: "grpc://localhost:8080/diode"
        "disallow_diode_target_override": True, # Disallow the Diode target to be overridden by the user, default: False
    }
}
```
- during initial migration, load secrets for diode related API keys from mounted paths under `/run/secrets/*`, with a fallback to environment variables and eventually generate keys in-flight

<img width="2032" alt="Screenshot 2024-09-23 at 17 58 21" src="https://github.com/user-attachments/assets/651a4a5b-4511-4cda-a965-f51bf7733edb">
<img width="2032" alt="Screenshot 2024-09-23 at 17 58 29" src="https://github.com/user-attachments/assets/4c3dc5af-eed5-4366-bde7-9a8f1aeefa80">
