### PR TITLE
perf: license update to NetBox Limited Use License 1.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,164 +1,85 @@
-# PolyForm Shield License 1.0.0
-
-<https://polyformproject.org/licenses/shield/1.0.0>
+# NetBox Limited Use License 1.0
 
 ## Acceptance
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+In order to get any license under these terms, you must agree to them as
+both strict obligations and conditions to all your licenses.
 
 ## Copyright License
 
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
+NetBox Labs grants you a copyright license to use and modify the software
+only as part of a NetBox installation obtained from NetBox Labs or a NetBox
+distributor authorized by NetBox Labs, and only for your own internal use.
 
-## Distribution License
-
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Notices
-
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
-
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
-
-## Changes and New Works License
-
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+For clarity, this license grants no rights to distribute the software or
+make it available to others as part of a commercial offering.
 
 ## Patent License
 
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
-
-## Noncompete
-
-Any purpose is a permitted purpose, except for providing any
-product that competes with the software or any product the
-licensor or any of its affiliates provides using the software.
-
-## Competition
-
-Goods and services compete even when they provide functionality
-through different kinds of interfaces or for different technical
-platforms.  Applications can compete with services, libraries
-with plugins, frameworks with development tools, and so on,
-even if they're written in different programming languages
-or for different computer architectures.  Goods and services
-compete even when provided free of charge.  If you market a
-product as a practical substitute for the software or another
-product, it definitely competes.
-
-## New Products
-
-If you are using the software to provide a product that does
-not compete, but the licensor or any of its affiliates brings
-your product into competition by providing a new version of
-the software or another product using the software, you may
-continue using versions of the software available under these
-terms beforehand to provide your competing product, but not
-any later versions.
-
-## Discontinued Products
-
-You may begin using the software to compete with a product
-or service that the licensor or any of its affiliates has
-stopped providing, unless the licensor includes a plain-text
-line beginning with `Licensor Line of Business:` with the
-software that mentions that line of business.  For example:
-
-> Licensor Line of Business: YoyodyneCMS Content Management
-System (http://example.com/cms)
-
-## Sales of Business
-
-If the licensor or any of its affiliates sells a line of
-business developing the software or using the software
-to provide a product, the buyer can also enforce
-[Noncompete](#noncompete) for that product.
-
-## Fair Use
-
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
-
-## No Other Rights
-
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
+NetBox Labs grants you a patent license for the software that covers patent
+claims the licensor can license, or becomes able to license, that you would
+infringe by using the software, as allowed in the copyright license above.
 
 ## Patent Defense
 
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
+If you make any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software granted
+under these terms ends immediately. If your company makes such a claim,
+your patent license ends immediately for work on behalf of your company.
+Competitive Restrictions
+
+This license does not grant you the right to use the software:
+
+- To provide a managed service or software products that includes, integrates
+  with, or extends NetBox in a way that competes with any product or service
+  of NetBox Labs.
+
+- To assist or enable a third party in offering a service or product that
+  competes with any product or service of NetBox Labs.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses
+to anyone else, or prevent NetBox Labs from granting licenses to anyone else.
+These terms do not imply any other licenses.
 
 ## Violations
 
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
+The first time you are notified in writing that you have violated any of
+these terms, or done anything with the software not covered by your licenses,
+your licenses can nonetheless continue if you come into full compliance with
+these terms, and take practical steps to correct past violations, within 30
+days of receiving notice.  Otherwise, all your licenses end immediately.
 
 ## No Liability
 
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
+As far as the law allows, the software comes as is, without any warranty or
+condition, and NetBox Labs will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.
+
+If this disclaimer is unenforceable under applicable law, this license is void.
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
+**NetBox Labs** is NetBox Labs, Inc.
 
-A **product** can be a good or service, or a combination
-of them.
+**NetBox** is the community edition of NetBox found at
+<https://github.com/netbox-community/netbox> or any derivative thereof.
 
-**You** refers to the individual or entity agreeing to these
-terms.
+The **software** is the software NetBox Labs makes available under these terms.
 
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-its affiliates.
+**You** refers to the individual or entity agreeing to these terms.
 
-**Affiliates** means the other organizations than an
-organization has control over, is under the control of, or is
-under common control with.
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
 
-**Control** means ownership of substantially all the assets of
-an entity, or the power to direct its management and policies
-by vote, contract, or otherwise.  Control can be direct or
-indirect.
+**Control** means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
 
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
 
-**Use** means anything you do with the software requiring one
-of your licenses.
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ make docker-compose-netbox-plugin-test
 
 ## License
 
-Distributed under the PolyForm Shield License 1.0.0 License. See [LICENSE.md](./LICENSE.md) for more information.
+Distributed under the NetBox Limited Use License 1.0. See [LICENSE.md](./LICENSE.md) for more information.
 
 ## Required Notice
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"  # Overwritten during the build process
 description = "NetBox Labs, Diode NetBox plugin"
 readme = "README.md"
 requires-python = ">=3.8"
-license = { text = "PolyForm Shield License 1.0.0" }
+license = { text = "NetBox Limited Use License 1.0" }
 authors = [
     {name = "NetBox Labs", email = "support@netboxlabs.com" }
 ]


### PR DESCRIPTION
This pull request updates the licensing terms for the project, transitioning from the PolyForm Shield License 1.0.0 to the NetBox Limited Use License 1.0. It modifies the license text, references, and metadata across several files to reflect this change.

### License Update

* [`LICENSE.md`](diffhunk://#diff-4673a3aba01813b595de187a7a6e9e63a3491d55821606fecd9f13a10c188a1dL1-R85): Replaced the PolyForm Shield License 1.0.0 with the NetBox Limited Use License 1.0, introducing new terms that restrict distribution and competitive use of the software. The updated license also clarifies definitions and conditions for use, modification, and patent defense.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R94): Updated the license reference to point to the NetBox Limited Use License 1.0.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Changed the license metadata from "PolyForm Shield License 1.0.0" to "NetBox Limited Use License 1.0."