### PR TITLE
feat: plugin configuration further improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,26 @@ PLUGINS = [
 ]
 ```
 
-Also in your `configuration.py` file, add `netbox_diode_plugin`to the `PLUGINS_CONFIG` dictionary, e.g.:
+Also in your `configuration.py` file, in order to customise the plugin settings, add `netbox_diode_plugin`to the
+`PLUGINS_CONFIG` dictionary, e.g.:
 
 ```python
 PLUGINS_CONFIG = {
     "netbox_diode_plugin": {
-        "diode_target": "grpc://localhost:8080/diode", # The Diode gRPC target for communication with Diode server, default: "grpc://localhost:8080/diode"
-        "disallow_diode_target_override": True, # Disallow the Diode target to be overridden by the user, default: False
-    }
+        # Diode gRPC target for communication with Diode server
+        "diode_target_override": "grpc://localhost:8080/diode",
+
+        # User allowed for Diode to NetBox communication
+        "diode_to_netbox_username": "diode-to-netbox",
+
+        # User allowed for NetBox to Diode communication
+        "netbox_to_diode_username": "netbox-to-diode",
+
+        # # User allowed for data ingestion
+        "diode_username": "diode-ingestion",
+    },
 }
+
 ```
 
 Restart NetBox services to load the plugin:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ PLUGINS_CONFIG = {
         "diode_username": "diode-ingestion",
     },
 }
-
 ```
+
+Note: Once you customise usernames with PLUGINS_CONFIG during first installation, you should not change or remove them
+later on. Doing so will cause the plugin to stop working properly.
 
 Restart NetBox services to load the plugin:
 

--- a/docker/netbox/configuration/plugins.py
+++ b/docker/netbox/configuration/plugins.py
@@ -6,18 +6,18 @@
 
 PLUGINS = ["netbox_diode_plugin"]
 
-PLUGINS_CONFIG = {
-    "netbox_diode_plugin": {
-        # Diode gRPC target for communication with Diode server
-        "diode_target_override": "grpc://localhost:8080/diode",
-
-        # User allowed for Diode to NetBox communication
-        "diode_to_netbox_username": "diode-to-netbox",
-
-        # User allowed for NetBox to Diode communication
-        "netbox_to_diode_username": "netbox-to-diode",
-
-        # User allowed for data ingestion
-        "diode_username": "diode-ingestion",
-    },
-}
+# PLUGINS_CONFIG = {
+#     "netbox_diode_plugin": {
+#         # Diode gRPC target for communication with Diode server
+#         "diode_target_override": "grpc://localhost:8080/diode",
+#
+#         # User allowed for Diode to NetBox communication
+#         "diode_to_netbox_username": "diode-to-netbox",
+#
+#         # User allowed for NetBox to Diode communication
+#         "netbox_to_diode_username": "netbox-to-diode",
+#
+#         # User allowed for data ingestion
+#         "diode_username": "diode-ingestion",
+#     },
+# }

--- a/docker/netbox/configuration/plugins.py
+++ b/docker/netbox/configuration/plugins.py
@@ -8,7 +8,16 @@ PLUGINS = ["netbox_diode_plugin"]
 
 PLUGINS_CONFIG = {
     "netbox_diode_plugin": {
-        "diode_target": "grpc://localhost:8080/diode", # The Diode gRPC target for communication with Diode server, default: "grpc://localhost:8080/diode"
-        "disallow_diode_target_override": False, # Disallow the Diode target to be overridden by the user, default: False
-    }
+        # Diode gRPC target for communication with Diode server
+        "diode_target_override": "grpc://localhost:8080/diode",
+
+        # User allowed for Diode to NetBox communication
+        "diode_to_netbox_username": "diode-to-netbox",
+
+        # User allowed for NetBox to Diode communication
+        "netbox_to_diode_username": "netbox-to-diode",
+
+        # User allowed for data ingestion
+        "diode_username": "diode-ingestion",
+    },
 }

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -16,6 +16,19 @@ class NetBoxDiodePluginConfig(PluginConfig):
     version = version_semver()
     base_url = "diode"
     min_version = "3.7.2"
+    default_settings = {
+        # Default Diode gRPC target for communication with Diode server
+        "diode_target": "grpc://localhost:8080/diode",
+
+        # User allowed for Diode to NetBox communication
+        "diode_to_netbox_username": "diode-to-netbox",
+
+        # User allowed for NetBox to Diode communication
+        "netbox_to_diode_username": "netbox-to-diode",
+
+        # User allowed for data ingestion
+        "diode_username": "diode-ingestion",
+    }
 
 
 config = NetBoxDiodePluginConfig

--- a/netbox_diode_plugin/forms.py
+++ b/netbox_diode_plugin/forms.py
@@ -1,7 +1,6 @@
 # !/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
 """Diode NetBox Plugin - Forms."""
-from django.conf import settings as netbox_settings
 from netbox.forms import NetBoxModelForm
 from netbox.plugins import get_plugin_config
 from utilities.forms.rendering import FieldSet

--- a/netbox_diode_plugin/forms.py
+++ b/netbox_diode_plugin/forms.py
@@ -3,6 +3,7 @@
 """Diode NetBox Plugin - Forms."""
 from django.conf import settings as netbox_settings
 from netbox.forms import NetBoxModelForm
+from netbox.plugins import get_plugin_config
 from utilities.forms.rendering import FieldSet
 
 from netbox_diode_plugin.models import Setting
@@ -29,12 +30,12 @@ class SettingsForm(NetBoxModelForm):
         """Initialize the form."""
         super().__init__(*args, **kwargs)
 
-        disallow_diode_target_override = netbox_settings.PLUGINS_CONFIG.get(
-            "netbox_diode_plugin", {}
-        ).get("disallow_diode_target_override", False)
+        diode_target_override = get_plugin_config(
+            "netbox_diode_plugin", "diode_target_override"
+        )
 
-        if disallow_diode_target_override:
+        if diode_target_override:
             self.fields["diode_target"].disabled = True
             self.fields["diode_target"].help_text = (
-                "This field is not allowed to be overridden."
+                "This field is not allowed to be modified."
             )

--- a/netbox_diode_plugin/migrations/0001_initial.py
+++ b/netbox_diode_plugin/migrations/0001_initial.py
@@ -5,10 +5,12 @@
 import os
 
 from django.apps import apps as django_apps
-from django.conf import settings
+from django.conf import settings as netbox_settings
 from django.contrib.contenttypes.management import create_contenttypes
 from django.db import migrations, models
 from users.models import Token as NetBoxToken
+
+from netbox_diode_plugin.plugin_config import get_diode_usernames
 
 
 # Read secret from file
@@ -22,8 +24,10 @@ def _read_secret(secret_name, default=None):
             return f.readline().strip()
 
 
-def _create_user_with_token(apps, username, group, is_superuser: bool = False):
-    User = apps.get_model(settings.AUTH_USER_MODEL)
+def _create_user_with_token(
+    apps, user_category, username, group, is_superuser: bool = False
+):
+    User = apps.get_model(netbox_settings.AUTH_USER_MODEL)
     """Create a user with the given username and API key if it does not exist."""
     try:
         user = User.objects.get(username=username)
@@ -38,7 +42,7 @@ def _create_user_with_token(apps, username, group, is_superuser: bool = False):
     Token = apps.get_model("users", "Token")
 
     if not Token.objects.filter(user=user).exists():
-        key = f"{username}_API_KEY"
+        key = f"{user_category.upper()}_API_KEY"
         api_key = _read_secret(key.lower(), os.getenv(key))
         if api_key is None:
             api_key = NetBoxToken.generate_key()
@@ -49,18 +53,16 @@ def _create_user_with_token(apps, username, group, is_superuser: bool = False):
 
 def configure_plugin(apps, schema_editor):
     """Configure the plugin."""
-    diode_to_netbox_username = "DIODE_TO_NETBOX"
-    netbox_to_diode_username = "NETBOX_TO_DIODE"
-    diode_username = "DIODE"
-
     Group = apps.get_model("users", "Group")
     group, _ = Group.objects.get_or_create(name="diode")
 
-    diode_to_netbox_user = _create_user_with_token(
-        apps, diode_to_netbox_username, group
-    )
-    _ = _create_user_with_token(apps, netbox_to_diode_username, group, True)
-    _ = _create_user_with_token(apps, diode_username, group)
+    diode_to_netbox_user_id = None
+
+    for user_category, username in get_diode_usernames.items():
+        is_superuser = user_category in ("netbox_to_diode", )
+        user = _create_user_with_token(apps, user_category, username, group, is_superuser)
+        if user_category == "diode_to_netbox":
+            diode_to_netbox_user_id = user.id
 
     app_config = django_apps.get_app_config("netbox_diode_plugin")
 
@@ -78,7 +80,7 @@ def configure_plugin(apps, schema_editor):
         actions=["add", "view"],
     )
 
-    permission.users.set([diode_to_netbox_user.id])
+    permission.users.set([diode_to_netbox_user_id])
     permission.object_types.set([diode_plugin_object_type.id])
 
 

--- a/netbox_diode_plugin/migrations/0001_initial.py
+++ b/netbox_diode_plugin/migrations/0001_initial.py
@@ -59,8 +59,10 @@ def configure_plugin(apps, schema_editor):
     diode_to_netbox_user_id = None
 
     for user_category, username in get_diode_usernames.items():
-        is_superuser = user_category in ("netbox_to_diode", )
-        user = _create_user_with_token(apps, user_category, username, group, is_superuser)
+        is_superuser = user_category in ("netbox_to_diode",)
+        user = _create_user_with_token(
+            apps, user_category, username, group, is_superuser
+        )
         if user_category == "diode_to_netbox":
             diode_to_netbox_user_id = user.id
 

--- a/netbox_diode_plugin/migrations/0001_initial.py
+++ b/netbox_diode_plugin/migrations/0001_initial.py
@@ -58,7 +58,7 @@ def configure_plugin(apps, schema_editor):
 
     diode_to_netbox_user_id = None
 
-    for user_category, username in get_diode_usernames.items():
+    for user_category, username in get_diode_usernames().items():
         is_superuser = user_category in ("netbox_to_diode",)
         user = _create_user_with_token(
             apps, user_category, username, group, is_superuser

--- a/netbox_diode_plugin/migrations/0001_initial.py
+++ b/netbox_diode_plugin/migrations/0001_initial.py
@@ -78,7 +78,6 @@ def configure_plugin(apps, schema_editor):
         actions=["add", "view"],
     )
 
-    permission.groups.set([group.id])
     permission.users.set([diode_to_netbox_user.id])
     permission.object_types.set([diode_plugin_object_type.id])
 

--- a/netbox_diode_plugin/migrations/0002_setting.py
+++ b/netbox_diode_plugin/migrations/0002_setting.py
@@ -3,7 +3,6 @@
 """Diode Netbox Plugin - Database migrations."""
 
 import utilities.json
-from django.conf import settings as netbox_settings
 from django.db import migrations, models
 from netbox.plugins import get_plugin_config
 

--- a/netbox_diode_plugin/migrations/0002_setting.py
+++ b/netbox_diode_plugin/migrations/0002_setting.py
@@ -5,15 +5,17 @@
 import utilities.json
 from django.conf import settings as netbox_settings
 from django.db import migrations, models
+from netbox.plugins import get_plugin_config
 
 
 def create_settings_entity(apps, schema_editor):
     """Create a Setting entity."""
     Setting = apps.get_model("netbox_diode_plugin", "Setting")
 
-    diode_target = netbox_settings.PLUGINS_CONFIG.get(
-        "netbox_diode_plugin", {}
-    ).get("diode_target", "grpc://localhost:8080/diode")
+    default_diode_target = get_plugin_config("netbox_diode_plugin", "diode_target")
+    diode_target = get_plugin_config(
+        "netbox_diode_plugin", "diode_target_override", default_diode_target
+    )
 
     Setting.objects.create(diode_target=diode_target)
 

--- a/netbox_diode_plugin/migrations/0003_clear_permissions.py
+++ b/netbox_diode_plugin/migrations/0003_clear_permissions.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""Diode Netbox Plugin - Database migrations."""
+
+from django.db import migrations
+
+
+def clear_diode_group_permissions(apps, schema_editor):
+    """Clear Diode group permissions."""
+    ObjectPermission = apps.get_model("users", "ObjectPermission")
+    permission = ObjectPermission.objects.get(name="Diode")
+    permission.groups.clear()
+
+
+class Migration(migrations.Migration):
+    """0003_clear_permissions migration."""
+
+    dependencies = [
+        ("netbox_diode_plugin", "0001_initial"),
+        ("netbox_diode_plugin", "0002_setting"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=clear_diode_group_permissions, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/netbox_diode_plugin/migrations/0004_rename_legacy_users.py
+++ b/netbox_diode_plugin/migrations/0004_rename_legacy_users.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""Diode Netbox Plugin - Database migrations."""
+
+from django.db import migrations
+
+from netbox_diode_plugin.plugin_config import get_diode_usernames
+
+
+def rename_legacy_users(apps, schema_editor):
+    """Rename legacy users."""
+    legacy_usernames_to_user_category_map = {
+        "DIODE_TO_NETBOX": "diode_to_netbox",
+        "NETBOX_TO_DIODE": "netbox_to_diode",
+        "DIODE": "diode",
+    }
+
+    User = apps.get_model("users", "User")
+    users = User.objects.filter(
+        username__in=legacy_usernames_to_user_category_map.keys(),
+        groups__name="diode",
+    )
+
+    for user in users:
+        user_category = legacy_usernames_to_user_category_map.get(user.username)
+        user.username = get_diode_usernames().get(user_category)
+        user.save()
+
+
+class Migration(migrations.Migration):
+    """0004_rename_legacy_users migration."""
+
+    dependencies = [
+        ("netbox_diode_plugin", "0001_initial"),
+        ("netbox_diode_plugin", "0002_setting"),
+        ("netbox_diode_plugin", "0003_clear_permissions"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=rename_legacy_users, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -4,7 +4,7 @@
 
 from netbox.plugins import get_plugin_config
 
-__all__ = ("get_diode_usernames",)
+__all__ = ("get_diode_usernames", "get_diode_username_for_user_category")
 
 
 def get_diode_usernames():
@@ -16,3 +16,8 @@ def get_diode_usernames():
         )
         for user_category in diode_user_categories
     }
+
+
+def get_diode_username_for_user_category(user_category):
+    """Returns a diode username for a given user category."""
+    return get_plugin_config("netbox_diode_plugin", f"{user_category}_username")

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -1,0 +1,18 @@
+# !/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""Diode NetBox Plugin - Plugin Settings."""
+
+from netbox.plugins import get_plugin_config
+
+__all__ = ("get_diode_usernames",)
+
+
+def get_diode_usernames():
+    """Returns a dictionary of diode user categories and their configured usernames."""
+    diode_user_categories = ("diode_to_netbox", "netbox_to_diode", "diode")
+    return {
+        user_category: get_plugin_config(
+            "netbox_diode_plugin", f"{user_category}_username"
+        )
+        for user_category in diode_user_categories
+    }

--- a/netbox_diode_plugin/templates/diode/ingestion_logs.html
+++ b/netbox_diode_plugin/templates/diode/ingestion_logs.html
@@ -7,10 +7,16 @@
 {% block title %}{% trans "Ingestion Logs" %}{% endblock %}
 
 {% block content %}
-{% if error %}
+
+{% if netbox_to_diode_user_error %}
 <div class="alert alert-danger mt-3" role="alert">
     <h4 class="alert-heading">{% trans "Error" %}</h4>
-    <p>{{ error.status_code }}: {{ error.details }}</p>
+    <p>{{ netbox_to_diode_user_error }}</p>
+</div>
+{% elif ingestion_logs_error %}
+<div class="alert alert-danger mt-3" role="alert">
+    <h4 class="alert-heading">{% trans "Error" %}</h4>
+    <p>{{ ingestion_logs_error.status_code }}: {{ ingestion_logs_error.details }}</p>
 </div>
 {% else %}
 <div>

--- a/netbox_diode_plugin/templates/diode/ingestion_logs.html
+++ b/netbox_diode_plugin/templates/diode/ingestion_logs.html
@@ -30,7 +30,7 @@
                     </div>
                     <div class="w-auto p-0">
                         <canvas id="ingestions-reconciled"></canvas>
-                        <div class="text-center metric-label">Reconciled</div>
+                        <div class="text-center metric-label">Changes</div>
                     </div>
                     <div class="w-auto p-0">
                         <canvas id="ingestions-failed"></canvas>

--- a/netbox_diode_plugin/templates/diode/settings.html
+++ b/netbox_diode_plugin/templates/diode/settings.html
@@ -53,7 +53,7 @@
                             <span class="diode-api-key font-monospace" data-diode-api-key="{{ user_info.api_key }}">{{ user_info.api_key|placeholder }}</span>
                         </td>
                         <td>
-                            {{ user_info.env_var_name}}
+                            Map to environment variable {{ user_info.env_var_name}} in Diode service{% if user_info.env_var_name == "DIODE_API_KEY" %} and Diode SDK{% endif %}
                         </td>
                         <td>
                             <div class="float-end">

--- a/netbox_diode_plugin/templates/diode/settings.html
+++ b/netbox_diode_plugin/templates/diode/settings.html
@@ -6,12 +6,14 @@
 {% block title %}{% trans "Settings" %}{% endblock %}
 
 {% block controls %}
+{% if not is_diode_target_overridden %}
 <div class="btn-list">
     {% block control-buttons %}
     {% url 'plugins:netbox_diode_plugin:settings_edit' as edit_url %}
     {% include "buttons/edit.html" with url=edit_url %}
     {% endblock control-buttons %}
 </div>
+{% endif %}
 {% endblock controls %}
 
 {% block content %}
@@ -22,10 +24,6 @@
                 <tr>
                     <th scope="row">{% trans "Diode target" %}</th>
                     <td>{{ diode_target }}</td>
-                </tr>
-                <tr>
-                    <th scope="row">{% trans "Last updated" %}</th>
-                    <td>{{ last_updated|isodatetime }}</td>
                 </tr>
             </table>
         </div>

--- a/netbox_diode_plugin/templates/diode/settings.html
+++ b/netbox_diode_plugin/templates/diode/settings.html
@@ -35,24 +35,39 @@
 <div class="row mb-3">
     <div class="col col-md-12">
         <div class="card">
-            <h2 class="card-header">{% trans "API keys" %}</h2>
-            <table class="table table-hover attr-table">
-                {% for username, api_key in api_keys.items %}
-                <tr>
-                    <th scope="row">{{ username }}</th>
-                    <td>
-                        <span class="diode-api-key font-monospace" data-diode-api-key="{{ api_key }}">{{ api_key|placeholder }}</span>
-                        <div class="float-end">
-                            <button type="button" class="btn btn-sm btn-info copy-content me-2" data-clipboard-text="{{ api_key }}" title="Copy to clipboard">
-                                <i class="mdi mdi-content-copy"></i>
-                            </button>
-                            <button type="button" class="btn btn-sm btn-primary toggle-diode-api-key float-end" data-bs-toggle="button">
-                                <i class="mdi mdi-eye"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
+            <h2 class="card-header">{% trans "Diode users" %}</h2>
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>{% trans "Username" %}</th>
+                        <th>{% trans "API key" %}</th>
+                        <th>{% trans "Environment variable" %}</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for username, user_info in diode_users_info.items %}
+                    <tr class="align-middle">
+                        <td>{{ username }}</td>
+                        <td>
+                            <span class="diode-api-key font-monospace" data-diode-api-key="{{ user_info.api_key }}">{{ user_info.api_key|placeholder }}</span>
+                        </td>
+                        <td>
+                            {{ user_info.env_var_name}}
+                        </td>
+                        <td>
+                            <div class="float-end">
+                                <button type="button" class="btn btn-sm btn-info copy-content me-2" data-clipboard-text="{{ user_info.api_key }}" title="Copy to clipboard">
+                                    <i class="mdi mdi-content-copy"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-primary toggle-diode-api-key float-end" data-bs-toggle="button">
+                                    <i class="mdi mdi-eye"></i>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
                 {% endfor %}
+                </tbody>
             </table>
         </div>
     </div>
@@ -67,7 +82,7 @@
 
     document.querySelectorAll('.toggle-diode-api-key').forEach(function (button) {
         button.addEventListener('click', function () {
-            var apiKey = this.parentElement.parentElement.querySelector(diodeAPIKeySelector);
+            var apiKey = this.parentElement.parentElement.parentElement.querySelector(diodeAPIKeySelector);
             if (apiKey.getAttribute(diodeAPIKeyAttr) === apiKey.textContent) {
                 apiKey.textContent = apiKey.getAttribute(diodeAPIKeyAttr).replace(/./g, '*');
                 button.getElementsByTagName('i')[0].classList.replace('mdi-eye-off', 'mdi-eye');

--- a/netbox_diode_plugin/templates/diode/settings.html
+++ b/netbox_diode_plugin/templates/diode/settings.html
@@ -30,6 +30,15 @@
     </div>
 </div>
 
+{% if diode_users_errors %}
+<div class="alert alert-danger mt-3" role="alert">
+    <h4 class="alert-heading">{% trans "Errors" %}</h4>
+    {% for error in diode_users_errors %}
+    <p>{{ error }}</p>
+    {% endfor %}
+</div>
+{% endif %}
+
 <div class="row mb-3">
     <div class="col col-md-12">
         <div class="card">

--- a/netbox_diode_plugin/tests/test_forms.py
+++ b/netbox_diode_plugin/tests/test_forms.py
@@ -18,24 +18,18 @@ class SettingsFormTestCase(TestCase):
 
     def test_form_initialization_with_override_allowed(self):
         """Test form initialization when override is allowed."""
-        with mock.patch("netbox_diode_plugin.forms.netbox_settings") as mock_settings:
-            mock_settings.PLUGINS_CONFIG = {
-                "netbox_diode_plugin": {
-                    "disallow_diode_target_override": False
-                }
-            }
+        with mock.patch("netbox_diode_plugin.forms.get_plugin_config") as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = None
             form = SettingsForm(instance=self.setting)
+            mock_get_plugin_config.assert_called_with("netbox_diode_plugin", "diode_target_override")
             self.assertFalse(form.fields["diode_target"].disabled)
-            self.assertNotIn("This field is not allowed to be overridden.", form.fields["diode_target"].help_text)
+            self.assertNotIn("This field is not allowed to be modified.", form.fields["diode_target"].help_text)
 
-    def test_form_initialization_with_override_disallowed(self):
+    def test_form_initialization_with_diode_targer_override(self):
         """Test form initialization when override is disallowed."""
-        with mock.patch("netbox_diode_plugin.forms.netbox_settings") as mock_settings:
-            mock_settings.PLUGINS_CONFIG = {
-                "netbox_diode_plugin": {
-                    "disallow_diode_target_override": True
-                }
-            }
+        with mock.patch("netbox_diode_plugin.forms.get_plugin_config") as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
             form = SettingsForm(instance=self.setting)
+            mock_get_plugin_config.assert_called_with("netbox_diode_plugin", "diode_target_override")
             self.assertTrue(form.fields["diode_target"].disabled)
-            self.assertEqual("This field is not allowed to be overridden.", form.fields["diode_target"].help_text)
+            self.assertEqual("This field is not allowed to be modified.", form.fields["diode_target"].help_text)

--- a/netbox_diode_plugin/tests/test_views.py
+++ b/netbox_diode_plugin/tests/test_views.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
 """Diode NetBox Plugin - Tests."""
+import html
 from unittest import mock
 
 from django.contrib.auth import get_user_model
@@ -12,6 +13,7 @@ from django.core.cache import cache
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from rest_framework import status
+from users.models import Token
 
 from netbox_diode_plugin.models import Setting
 from netbox_diode_plugin.reconciler.sdk.v1 import ingester_pb2, reconciler_pb2
@@ -158,6 +160,35 @@ class IngestionLogsViewTestCase(TestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertNotIn("Server Error", str(response.content))
 
+    def test_error_message_displayed_on_missing_diode_user(self):
+        """Test that an error message is displayed when the Diode user is missing on settings page."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.request.user.is_staff = True
+
+        with (
+            mock.patch(
+                "netbox_diode_plugin.views.get_diode_username_for_user_category"
+            ) as mock_get_diode_username_for_user_category,
+            mock.patch(
+                "netbox_diode_plugin.views.get_user_model"
+            ) as mock_get_user_model,
+        ):
+            mock_get_diode_username_for_user_category.return_value = (
+                "fake-netbox-to-diode"
+            )
+            mock_get_user_model.return_value.objects.get.side_effect = User.DoesNotExist
+
+            response = self.view.get(self.request)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertNotIn("Server Error", str(response.content))
+            self.assertIn(
+                html.escape(
+                    "User 'fake-netbox-to-diode' does not exist, please check plugin configuration."
+                ),
+                str(response.content),
+            )
+
 
 class SettingsViewTestCase(TestCase):
     """Test case for the SettingsView."""
@@ -197,8 +228,41 @@ class SettingsViewTestCase(TestCase):
 
             response = self.view.get(self.request)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpc://localhost:8080/diode", str(response.content))
+
+    def test_error_message_displayed_on_missing_diode_user(self):
+        """Test that an error message is displayed when the Diode user is missing on settings page."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.request.user.is_staff = True
+
+        with (
+            mock.patch(
+                "netbox_diode_plugin.views.get_diode_usernames"
+            ) as mock_get_diode_usernames,
+            mock.patch(
+                "netbox_diode_plugin.views.get_user_model"
+            ) as mock_get_user_model,
+        ):
+            mock_get_diode_usernames.return_value = {
+                "diode_to_netbox": "diode-to-netbox",
+                "netbox_to_diode": "fake-netbox-to-diode",
+                "diode": "diode-ingestion",
+            }
+            mock_get_user_model.return_value.objects.get.side_effect = [
+                User.objects.get(username="diode-to-netbox"),
+                User.DoesNotExist,
+                User.objects.get(username="diode-ingestion"),
+            ]
+
+            response = self.view.get(self.request)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertNotIn("Server Error", str(response.content))
             self.assertIn(
-                "grpc://localhost:8080/diode", str(response.content)
+                html.escape(
+                    "User 'fake-netbox-to-diode' does not exist, please check plugin configuration."
+                ),
+                str(response.content),
             )
 
 
@@ -287,7 +351,9 @@ class SettingsEditViewTestCase(TestCase):
 
     def test_settings_update_disallowed_on_get_method(self):
         """Test that the accessing settings edit is not allowed with diode target override."""
-        with mock.patch("netbox_diode_plugin.views.get_plugin_config") as mock_get_plugin_config:
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config"
+        ) as mock_get_plugin_config:
             mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
 
             user = User.objects.create_user("foo", password="pass")
@@ -305,7 +371,7 @@ class SettingsEditViewTestCase(TestCase):
             middleware.process_request(request)
             request.session.save()
 
-            setattr(request, 'session', 'session')
+            setattr(request, "session", "session")
             messages = FallbackStorage(request)
             request._messages = messages
 
@@ -313,7 +379,9 @@ class SettingsEditViewTestCase(TestCase):
             response = self.view.get(request)
 
             self.assertEqual(response.status_code, status.HTTP_302_FOUND)
-            self.assertEqual(response.url, reverse("plugins:netbox_diode_plugin:settings"))
+            self.assertEqual(
+                response.url, reverse("plugins:netbox_diode_plugin:settings")
+            )
             self.assertEqual(len(request._messages._queued_messages), 1)
             self.assertEqual(
                 str(request._messages._queued_messages[0]),
@@ -322,7 +390,9 @@ class SettingsEditViewTestCase(TestCase):
 
     def test_settings_update_disallowed_on_post_method(self):
         """Test that the updating settings is not allowed with diode target override."""
-        with mock.patch("netbox_diode_plugin.views.get_plugin_config") as mock_get_plugin_config:
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config"
+        ) as mock_get_plugin_config:
             mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
 
             user = User.objects.create_user("foo", password="pass")
@@ -341,7 +411,7 @@ class SettingsEditViewTestCase(TestCase):
             middleware.process_request(request)
             request.session.save()
 
-            setattr(request, 'session', 'session')
+            setattr(request, "session", "session")
             messages = FallbackStorage(request)
             request._messages = messages
 
@@ -349,7 +419,9 @@ class SettingsEditViewTestCase(TestCase):
             response = self.view.post(request)
 
             self.assertEqual(response.status_code, status.HTTP_302_FOUND)
-            self.assertEqual(response.url, reverse("plugins:netbox_diode_plugin:settings"))
+            self.assertEqual(
+                response.url, reverse("plugins:netbox_diode_plugin:settings")
+            )
             self.assertEqual(len(request._messages._queued_messages), 1)
             self.assertEqual(
                 str(request._messages._queued_messages[0]),

--- a/netbox_diode_plugin/views.py
+++ b/netbox_diode_plugin/views.py
@@ -13,7 +13,10 @@ from utilities.views import register_model_view
 
 from netbox_diode_plugin.forms import SettingsForm
 from netbox_diode_plugin.models import Setting
-from netbox_diode_plugin.plugin_config import get_diode_usernames
+from netbox_diode_plugin.plugin_config import (
+    get_diode_usernames,
+    get_diode_username_for_user_category,
+)
 from netbox_diode_plugin.reconciler.sdk.client import ReconcilerClient
 from netbox_diode_plugin.reconciler.sdk.exceptions import ReconcilerClientError
 from netbox_diode_plugin.tables import IngestionLogsTable
@@ -31,7 +34,8 @@ class IngestionLogsView(View):
 
         diode_settings = Setting.objects.get()
 
-        user = get_user_model().objects.get(username="NETBOX_TO_DIODE")
+        netbox_to_diode_username = get_diode_username_for_user_category("netbox_to_diode")
+        user = get_user_model().objects.get(username=netbox_to_diode_username)
         token = Token.objects.get(user=user)
 
         reconciler_client = ReconcilerClient(

--- a/netbox_diode_plugin/views.py
+++ b/netbox_diode_plugin/views.py
@@ -22,6 +22,8 @@ from netbox_diode_plugin.reconciler.sdk.client import ReconcilerClient
 from netbox_diode_plugin.reconciler.sdk.exceptions import ReconcilerClientError
 from netbox_diode_plugin.tables import IngestionLogsTable
 
+User = get_user_model()
+
 
 class IngestionLogsView(View):
     """Ingestion logs view."""
@@ -38,7 +40,7 @@ class IngestionLogsView(View):
         )
         try:
             user = get_user_model().objects.get(username=netbox_to_diode_username)
-        except get_user_model().DoesNotExist:
+        except User.DoesNotExist:
             context = {
                 "netbox_to_diode_user_error": f"User '{netbox_to_diode_username}' does not exist, please check plugin configuration.",
             }
@@ -138,8 +140,10 @@ class SettingsView(View):
         for user_category, username in get_diode_usernames().items():
             try:
                 user = get_user_model().objects.get(username=username)
-            except get_user_model().DoesNotExist:
-                diode_users_errors.append(f"User '{username}' does not exist, please check plugin configuration.")
+            except User.DoesNotExist:
+                diode_users_errors.append(
+                    f"User '{username}' does not exist, please check plugin configuration."
+                )
                 continue
 
             token = Token.objects.get(user=user)

--- a/netbox_diode_plugin/views.py
+++ b/netbox_diode_plugin/views.py
@@ -14,8 +14,8 @@ from utilities.views import register_model_view
 from netbox_diode_plugin.forms import SettingsForm
 from netbox_diode_plugin.models import Setting
 from netbox_diode_plugin.plugin_config import (
-    get_diode_usernames,
     get_diode_username_for_user_category,
+    get_diode_usernames,
 )
 from netbox_diode_plugin.reconciler.sdk.client import ReconcilerClient
 from netbox_diode_plugin.reconciler.sdk.exceptions import ReconcilerClientError
@@ -34,7 +34,9 @@ class IngestionLogsView(View):
 
         diode_settings = Setting.objects.get()
 
-        netbox_to_diode_username = get_diode_username_for_user_category("netbox_to_diode")
+        netbox_to_diode_username = get_diode_username_for_user_category(
+            "netbox_to_diode"
+        )
         user = get_user_model().objects.get(username=netbox_to_diode_username)
         token = Token.objects.get(user=user)
 

--- a/netbox_diode_plugin/views.py
+++ b/netbox_diode_plugin/views.py
@@ -109,17 +109,20 @@ class SettingsView(View):
                 diode_target="grpc://localhost:8080/diode"
             )
 
-        diode_api_keys = {}
+        diode_users_info = {}
 
         for user_category, username in get_diode_usernames().items():
             user = get_user_model().objects.get(username=username)
             token = Token.objects.get(user=user)
-            diode_api_keys[f"{user_category.upper()}_API_KEY"] = token.key
+            diode_users_info[username] = {
+                "api_key": token.key,
+                "env_var_name": f"{user_category.upper()}_API_KEY",
+            }
 
         context = {
             "diode_target": settings.diode_target,
             "last_updated": settings.last_updated,
-            "api_keys": diode_api_keys,
+            "diode_users_info": diode_users_info,
         }
 
         return render(request, "diode/settings.html", context)

--- a/netbox_diode_plugin/views.py
+++ b/netbox_diode_plugin/views.py
@@ -13,6 +13,7 @@ from utilities.views import register_model_view
 
 from netbox_diode_plugin.forms import SettingsForm
 from netbox_diode_plugin.models import Setting
+from netbox_diode_plugin.plugin_config import get_diode_usernames
 from netbox_diode_plugin.reconciler.sdk.client import ReconcilerClient
 from netbox_diode_plugin.reconciler.sdk.exceptions import ReconcilerClientError
 from netbox_diode_plugin.tables import IngestionLogsTable
@@ -108,18 +109,12 @@ class SettingsView(View):
                 diode_target="grpc://localhost:8080/diode"
             )
 
-        diode_users = [
-            "DIODE",
-            "DIODE_TO_NETBOX",
-            "NETBOX_TO_DIODE",
-        ]
-
         diode_api_keys = {}
 
-        for username in diode_users:
+        for user_category, username in get_diode_usernames().items():
             user = get_user_model().objects.get(username=username)
             token = Token.objects.get(user=user)
-            diode_api_keys[f"{username}_API_KEY"] = token.key
+            diode_api_keys[f"{user_category.upper()}_API_KEY"] = token.key
 
         context = {
             "diode_target": settings.diode_target,


### PR DESCRIPTION
- clear diode permissions (migration)
- add default settings with usernames and diode target (placeholder)
- allow plugin configuration with PLUGINS_CONFIG:
  - `diode_target_override`, which takes precedence over diode target stored in the settings model (db)
  - `diode_to_netbox_username`, `netbox_to_diode_username`, `diode_username` to customise diode related usernames
- rename legacy users to new usernames (using new default or custom ones)