### PR TITLE
chore: linux extra hosts

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
       - netbox-media-files:/opt/netbox/netbox/media:rw
       - netbox-reports-files:/opt/netbox/netbox/reports:rw
       - netbox-scripts-files:/opt/netbox/netbox/scripts:rw
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "8000:8080"
   


### PR DESCRIPTION
This pull request includes a small change to the `docker/docker-compose.yaml` file. The change adds an `extra_hosts` entry to map `host.docker.internal` to `host-gateway`.