### PR TITLE
Fixes running in netbox-docker with errors on version strings

### DIFF
--- a/netbox_diode_plugin/api/serializers.py
+++ b/netbox_diode_plugin/api/serializers.py
@@ -19,10 +19,16 @@ from packaging import version
 
 from netbox_diode_plugin.models import Setting
 
-if version.parse(version.parse(settings.VERSION).base_version) >= version.parse("4.1"):
+try:
+    if version.parse(version.parse(settings.VERSION).base_version) >= version.parse(
+        "4.1"
+    ):
+        from core.models import ObjectChange
+    else:
+        from extras.models import ObjectChange
+except version.InvalidVersion as e:
     from core.models import ObjectChange
-else:
-    from extras.models import ObjectChange
+
 from ipam.api.serializers import IPAddressSerializer, PrefixSerializer
 from rest_framework import serializers
 from utilities.api import get_serializer_for_model

--- a/netbox_diode_plugin/api/serializers.py
+++ b/netbox_diode_plugin/api/serializers.py
@@ -26,7 +26,7 @@ try:
         from core.models import ObjectChange
     else:
         from extras.models import ObjectChange
-except version.InvalidVersion as e:
+except version.InvalidVersion:
     from core.models import ObjectChange
 
 from ipam.api.serializers import IPAddressSerializer, PrefixSerializer

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -7,10 +7,13 @@ from typing import Any, Dict, Optional
 from django.conf import settings
 from packaging import version
 
-if version.parse(settings.VERSION).major >= 4:
+try:
+    if version.parse(settings.VERSION).major >= 4:
+        from core.models import ObjectType as NetBoxType
+    else:
+        from django.contrib.contenttypes.models import ContentType as NetBoxType
+except version.InvalidVersion as e:
     from core.models import ObjectType as NetBoxType
-else:
-    from django.contrib.contenttypes.models import ContentType as NetBoxType
 from django.core.exceptions import FieldError
 from django.db import transaction
 from django.db.models import Q

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -12,7 +12,7 @@ try:
         from core.models import ObjectType as NetBoxType
     else:
         from django.contrib.contenttypes.models import ContentType as NetBoxType
-except version.InvalidVersion as e:
+except version.InvalidVersion:
     from core.models import ObjectType as NetBoxType
 from django.core.exceptions import FieldError
 from django.db import transaction

--- a/netbox_diode_plugin/tables.py
+++ b/netbox_diode_plugin/tables.py
@@ -13,7 +13,7 @@ try:
         from core.models import ObjectType as NetBoxType
     else:
         from django.contrib.contenttypes.models import ContentType as NetBoxType
-except version.InvalidVersion as e:
+except version.InvalidVersion:
     from core.models import ObjectType as NetBoxType
 
 from netbox.tables import BaseTable, columns

--- a/netbox_diode_plugin/tables.py
+++ b/netbox_diode_plugin/tables.py
@@ -8,10 +8,13 @@ import zoneinfo
 from django.conf import settings
 from packaging import version
 
-if version.parse(settings.VERSION).major >= 4:
+try:
+    if version.parse(settings.VERSION).major >= 4:
+        from core.models import ObjectType as NetBoxType
+    else:
+        from django.contrib.contenttypes.models import ContentType as NetBoxType
+except version.InvalidVersion as e:
     from core.models import ObjectType as NetBoxType
-else:
-    from django.contrib.contenttypes.models import ContentType as NetBoxType
 
 from netbox.tables import BaseTable, columns
 from utilities.object_types import object_type_identifier, object_type_name


### PR DESCRIPTION
`packaging.version.InvalidVersion: Invalid version: '4.2.3-Docker-3.2.0'`

If it's new enough to break due to this reason, it's already on the new module names for import.

Alternative is to check `settings.RELEASE.version` vs `settings.VERSION`