### PR TITLE
chore: GHA release - use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GH_TOKEN: ${{ secrets.ORB_CI_GH_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
   PYTHON_RUNTIME_VERSION: "3.11"
   APP_NAME: diode-netbox-plugin


### PR DESCRIPTION
- reason: decommission use of `ORB_CI_GH_TOKEN`