### PR TITLE
chore: gha - skip coverage comment step on fork PRs

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -48,6 +48,7 @@ jobs:
           make docker-compose-netbox-plugin-test-cover
       - name: Coverage comment
         uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           coverageFile: ./docker/coverage/report.xml
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow for lint tests to ensure that the coverage comment step only runs for pull requests originating from the same repository.

Changes to GitHub Actions workflow:

* [`.github/workflows/lint-tests.yml`](diffhunk://#diff-7ff5b316f9a4896dcea6d970dc3df6d670c4b14744a5d6e3ae19358ce6835dfcR51): Added a condition to the "Coverage comment" step to check if the pull request's source repository matches the target repository (`github.event.pull_request.head.repo.full_name == github.repository`). This prevents the step from running on external pull requests.