### PR TITLE
fix: type validation against ChangeType(Enum)

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -48,6 +48,7 @@ jobs:
           make docker-compose-netbox-plugin-test-cover
       - name: Coverage comment
         uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           coverageFile: ./docker/coverage/report.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -131,7 +131,7 @@ def _validate_change_set(change_set: ChangeSet):
     for change in change_set.changes:
         if change.object_id is None and change.ref_id is None:
             raise _err("Object ID or Ref ID must be provided", change.object_type, NON_FIELD_ERRORS)
-        if change.change_type not in ChangeType:
+        if change.change_type not in [ct.value for ct in ChangeType]:
             raise _err(f"Unsupported change type '{change.change_type}'", change.object_type, "change_type")
 
 def _err(message, object_name, field):


### PR DESCRIPTION
### Pull Request Message

#### Summary
Refactored the condition in `applier.py` to ensure proper comparison of `change.change_type` against the values of `ChangeType`. This was done to address a `TypeError` encountered when attempting to check membership of `change.change_type` in `ChangeType`.

#### Changes
- Updated the condition in `applier.py`:
  ```python
  if change.change_type not in ChangeType:
  ```
  to:
  ```python
  if change.change_type not in [ct.value for ct in ChangeType]:
  ```

#### Testing
- Verified that the updated condition correctly handles `change.change_type` values.
- Ensured no regressions in functionality by running existing tests.

#### Notes
- The previous implementation caused the following error:
  ```
{“time”:“2025-05-06T08:55:23.799916916Z”,“level”:“ERROR”,“msg”:“error applying changeset”,“error”:“apply change set failed - ERR_OPS_APPLY_CHANGE_SET - {“error”: “unsupported operand type(s) for ‘in’: ‘str’ and ‘EnumMeta’“, “exception”: “TypeError”, “netbox_version”: “4.3.0", “python_version”: “3.10.12"}“}
  ```
- This change ensures that `change.change_type` is compared against the actual values of `ChangeType` rather than the enum itself, improving compatibility and correctness.