### PR TITLE
fix: generate diff - set branch for the change set

### DIFF
--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -103,15 +103,15 @@ class GenerateDiffView(views.APIView):
             )
             return Response(result.to_dict(), status=result.get_status_code())
 
-        branch_id = request.headers.get("X-NetBox-Branch")
+        branch_schema_id = request.headers.get("X-NetBox-Branch")
 
-        # If branch ID is provided and branching plugin is installed, get branch name
-        if branch_id and Branch is not None:
+        # If branch schema ID is provided and branching plugin is installed, get branch name
+        if branch_schema_id and Branch is not None:
             try:
-                branch = Branch.objects.get(id=branch_id)
-                result.branch = {"id": branch.id, "name": branch.name}
+                branch = Branch.objects.get(schema_id=branch_schema_id)
+                result.change_set.branch = {"id": branch.schema_id, "name": branch.name}
             except Branch.DoesNotExist:
-                sanitized_branch_id = branch_id.replace('\n', '').replace('\r', '')
+                sanitized_branch_id = branch_schema_id.replace('\n', '').replace('\r', '')
                 logger.warning(f"Branch with ID {sanitized_branch_id} does not exist")
 
         return Response(result.to_dict(), status=result.get_status_code())


### PR DESCRIPTION
This pull request includes a change to improve naming consistency and functionality in the `_post` method of `netbox_diode_plugin/api/views.py`. The key update involves renaming variables and updating logic to reflect the use of `schema_id` instead of `id` for branch identification.

### Changes to branch identification logic:

* Renamed `branch_id` to `branch_schema_id` to align with the use of `schema_id` for branch identification. Updated all relevant references in the `_post` method.
* Modified the logic to retrieve a branch using `schema_id` instead of `id` and updated the `result.change_set.branch` structure to include `schema_id` and `name`.
* Adjusted the error logging to sanitize and log `branch_schema_id` instead of `branch_id` when a branch does not exist.