### PR TITLE
fix: add backwards compatible support for mac_address field

### DIFF
--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -471,10 +471,13 @@ class ApplyChangeSetView(views.APIView):
             object_data["assigned_object_type"] = assigned_object_type
             object_data["assigned_object_id"] = assigned_object_instance.id
         return None
-    
+
     def _handle_interface_mac_address_compat(self,  instance, object_type: str, object_data: dict) -> Optional[Dict[str, Any]]:
-        """Handle interface mac address backward compatibility"""
-        # TODO(ltucker): deprecate.  
+        """Handle interface mac address backward compatibility."""
+        # TODO(ltucker): deprecate.
+        if object_type != "dcim.interface" and object_type != "virtualization.vminterface":
+            return None
+
         if object_data.get("mac_address"):
             mac_address_value = object_data.pop("mac_address")
             mac_address_instance, _ = instance.mac_addresses.get_or_create(
@@ -547,11 +550,10 @@ class ApplyChangeSetView(views.APIView):
                         )
                         continue
 
-                    if object_type == "dcim.interface" or object_type == "virtualization.vminterface":
-                        errors = self._handle_interface_mac_address_compat(serializer.instance, object_type, object_data)
-                        if errors is not None:
-                            serializer_errors.append({"change_id": change_id, **errors})
-                            continue
+                    errors = self._handle_interface_mac_address_compat(serializer.instance, object_type, object_data)
+                    if errors is not None:
+                        serializer_errors.append({"change_id": change_id, **errors})
+                        continue
                 if len(serializer_errors) > 0:
                     raise ApplyChangeSetException
         except ApplyChangeSetException:

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -471,6 +471,18 @@ class ApplyChangeSetView(views.APIView):
             object_data["assigned_object_type"] = assigned_object_type
             object_data["assigned_object_id"] = assigned_object_instance.id
         return None
+    
+    def _handle_interface_mac_address_compat(self,  instance, object_type: str, object_data: dict) -> Optional[Dict[str, Any]]:
+        """Handle interface mac address backward compatibility"""
+        # TODO(ltucker): deprecate.  
+        if object_data.get("mac_address"):
+            mac_address_value = object_data.pop("mac_address")
+            mac_address_instance, _ = instance.mac_addresses.get_or_create(
+                mac_address=mac_address_value,
+            )
+            instance.primary_mac_address = mac_address_instance
+            instance.save()
+        return None
 
     def post(self, request, *args, **kwargs):
         """
@@ -533,6 +545,13 @@ class ApplyChangeSetView(views.APIView):
                         serializer_errors.append(
                             {"change_id": change_id, **errors_dict}
                         )
+                        continue
+
+                    if object_type == "dcim.interface" or object_type == "virtualization.vminterface":
+                        errors = self._handle_interface_mac_address_compat(serializer.instance, object_type, object_data)
+                        if errors is not None:
+                            serializer_errors.append({"change_id": change_id, **errors})
+                            continue
                 if len(serializer_errors) > 0:
                     raise ApplyChangeSetException
         except ApplyChangeSetException:

--- a/netbox_diode_plugin/tests/test_api_apply_change_set.py
+++ b/netbox_diode_plugin/tests/test_api_apply_change_set.py
@@ -19,7 +19,7 @@ from netaddr import IPNetwork
 from rest_framework import status
 from users.models import Token
 from utilities.testing import APITestCase
-from virtualization.models import Cluster, ClusterType
+from virtualization.models import Cluster, ClusterType, VMInterface, VirtualMachine
 
 User = get_user_model()
 
@@ -144,6 +144,12 @@ class BaseApplyChangeSet(APITestCase):
             ),
         )
         IPAddress.objects.bulk_create(self.ip_addresses)
+
+        self.virtual_machines = (
+            VirtualMachine(name="Virtual Machine 1"),
+            VirtualMachine(name="Virtual Machine 2"),
+        )
+        VirtualMachine.objects.bulk_create(self.virtual_machines)
 
         self.url = "/netbox/api/plugins/diode/apply-change-set/"
 
@@ -982,3 +988,110 @@ class ApplyChangeSetTestCase(BaseApplyChangeSet):
         self.assertEqual(response.json().get("result"), "success")
         self.assertEqual(device_updated.name, self.devices[0].name)
         self.assertEqual(device_updated.primary_ip4, self.ip_addresses[0])
+
+    def test_create_and_update_interface_with_compat_mac_address_field(self):
+        """Test create interface using backward compatible mac_address field."""
+        payload = {
+            "change_set_id": str(uuid.uuid4()),
+            "change_set": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.interface",
+                    "object_id": None,
+                    "data": {
+                        "name": "Interface 6",
+                        "type": "virtual",
+                        "mac_address": "00:00:00:00:00:01",
+                        "device": {
+                            "id": self.devices[1].pk,
+                        },
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload)        
+        self.assertEqual(response.json().get("result"), "success")
+        self.assertEqual(Interface.objects.count(), 6)
+        interface_id = Interface.objects.order_by('-id').first().id
+        self.assertEqual(Interface.objects.get(id=interface_id).mac_address, "00:00:00:00:00:01")
+
+        payload = {
+            "change_set_id": str(uuid.uuid4()),
+            "change_set": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.interface",
+                    "object_id": interface_id,
+                    "data": {
+                        "name": "Interface 6",
+                        "mac_address": "00:00:00:00:00:02",
+                        "type": "virtual",
+                        "device": {
+                            "id": self.devices[1].pk,
+                        },
+                    },
+                },
+            ],
+        }
+        response = self.send_request(payload)        
+        self.assertEqual(response.json().get("result"), "success")
+        self.assertEqual(response.json().get("result"), "success")
+        self.assertEqual(Interface.objects.count(), 6)
+        self.assertEqual(Interface.objects.get(id=interface_id).mac_address, "00:00:00:00:00:02")
+
+    def test_create_and_update_vminterface_with_compat_mac_address_field(self):
+        """Test create vminterface using backward compatible mac_address field."""
+        payload = {
+            "change_set_id": str(uuid.uuid4()),
+            "change_set": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "virtualization.vminterface",
+                    "object_id": None,
+                    "data": {
+                        "name": "VM Interface 1",
+                        "mac_address": "00:00:00:00:00:01",
+                        "virtual_machine": {
+                            "id": self.virtual_machines[0].pk,
+                        },
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload)        
+        self.assertEqual(response.json().get("result"), "success")
+        self.assertEqual(VMInterface.objects.count(), 1)
+        interface_id = VMInterface.objects.order_by('-id').first().id
+        self.assertEqual(VMInterface.objects.get(id=interface_id).mac_address, "00:00:00:00:00:01")
+
+        payload = {
+            "change_set_id": str(uuid.uuid4()),
+            "change_set": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "virtualization.vminterface",
+                    "object_id": interface_id,
+                    "data": {
+                        "name": "VM Interface 1",
+                        "mac_address": "00:00:00:00:00:02",
+                        "virtual_machine": {
+                            "id": self.virtual_machines[0].pk,
+                        },
+                    },
+                },
+            ],
+        }
+        response = self.send_request(payload)        
+        self.assertEqual(response.json().get("result"), "success")
+        self.assertEqual(VMInterface.objects.count(), 1)
+        self.assertEqual(VMInterface.objects.get(id=interface_id).mac_address, "00:00:00:00:00:02")

--- a/netbox_diode_plugin/tests/test_api_apply_change_set.py
+++ b/netbox_diode_plugin/tests/test_api_apply_change_set.py
@@ -19,7 +19,12 @@ from netaddr import IPNetwork
 from rest_framework import status
 from users.models import Token
 from utilities.testing import APITestCase
-from virtualization.models import Cluster, ClusterType, VMInterface, VirtualMachine
+from virtualization.models import (
+    Cluster,
+    ClusterType,
+    VirtualMachine,
+    VMInterface,
+)
 
 User = get_user_model()
 
@@ -1012,7 +1017,7 @@ class ApplyChangeSetTestCase(BaseApplyChangeSet):
             ],
         }
 
-        response = self.send_request(payload)        
+        response = self.send_request(payload)
         self.assertEqual(response.json().get("result"), "success")
         self.assertEqual(Interface.objects.count(), 6)
         interface_id = Interface.objects.order_by('-id').first().id
@@ -1038,7 +1043,7 @@ class ApplyChangeSetTestCase(BaseApplyChangeSet):
                 },
             ],
         }
-        response = self.send_request(payload)        
+        response = self.send_request(payload)
         self.assertEqual(response.json().get("result"), "success")
         self.assertEqual(response.json().get("result"), "success")
         self.assertEqual(Interface.objects.count(), 6)
@@ -1066,7 +1071,7 @@ class ApplyChangeSetTestCase(BaseApplyChangeSet):
             ],
         }
 
-        response = self.send_request(payload)        
+        response = self.send_request(payload)
         self.assertEqual(response.json().get("result"), "success")
         self.assertEqual(VMInterface.objects.count(), 1)
         interface_id = VMInterface.objects.order_by('-id').first().id
@@ -1091,7 +1096,7 @@ class ApplyChangeSetTestCase(BaseApplyChangeSet):
                 },
             ],
         }
-        response = self.send_request(payload)        
+        response = self.send_request(payload)
         self.assertEqual(response.json().get("result"), "success")
         self.assertEqual(VMInterface.objects.count(), 1)
         self.assertEqual(VMInterface.objects.get(id=interface_id).mac_address, "00:00:00:00:00:02")


### PR DESCRIPTION
This fix adds backwards compatible support for specifying interface mac addresses as `mac_address` in the diode apply changeset api for `dcim.interface` and `virtualization.vminterface`.  In netbox 4.2 there is really a list of mac addresses associated with an interface and one can be specified as the primary.  Until this is supported in diode, the `mac_address` field specified when applying a change set is treated as the specification of the primary mac address for the object being created or updated.

**caveats**

This does not disassociate any mac addresses ... it just ensures that the specified mac address is present and promotes it to the primary mac address.  So a changing mac address would leave a set of old mac addresses associated until multiple associations are supported directly.  Alternatively we could make the specified mac address the only associated address?  Not sure which is better.

**etc**

This pull request introduces a new method to handle backward compatibility for MAC addresses in interfaces and updates the relevant tests to ensure this functionality works correctly. The most important changes include adding the `_handle_interface_mac_address_compat` method, updating the `post` method to use this new method, and adding new test cases to verify the backward compatibility.

### Backward Compatibility for MAC Addresses:

* [`netbox_diode_plugin/api/views.py`](diffhunk://#diff-684907cd4c422de8e7c1b9b405253a3e204f4d168e79e8cd073bf805a66f6ba4R476-R487): Added the `_handle_interface_mac_address_compat` method to handle backward compatibility for MAC addresses in interfaces.

### Updates to the `post` Method:

* [`netbox_diode_plugin/api/views.py`](diffhunk://#diff-684907cd4c422de8e7c1b9b405253a3e204f4d168e79e8cd073bf805a66f6ba4R549-R555): Updated the `post` method to call `_handle_interface_mac_address_compat` for `dcim.interface` and `virtualization.vminterface` object types.

### Test Enhancements:

* [`netbox_diode_plugin/tests/test_api_apply_change_set.py`](diffhunk://#diff-419cb64146d8c597b51537f4312c6771d1bc2958b719fbd67ef32dd69303b24cL22-R22): Imported `VMInterface` and `VirtualMachine` models to test backward compatibility.
* [`netbox_diode_plugin/tests/test_api_apply_change_set.py`](diffhunk://#diff-419cb64146d8c597b51537f4312c6771d1bc2958b719fbd67ef32dd69303b24cR148-R153): Added setup for `VirtualMachine` instances.
* [`netbox_diode_plugin/tests/test_api_apply_change_set.py`](diffhunk://#diff-419cb64146d8c597b51537f4312c6771d1bc2958b719fbd67ef32dd69303b24cR991-R1097): Added test cases `test_create_and_update_interface_with_compat_mac_address_field` and `test_create_and_update_vminterface_with_compat_mac_address_field` to verify the backward compatibility for MAC addresses.