### PR TITLE
fix: special cases for ip network defaulting

### DIFF
--- a/netbox_diode_plugin/api/common.py
+++ b/netbox_diode_plugin/api/common.py
@@ -238,7 +238,7 @@ class AutoSlug:
 
 
 def error_from_validation_error(e, object_name):
-    """Convert a drf ValidationError to a ChangeSetException."""
+    """Convert a from rest_framework.exceptions.ValidationError to a ChangeSetException."""
     errors = {}
     if e.detail:
         if isinstance(e.detail, dict):

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -10,6 +10,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from utilities.data import shallow_compare_dict
 from django.db.backends.postgresql.psycopg_any import NumericRange
+import netaddr
 
 from .common import Change, ChangeSet, ChangeSetException, ChangeSetResult, ChangeType, error_from_validation_error
 from .plugin_utils import get_primary_value, legal_fields
@@ -84,6 +85,10 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
 
 
 def _harmonize_formats(prechange_data):
+    if prechange_data is None:
+        return None
+    if isinstance(prechange_data, (str, int, float, bool)):
+        return prechange_data
     if isinstance(prechange_data, dict):
         return {k: _harmonize_formats(v) for k, v in prechange_data.items()}
     if isinstance(prechange_data, (list, tuple)):
@@ -94,8 +99,11 @@ def _harmonize_formats(prechange_data):
         return prechange_data.strftime("%Y-%m-%d")
     if isinstance(prechange_data, NumericRange):
         return (prechange_data.lower, prechange_data.upper-1)
+    if isinstance(prechange_data, netaddr.IPNetwork):
+        return str(prechange_data)
 
-    return prechange_data
+    logger.warning(f"Unknown type in prechange_data: {type(prechange_data)}")
+    return str(prechange_data)
 
 def clean_diff_data(data: dict, exclude_empty_values: bool = True) -> dict:
     """Clean diff data by removing null values."""

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -17,6 +17,7 @@ from django.db.models import F, Value
 from django.db.models.fields import SlugField
 from django.db.models.lookups import Exact
 from django.db.models.query_utils import Q
+import netaddr
 from extras.models.customfields import CustomField
 
 from .common import AutoSlug, UnresolvedReference
@@ -46,17 +47,17 @@ _LOGICAL_MATCHERS = {
         ),
     ],
     "ipam.ipaddress": lambda: [
-        ObjectMatchCriteria(
-            fields=("address", ),
+        GlobalIPNetworkIPMatcher(
+            ip_field="address",
+            vrf_field="vrf",
+            model_class=get_object_type_model("ipam.ipaddress"),
             name="logical_ip_address_global_no_vrf",
-            model_class=get_object_type_model("ipam.ipaddress"),
-            condition=Q(vrf__isnull=True),
         ),
-        ObjectMatchCriteria(
-            fields=("address", "assigned_object_type", "assigned_object_id"),
-            name="logical_ip_address_within_vrf",
+        VRFIPNetworkIPMatcher(
+            ip_field="address",
+            vrf_field="vrf",
             model_class=get_object_type_model("ipam.ipaddress"),
-            condition=Q(vrf__isnull=False)
+            name="logical_ip_address_within_vrf",
         ),
     ],
     "ipam.prefix": lambda: [
@@ -271,6 +272,8 @@ class ObjectMatchCriteria:
                 continue
         return prepared
 
+
+
 @dataclass
 class CustomFieldMatcher:
     """A matcher for a unique custom field."""
@@ -304,6 +307,124 @@ class CustomFieldMatcher:
     def has_required_fields(self, data: dict) -> bool:
         """Returns True if the data given contains a value for all fields referenced by the constraint."""
         return self.custom_field in data.get("custom_fields", {})
+
+
+@dataclass
+class GlobalIPNetworkIPMatcher:
+    """A matcher that ignores the mask."""
+
+    ip_field: str
+    vrf_field: str
+    model_class: Type[models.Model]
+    name: str
+
+    def _check_condition(self, data: dict) -> bool:
+        """Check the condition for the custom field."""
+        return data.get(self.vrf_field, None) is None
+
+    def fingerprint(self, data: dict) -> str|None:
+        """Fingerprint the custom field value."""
+        if not self.has_required_fields(data):
+            return None
+
+        if not self._check_condition(data):
+            return None
+
+        value = self.ip_value(data)
+        if value is None:
+            return None
+
+        return hash((self.model_class.__name__, self.name, value))
+
+    def has_required_fields(self, data: dict) -> bool:
+        """Returns True if the data given contains a value for all fields referenced by the constraint."""
+        return self.ip_field in data
+
+    def ip_value(self, data: dict) -> str|None:
+        """Get the IP value from the data."""
+        value = data.get(self.ip_field)
+        if value is None:
+            return None
+        return _ip_only(value)
+
+    def build_queryset(self, data: dict) -> models.QuerySet:
+        """Build a queryset for the custom field."""
+        if not self.has_required_fields(data):
+            return None
+
+        if not self._check_condition(data):
+            return None
+
+        value = self.ip_value(data)
+        if value is None:
+            return None
+
+        return self.model_class.objects.filter(**{f'{self.ip_field}__net_host': value, f'{self.vrf_field}__isnull': True})
+
+@dataclass
+class VRFIPNetworkIPMatcher:
+    """Matches ip in a vrf, ignores mask."""
+
+    ip_field: str
+    vrf_field: str
+    model_class: Type[models.Model]
+    name: str
+
+    def _check_condition(self, data: dict) -> bool:
+        """Check the condition for the custom field."""
+        return data.get('vrf_id', None) is not None
+
+    def fingerprint(self, data: dict) -> str|None:
+        """Fingerprint the custom field value."""
+        if not self.has_required_fields(data):
+            return None
+
+        if not self._check_condition(data):
+            return None
+
+        value = self.ip_value(data)
+        if value is None:
+            return None
+
+        vrf_id = data[self.vrf_field]
+
+        return hash((self.model_class.__name__, self.name, value, vrf_id))
+
+    def has_required_fields(self, data: dict) -> bool:
+        """Returns True if the data given contains a value for all fields referenced by the constraint."""
+        return self.ip_field in data and self.vrf_field in data
+
+    def ip_value(self, data: dict) -> str|None:
+        """Get the IP value from the data."""
+        value = data.get(self.ip_field)
+        if value is None:
+            return None
+        return _ip_only(value)
+
+    def build_queryset(self, data: dict) -> models.QuerySet:
+        """Build a queryset for the custom field."""
+        if not self.has_required_fields(data):
+            return None
+
+        if not self._check_condition(data):
+            return None
+
+        value = self.ip_value(data)
+        if value is None:
+            return None
+
+        vrf_id = data[self.vrf_field]
+        return self.model_class.objects.filter(**{f'{self.ip_field}__net_host': value, f'{self.vrf_field}': vrf_id})
+
+
+def _ip_only(value: str) -> str|None:
+    try:
+        ip = netaddr.IPNetwork(value)
+        value = ip.ip
+    except netaddr.core.AddrFormatError:
+        return None
+
+    return value
 
 @dataclass
 class AutoSlugMatcher:

--- a/netbox_diode_plugin/api/plugin_utils.py
+++ b/netbox_diode_plugin/api/plugin_utils.py
@@ -1,7 +1,7 @@
 """Diode plugin helpers."""
 
 # Generated code. DO NOT EDIT.
-# Timestamp: 2025-04-13 13:20:10Z
+# Timestamp: 2025-04-13 16:50:25Z
 
 from dataclasses import dataclass
 import datetime
@@ -13,6 +13,8 @@ from typing import Type
 from core.models import ObjectType as NetBoxType
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
+import netaddr
+from rest_framework.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -1014,6 +1016,12 @@ def transform_float_to_decimal(value: float) -> decimal.Decimal:
 def int_from_int64string(value: str) -> int:
     return int(value)
 
+def ip_network_defaulting(value: str) -> str:
+    try:
+        return str(netaddr.IPNetwork(value))
+    except netaddr.AddrFormatError:
+        raise ValueError(f'Invalid IP network value: {value}')
+
 def collect_integer_pairs(value: list[int]) -> list[tuple[int, int]]:
     if len(value) % 2 != 0:
         raise ValueError('Array must have an even number of elements')
@@ -1114,6 +1122,7 @@ _FORMAT_TRANSFORMATIONS = {
     },
     'ipam.aggregate': {
         'date_added': transform_timestamp_to_date_only,
+        'prefix': ip_network_defaulting,
     },
     'ipam.asn': {
         'asn': int_from_int64string,
@@ -1127,6 +1136,16 @@ _FORMAT_TRANSFORMATIONS = {
     },
     'ipam.fhrpgroupassignment': {
         'priority': int_from_int64string,
+    },
+    'ipam.ipaddress': {
+        'address': ip_network_defaulting,
+    },
+    'ipam.iprange': {
+        'end_address': ip_network_defaulting,
+        'start_address': ip_network_defaulting,
+    },
+    'ipam.prefix': {
+        'prefix': ip_network_defaulting,
     },
     'ipam.role': {
         'weight': int_from_int64string,

--- a/netbox_diode_plugin/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/test_api_diff_and_apply.py
@@ -638,6 +638,128 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         self.assertEqual(new_vlan_group.vid_ranges[1].lower, 12)
         self.assertEqual(new_vlan_group.vid_ranges[1].upper, 21)
 
+    def test_generate_diff_and_apply_ip_address_with_assigned_object_interface(self):
+        """Test ip."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                    "assigned_object_interface": {
+                        "device": {
+                            "name": "Device ABC",
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Manufacturer ABC"
+                                },
+                                "model": "Device Type ABC"
+                            },
+                            "role": {
+                                "name": "Role ABC"
+                            },
+                            "platform": {
+                            "name": "Platform ABC",
+                            "manufacturer": {
+                                "name": "Manufacturer ABC"
+                            }
+                            },
+                            "site": {
+                                "name": "Site ABC"
+                            }
+                        },
+                        "name": "Interface ABC",
+                        "type": "1000base-t",
+                        "mode": "access"
+                    },
+                    "description": "IP Address description",
+                    "comments": "Lorem ipsum dolor sit amet",
+                    "tags": [
+                        {
+                            "name": "tag 1"
+                        },
+                        {
+                            "name": "tag 2"
+                        }
+                    ]
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_generate_diff_update_ip_address(self):
+        """Test generate diff update ip address."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.user_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/32",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.user_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "active",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116")
+        self.assertEqual(ip.status, "active")
+
 
     def diff_and_apply(self, payload):
         """Diff and apply the payload."""

--- a/netbox_diode_plugin/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/test_api_diff_and_apply.py
@@ -7,6 +7,7 @@ import decimal
 import logging
 from uuid import uuid4
 
+
 from core.models import ObjectType
 from dcim.models import Device, Interface, Site
 from ipam.models import VLANGroup
@@ -15,6 +16,7 @@ from django.contrib.auth import get_user_model
 from extras.models import CustomField
 from extras.models.customfields import CustomFieldTypeChoices
 from ipam.models import IPAddress
+import netaddr
 from rest_framework import status
 from users.models import Token
 from utilities.testing import APITestCase
@@ -759,6 +761,67 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         _ = self.diff_and_apply(payload)
         ip = IPAddress.objects.get(address="254.198.174.116")
         self.assertEqual(ip.status, "active")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/24",
+                    "status": "deprecated",
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116/24")
+        self.assertEqual(ip.role, "secondary")
+        self.assertEqual(ip.status, "deprecated")
+        self.assertEqual(ip.address, netaddr.IPNetwork("254.198.174.0/24"))
+
+        vrf_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/24",
+                    "status": "active",
+                    "vrf": {
+                        "name": f"VRF {vrf_uuid}"
+                    }
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116/24", vrf__name=f"VRF {vrf_uuid}")
+        self.assertEqual(ip.vrf.name, f"VRF {vrf_uuid}")
+        self.assertEqual(ip.status, "active")
+
+        ip2 = IPAddress.objects.get(address="254.198.174.116/24", vrf__isnull=True)
+        self.assertEqual(ip2.vrf, None)
+        self.assertEqual(ip2.status, "deprecated")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "dhcp",
+                    "vrf": {
+                        "name": f"VRF {vrf_uuid}"
+                    }
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116", vrf__name=f"VRF {vrf_uuid}")
+        self.assertEqual(ip.status, "dhcp")
+
+        ip2 = IPAddress.objects.get(address="254.198.174.116/24", vrf__isnull=True)
+        self.assertEqual(ip2.vrf, None)
+        self.assertEqual(ip2.status, "deprecated")
+
 
 
     def diff_and_apply(self, payload):


### PR DESCRIPTION
ip address fields and ip network fields have special defaulting in place that makes them appear to differ.
eg if `192.168.1.1` is specified in an ip address field, it will be stored (and the prior value will appear as) `192.168.1.1/32` this add some special handling to use the defaulted network when comparing.

secondarily, this uses special matchers for ip address  that ignore the mask given on the address.  This is the actual uniqueness check that is performed during the model validation.

this also resolves an issue rendering the prior state of an ipaddress which cannot directly be json serialized since it is sent back as an instance of netddr.IPNetwork 