### PR TITLE
feat: allow configuring required token audience

### DIFF
--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -31,6 +31,10 @@ class NetBoxDiodePluginConfig(PluginConfig):
         "secrets_path": "/run/secrets/",
         "netbox_to_diode_client_secret_name": "netbox_to_diode",
         "diode_max_auth_retries": 3,
+
+        # List of audiences to require for the diode-to-netbox token.
+        # If empty, no audience is required.
+        "required_token_audience": [],
     }
 
 

--- a/netbox_diode_plugin/api/authentication.py
+++ b/netbox_diode_plugin/api/authentication.py
@@ -69,12 +69,12 @@ class DiodeOAuth2Authentication(BaseAuthentication):
             # if the plugin is configured to require specific token audience(s),
             # reject the token if any are missing.
             required_audience = get_required_token_audience()
-            if len(required_audience) > 0:
+            if required_audience:
                 token_audience = set(data.get("aud", []))
-                for aud in required_audience:
-                    if aud not in token_audience:
-                        logger.error(f"Token audience {aud} not found in {token_audience}")
-                        return None
+                missing_audience = set(required_audience) - token_audience
+                if missing_audience:
+                    logger.error(f"Token audience(s) {missing_audience} not found in {token_audience}")
+                    return None
 
             diode_user = SimpleNamespace(
                 user=get_diode_user(),

--- a/netbox_diode_plugin/api/authentication.py
+++ b/netbox_diode_plugin/api/authentication.py
@@ -14,6 +14,7 @@ from rest_framework.exceptions import AuthenticationFailed
 from netbox_diode_plugin.plugin_config import (
     get_diode_auth_introspect_url,
     get_diode_user,
+    get_required_token_audience,
 )
 
 logger = logging.getLogger("netbox.diode_data")
@@ -65,6 +66,16 @@ class DiodeOAuth2Authentication(BaseAuthentication):
             return None
 
         if data.get("active"):
+            # if the plugin is configured to require specific token audience(s),
+            # reject the token if any are missing.
+            required_audience = get_required_token_audience()
+            if len(required_audience) > 0:
+                token_audience = set(data.get("aud", []))
+                for aud in required_audience:
+                    if aud not in token_audience:
+                        logger.error(f"Token audience {aud} not found in {token_audience}")
+                        return None
+
             diode_user = SimpleNamespace(
                 user=get_diode_user(),
                 token_scopes=data.get("scope", "").split(),

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -89,3 +89,7 @@ def get_diode_user():
         diode_user = User.objects.create(username=diode_username, is_active=True)
 
     return diode_user
+
+def get_required_token_audience():
+    """Returns the require token audience."""
+    return get_plugin_config("netbox_diode_plugin", "required_token_audience")

--- a/netbox_diode_plugin/tests/test_authentication.py
+++ b/netbox_diode_plugin/tests/test_authentication.py
@@ -49,12 +49,19 @@ class DiodeOAuth2AuthenticationTestCase(TestCase):
         )
         self.introspect_url_patcher.start()
 
+        self.required_audience_patcher = mock.patch(
+            'netbox_diode_plugin.api.authentication.get_required_token_audience',
+            return_value=[]
+        )
+        self.required_audience_mock = self.required_audience_patcher.start()
+
     def tearDown(self):
         """Clean up after tests."""
         self.cache_patcher.stop()
         self.cache_set_patcher.stop()
         self.requests_patcher.stop()
         self.introspect_url_patcher.stop()
+        self.required_audience_patcher.stop()
 
     def test_authenticate_no_auth_header(self):
         """Test authentication with no Authorization header."""
@@ -102,6 +109,42 @@ class DiodeOAuth2AuthenticationTestCase(TestCase):
         user, _ = self.auth.authenticate(request)
         self.assertEqual(user, self.diode_user.user)
         self.cache_set_mock.assert_called_once()
+
+    def test_authenticate_token_with_required_audience(self):
+        """Test authentication with token having required audience."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write',
+            'exp': 1000,
+            'iat': 500
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.token_with_scope}')
+
+        self.cache_get_mock.return_value = None
+        self.required_audience_mock.return_value = ['netbox']
+        try:
+            # should fail if the token does not have the required audience
+            with self.assertRaises(AuthenticationFailed):
+                self.auth.authenticate(request)
+            self.required_audience_mock.assert_called_once()
+            self.cache_set_mock.assert_not_called()
+
+            # should succeed if the token has the required audience
+            self.requests_mock.return_value.json.return_value = {
+                'active': True,
+                'aud': ['netbox', 'api', 'other'],
+                'scope': 'netbox:read netbox:write',
+                'exp': 1000,
+                'iat': 500
+            }
+
+            user, _ = self.auth.authenticate(request)
+            self.assertEqual(user, self.diode_user.user)
+            self.cache_set_mock.assert_called_once()
+        finally:
+            self.required_audience_patcher.return_value = []
 
     def test_authenticate_token_introspection_failure(self):
         """Test authentication when token introspection fails."""


### PR DESCRIPTION
* Adds a setting to specify a required token audience (JWT `aud` claim) for diode-to-netbox tokens 
* Defaults to nothing particular required

*etc*

This pull request introduces support for validating token audiences in the NetBox Diode plugin. The changes ensure that authentication tokens can be checked against a configurable list of required audiences, enhancing security and compliance. Key updates include modifications to the plugin configuration, authentication logic, and unit tests.

### Token Audience Validation

* [`netbox_diode_plugin/__init__.py`](diffhunk://#diff-09de430bb82401a2bc4065f34ade9d03fde1ed538e7c127153283717ca42a14cR34-R37): Added a new configuration option, `required_token_audience`, which allows specifying a list of audiences that must be present in the authentication token.
* [`netbox_diode_plugin/api/authentication.py`](diffhunk://#diff-ffbbb6265832a25465c115638db04ec616654bd5ab1d466380bbc0e03498ba64R69-R78): Updated the `_introspect_token` method to validate the token's audience against the `required_token_audience` configuration, rejecting tokens missing required audiences.
* [`netbox_diode_plugin/plugin_config.py`](diffhunk://#diff-cd38732898d6f168ea43f59bf97609aadc68e88f1b464cd7f15113b26aba5c89R92-R95): Added the `get_required_token_audience` function to retrieve the `required_token_audience` setting from the plugin configuration.

### Unit Tests for Token Audience Validation

* [`netbox_diode_plugin/tests/test_authentication.py`](diffhunk://#diff-948442878a649efdad3684c0f96a393341d1112e37c6b2b92a60129d7608e82aR52-R64): Enhanced test setup to mock `get_required_token_audience` and added a new test, `test_authenticate_token_with_required_audience`, to verify that tokens are correctly authenticated based on their audience. [[1]](diffhunk://#diff-948442878a649efdad3684c0f96a393341d1112e37c6b2b92a60129d7608e82aR52-R64) [[2]](diffhunk://#diff-948442878a649efdad3684c0f96a393341d1112e37c6b2b92a60129d7608e82aR113-R148)