### PR TITLE
chore: create tests for double created objects

### DIFF
--- a/netbox_diode_plugin/tests/test_api_apply_change_set.py
+++ b/netbox_diode_plugin/tests/test_api_apply_change_set.py
@@ -1062,3 +1062,46 @@ class ApplyChangeSetTestCase(BaseApplyChangeSet):
         }
         _ = self.send_request(payload)
         self.assertEqual(VirtualMachine.objects.get(name="VM foobar", site_id=self.sites[0].id).cluster.scope, self.sites[0])
+
+    def test_apply_two_changes_that_create_the_same_object_return_200(self):
+        """Test apply two changes that create the same object return 200."""
+        site_name = uuid.uuid4()
+        payload1 = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": f"Site {site_name}",
+                        "slug": f"site-{site_name}",
+                        "comments": "comment 1",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload1)
+
+        payload2 = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": f"Site {site_name}",
+                        "slug": f"site-{site_name}",
+                        "comments": "comment 1",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload2)


### PR DESCRIPTION
This pull request adds a new test case to the `netbox_diode_plugin` test suite to ensure proper handling of duplicate object creation requests.

### Additions to test coverage:

* [`netbox_diode_plugin/tests/test_api_apply_change_set.py`](diffhunk://#diff-419cb64146d8c597b51537f4312c6771d1bc2958b719fbd67ef32dd69303b24cR1065-R1107): Added the `test_apply_two_changes_that_create_the_same_object_return_200` method to verify that applying two changes that attempt to create the same object returns a 200 status code. This test ensures the system can handle duplicate creation requests gracefully.