### PR TITLE
fix: consider object type in fingerprint all deduplication

### DIFF
--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -735,7 +735,7 @@ def _get_refs(expr) -> set[str]:
         logger.warning(f"Unhandled expression type for _get_refs: {type(expr)}")
     return refs
 
-def _fingerprint_all(data: dict) -> str:
+def _fingerprint_all(data: dict, object_type: str|None = None) -> str:
     """
     Returns a fingerprint of the data based on all fields.
 
@@ -745,7 +745,7 @@ def _fingerprint_all(data: dict) -> str:
     if data is None:
         return None
 
-    values = []
+    values = ["object_type", object_type]
     for k, v in sorted(data.items()):
         if k.startswith("_"):
             continue
@@ -776,7 +776,7 @@ def fingerprints(data: dict, object_type: str) -> list[str]:
         fp = matcher.fingerprint(data)
         if fp is not None:
             fps.append(fp)
-    fp = _fingerprint_all(data)
+    fp = _fingerprint_all(data, object_type)
     fps.append(fp)
     return fps
 

--- a/netbox_diode_plugin/tests/test_api_generate_diff.py
+++ b/netbox_diode_plugin/tests/test_api_generate_diff.py
@@ -3,6 +3,7 @@
 """Diode NetBox Plugin - Tests."""
 
 import logging
+from collections import defaultdict
 from types import SimpleNamespace
 from unittest import mock
 from uuid import uuid4
@@ -377,6 +378,39 @@ class GenerateDiffTestCase(APITestCase):
         }
         _ = self.send_request(payload)
 
+    def test_generate_diff_dedupe_different_object_types(self):
+        """Test generate diff dedupe different object types with same values."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "Cat8000V",
+                    "role": {"name": "undefined"},
+                    "site": {"name": "undefined"},
+                    "serial": "9OBXJHNNU5V",
+                    "status": "active",
+                    "platform": {"name": "ios", "manufacturer": {"name": "undefined"}},
+                    "device_type": {"model": "C8000V", "manufacturer": {"name": "undefined"}}
+                },
+            },
+        }
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 6)
+        by_object_type = defaultdict(int)
+        for change in changes:
+            by_object_type[change.get("object_type")] += 1
+
+        self.assertEqual(by_object_type["dcim.device"], 1)
+        self.assertEqual(by_object_type["dcim.manufacturer"], 1)
+        self.assertEqual(by_object_type["dcim.platform"], 1)
+        self.assertEqual(by_object_type["dcim.devicetype"], 1)
+        self.assertEqual(by_object_type["dcim.site"], 1)
+        self.assertEqual(by_object_type["dcim.devicerole"], 1)
 
     def send_request(self, payload, status_code=status.HTTP_200_OK):
         """Post the payload to the url and return the response."""


### PR DESCRIPTION
This pull request introduces updates to the `netbox_diode_plugin` to enhance fingerprinting functionality and improve testing coverage. The most significant changes include modifying the `_fingerprint_all` function to handle object types, updating its usage in the `fingerprints` function, and adding a new test case to ensure proper deduplication of changes across different object types.

### Enhancements to fingerprinting functionality:
* Modified `_fingerprint_all` in `netbox_diode_plugin/api/matcher.py` to accept an optional `object_type` parameter, which is included in the fingerprint calculation. This ensures that fingerprints account for the object type, improving uniqueness. [[1]](diffhunk://#diff-4cca9b7dd314e8d7f7a731781d279a81a7392da766e3af0c40041860d91e8feaL738-R738) [[2]](diffhunk://#diff-4cca9b7dd314e8d7f7a731781d279a81a7392da766e3af0c40041860d91e8feaL748-R748)
* Updated the `fingerprints` function to pass the `object_type` parameter when calling `_fingerprint_all`, ensuring consistent behavior across the fingerprinting process.

### Improvements to testing:
* Added a new test case, `test_generate_diff_dedupe_different_object_types`, in `netbox_diode_plugin/tests/test_api_generate_diff.py`. This test verifies that the system correctly deduplicates changes for different object types with the same values, ensuring accurate change tracking.
* Imported `defaultdict` in the test file to support the new test case.