### PR TITLE
fix: do not treat _branch parameter as search criterion

### DIFF
--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -145,7 +145,7 @@ class ObjectStateView(views.APIView):
         """Get the additional attributes query filter."""
         additional_attributes = {}
         for attr in self.request.query_params:
-            if attr not in ["object_type", "id", "q"]:
+            if attr not in ["object_type", "id", "q", "_branch"]:
                 additional_attributes[attr] = self.request.query_params.get(attr)
 
         return dict(additional_attributes.items())

--- a/netbox_diode_plugin/tests/test_api_object_state.py
+++ b/netbox_diode_plugin/tests/test_api_object_state.py
@@ -379,3 +379,17 @@ class ObjectStateTestCase(APITestCase):
             .get("name"),
             self.interfaces[0].name,
         )
+
+    def test_common_user_get_object_state_with_branch_parameter_specified(self):
+        """Test searching accepts _branch parameter with additional attributes specified."""
+        query_parameters = {
+            "q": self.ip_addresses[0].address.__str__(),
+            "object_type": "ipam.ipaddress",
+            "interface": self.interfaces[0].id,
+            "_branch": ""
+        }
+
+        response = self.client.get(self.url, query_parameters, **self.user_header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("object_type"), "ipam.ipaddress")


### PR DESCRIPTION
Ignores netbox_branching plugin `_branch` parameter when collecting additional search criteria from query parameters in the `diode/object-state/` endpoint.

Previously, a call containing search criteria and the `_branch` parameter would return 
```
{"errors":["invalid additional attributes provided"]}
```