### PR TITLE
feat: manual users provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Also in your `configuration.py` file, in order to customise the plugin settings,
 ```python
 PLUGINS_CONFIG = {
     "netbox_diode_plugin": {
+        # Auto-provision users for Diode plugin
+        "auto_provision_users": False,
+
         # Diode gRPC target for communication with Diode server
         "diode_target_override": "grpc://localhost:8080/diode",
 
@@ -63,6 +66,11 @@ PLUGINS_CONFIG = {
 
 Note: Once you customise usernames with PLUGINS_CONFIG during first installation, you should not change or remove them
 later on. Doing so will cause the plugin to stop working properly.
+
+`auto_provision_users` is a boolean flag (default: `False`) that determines whether the plugin should automatically
+create the users during
+migration. If set to `False`, you will need to provision Diode users with their API keys manually via the plugin's setup
+page in the NetBox UI.
 
 Restart NetBox services to load the plugin:
 
@@ -93,7 +101,16 @@ export NETBOX_TO_DIODE_API_KEY=$(head -c20 </dev/urandom|xxd -p); env | grep NET
 export DIODE_API_KEY=$(head -c20 </dev/urandom|xxd -p); env | grep DIODE_API_KEY
 ```
 
-**Note:** store these API key strings in a safe place as they will be needed later to configure the Diode server
+**Note:** store these API key strings in a safe place as they will be needed later to configure the Diode server.
+
+If you don't set these environment variables, the plugin will generate random API keys for you either during the
+migration process (with `auto_provision_users` set to `True`) or when you manually create the users in the plugin's
+setup page in the NetBox UI.
+
+It's important to note that the environment variables with API keys should be populated in the Diode server's
+environment variables (
+see [docs](https://github.com/netboxlabs/diode/tree/develop/diode-server#running-the-diode-server)) as well to ensure
+proper communication between the Diode SDK, Diode server and the NetBox plugin.
 
 Run migrations to create all necessary resources:
 

--- a/docker/netbox/configuration/plugins.py
+++ b/docker/netbox/configuration/plugins.py
@@ -8,6 +8,9 @@ PLUGINS = ["netbox_diode_plugin"]
 
 # PLUGINS_CONFIG = {
 #     "netbox_diode_plugin": {
+#         # Auto-provision users for Diode plugin
+#         "auto_provision_users": True,
+#
 #         # Diode gRPC target for communication with Diode server
 #         "diode_target_override": "grpc://localhost:8080/diode",
 #

--- a/docker/netbox/plugins_test.py
+++ b/docker/netbox/plugins_test.py
@@ -8,6 +8,6 @@ PLUGINS = ["netbox_diode_plugin"]
 
 PLUGINS_CONFIG = {
     "netbox_diode_plugin": {
-        "enable_ingestion_logs": True,
+        "auto_provision_users": True,
     }
 }

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -19,16 +19,12 @@ class NetBoxDiodePluginConfig(PluginConfig):
     default_settings = {
         # Auto-provision users for Diode plugin
         "auto_provision_users": False,
-
         # Default Diode gRPC target for communication with Diode server
         "diode_target": "grpc://localhost:8080/diode",
-
         # User allowed for Diode to NetBox communication
         "diode_to_netbox_username": "diode-to-netbox",
-
         # User allowed for NetBox to Diode communication
         "netbox_to_diode_username": "netbox-to-diode",
-
         # User allowed for data ingestion
         "diode_username": "diode-ingestion",
     }

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -17,6 +17,9 @@ class NetBoxDiodePluginConfig(PluginConfig):
     base_url = "diode"
     min_version = "3.7.2"
     default_settings = {
+        # Auto-provision users for Diode plugin
+        "auto_provision_users": False,
+
         # Default Diode gRPC target for communication with Diode server
         "diode_target": "grpc://localhost:8080/diode",
 

--- a/netbox_diode_plugin/forms.py
+++ b/netbox_diode_plugin/forms.py
@@ -1,13 +1,20 @@
 # !/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
 """Diode NetBox Plugin - Forms."""
+from django import forms
+from django.core.validators import MinLengthValidator
+from django.utils.translation import gettext_lazy as _
 from netbox.forms import NetBoxModelForm
 from netbox.plugins import get_plugin_config
+from users.models import Token as NetBoxToken
 from utilities.forms.rendering import FieldSet
 
 from netbox_diode_plugin.models import Setting
 
-__all__ = ("SettingsForm",)
+__all__ = (
+    "SettingsForm",
+    "SetupForm",
+)
 
 
 class SettingsForm(NetBoxModelForm):
@@ -37,4 +44,55 @@ class SettingsForm(NetBoxModelForm):
             self.fields["diode_target"].disabled = True
             self.fields["diode_target"].help_text = (
                 "This field is not allowed to be modified."
+            )
+
+
+class SetupForm(forms.Form):
+    """Setup form."""
+
+    def __init__(self, users, *args, **kwargs):
+        """Initialize the form."""
+        super().__init__(*args, **kwargs)
+
+        for user_type, user_properties in users.items():
+            field_name = f"{user_type}_api_key"
+            username_or_type = user_properties.get("username") or user_type
+            label = f"{username_or_type}"
+
+            disabled = user_properties.get("user") is not None or (
+                user_properties.get("predefined_api_key") is not None
+                or user_properties.get("api_key") is not None
+            )
+            help_text = _(
+                f"Key must be at least 40 characters in length.<br />Map to environment variable "
+                f'{user_properties["api_key_env_var_name"]} in Diode service'
+                f'{" and Diode SDK" if user_type == "diode" else ""}'
+            )
+
+            initial_value = user_properties.get("api_key") or user_properties.get(
+                "predefined_api_key"
+            )
+
+            if (
+                user_properties.get("predefined_api_key") is None
+                and user_properties.get("api_key") is None
+            ):
+                initial_value = NetBoxToken.generate_key()
+
+            self.fields[field_name] = forms.CharField(
+                required=True,
+                max_length=40,
+                validators=[MinLengthValidator(40)],
+                label=label,
+                disabled=disabled,
+                initial=initial_value,
+                help_text=help_text,
+                widget=forms.TextInput(
+                    attrs={
+                        "data-clipboard": "true",
+                        "placeholder": _(
+                            f"Enter a valid API key for {username_or_type} user"
+                        ),
+                    }
+                ),
             )

--- a/netbox_diode_plugin/forms.py
+++ b/netbox_diode_plugin/forms.py
@@ -59,10 +59,7 @@ class SetupForm(forms.Form):
             username_or_type = user_properties.get("username") or user_type
             label = f"{username_or_type}"
 
-            disabled = user_properties.get("user") is not None or (
-                user_properties.get("predefined_api_key") is not None
-                or user_properties.get("api_key") is not None
-            )
+            disabled = user_properties.get("predefined_api_key") is not None or user_properties.get("api_key") is not None
             help_text = _(
                 f"Key must be at least 40 characters in length.<br />Map to environment variable "
                 f'{user_properties["api_key_env_var_name"]} in Diode service'

--- a/netbox_diode_plugin/migrations/0001_initial.py
+++ b/netbox_diode_plugin/migrations/0001_initial.py
@@ -9,6 +9,7 @@ from django.conf import settings as netbox_settings
 from django.contrib.contenttypes.management import create_contenttypes
 from django.db import migrations, models
 from users.models import Token as NetBoxToken
+from netbox.plugins import get_plugin_config
 
 from netbox_diode_plugin.plugin_config import get_diode_usernames
 
@@ -65,6 +66,13 @@ def configure_plugin(apps, schema_editor):
         actions=["add", "view"],
     )
     permission.object_types.set([diode_plugin_object_type.id])
+
+    auto_provision_users = get_plugin_config(
+        "netbox_diode_plugin", "auto_provision_users"
+    )
+
+    if not auto_provision_users:
+        return
 
     diode_to_netbox_user_id = None
 

--- a/netbox_diode_plugin/migrations/0004_rename_legacy_users.py
+++ b/netbox_diode_plugin/migrations/0004_rename_legacy_users.py
@@ -9,7 +9,7 @@ from netbox_diode_plugin.plugin_config import get_diode_usernames
 
 def rename_legacy_users(apps, schema_editor):
     """Rename legacy users."""
-    legacy_usernames_to_user_category_map = {
+    legacy_usernames_to_user_type_map = {
         "DIODE_TO_NETBOX": "diode_to_netbox",
         "NETBOX_TO_DIODE": "netbox_to_diode",
         "DIODE": "diode",
@@ -17,13 +17,13 @@ def rename_legacy_users(apps, schema_editor):
 
     User = apps.get_model("users", "User")
     users = User.objects.filter(
-        username__in=legacy_usernames_to_user_category_map.keys(),
+        username__in=legacy_usernames_to_user_type_map.keys(),
         groups__name="diode",
     )
 
     for user in users:
-        user_category = legacy_usernames_to_user_category_map.get(user.username)
-        user.username = get_diode_usernames().get(user_category)
+        user_type = legacy_usernames_to_user_type_map.get(user.username)
+        user.username = get_diode_usernames().get(user_type)
         user.save()
 
 

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -4,20 +4,35 @@
 
 from netbox.plugins import get_plugin_config
 
-__all__ = ("get_diode_usernames", "get_diode_username_for_user_category")
+__all__ = (
+    "get_diode_user_types",
+    "get_diode_usernames",
+    "get_diode_username_for_user_type",
+)
+
+
+def get_diode_user_types():
+    """Returns a list of diode user types."""
+    return "diode_to_netbox", "netbox_to_diode", "diode"
+
+
+def get_diode_user_types_with_labels():
+    """Returns a list of diode user types with labels."""
+    return (
+        ("diode_to_netbox", "Diode to NetBox"),
+        ("netbox_to_diode", "NetBox to Diode"),
+        ("diode", "Diode"),
+    )
 
 
 def get_diode_usernames():
-    """Returns a dictionary of diode user categories and their configured usernames."""
-    diode_user_categories = ("diode_to_netbox", "netbox_to_diode", "diode")
+    """Returns a dictionary of diode user types and their configured usernames."""
     return {
-        user_category: get_plugin_config(
-            "netbox_diode_plugin", f"{user_category}_username"
-        )
-        for user_category in diode_user_categories
+        user_type: get_plugin_config("netbox_diode_plugin", f"{user_type}_username")
+        for user_type in get_diode_user_types()
     }
 
 
-def get_diode_username_for_user_category(user_category):
-    """Returns a diode username for a given user category."""
-    return get_plugin_config("netbox_diode_plugin", f"{user_category}_username")
+def get_diode_username_for_user_type(user_type):
+    """Returns a diode username for a given user type."""
+    return get_plugin_config("netbox_diode_plugin", f"{user_type}_username")

--- a/netbox_diode_plugin/templates/diode/setup.html
+++ b/netbox_diode_plugin/templates/diode/setup.html
@@ -4,6 +4,13 @@
 {% block title %}{% trans "Setup" %}{% endblock %}
 
 {% block content %}
+
+<div class="alert alert-warning mt-3" role="alert">
+    <h4 class="alert-heading">{% trans "Important" %}</h4>
+    <p>{% trans "The following Diode users and API keys are required for the plugin to work correctly. If the field is disabled, it means we pre-populated it with detected pre-defined API keys." %}</p>
+    <p>{% trans "Please ensure you click the \"Create\" button to make these users and their API keys active." %}</p>
+</div>
+
 <div class="tab-pane show active" id="setup-form" role="tabpanel" aria-labelledby="setup-tab">
     <form action="" method="post" enctype="multipart/form-data" class="object-edit mt-5">
         {% csrf_token %}
@@ -21,7 +28,7 @@
         <div class="text-end my-3">
             {% block buttons %}
             <button type="submit" name="_update" class="btn btn-primary">
-                {% trans "Save" %}
+                {% trans "Create" %}
             </button>
             {% endblock buttons %}
         </div>

--- a/netbox_diode_plugin/templates/diode/setup.html
+++ b/netbox_diode_plugin/templates/diode/setup.html
@@ -1,0 +1,31 @@
+{% extends 'generic/_base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Setup" %}{% endblock %}
+
+{% block content %}
+<div class="tab-pane show active" id="setup-form" role="tabpanel" aria-labelledby="setup-tab">
+    <form action="" method="post" enctype="multipart/form-data" class="object-edit mt-5">
+        {% csrf_token %}
+
+        <div class="row">
+            <h2 class="col-9 offset-3">{% trans "Diode users and API Keys" %}</h2>
+        </div>
+
+        <div id="form_fields" hx-disinherit="hx-select hx-swap">
+            {% block form %}
+            {% include 'htmx/form.html' %}
+            {% endblock form %}
+        </div>
+
+        <div class="text-end my-3">
+            {% block buttons %}
+            <button type="submit" name="_update" class="btn btn-primary">
+                {% trans "Save" %}
+            </button>
+            {% endblock buttons %}
+        </div>
+    </form>
+</div>
+{% endblock content %}
+

--- a/netbox_diode_plugin/templates/diode/setup.html
+++ b/netbox_diode_plugin/templates/diode/setup.html
@@ -7,8 +7,8 @@
 
 <div class="alert alert-warning mt-3" role="alert">
     <h4 class="alert-heading">{% trans "Important" %}</h4>
-    <p>{% trans "The following Diode users and API keys are required for the plugin to work correctly. If the field is disabled, it means it's been pre-populated with detected predefined API keys." %}</p>
-    <p>{% trans "Please ensure you click the \"Create\" button to make these users and their API keys active." %}</p>
+    <p>{% trans "Diode is not currently configured and requires a set of users and API keys to be created before using Diode. If fields in this form are read-only, they have been pre-populated based on application settings that cannot be overwritten." %}</p>
+    <p>{% trans "Click the \"Create\" button to create the required Diode users and API keys and proceed." %}</p>
 </div>
 
 <div class="tab-pane show active" id="setup-form" role="tabpanel" aria-labelledby="setup-tab">

--- a/netbox_diode_plugin/templates/diode/setup.html
+++ b/netbox_diode_plugin/templates/diode/setup.html
@@ -7,7 +7,7 @@
 
 <div class="alert alert-warning mt-3" role="alert">
     <h4 class="alert-heading">{% trans "Important" %}</h4>
-    <p>{% trans "The following Diode users and API keys are required for the plugin to work correctly. If the field is disabled, it means it's been pre-populated with detected pre-defined API keys." %}</p>
+    <p>{% trans "The following Diode users and API keys are required for the plugin to work correctly. If the field is disabled, it means it's been pre-populated with detected predefined API keys." %}</p>
     <p>{% trans "Please ensure you click the \"Create\" button to make these users and their API keys active." %}</p>
 </div>
 

--- a/netbox_diode_plugin/templates/diode/setup.html
+++ b/netbox_diode_plugin/templates/diode/setup.html
@@ -7,7 +7,7 @@
 
 <div class="alert alert-warning mt-3" role="alert">
     <h4 class="alert-heading">{% trans "Important" %}</h4>
-    <p>{% trans "The following Diode users and API keys are required for the plugin to work correctly. If the field is disabled, it means we pre-populated it with detected pre-defined API keys." %}</p>
+    <p>{% trans "The following Diode users and API keys are required for the plugin to work correctly. If the field is disabled, it means it's been pre-populated with detected pre-defined API keys." %}</p>
     <p>{% trans "Please ensure you click the \"Create\" button to make these users and their API keys active." %}</p>
 </div>
 

--- a/netbox_diode_plugin/tests/test_forms.py
+++ b/netbox_diode_plugin/tests/test_forms.py
@@ -3,10 +3,13 @@
 """Diode NetBox Plugin - Tests."""
 from unittest import mock
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from netbox_diode_plugin.forms import SettingsForm
+from netbox_diode_plugin.forms import SettingsForm, SetupForm
 from netbox_diode_plugin.models import Setting
+
+User = get_user_model()
 
 
 class SettingsFormTestCase(TestCase):
@@ -14,22 +17,73 @@ class SettingsFormTestCase(TestCase):
 
     def setUp(self):
         """Set up the test case."""
-        self.setting = Setting.objects.create(diode_target="grpc://localhost:8080/diode")
+        self.setting = Setting.objects.create(
+            diode_target="grpc://localhost:8080/diode"
+        )
 
     def test_form_initialization_with_override_allowed(self):
         """Test form initialization when override is allowed."""
-        with mock.patch("netbox_diode_plugin.forms.get_plugin_config") as mock_get_plugin_config:
+        with mock.patch(
+            "netbox_diode_plugin.forms.get_plugin_config"
+        ) as mock_get_plugin_config:
             mock_get_plugin_config.return_value = None
             form = SettingsForm(instance=self.setting)
-            mock_get_plugin_config.assert_called_with("netbox_diode_plugin", "diode_target_override")
+            mock_get_plugin_config.assert_called_with(
+                "netbox_diode_plugin", "diode_target_override"
+            )
             self.assertFalse(form.fields["diode_target"].disabled)
-            self.assertNotIn("This field is not allowed to be modified.", form.fields["diode_target"].help_text)
+            self.assertNotIn(
+                "This field is not allowed to be modified.",
+                form.fields["diode_target"].help_text,
+            )
 
     def test_form_initialization_with_diode_targer_override(self):
         """Test form initialization when override is disallowed."""
-        with mock.patch("netbox_diode_plugin.forms.get_plugin_config") as mock_get_plugin_config:
+        with mock.patch(
+            "netbox_diode_plugin.forms.get_plugin_config"
+        ) as mock_get_plugin_config:
             mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
             form = SettingsForm(instance=self.setting)
-            mock_get_plugin_config.assert_called_with("netbox_diode_plugin", "diode_target_override")
+            mock_get_plugin_config.assert_called_with(
+                "netbox_diode_plugin", "diode_target_override"
+            )
             self.assertTrue(form.fields["diode_target"].disabled)
-            self.assertEqual("This field is not allowed to be modified.", form.fields["diode_target"].help_text)
+            self.assertEqual(
+                "This field is not allowed to be modified.",
+                form.fields["diode_target"].help_text,
+            )
+
+
+class SetupFormTestCase(TestCase):
+    """Test case for the SetupForm."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.users = {
+            "diode_to_netbox": {
+                "username": "diode-to-netbox",
+                "api_key_env_var_name": "DIODE_TO_NETBOX_API_KEY",
+                "predefined_api_key": None,
+                "api_key": None,
+                "user": None,
+            },
+            "diode": {
+                "username": "diode-ingestion",
+                "api_key_env_var_name": "DIODE_API_KEY",
+                "predefined_api_key": "5a52c45ee8231156cb620d193b0291912dd15433",
+                "api_key": None,
+                "user": User.objects.get(username="diode-ingestion"),
+            },
+        }
+
+    def test_form_initialization(self):
+        """Test form initialization with given users."""
+        form = SetupForm(users=self.users)
+        self.assertIn("diode_to_netbox_api_key", form.fields)
+        self.assertFalse(form.fields["diode_to_netbox_api_key"].disabled)
+        self.assertIn("diode_api_key", form.fields)
+        self.assertTrue(form.fields["diode_api_key"].disabled)
+        self.assertEqual(
+            form.fields["diode_api_key"].initial,
+            self.users["diode"]["predefined_api_key"],
+        )

--- a/netbox_diode_plugin/tests/test_plugin_config.py
+++ b/netbox_diode_plugin/tests/test_plugin_config.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""Diode NetBox Plugin - Tests."""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from netbox_diode_plugin.plugin_config import (
+    get_diode_user_types,
+    get_diode_user_types_with_labels,
+    get_diode_username_for_user_type,
+    get_diode_usernames,
+)
+
+
+class PluginConfigTestCase(TestCase):
+    """Test case for plugin config helpers."""
+
+    def test_get_diode_user_types(self):
+        """Test get_diode_user_types function."""
+        expected = ("diode_to_netbox", "netbox_to_diode", "diode")
+        self.assertEqual(get_diode_user_types(), expected)
+
+    def test_get_diode_user_types_with_labels(self):
+        """Test get_diode_user_types_with_labels function."""
+        expected = (
+            ("diode_to_netbox", "Diode to NetBox"),
+            ("netbox_to_diode", "NetBox to Diode"),
+            ("diode", "Diode"),
+        )
+        self.assertEqual(get_diode_user_types_with_labels(), expected)
+
+    @patch("netbox_diode_plugin.plugin_config.get_plugin_config")
+    def test_get_diode_usernames(self, mock_get_plugin_config):
+        """Test get_diode_usernames function."""
+        mock_usernames = {
+            "diode_to_netbox_username": "diode-to-netbox",
+            "netbox_to_diode_username": "netbox-to-diode",
+            "diode_username": "diode-ingestion",
+        }
+        mock_get_plugin_config.side_effect = lambda plugin, key: mock_usernames[key]
+        expected = {
+            "diode_to_netbox": "diode-to-netbox",
+            "netbox_to_diode": "netbox-to-diode",
+            "diode": "diode-ingestion",
+        }
+        self.assertEqual(get_diode_usernames(), expected)
+
+    @patch("netbox_diode_plugin.plugin_config.get_plugin_config")
+    def test_get_diode_username_for_user_type(self, mock_get_plugin_config):
+        """Test get_diode_username_for_user_type function."""
+        mock_usernames = {
+            "diode_to_netbox_username": "diode-to-netbox",
+            "netbox_to_diode_username": "netbox-to-diode",
+            "diode_username": "diode-ingestion",
+        }
+        mock_get_plugin_config.side_effect = lambda plugin, key: mock_usernames[key]
+        self.assertEqual(
+            get_diode_username_for_user_type("netbox_to_diode"), "netbox-to-diode"
+        )
+        self.assertEqual(
+            get_diode_username_for_user_type("diode_to_netbox"), "diode-to-netbox"
+        )
+        self.assertEqual(get_diode_username_for_user_type("diode"), "diode-ingestion")

--- a/netbox_diode_plugin/urls.py
+++ b/netbox_diode_plugin/urls.py
@@ -8,6 +8,7 @@ from . import views
 
 urlpatterns = (
     path("ingestion-logs/", views.IngestionLogsView.as_view(), name="ingestion_logs"),
+    path("setup/", views.SetupView.as_view(), name="setup"),
     path("settings/", views.SettingsView.as_view(), name="settings"),
     path("settings/edit/", views.SettingsEditView.as_view(), name="settings_edit"),
 )


### PR DESCRIPTION
- disable auto provisioning of diode users via migrations (with `auto_provision_users` plugin config setting)
- detect missing diode users and redirect user to plugin setup view with a form composed of pre-defined or generated API keys for diode users, create missing users and api keys on submit