### PR TITLE
fix: merge tags rather than overwrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,7 @@ docker-compose-netbox-plugin-down:
 
 .PHONY: docker-compose-netbox-plugin-test
 docker-compose-netbox-plugin-test:
-	-@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run -u root --rm netbox ./manage.py test --keepdb netbox_diode_plugin
-	@$(MAKE) docker-compose-netbox-plugin-down
-
-.PHONY: docker-compose-netbox-plugin-test-ff
-docker-compose-netbox-plugin-test-ff:
-	-@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run -u root --rm netbox ./manage.py test --failfast --keepdb netbox_diode_plugin
+	-@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run -u root --rm netbox ./manage.py test $(TEST_FLAGS) --keepdb netbox_diode_plugin
 	@$(MAKE) docker-compose-netbox-plugin-down
 
 .PHONY: docker-compose-netbox-plugin-test-cover

--- a/docker/netbox/configuration/logging.py
+++ b/docker/netbox/configuration/logging.py
@@ -1,3 +1,20 @@
+from os import environ
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        '': {  # root logger
+            'handlers': ['console'],
+            'level': 'DEBUG' if environ.get('DEBUG', 'false').lower() == 'true' else 'INFO',
+        },
+    },
+}
 # # Remove first comment(#) on each line to implement this working logging example.
 # # Add LOGLEVEL environment variable to netbox if you use this example & want a different log level.
 # from os import environ

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -55,7 +55,7 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
         if hasattr(value, "all"):  # Handle many-to-many and many-to-one relationships
             # For any relationship that has an 'all' method, get all related objects' primary keys
             prechange_data[field_name] = (
-                [item.pk for item in value.all()] if value is not None else []
+                sorted([item.pk for item in value.all()] if value is not None else [])
             )
         elif hasattr(
             value, "pk"
@@ -233,8 +233,11 @@ def _partially_merge(prechange_data: dict, postchange_data: dict, instance) -> d
     """Merge lists and custom_fields rather than replacing the full value..."""
     result = {}
     for key, value in postchange_data.items():
-        # TODO: partially merge lists like tags? all lists?
-        result[key] = value
+        # currently we only merge tags, but this could be extended to other reference lists?
+        if key == "tags":
+            result[key] = _merge_reference_list(prechange_data.get(key, []), value)
+        else:
+            result[key] = value
 
     # these are fully merged in from the prechange state because
     # they don't respect partial update serialization.
@@ -244,3 +247,11 @@ def _partially_merge(prechange_data: dict, postchange_data: dict, instance) -> d
                 result["custom_fields"][key] = value
         set_custom_field_defaults(result, instance)
     return result
+
+def _merge_reference_list(prechange_list: list, postchange_list: list) -> list:
+    """Merge reference lists rather than replacing the full value."""
+    result = set(prechange_list)
+    result.update(postchange_list)
+    return sorted(result, key=str)
+
+

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -319,7 +319,7 @@ def _update_unresolved_refs(entity, new_refs):
 def _update_dict_refs(data, new_refs):
     for k, v in data.items():
         if isinstance(v, UnresolvedReference) and v.uuid in new_refs:
-            data[k] = new_refs[v.uuid]
+            v.uuid = new_refs[v.uuid]
         elif isinstance(v, (list, tuple)):
             for item in v:
                 if isinstance(item, UnresolvedReference) and item.uuid in new_refs:
@@ -439,7 +439,7 @@ def _check_unresolved_refs(entities: list[dict]) -> list[str]:
                     )
 
 
-def _prepare_custom_fields(object_type: str, custom_fields: dict) -> tuple[dict, set, list]:
+def _prepare_custom_fields(object_type: str, custom_fields: dict) -> tuple[dict, set, list]: # noqa: C901
     """Prepare custom fields for transformation."""
     out = {}
     refs = set()

--- a/netbox_diode_plugin/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/test_api_diff_and_apply.py
@@ -189,6 +189,97 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         new_site = Site.objects.get(name=f"Site {site_uuid}")
         self.assertEqual(new_site.slug, f"site-{site_uuid}")
 
+    def test_generate_diff_and_apply_tags_merged(self):
+        """Test generate diff and apply merges tags."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "tags": [
+                        {"name": "tag 1"},
+                        {"name": "tag 2"},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.tags.count(), 2)
+        tag_names = [tag.name for tag in new_site.tags.all()]
+        self.assertIn("tag 1", tag_names)
+        self.assertIn("tag 2", tag_names)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "tags": [
+                        {"name": "tag 3"},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.tags.count(), 3)
+        tag_names = [tag.name for tag in new_site.tags.all()]
+        self.assertIn("tag 1", tag_names)
+        self.assertIn("tag 2", tag_names)
+        self.assertIn("tag 3", tag_names)
+
+    def test_generate_diff_and_apply_refs_not_merged(self):
+        """Test generate diff and apply does not merge reference lists."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "asns": [
+                        {"asn": "1", "rir": {"name": "RIR 1"}},
+                        {"asn": "2", "rir": {"name": "RIR 1"}},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.asns.count(), 2)
+        asns = [asn.asn for asn in new_site.asns.all()]
+        self.assertIn(1, asns)
+        self.assertIn(2, asns)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "asns": [
+                        {"asn": "3", "rir": {"name": "RIR 1"}},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.asns.count(), 1)
+        asns = [asn.asn for asn in new_site.asns.all()]
+        self.assertNotIn(1, asns)
+        self.assertNotIn(2, asns)
+        self.assertIn(3, asns)
+
+
     def test_generate_diff_and_apply_create_interface_with_primay_mac_address(self):
         """Test generate diff and apply create interface with primary mac address."""
         interface_uuid = str(uuid4())


### PR DESCRIPTION
* merges tags rather than overwrite.
* leaves other multi-reference types as overwrite ... (questionable?)
* adds test of current behavior
* fixes issue with deduplicated references
* add ability to pass arbitrary flags to test rather than target-per-option
* enable debug logging output in docker