### PR TITLE
docs: add command to generate docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docker-compose-netbox-plugin-test-cover:
 
 .PHONY: docker-compose-generate-matching-docs
 docker-compose-generate-matching-docs: docker-compose-migrate
-	@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run --rm netbox python manage.py generate_matching_docs
+	@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run --rm netbox python manage.py generate_matching_docs > ./docs/matching-criteria-documentation.md
 
 .PHONY: docker-compose-migrate
 docker-compose-migrate:

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,11 @@ docker-compose-netbox-plugin-test:
 docker-compose-netbox-plugin-test-cover:
 	-@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run --rm -u root -e COVERAGE_FILE=/opt/netbox/netbox/coverage/.coverage netbox sh -c "coverage run --source=netbox_diode_plugin --omit=*/migrations/* ./manage.py test --keepdb netbox_diode_plugin && coverage xml -o /opt/netbox/netbox/coverage/report.xml && coverage report -m | tee /opt/netbox/netbox/coverage/report.txt"
 	@$(MAKE) docker-compose-netbox-plugin-down
+
+.PHONY: docker-compose-generate-matching-docs
+docker-compose-generate-matching-docs: docker-compose-migrate
+	@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run --rm netbox python manage.py generate_matching_docs
+
+.PHONY: docker-compose-migrate
+docker-compose-migrate:
+	@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run --rm netbox python manage.py migrate

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ docker-compose-netbox-plugin-test-cover:
 	@$(MAKE) docker-compose-netbox-plugin-down
 
 .PHONY: docker-compose-generate-matching-docs
-docker-compose-generate-matching-docs: docker-compose-migrate
-	@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run --rm netbox python manage.py generate_matching_docs > ./docs/matching-criteria-documentation.md
+docker-compose-generate-matching-docs:
+	@$(DOCKER_COMPOSE) -f docker/docker-compose.yaml -f docker/docker-compose.test.yaml run --rm netbox python manage.py generate_matching_docs | awk '/Generating markdown documentation.../{p=1;next} p' > ./docs/matching-criteria-documentation.md
 
 .PHONY: docker-compose-migrate
 docker-compose-migrate:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ cd /opt/netbox/netbox
 make docker-compose-netbox-plugin-test
 ```
 
+## Generating Documentation
+Generates documentation on how diode entities are matched. The generated documentation is output to [here](./docs/matching-criteria-documentation.md).
+```shell
+make docker-compose-generate-matching-docs
+```
+
 ## License
 
 Distributed under the NetBox Limited Use License 1.0. See [LICENSE.md](./LICENSE.md) for more information.

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -2,110 +2,772 @@
 
 This document describes how the Diode NetBox Plugin matches existing objects when applying changes.
 
+## Matcher Types
+
+- **Logical Matchers**: Custom matching criteria that represent likely user intent
+- **Builtin Matchers**: Automatically generated from NetBox model constraints (unique fields, unique constraints, custom fields, auto-slugs)
+
+## circuits.circuit
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| circuits_circuit_unique_provider_cid | builtin | provider, cid | N/A | Matches on unique constraint fields: provider, cid | All versions |
+| circuits_circuit_unique_provideraccount_cid | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |
+
+## circuits.circuitgroup
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## circuits.circuitgroupassignment
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| circuits_circuitgroupassignment_unique_member_group | builtin | member_type, member_id, group | N/A | Matches on unique constraint fields: member_type, member_id, group | All versions |
+
+## circuits.circuittermination
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| circuits_circuittermination_unique_circuit_term_side | builtin | circuit, term_side | N/A | Matches on unique constraint fields: circuit, term_side | All versions |
+
+## circuits.circuittype
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## circuits.provider
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## circuits.provideraccount
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| circuits_provideraccount_unique_provider_account | builtin | provider, account | N/A | Matches on unique constraint fields: provider, account | All versions |
+| circuits_provideraccount_unique_provider_name | builtin | provider, name | name =  | Matches on unique constraint fields: provider, name where name =  | All versions |
+
+## circuits.providernetwork
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| circuits_providernetwork_unique_provider_name | builtin | provider, name | N/A | Matches on unique constraint fields: provider, name | All versions |
+
+## circuits.virtualcircuit
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| circuits_virtualcircuit_unique_provider_network_cid | builtin | provider_network, cid | N/A | Matches on unique constraint fields: provider_network, cid | All versions |
+| circuits_virtualcircuit_unique_provideraccount_cid | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |
+
+## circuits.virtualcircuittermination
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_interface | builtin | interface | N/A | Matches on unique field(s): interface | All versions |
+
+## circuits.virtualcircuittype
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.cabletermination
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_cabletermination_unique_termination | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |
+
+## dcim.consoleport
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_consoleport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.consoleporttemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_consoleporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_consoleporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+
+## dcim.consoleserverport
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_consoleserverport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.consoleserverporttemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_consoleserverporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_consoleserverporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+
+## dcim.device
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_asset_tag | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| unique_primary_ip4 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
+| unique_primary_ip6 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
+| unique_oob_ip | builtin | oob_ip | N/A | Matches on unique field(s): oob_ip | All versions |
+| dcim_device_unique_name_site_tenant | builtin |  | N/A | Custom matcher | All versions |
+| dcim_device_unique_name_site | builtin |  | tenant is NULL | Custom matcher | All versions |
+| dcim_device_unique_rack_position_face | builtin | rack, position, face | N/A | Matches on unique constraint fields: rack, position, face | All versions |
+| dcim_device_unique_virtual_chassis_vc_position | builtin | virtual_chassis, vc_position | N/A | Matches on unique constraint fields: virtual_chassis, vc_position | All versions |
+
+## dcim.devicebay
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_installed_device | builtin | installed_device | N/A | Matches on unique field(s): installed_device | All versions |
+| dcim_devicebay_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.devicebaytemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_devicebaytemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+
 ## dcim.devicerole
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_device_role_name_no_parent | name | parent is NULL | Matches on fields: name where parent is NULL | ≥4.3.0 |
-| logical_device_role_slug_no_parent | slug | parent is NULL | Matches on fields: slug where parent is NULL | ≥4.3.0 |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_device_role_name_no_parent | logical | name | parent is NULL | Matches on fields: name where parent is NULL | ≥4.3.0 |
+| logical_device_role_slug_no_parent | logical | slug | parent is NULL | Matches on fields: slug where parent is NULL | ≥4.3.0 |
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.devicetype
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_devicetype_unique_manufacturer_model | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
+| dcim_devicetype_unique_manufacturer_slug | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.frontport
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_frontport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_frontport_unique_rear_port_position | builtin | rear_port, rear_port_position | N/A | Matches on unique constraint fields: rear_port, rear_port_position | All versions |
+
+## dcim.frontporttemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_frontporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_frontporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| dcim_frontporttemplate_unique_rear_port_position | builtin | rear_port, rear_port_position | N/A | Matches on unique constraint fields: rear_port, rear_port_position | All versions |
+
+## dcim.interface
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_primary_mac_address | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
+| dcim_interface_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.interfacetemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_interfacetemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_interfacetemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
 
 ## dcim.inventoryitem
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_inventory_item_name_on_device_no_parent | name, device | parent is NULL | Matches on fields: name, device where parent is NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_inventory_item_name_on_device_no_parent | logical | name, device | parent is NULL | Matches on fields: name, device where parent is NULL | All versions |
+| unique_asset_tag | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| dcim_inventoryitem_unique_device_parent_name | builtin | device, parent, name | N/A | Matches on unique constraint fields: device, parent, name | All versions |
+
+## dcim.inventoryitemrole
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.inventoryitemtemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_inventoryitemtemplate_unique_device_type_parent_name | builtin | device_type, parent, name | N/A | Matches on unique constraint fields: device_type, parent, name | All versions |
+
+## dcim.location
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_location_parent_name | builtin | site, parent, name | N/A | Matches on unique constraint fields: site, parent, name | All versions |
+| dcim_location_name | builtin | site, name | parent is NULL | Matches on unique constraint fields: site, name where parent is NULL | All versions |
+| dcim_location_parent_slug | builtin | site, parent, slug | N/A | Matches on unique constraint fields: site, parent, slug | All versions |
+| dcim_location_slug | builtin | site, slug | parent is NULL | Matches on unique constraint fields: site, slug where parent is NULL | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.macaddress
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_mac_address_within_parent | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NOT NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NOT NULL | All versions |
-| logical_mac_address_within_parent | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_mac_address_within_parent | logical | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NOT NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NOT NULL | All versions |
+| logical_mac_address_within_parent | logical | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NULL | All versions |
+
+## dcim.manufacturer
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.module
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_module_bay | builtin | module_bay | N/A | Matches on unique field(s): module_bay | All versions |
+| unique_asset_tag | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
 
 ## dcim.modulebay
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_module_bay_name_on_device | name, device | N/A | Matches on fields: name, device | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_module_bay_name_on_device | logical | name, device | N/A | Matches on fields: name, device | All versions |
+| dcim_modulebay_unique_device_module_name | builtin | device, module, name | N/A | Matches on unique constraint fields: device, module, name | All versions |
+
+## dcim.modulebaytemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_modulebaytemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_modulebaytemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+
+## dcim.moduletype
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_moduletype_unique_manufacturer_model | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
+
+## dcim.platform
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.powerfeed
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_powerfeed_unique_power_panel_name | builtin | power_panel, name | N/A | Matches on unique constraint fields: power_panel, name | All versions |
+
+## dcim.poweroutlet
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_poweroutlet_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.poweroutlettemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_poweroutlettemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_poweroutlettemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+
+## dcim.powerpanel
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_powerpanel_unique_site_name | builtin | site, name | N/A | Matches on unique constraint fields: site, name | All versions |
+
+## dcim.powerport
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_powerport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.powerporttemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_powerporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_powerporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+
+## dcim.rack
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_asset_tag | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| dcim_rack_unique_location_name | builtin | location, name | N/A | Matches on unique constraint fields: location, name | All versions |
+| dcim_rack_unique_location_facility_id | builtin | location, facility_id | N/A | Matches on unique constraint fields: location, facility_id | All versions |
+
+## dcim.rackrole
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.racktype
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| dcim_racktype_unique_manufacturer_model | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
+| dcim_racktype_unique_manufacturer_slug | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.rearport
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_rearport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.rearporttemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_rearporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_rearporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+
+## dcim.region
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_region_parent_name | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
+| dcim_region_name | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
+| dcim_region_parent_slug | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
+| dcim_region_slug | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.site
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.sitegroup
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| dcim_sitegroup_parent_name | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
+| dcim_sitegroup_name | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
+| dcim_sitegroup_parent_slug | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
+| dcim_sitegroup_slug | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## dcim.virtualchassis
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_master | builtin | master | N/A | Matches on unique field(s): master | All versions |
+
+## dcim.virtualdevicecontext
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_primary_ip4 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
+| unique_primary_ip6 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
+| dcim_virtualdevicecontext_device_identifier | builtin | device, identifier | N/A | Matches on unique constraint fields: device, identifier | All versions |
+| dcim_virtualdevicecontext_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## extras.bookmark
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| extras_bookmark_unique_per_object_and_user | builtin | object_type, object_id, user | N/A | Matches on unique constraint fields: object_type, object_id, user | All versions |
+
+## extras.configcontext
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## extras.customfield
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## extras.customfieldchoiceset
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## extras.customlink
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## extras.eventrule
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## extras.notificationgroup
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## extras.savedfilter
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## extras.script
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| extras_script_unique_name_module | builtin | name, module | N/A | Matches on unique constraint fields: name, module | All versions |
+
+## extras.tag
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## extras.webhook
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## ipam.aggregate
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_aggregate_prefix_no_rir | prefix | rir is NULL | Matches on fields: prefix where rir is NULL | All versions |
-| logical_aggregate_prefix_within_rir | prefix, rir | rir is NOT NULL | Matches on fields: prefix, rir where rir is NOT NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_aggregate_prefix_no_rir | logical | prefix | rir is NULL | Matches on fields: prefix where rir is NULL | All versions |
+| logical_aggregate_prefix_within_rir | logical | prefix, rir | rir is NOT NULL | Matches on fields: prefix, rir where rir is NOT NULL | All versions |
+
+## ipam.asn
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_asn | builtin | asn | N/A | Matches on unique field(s): asn | All versions |
+
+## ipam.asnrange
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## ipam.fhrpgroup
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_fhrp_group_id | group_id | N/A | Matches on fields: group_id | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_fhrp_group_id | logical | group_id | N/A | Matches on fields: group_id | All versions |
+
+## ipam.fhrpgroupassignment
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| ipam_fhrpgroupassignment_unique_interface_group | builtin | interface_type, interface_id, group | N/A | Matches on unique constraint fields: interface_type, interface_id, group | All versions |
 
 ## ipam.ipaddress
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_ip_address_global_no_vrf |  | N/A | Matches IP address address in global namespace (no VRF) | All versions |
-| logical_ip_address_within_vrf |  | N/A | Matches IP address address within VRF | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_ip_address_global_no_vrf | logical |  | N/A | Matches IP address address in global namespace (no VRF) | All versions |
+| logical_ip_address_within_vrf | logical |  | N/A | Matches IP address address within VRF | All versions |
 
 ## ipam.iprange
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_ip_range_start_end_global_no_vrf |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
-| logical_ip_range_start_end_within_vrf |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_ip_range_start_end_global_no_vrf | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
+| logical_ip_range_start_end_within_vrf | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
 
 ## ipam.prefix
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_prefix_global_no_vrf | prefix | vrf is NULL | Matches on fields: prefix where vrf is NULL | All versions |
-| logical_prefix_within_vrf | prefix, vrf | vrf is NOT NULL | Matches on fields: prefix, vrf where vrf is NOT NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_prefix_global_no_vrf | logical | prefix | vrf is NULL | Matches on fields: prefix where vrf is NULL | All versions |
+| logical_prefix_within_vrf | logical | prefix, vrf | vrf is NOT NULL | Matches on fields: prefix, vrf where vrf is NOT NULL | All versions |
+
+## ipam.rir
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## ipam.role
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## ipam.routetarget
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## ipam.service
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_service_name_no_device_or_vm | name | device is NULL AND virtual_machine is NULL | Matches on fields: name where device is NULL AND virtual_machine is NULL | ≤4.2.99 |
-| logical_service_name_on_device | name, device | device is NOT NULL | Matches on fields: name, device where device is NOT NULL | ≤4.2.99 |
-| logical_service_name_on_vm | name, virtual_machine | virtual_machine is NOT NULL | Matches on fields: name, virtual_machine where virtual_machine is NOT NULL | ≤4.2.99 |
-| logical_service_name_on_parent | name, parent_object_type, parent_object_id | parent_object_type is NOT NULL | Matches on fields: name, parent_object_type, parent_object_id where parent_object_type is NOT NULL | ≥4.3.0 |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_service_name_no_device_or_vm | logical | name | device is NULL AND virtual_machine is NULL | Matches on fields: name where device is NULL AND virtual_machine is NULL | ≤4.2.99 |
+| logical_service_name_on_device | logical | name, device | device is NOT NULL | Matches on fields: name, device where device is NOT NULL | ≤4.2.99 |
+| logical_service_name_on_vm | logical | name, virtual_machine | virtual_machine is NOT NULL | Matches on fields: name, virtual_machine where virtual_machine is NOT NULL | ≤4.2.99 |
+| logical_service_name_on_parent | logical | name, parent_object_type, parent_object_id | parent_object_type is NOT NULL | Matches on fields: name, parent_object_type, parent_object_id where parent_object_type is NOT NULL | ≥4.3.0 |
+
+## ipam.servicetemplate
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## ipam.vlan
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_vlan_vid_no_group_or_svlan | vid | group is NULL AND qinq_svlan is NULL | Matches on fields: vid where group is NULL AND qinq_svlan is NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_vlan_vid_no_group_or_svlan | logical | vid | group is NULL AND qinq_svlan is NULL | Matches on fields: vid where group is NULL AND qinq_svlan is NULL | All versions |
+| ipam_vlan_unique_group_vid | builtin | group, vid | N/A | Matches on unique constraint fields: group, vid | All versions |
+| ipam_vlan_unique_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| ipam_vlan_unique_qinq_svlan_vid | builtin | qinq_svlan, vid | N/A | Matches on unique constraint fields: qinq_svlan, vid | All versions |
+| ipam_vlan_unique_qinq_svlan_name | builtin | qinq_svlan, name | N/A | Matches on unique constraint fields: qinq_svlan, name | All versions |
 
 ## ipam.vlangroup
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_vlan_group_name_no_scope | name | scope_type is NULL | Matches on fields: name where scope_type is NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_vlan_group_name_no_scope | logical | name | scope_type is NULL | Matches on fields: name where scope_type is NULL | All versions |
+| ipam_vlangroup_unique_scope_name | builtin | scope_type, scope_id, name | N/A | Matches on unique constraint fields: scope_type, scope_id, name | All versions |
+| ipam_vlangroup_unique_scope_slug | builtin | scope_type, scope_id, slug | N/A | Matches on unique constraint fields: scope_type, scope_id, slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## ipam.vlantranslationpolicy
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## ipam.vlantranslationrule
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| ipam_vlantranslationrule_unique_policy_local_vid | builtin | policy, local_vid | N/A | Matches on unique constraint fields: policy, local_vid | All versions |
+| ipam_vlantranslationrule_unique_policy_remote_vid | builtin | policy, remote_vid | N/A | Matches on unique constraint fields: policy, remote_vid | All versions |
+
+## ipam.vrf
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_rd | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
 
 ## tenancy.contact
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_contact_name | name | N/A | Matches on fields: name | ≥4.3.0 |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_contact_name | logical | name | N/A | Matches on fields: name | ≥4.3.0 |
+| tenancy_contact_unique_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+
+## tenancy.contactassignment
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| tenancy_contactassignment_unique_object_contact_role | builtin | object_type, object_id, contact, role | N/A | Matches on unique constraint fields: object_type, object_id, contact, role | All versions |
+
+## tenancy.contactgroup
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| tenancy_contactgroup_unique_parent_name | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## tenancy.contactrole
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## tenancy.tenant
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| tenancy_tenant_unique_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| tenancy_tenant_unique_name | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
+| tenancy_tenant_unique_group_slug | builtin | group, slug | N/A | Matches on unique constraint fields: group, slug | All versions |
+| tenancy_tenant_unique_slug | builtin | slug | group is NULL | Matches on unique constraint fields: slug where group is NULL | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## tenancy.tenantgroup
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## virtualization.cluster
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_cluster_within_scope | name, scope_type, scope_id | scope_type is NOT NULL | Matches on fields: name, scope_type, scope_id where scope_type is NOT NULL | All versions |
-| logical_cluster_with_no_scope_or_group | name | group is NULL AND scope_type is NULL | Matches on fields: name where group is NULL AND scope_type is NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_cluster_within_scope | logical | name, scope_type, scope_id | scope_type is NOT NULL | Matches on fields: name, scope_type, scope_id where scope_type is NOT NULL | All versions |
+| logical_cluster_with_no_scope_or_group | logical | name | group is NULL AND scope_type is NULL | Matches on fields: name where group is NULL AND scope_type is NULL | All versions |
+| virtualization_cluster_unique_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| virtualization_cluster_unique__site_name | builtin | _site, name | N/A | Matches on unique constraint fields: _site, name | All versions |
+
+## virtualization.clustergroup
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## virtualization.clustertype
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## virtualization.virtualdisk
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| virtualization_virtualdisk_unique_virtual_machine_name | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |
 
 ## virtualization.virtualmachine
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_virtual_machine_name_no_cluster | name | cluster is NULL | Matches on fields: name where cluster is NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_virtual_machine_name_no_cluster | logical | name | cluster is NULL | Matches on fields: name where cluster is NULL | All versions |
+| unique_primary_ip4 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
+| unique_primary_ip6 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
+| virtualization_virtualmachine_unique_name_cluster_tenant | builtin |  | N/A | Custom matcher | All versions |
+| virtualization_virtualmachine_unique_name_cluster | builtin |  | tenant is NULL | Custom matcher | All versions |
+
+## virtualization.vminterface
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_primary_mac_address | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
+| virtualization_vminterface_unique_virtual_machine_name | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |
+
+## vpn.ikepolicy
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## vpn.ikeproposal
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## vpn.ipsecpolicy
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## vpn.ipsecprofile
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## vpn.ipsecproposal
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+
+## vpn.l2vpn
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## vpn.l2vpntermination
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| vpn_l2vpntermination_assigned_object | builtin | assigned_object_type, assigned_object_id | N/A | Matches on unique constraint fields: assigned_object_type, assigned_object_id | All versions |
+
+## vpn.tunnel
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| vpn_tunnel_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| vpn_tunnel_name | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
+
+## vpn.tunnelgroup
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## vpn.tunneltermination
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| vpn_tunneltermination_termination | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |
 
 ## wireless.wirelesslan
 
-| Matcher Name | Fields | Condition | Description | Version Constraints |
-|--------------|--------|-----------|-------------|-------------------|
-| logical_wireless_lan_ssid_no_group_or_vlan | ssid | group is NULL AND vlan is NULL | Matches on fields: ssid where group is NULL AND vlan is NULL | All versions |
-| logical_wireless_lan_ssid_in_group | ssid, group | group is NOT NULL | Matches on fields: ssid, group where group is NOT NULL | All versions |
-| logical_wireless_lan_ssid_in_vlan | ssid, vlan | vlan is NOT NULL | Matches on fields: ssid, vlan where vlan is NOT NULL | All versions |
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| logical_wireless_lan_ssid_no_group_or_vlan | logical | ssid | group is NULL AND vlan is NULL | Matches on fields: ssid where group is NULL AND vlan is NULL | All versions |
+| logical_wireless_lan_ssid_in_group | logical | ssid, group | group is NOT NULL | Matches on fields: ssid, group where group is NOT NULL | All versions |
+| logical_wireless_lan_ssid_in_vlan | logical | ssid, vlan | vlan is NOT NULL | Matches on fields: ssid, vlan where vlan is NOT NULL | All versions |
+
+## wireless.wirelesslangroup
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| wireless_wirelesslangroup_unique_parent_name | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
+| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
+## wireless.wirelesslink
+
+| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------|--------|-----------|-------------|-------------------|
+| wireless_wirelesslink_unique_interfaces | builtin | interface_a, interface_b | N/A | Matches on unique constraint fields: interface_a, interface_b | All versions |

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -1,149 +1,117 @@
+🧬 loaded config '/etc/netbox/config/configuration.py'
+🧬 loaded config '/etc/netbox/config/extra.py'
+🧬 loaded config '/etc/netbox/config/logging.py'
+🧬 loaded config '/etc/netbox/config/plugins.py'
+Analyzing matching criteria...
+Generating markdown documentation...
 # NetBox Diode Plugin - Object Matching Criteria
 
 This document describes how the Diode NetBox Plugin matches existing objects when applying changes.
+
+## dcim.devicerole
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| logical_device_role_name_no_parent | name | parent is NULL | Matches on fields: name where parent is NULL | ≥4.3.0 |
+| logical_device_role_slug_no_parent | slug | parent is NULL | Matches on fields: slug where parent is NULL | ≥4.3.0 |
 
 ## dcim.inventoryitem
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_inventory_item_name_on_device_no_parent | name, device | parent is NULL | Matches on fields: name, device where parent is NULL | All versions |
 
 ## dcim.macaddress
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_mac_address_within_parent | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NOT NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NOT NULL | All versions |
+| logical_mac_address_within_parent | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NULL | All versions |
 
 ## dcim.modulebay
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_module_bay_name_on_device | name, device | N/A | Matches on fields: name, device | All versions |
 
 ## ipam.aggregate
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_aggregate_prefix_no_rir | prefix | rir is NULL | Matches on fields: prefix where rir is NULL | All versions |
+| logical_aggregate_prefix_within_rir | prefix, rir | rir is NOT NULL | Matches on fields: prefix, rir where rir is NOT NULL | All versions |
 
 ## ipam.fhrpgroup
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_fhrp_group_id | group_id | N/A | Matches on fields: group_id | All versions |
 
 ## ipam.ipaddress
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Matches IP address in global namespace (no VRF) | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Matches IP address within VRF | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_ip_address_global_no_vrf | N/A | N/A | Matches IP address address in global namespace (no VRF) | All versions |
+| logical_ip_address_within_vrf | N/A | N/A | Matches IP address address within VRF | All versions |
 
 ## ipam.iprange
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Matches IP address in global namespace (no VRF) | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Matches IP address within VRF | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_ip_range_start_end_global_no_vrf | N/A | N/A | Matches IP range start_address, end_address within VRF context | All versions |
+| logical_ip_range_start_end_within_vrf | N/A | N/A | Matches IP range start_address, end_address within VRF context | All versions |
 
 ## ipam.prefix
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_prefix_global_no_vrf | prefix | vrf is NULL | Matches on fields: prefix where vrf is NULL | All versions |
+| logical_prefix_within_vrf | prefix, vrf | vrf is NOT NULL | Matches on fields: prefix, vrf where vrf is NOT NULL | All versions |
 
 ## ipam.service
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_service_name_no_device_or_vm | name | device is NULL AND virtual_machine is NULL | Matches on fields: name where device is NULL AND virtual_machine is NULL | ≤4.2.99 |
+| logical_service_name_on_device | name, device | device is NOT NULL | Matches on fields: name, device where device is NOT NULL | ≤4.2.99 |
+| logical_service_name_on_vm | name, virtual_machine | virtual_machine is NOT NULL | Matches on fields: name, virtual_machine where virtual_machine is NOT NULL | ≤4.2.99 |
+| logical_service_name_on_parent | name, parent_object_type, parent_object_id | parent_object_type is NOT NULL | Matches on fields: name, parent_object_type, parent_object_id where parent_object_type is NOT NULL | ≥4.3.0 |
 
 ## ipam.vlan
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_vlan_vid_no_group_or_svlan | vid | group is NULL AND qinq_svlan is NULL | Matches on fields: vid where group is NULL AND qinq_svlan is NULL | All versions |
 
 ## ipam.vlangroup
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_vlan_group_name_no_scope | name | scope_type is NULL | Matches on fields: name where scope_type is NULL | All versions |
 
 ## tenancy.contact
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_contact_name | name | N/A | Matches on fields: name | ≥4.3.0 |
 
 ## virtualization.cluster
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_cluster_within_scope | name, scope_type, scope_id | scope_type is NOT NULL | Matches on fields: name, scope_type, scope_id where scope_type is NOT NULL | All versions |
+| logical_cluster_with_no_scope_or_group | name | group is NULL AND scope_type is NULL | Matches on fields: name where group is NULL AND scope_type is NULL | All versions |
 
 ## virtualization.virtualmachine
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_virtual_machine_name_no_cluster | name | cluster is NULL | Matches on fields: name where cluster is NULL | All versions |
 
 ## wireless.wirelesslan
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
-| unknown | N/A | N/A | Custom matcher | All versions |
+| logical_wireless_lan_ssid_no_group_or_vlan | ssid | group is NULL AND vlan is NULL | Matches on fields: ssid where group is NULL AND vlan is NULL | All versions |
+| logical_wireless_lan_ssid_in_group | ssid, group | group is NOT NULL | Matches on fields: ssid, group where group is NOT NULL | All versions |
+| logical_wireless_lan_ssid_in_vlan | ssid, vlan | vlan is NOT NULL | Matches on fields: ssid, vlan where vlan is NOT NULL | All versions |

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -1,0 +1,149 @@
+# NetBox Diode Plugin - Object Matching Criteria
+
+This document describes how the Diode NetBox Plugin matches existing objects when applying changes.
+
+## dcim.inventoryitem
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## dcim.macaddress
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## dcim.modulebay
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## ipam.aggregate
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## ipam.fhrpgroup
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## ipam.ipaddress
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Matches IP address in global namespace (no VRF) | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Matches IP address within VRF | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## ipam.iprange
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Matches IP address in global namespace (no VRF) | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Matches IP address within VRF | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## ipam.prefix
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## ipam.service
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## ipam.vlan
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## ipam.vlangroup
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## tenancy.contact
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## virtualization.cluster
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## virtualization.virtualmachine
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+
+## wireless.wirelesslan
+
+| Matcher Name | Fields | Condition | Description | Version Constraints |
+|--------------|--------|-----------|-------------|-------------------|
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |
+| unknown | N/A | N/A | Custom matcher | All versions |

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -1,9 +1,3 @@
-🧬 loaded config '/etc/netbox/config/configuration.py'
-🧬 loaded config '/etc/netbox/config/extra.py'
-🧬 loaded config '/etc/netbox/config/logging.py'
-🧬 loaded config '/etc/netbox/config/plugins.py'
-Analyzing matching criteria...
-Generating markdown documentation...
 # NetBox Diode Plugin - Object Matching Criteria
 
 This document describes how the Diode NetBox Plugin matches existing objects when applying changes.

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -45,15 +45,15 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| logical_ip_address_global_no_vrf | N/A | N/A | Matches IP address address in global namespace (no VRF) | All versions |
-| logical_ip_address_within_vrf | N/A | N/A | Matches IP address address within VRF | All versions |
+| logical_ip_address_global_no_vrf |  | N/A | Matches IP address address in global namespace (no VRF) | All versions |
+| logical_ip_address_within_vrf |  | N/A | Matches IP address address within VRF | All versions |
 
 ## ipam.iprange
 
 | Matcher Name | Fields | Condition | Description | Version Constraints |
 |--------------|--------|-----------|-------------|-------------------|
-| logical_ip_range_start_end_global_no_vrf | N/A | N/A | Matches IP range start_address, end_address within VRF context | All versions |
-| logical_ip_range_start_end_within_vrf | N/A | N/A | Matches IP range start_address, end_address within VRF context | All versions |
+| logical_ip_range_start_end_global_no_vrf |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
+| logical_ip_range_start_end_within_vrf |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
 
 ## ipam.prefix
 

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -1,6 +1,6 @@
 # NetBox Diode Plugin - Object Matching Criteria
 
-This document describes how the Diode NetBox Plugin matches existing objects when applying changes.
+This document describes how the Diode NetBox Plugin matches existing objects when applying changes. The matchers will be applied in the order of their precedence, unttil one of them matches.
 
 ## Matcher Types
 
@@ -9,765 +9,765 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 ## circuits.circuit
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| circuits_circuit_unique_provider_cid | builtin | provider, cid | N/A | Matches on unique constraint fields: provider, cid | All versions |
-| circuits_circuit_unique_provideraccount_cid | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| circuits_circuit_unique_provider_cid | 1 | builtin | provider, cid | N/A | Matches on unique constraint fields: provider, cid | All versions |
+| circuits_circuit_unique_provideraccount_cid | 2 | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |
 
 ## circuits.circuitgroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## circuits.circuitgroupassignment
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| circuits_circuitgroupassignment_unique_member_group | builtin | member_type, member_id, group | N/A | Matches on unique constraint fields: member_type, member_id, group | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| circuits_circuitgroupassignment_unique_member_group | 1 | builtin | member_type, member_id, group | N/A | Matches on unique constraint fields: member_type, member_id, group | All versions |
 
 ## circuits.circuittermination
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| circuits_circuittermination_unique_circuit_term_side | builtin | circuit, term_side | N/A | Matches on unique constraint fields: circuit, term_side | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| circuits_circuittermination_unique_circuit_term_side | 1 | builtin | circuit, term_side | N/A | Matches on unique constraint fields: circuit, term_side | All versions |
 
 ## circuits.circuittype
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## circuits.provider
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## circuits.provideraccount
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| circuits_provideraccount_unique_provider_account | builtin | provider, account | N/A | Matches on unique constraint fields: provider, account | All versions |
-| circuits_provideraccount_unique_provider_name | builtin | provider, name | name =  | Matches on unique constraint fields: provider, name where name =  | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| circuits_provideraccount_unique_provider_account | 1 | builtin | provider, account | N/A | Matches on unique constraint fields: provider, account | All versions |
+| circuits_provideraccount_unique_provider_name | 2 | builtin | provider, name | name =  | Matches on unique constraint fields: provider, name where name =  | All versions |
 
 ## circuits.providernetwork
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| circuits_providernetwork_unique_provider_name | builtin | provider, name | N/A | Matches on unique constraint fields: provider, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| circuits_providernetwork_unique_provider_name | 1 | builtin | provider, name | N/A | Matches on unique constraint fields: provider, name | All versions |
 
 ## circuits.virtualcircuit
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| circuits_virtualcircuit_unique_provider_network_cid | builtin | provider_network, cid | N/A | Matches on unique constraint fields: provider_network, cid | All versions |
-| circuits_virtualcircuit_unique_provideraccount_cid | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| circuits_virtualcircuit_unique_provider_network_cid | 1 | builtin | provider_network, cid | N/A | Matches on unique constraint fields: provider_network, cid | All versions |
+| circuits_virtualcircuit_unique_provideraccount_cid | 2 | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |
 
 ## circuits.virtualcircuittermination
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_interface | builtin | interface | N/A | Matches on unique field(s): interface | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_interface | 1 | builtin | interface | N/A | Matches on unique field(s): interface | All versions |
 
 ## circuits.virtualcircuittype
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.cabletermination
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_cabletermination_unique_termination | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_cabletermination_unique_termination | 1 | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |
 
 ## dcim.consoleport
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_consoleport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_consoleport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
 ## dcim.consoleporttemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_consoleporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
-| dcim_consoleporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_consoleporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_consoleporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
 
 ## dcim.consoleserverport
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_consoleserverport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_consoleserverport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
 ## dcim.consoleserverporttemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_consoleserverporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
-| dcim_consoleserverporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_consoleserverporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_consoleserverporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
 
 ## dcim.device
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_asset_tag | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
-| unique_primary_ip4 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
-| unique_primary_ip6 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
-| unique_oob_ip | builtin | oob_ip | N/A | Matches on unique field(s): oob_ip | All versions |
-| dcim_device_unique_name_site_tenant | builtin |  | N/A | Custom matcher | All versions |
-| dcim_device_unique_name_site | builtin |  | tenant is NULL | Custom matcher | All versions |
-| dcim_device_unique_rack_position_face | builtin | rack, position, face | N/A | Matches on unique constraint fields: rack, position, face | All versions |
-| dcim_device_unique_virtual_chassis_vc_position | builtin | virtual_chassis, vc_position | N/A | Matches on unique constraint fields: virtual_chassis, vc_position | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_asset_tag | 1 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
+| unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
+| unique_oob_ip | 4 | builtin | oob_ip | N/A | Matches on unique field(s): oob_ip | All versions |
+| dcim_device_unique_name_site_tenant | 5 | builtin |  | N/A | Custom matcher | All versions |
+| dcim_device_unique_name_site | 6 | builtin |  | tenant is NULL | Custom matcher | All versions |
+| dcim_device_unique_rack_position_face | 7 | builtin | rack, position, face | N/A | Matches on unique constraint fields: rack, position, face | All versions |
+| dcim_device_unique_virtual_chassis_vc_position | 8 | builtin | virtual_chassis, vc_position | N/A | Matches on unique constraint fields: virtual_chassis, vc_position | All versions |
 
 ## dcim.devicebay
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_installed_device | builtin | installed_device | N/A | Matches on unique field(s): installed_device | All versions |
-| dcim_devicebay_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_installed_device | 1 | builtin | installed_device | N/A | Matches on unique field(s): installed_device | All versions |
+| dcim_devicebay_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
 ## dcim.devicebaytemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_devicebaytemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_devicebaytemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
 
 ## dcim.devicerole
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_device_role_name_no_parent | logical | name | parent is NULL | Matches on fields: name where parent is NULL | ≥4.3.0 |
-| logical_device_role_slug_no_parent | logical | slug | parent is NULL | Matches on fields: slug where parent is NULL | ≥4.3.0 |
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_device_role_name_no_parent | 1 | logical | name | parent is NULL | Matches on fields: name where parent is NULL | ≥4.3.0 |
+| logical_device_role_slug_no_parent | 2 | logical | slug | parent is NULL | Matches on fields: slug where parent is NULL | ≥4.3.0 |
+| unique_name | 3 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 4 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.devicetype
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_devicetype_unique_manufacturer_model | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
-| dcim_devicetype_unique_manufacturer_slug | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_devicetype_unique_manufacturer_model | 1 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
+| dcim_devicetype_unique_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.frontport
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_frontport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
-| dcim_frontport_unique_rear_port_position | builtin | rear_port, rear_port_position | N/A | Matches on unique constraint fields: rear_port, rear_port_position | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_frontport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_frontport_unique_rear_port_position | 2 | builtin | rear_port, rear_port_position | N/A | Matches on unique constraint fields: rear_port, rear_port_position | All versions |
 
 ## dcim.frontporttemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_frontporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
-| dcim_frontporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
-| dcim_frontporttemplate_unique_rear_port_position | builtin | rear_port, rear_port_position | N/A | Matches on unique constraint fields: rear_port, rear_port_position | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_frontporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_frontporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| dcim_frontporttemplate_unique_rear_port_position | 3 | builtin | rear_port, rear_port_position | N/A | Matches on unique constraint fields: rear_port, rear_port_position | All versions |
 
 ## dcim.interface
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_primary_mac_address | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
-| dcim_interface_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
+| dcim_interface_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
 ## dcim.interfacetemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_interfacetemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
-| dcim_interfacetemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_interfacetemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_interfacetemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
 
 ## dcim.inventoryitem
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_inventory_item_name_on_device_no_parent | logical | name, device | parent is NULL | Matches on fields: name, device where parent is NULL | All versions |
-| unique_asset_tag | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
-| dcim_inventoryitem_unique_device_parent_name | builtin | device, parent, name | N/A | Matches on unique constraint fields: device, parent, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_inventory_item_name_on_device_no_parent | 1 | logical | name, device | parent is NULL | Matches on fields: name, device where parent is NULL | All versions |
+| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| dcim_inventoryitem_unique_device_parent_name | 3 | builtin | device, parent, name | N/A | Matches on unique constraint fields: device, parent, name | All versions |
 
 ## dcim.inventoryitemrole
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.inventoryitemtemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_inventoryitemtemplate_unique_device_type_parent_name | builtin | device_type, parent, name | N/A | Matches on unique constraint fields: device_type, parent, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_inventoryitemtemplate_unique_device_type_parent_name | 1 | builtin | device_type, parent, name | N/A | Matches on unique constraint fields: device_type, parent, name | All versions |
 
 ## dcim.location
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_location_parent_name | builtin | site, parent, name | N/A | Matches on unique constraint fields: site, parent, name | All versions |
-| dcim_location_name | builtin | site, name | parent is NULL | Matches on unique constraint fields: site, name where parent is NULL | All versions |
-| dcim_location_parent_slug | builtin | site, parent, slug | N/A | Matches on unique constraint fields: site, parent, slug | All versions |
-| dcim_location_slug | builtin | site, slug | parent is NULL | Matches on unique constraint fields: site, slug where parent is NULL | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_location_parent_name | 1 | builtin | site, parent, name | N/A | Matches on unique constraint fields: site, parent, name | All versions |
+| dcim_location_name | 2 | builtin | site, name | parent is NULL | Matches on unique constraint fields: site, name where parent is NULL | All versions |
+| dcim_location_parent_slug | 3 | builtin | site, parent, slug | N/A | Matches on unique constraint fields: site, parent, slug | All versions |
+| dcim_location_slug | 4 | builtin | site, slug | parent is NULL | Matches on unique constraint fields: site, slug where parent is NULL | All versions |
+| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.macaddress
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_mac_address_within_parent | logical | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NOT NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NOT NULL | All versions |
-| logical_mac_address_within_parent | logical | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NULL | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_mac_address_within_parent | 1 | logical | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NOT NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NOT NULL | All versions |
+| logical_mac_address_within_parent | 2 | logical | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NULL | All versions |
 
 ## dcim.manufacturer
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.module
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_module_bay | builtin | module_bay | N/A | Matches on unique field(s): module_bay | All versions |
-| unique_asset_tag | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_module_bay | 1 | builtin | module_bay | N/A | Matches on unique field(s): module_bay | All versions |
+| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
 
 ## dcim.modulebay
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_module_bay_name_on_device | logical | name, device | N/A | Matches on fields: name, device | All versions |
-| dcim_modulebay_unique_device_module_name | builtin | device, module, name | N/A | Matches on unique constraint fields: device, module, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_module_bay_name_on_device | 1 | logical | name, device | N/A | Matches on fields: name, device | All versions |
+| dcim_modulebay_unique_device_module_name | 2 | builtin | device, module, name | N/A | Matches on unique constraint fields: device, module, name | All versions |
 
 ## dcim.modulebaytemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_modulebaytemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
-| dcim_modulebaytemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_modulebaytemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_modulebaytemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
 
 ## dcim.moduletype
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_moduletype_unique_manufacturer_model | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_moduletype_unique_manufacturer_model | 1 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
 
 ## dcim.platform
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.powerfeed
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_powerfeed_unique_power_panel_name | builtin | power_panel, name | N/A | Matches on unique constraint fields: power_panel, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_powerfeed_unique_power_panel_name | 1 | builtin | power_panel, name | N/A | Matches on unique constraint fields: power_panel, name | All versions |
 
 ## dcim.poweroutlet
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_poweroutlet_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_poweroutlet_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
 ## dcim.poweroutlettemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_poweroutlettemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
-| dcim_poweroutlettemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_poweroutlettemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_poweroutlettemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
 
 ## dcim.powerpanel
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_powerpanel_unique_site_name | builtin | site, name | N/A | Matches on unique constraint fields: site, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_powerpanel_unique_site_name | 1 | builtin | site, name | N/A | Matches on unique constraint fields: site, name | All versions |
 
 ## dcim.powerport
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_powerport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_powerport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
 ## dcim.powerporttemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_powerporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
-| dcim_powerporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_powerporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_powerporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
 
 ## dcim.rack
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_asset_tag | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
-| dcim_rack_unique_location_name | builtin | location, name | N/A | Matches on unique constraint fields: location, name | All versions |
-| dcim_rack_unique_location_facility_id | builtin | location, facility_id | N/A | Matches on unique constraint fields: location, facility_id | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_asset_tag | 1 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| dcim_rack_unique_location_name | 2 | builtin | location, name | N/A | Matches on unique constraint fields: location, name | All versions |
+| dcim_rack_unique_location_facility_id | 3 | builtin | location, facility_id | N/A | Matches on unique constraint fields: location, facility_id | All versions |
 
 ## dcim.rackrole
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.racktype
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| dcim_racktype_unique_manufacturer_model | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
-| dcim_racktype_unique_manufacturer_slug | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_slug | 1 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| dcim_racktype_unique_manufacturer_model | 2 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
+| dcim_racktype_unique_manufacturer_slug | 3 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
+| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.rearport
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_rearport_unique_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_rearport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
 ## dcim.rearporttemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_rearporttemplate_unique_device_type_name | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
-| dcim_rearporttemplate_unique_module_type_name | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_rearporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
+| dcim_rearporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
 
 ## dcim.region
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_region_parent_name | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| dcim_region_name | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
-| dcim_region_parent_slug | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
-| dcim_region_slug | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_region_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
+| dcim_region_name | 2 | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
+| dcim_region_parent_slug | 3 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
+| dcim_region_slug | 4 | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
+| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.site
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.sitegroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| dcim_sitegroup_parent_name | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| dcim_sitegroup_name | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
-| dcim_sitegroup_parent_slug | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
-| dcim_sitegroup_slug | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| dcim_sitegroup_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
+| dcim_sitegroup_name | 2 | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
+| dcim_sitegroup_parent_slug | 3 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
+| dcim_sitegroup_slug | 4 | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
+| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.virtualchassis
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_master | builtin | master | N/A | Matches on unique field(s): master | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_master | 1 | builtin | master | N/A | Matches on unique field(s): master | All versions |
 
 ## dcim.virtualdevicecontext
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_primary_ip4 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
-| unique_primary_ip6 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
-| dcim_virtualdevicecontext_device_identifier | builtin | device, identifier | N/A | Matches on unique constraint fields: device, identifier | All versions |
-| dcim_virtualdevicecontext_device_name | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_primary_ip4 | 1 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
+| unique_primary_ip6 | 2 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
+| dcim_virtualdevicecontext_device_identifier | 3 | builtin | device, identifier | N/A | Matches on unique constraint fields: device, identifier | All versions |
+| dcim_virtualdevicecontext_device_name | 4 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
 ## extras.bookmark
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| extras_bookmark_unique_per_object_and_user | builtin | object_type, object_id, user | N/A | Matches on unique constraint fields: object_type, object_id, user | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| extras_bookmark_unique_per_object_and_user | 1 | builtin | object_type, object_id, user | N/A | Matches on unique constraint fields: object_type, object_id, user | All versions |
 
 ## extras.configcontext
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## extras.customfield
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## extras.customfieldchoiceset
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## extras.customlink
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## extras.eventrule
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## extras.notificationgroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## extras.savedfilter
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## extras.script
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| extras_script_unique_name_module | builtin | name, module | N/A | Matches on unique constraint fields: name, module | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| extras_script_unique_name_module | 1 | builtin | name, module | N/A | Matches on unique constraint fields: name, module | All versions |
 
 ## extras.tag
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## extras.webhook
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## ipam.aggregate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_aggregate_prefix_no_rir | logical | prefix | rir is NULL | Matches on fields: prefix where rir is NULL | All versions |
-| logical_aggregate_prefix_within_rir | logical | prefix, rir | rir is NOT NULL | Matches on fields: prefix, rir where rir is NOT NULL | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_aggregate_prefix_no_rir | 1 | logical | prefix | rir is NULL | Matches on fields: prefix where rir is NULL | All versions |
+| logical_aggregate_prefix_within_rir | 2 | logical | prefix, rir | rir is NOT NULL | Matches on fields: prefix, rir where rir is NOT NULL | All versions |
 
 ## ipam.asn
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_asn | builtin | asn | N/A | Matches on unique field(s): asn | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_asn | 1 | builtin | asn | N/A | Matches on unique field(s): asn | All versions |
 
 ## ipam.asnrange
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## ipam.fhrpgroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_fhrp_group_id | logical | group_id | N/A | Matches on fields: group_id | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_fhrp_group_id | 1 | logical | group_id | N/A | Matches on fields: group_id | All versions |
 
 ## ipam.fhrpgroupassignment
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| ipam_fhrpgroupassignment_unique_interface_group | builtin | interface_type, interface_id, group | N/A | Matches on unique constraint fields: interface_type, interface_id, group | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| ipam_fhrpgroupassignment_unique_interface_group | 1 | builtin | interface_type, interface_id, group | N/A | Matches on unique constraint fields: interface_type, interface_id, group | All versions |
 
 ## ipam.ipaddress
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_ip_address_global_no_vrf | logical |  | N/A | Matches IP address address in global namespace (no VRF) | All versions |
-| logical_ip_address_within_vrf | logical |  | N/A | Matches IP address address within VRF | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_ip_address_global_no_vrf | 1 | logical |  | N/A | Matches IP address address in global namespace (no VRF) | All versions |
+| logical_ip_address_within_vrf | 2 | logical |  | N/A | Matches IP address address within VRF | All versions |
 
 ## ipam.iprange
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_ip_range_start_end_global_no_vrf | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
-| logical_ip_range_start_end_within_vrf | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_ip_range_start_end_global_no_vrf | 1 | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
+| logical_ip_range_start_end_within_vrf | 2 | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
 
 ## ipam.prefix
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_prefix_global_no_vrf | logical | prefix | vrf is NULL | Matches on fields: prefix where vrf is NULL | All versions |
-| logical_prefix_within_vrf | logical | prefix, vrf | vrf is NOT NULL | Matches on fields: prefix, vrf where vrf is NOT NULL | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_prefix_global_no_vrf | 1 | logical | prefix | vrf is NULL | Matches on fields: prefix where vrf is NULL | All versions |
+| logical_prefix_within_vrf | 2 | logical | prefix, vrf | vrf is NOT NULL | Matches on fields: prefix, vrf where vrf is NOT NULL | All versions |
 
 ## ipam.rir
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## ipam.role
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## ipam.routetarget
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## ipam.service
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_service_name_no_device_or_vm | logical | name | device is NULL AND virtual_machine is NULL | Matches on fields: name where device is NULL AND virtual_machine is NULL | ≤4.2.99 |
-| logical_service_name_on_device | logical | name, device | device is NOT NULL | Matches on fields: name, device where device is NOT NULL | ≤4.2.99 |
-| logical_service_name_on_vm | logical | name, virtual_machine | virtual_machine is NOT NULL | Matches on fields: name, virtual_machine where virtual_machine is NOT NULL | ≤4.2.99 |
-| logical_service_name_on_parent | logical | name, parent_object_type, parent_object_id | parent_object_type is NOT NULL | Matches on fields: name, parent_object_type, parent_object_id where parent_object_type is NOT NULL | ≥4.3.0 |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_service_name_no_device_or_vm | 1 | logical | name | device is NULL AND virtual_machine is NULL | Matches on fields: name where device is NULL AND virtual_machine is NULL | ≤4.2.99 |
+| logical_service_name_on_device | 2 | logical | name, device | device is NOT NULL | Matches on fields: name, device where device is NOT NULL | ≤4.2.99 |
+| logical_service_name_on_vm | 3 | logical | name, virtual_machine | virtual_machine is NOT NULL | Matches on fields: name, virtual_machine where virtual_machine is NOT NULL | ≤4.2.99 |
+| logical_service_name_on_parent | 4 | logical | name, parent_object_type, parent_object_id | parent_object_type is NOT NULL | Matches on fields: name, parent_object_type, parent_object_id where parent_object_type is NOT NULL | ≥4.3.0 |
 
 ## ipam.servicetemplate
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## ipam.vlan
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_vlan_vid_no_group_or_svlan | logical | vid | group is NULL AND qinq_svlan is NULL | Matches on fields: vid where group is NULL AND qinq_svlan is NULL | All versions |
-| ipam_vlan_unique_group_vid | builtin | group, vid | N/A | Matches on unique constraint fields: group, vid | All versions |
-| ipam_vlan_unique_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| ipam_vlan_unique_qinq_svlan_vid | builtin | qinq_svlan, vid | N/A | Matches on unique constraint fields: qinq_svlan, vid | All versions |
-| ipam_vlan_unique_qinq_svlan_name | builtin | qinq_svlan, name | N/A | Matches on unique constraint fields: qinq_svlan, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_vlan_vid_no_group_or_svlan | 1 | logical | vid | group is NULL AND qinq_svlan is NULL | Matches on fields: vid where group is NULL AND qinq_svlan is NULL | All versions |
+| ipam_vlan_unique_group_vid | 2 | builtin | group, vid | N/A | Matches on unique constraint fields: group, vid | All versions |
+| ipam_vlan_unique_group_name | 3 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| ipam_vlan_unique_qinq_svlan_vid | 4 | builtin | qinq_svlan, vid | N/A | Matches on unique constraint fields: qinq_svlan, vid | All versions |
+| ipam_vlan_unique_qinq_svlan_name | 5 | builtin | qinq_svlan, name | N/A | Matches on unique constraint fields: qinq_svlan, name | All versions |
 
 ## ipam.vlangroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_vlan_group_name_no_scope | logical | name | scope_type is NULL | Matches on fields: name where scope_type is NULL | All versions |
-| ipam_vlangroup_unique_scope_name | builtin | scope_type, scope_id, name | N/A | Matches on unique constraint fields: scope_type, scope_id, name | All versions |
-| ipam_vlangroup_unique_scope_slug | builtin | scope_type, scope_id, slug | N/A | Matches on unique constraint fields: scope_type, scope_id, slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_vlan_group_name_no_scope | 1 | logical | name | scope_type is NULL | Matches on fields: name where scope_type is NULL | All versions |
+| ipam_vlangroup_unique_scope_name | 2 | builtin | scope_type, scope_id, name | N/A | Matches on unique constraint fields: scope_type, scope_id, name | All versions |
+| ipam_vlangroup_unique_scope_slug | 3 | builtin | scope_type, scope_id, slug | N/A | Matches on unique constraint fields: scope_type, scope_id, slug | All versions |
+| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## ipam.vlantranslationpolicy
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## ipam.vlantranslationrule
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| ipam_vlantranslationrule_unique_policy_local_vid | builtin | policy, local_vid | N/A | Matches on unique constraint fields: policy, local_vid | All versions |
-| ipam_vlantranslationrule_unique_policy_remote_vid | builtin | policy, remote_vid | N/A | Matches on unique constraint fields: policy, remote_vid | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| ipam_vlantranslationrule_unique_policy_local_vid | 1 | builtin | policy, local_vid | N/A | Matches on unique constraint fields: policy, local_vid | All versions |
+| ipam_vlantranslationrule_unique_policy_remote_vid | 2 | builtin | policy, remote_vid | N/A | Matches on unique constraint fields: policy, remote_vid | All versions |
 
 ## ipam.vrf
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_rd | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_rd | 1 | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
 
 ## tenancy.contact
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_contact_name | logical | name | N/A | Matches on fields: name | ≥4.3.0 |
-| tenancy_contact_unique_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_contact_name | 1 | logical | name | N/A | Matches on fields: name | ≥4.3.0 |
+| tenancy_contact_unique_group_name | 2 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
 
 ## tenancy.contactassignment
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| tenancy_contactassignment_unique_object_contact_role | builtin | object_type, object_id, contact, role | N/A | Matches on unique constraint fields: object_type, object_id, contact, role | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| tenancy_contactassignment_unique_object_contact_role | 1 | builtin | object_type, object_id, contact, role | N/A | Matches on unique constraint fields: object_type, object_id, contact, role | All versions |
 
 ## tenancy.contactgroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| tenancy_contactgroup_unique_parent_name | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| tenancy_contactgroup_unique_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
+| unique_autoslug_slug | 2 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## tenancy.contactrole
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## tenancy.tenant
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| tenancy_tenant_unique_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| tenancy_tenant_unique_name | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
-| tenancy_tenant_unique_group_slug | builtin | group, slug | N/A | Matches on unique constraint fields: group, slug | All versions |
-| tenancy_tenant_unique_slug | builtin | slug | group is NULL | Matches on unique constraint fields: slug where group is NULL | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| tenancy_tenant_unique_group_name | 1 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| tenancy_tenant_unique_name | 2 | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
+| tenancy_tenant_unique_group_slug | 3 | builtin | group, slug | N/A | Matches on unique constraint fields: group, slug | All versions |
+| tenancy_tenant_unique_slug | 4 | builtin | slug | group is NULL | Matches on unique constraint fields: slug where group is NULL | All versions |
+| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## tenancy.tenantgroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## virtualization.cluster
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_cluster_within_scope | logical | name, scope_type, scope_id | scope_type is NOT NULL | Matches on fields: name, scope_type, scope_id where scope_type is NOT NULL | All versions |
-| logical_cluster_with_no_scope_or_group | logical | name | group is NULL AND scope_type is NULL | Matches on fields: name where group is NULL AND scope_type is NULL | All versions |
-| virtualization_cluster_unique_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| virtualization_cluster_unique__site_name | builtin | _site, name | N/A | Matches on unique constraint fields: _site, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_cluster_within_scope | 1 | logical | name, scope_type, scope_id | scope_type is NOT NULL | Matches on fields: name, scope_type, scope_id where scope_type is NOT NULL | All versions |
+| logical_cluster_with_no_scope_or_group | 2 | logical | name | group is NULL AND scope_type is NULL | Matches on fields: name where group is NULL AND scope_type is NULL | All versions |
+| virtualization_cluster_unique_group_name | 3 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| virtualization_cluster_unique__site_name | 4 | builtin | _site, name | N/A | Matches on unique constraint fields: _site, name | All versions |
 
 ## virtualization.clustergroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## virtualization.clustertype
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## virtualization.virtualdisk
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| virtualization_virtualdisk_unique_virtual_machine_name | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| virtualization_virtualdisk_unique_virtual_machine_name | 1 | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |
 
 ## virtualization.virtualmachine
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_virtual_machine_name_no_cluster | logical | name | cluster is NULL | Matches on fields: name where cluster is NULL | All versions |
-| unique_primary_ip4 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
-| unique_primary_ip6 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
-| virtualization_virtualmachine_unique_name_cluster_tenant | builtin |  | N/A | Custom matcher | All versions |
-| virtualization_virtualmachine_unique_name_cluster | builtin |  | tenant is NULL | Custom matcher | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_virtual_machine_name_no_cluster | 1 | logical | name | cluster is NULL | Matches on fields: name where cluster is NULL | All versions |
+| unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
+| unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
+| virtualization_virtualmachine_unique_name_cluster_tenant | 4 | builtin |  | N/A | Custom matcher | All versions |
+| virtualization_virtualmachine_unique_name_cluster | 5 | builtin |  | tenant is NULL | Custom matcher | All versions |
 
 ## virtualization.vminterface
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_primary_mac_address | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
-| virtualization_vminterface_unique_virtual_machine_name | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
+| virtualization_vminterface_unique_virtual_machine_name | 2 | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |
 
 ## vpn.ikepolicy
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## vpn.ikeproposal
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## vpn.ipsecpolicy
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## vpn.ipsecprofile
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## vpn.ipsecproposal
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 
 ## vpn.l2vpn
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## vpn.l2vpntermination
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| vpn_l2vpntermination_assigned_object | builtin | assigned_object_type, assigned_object_id | N/A | Matches on unique constraint fields: assigned_object_type, assigned_object_id | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| vpn_l2vpntermination_assigned_object | 1 | builtin | assigned_object_type, assigned_object_id | N/A | Matches on unique constraint fields: assigned_object_type, assigned_object_id | All versions |
 
 ## vpn.tunnel
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| vpn_tunnel_group_name | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| vpn_tunnel_name | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| vpn_tunnel_group_name | 2 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
+| vpn_tunnel_name | 3 | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
 
 ## vpn.tunnelgroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## vpn.tunneltermination
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| vpn_tunneltermination_termination | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| vpn_tunneltermination_termination | 1 | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |
 
 ## wireless.wirelesslan
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| logical_wireless_lan_ssid_no_group_or_vlan | logical | ssid | group is NULL AND vlan is NULL | Matches on fields: ssid where group is NULL AND vlan is NULL | All versions |
-| logical_wireless_lan_ssid_in_group | logical | ssid, group | group is NOT NULL | Matches on fields: ssid, group where group is NOT NULL | All versions |
-| logical_wireless_lan_ssid_in_vlan | logical | ssid, vlan | vlan is NOT NULL | Matches on fields: ssid, vlan where vlan is NOT NULL | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| logical_wireless_lan_ssid_no_group_or_vlan | 1 | logical | ssid | group is NULL AND vlan is NULL | Matches on fields: ssid where group is NULL AND vlan is NULL | All versions |
+| logical_wireless_lan_ssid_in_group | 2 | logical | ssid, group | group is NOT NULL | Matches on fields: ssid, group where group is NOT NULL | All versions |
+| logical_wireless_lan_ssid_in_vlan | 3 | logical | ssid, vlan | vlan is NOT NULL | Matches on fields: ssid, vlan where vlan is NOT NULL | All versions |
 
 ## wireless.wirelesslangroup
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| unique_name | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| wireless_wirelesslangroup_unique_parent_name | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| unique_autoslug_slug | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
+| wireless_wirelesslangroup_unique_parent_name | 3 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
+| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## wireless.wirelesslink
 
-| Matcher Name | Type | Fields | Condition | Description | Version Constraints |
-|--------------|------|--------|-----------|-------------|-------------------|
-| wireless_wirelesslink_unique_interfaces | builtin | interface_a, interface_b | N/A | Matches on unique constraint fields: interface_a, interface_b | All versions |
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|------------|------|--------|-----------|-------------|---------------------|
+| wireless_wirelesslink_unique_interfaces | 1 | builtin | interface_a, interface_b | N/A | Matches on unique constraint fields: interface_a, interface_b | All versions |

--- a/netbox_diode_plugin/management/__init__.py
+++ b/netbox_diode_plugin/management/__init__.py
@@ -1,1 +1,1 @@
-# Django management package for netbox_diode_plugin 
+"""Django management package for netbox_diode_plugin."""

--- a/netbox_diode_plugin/management/__init__.py
+++ b/netbox_diode_plugin/management/__init__.py
@@ -1,0 +1,1 @@
+# Django management package for netbox_diode_plugin 

--- a/netbox_diode_plugin/management/commands/__init__.py
+++ b/netbox_diode_plugin/management/commands/__init__.py
@@ -1,1 +1,1 @@
-# Django management commands for netbox_diode_plugin 
+"""Django management commands for netbox_diode_plugin."""

--- a/netbox_diode_plugin/management/commands/__init__.py
+++ b/netbox_diode_plugin/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# Django management commands for netbox_diode_plugin 

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -198,7 +198,7 @@ class Command(BaseCommand):
         markdown = []
         markdown.append("# NetBox Diode Plugin - Object Matching Criteria")
         markdown.append("")
-        markdown.append("This document describes how the Diode NetBox Plugin matches existing objects when applying changes.")
+        markdown.append("This document describes how the Diode NetBox Plugin matches existing objects when applying changes. The matchers will be applied in the order of their precedence, unttil one of them matches.")
         markdown.append("")
         markdown.append("## Matcher Types")
         markdown.append("")
@@ -221,10 +221,10 @@ class Command(BaseCommand):
                 continue
             
             # Create table header
-            markdown.append("| Matcher Name | Type | Fields | Condition | Description | Version Constraints |")
-            markdown.append("|--------------|------|--------|-----------|-------------|-------------------|")
+            markdown.append("| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |")
+            markdown.append("|--------------|---------------------|------|--------|-----------|-------------|---------------------|")
             
-            for matcher in matchers:
+            for precedence, matcher in enumerate(matchers, start=1):
                 # Escape pipe characters in table cells
                 name = matcher.name.replace("|", "\\|") if matcher.name else "N/A"
                 matcher_type = matcher.matcher_source.replace("|", "\\|")
@@ -233,7 +233,7 @@ class Command(BaseCommand):
                 description = matcher.description.replace("|", "\\|") if matcher.description else "N/A"
                 version_str = matcher.version_constraints.replace("|", "\\|") if matcher.version_constraints else "All versions"
                 
-                markdown.append(f"| {name} | {matcher_type} | {fields_str} | {condition_str} | {description} | {version_str} |")
+                markdown.append(f"| {name} | {precedence} | {matcher_type} | {fields_str} | {condition_str} | {description} | {version_str} |")
             
             markdown.append("")
         

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -160,16 +160,6 @@ class Command(BaseCommand):
         """Handle the command execution."""
         self.stdout.write("Analyzing matching criteria...")
         docs = self.analyze_logical_matchers()
-        
         self.stdout.write("Generating markdown documentation...")
-        markdown_content = self.generate_markdown_table(docs)
-        
-        # Output to file or stdout
-        if options['output']:
-            with open(options['output'], 'w') as f:
-                f.write(markdown_content)
-            self.stdout.write(
-                self.style.SUCCESS(f"Documentation generated and saved to: {options['output']}")
-            )
-        else:
-            self.stdout.write(markdown_content) 
+        markdown_content = self.generate_markdown_table(docs)        
+        self.stdout.write(markdown_content) 

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+"""Django management command to generate markdown documentation for NetBox Diode Plugin matching criteria."""
+
+from django.core.management.base import BaseCommand
+from typing import Dict, List, Optional
+from dataclasses import dataclass
+
+from netbox_diode_plugin.api.matcher import _LOGICAL_MATCHERS
+
+
+@dataclass
+class MatcherInfo:
+    """Information about a matcher for documentation."""
+    name: str
+    fields: Optional[List[str]] = None
+    condition: Optional[str] = None
+    description: Optional[str] = None
+    matcher_type: str = "ObjectMatchCriteria"
+    version_constraints: Optional[str] = None
+
+
+class Command(BaseCommand):
+    help = "Generate markdown documentation for NetBox Diode Plugin matching criteria"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--output',
+            type=str,
+            help='Output file path (default: stdout)',
+        )
+
+    def extract_condition_description(self, condition) -> str:
+        """Extract a human-readable description of a Q condition."""
+        if condition is None:
+            return "None"
+        
+        # Handle simple conditions
+        if hasattr(condition, 'children'):
+            conditions = []
+            for child in condition.children:
+                if isinstance(child, tuple):
+                    field, value = child
+                    if field.endswith('__isnull'):
+                        field_name = field[:-8]
+                        if value:
+                            conditions.append(f"{field_name} is NULL")
+                        else:
+                            conditions.append(f"{field_name} is NOT NULL")
+                    else:
+                        conditions.append(f"{field} = {value}")
+                else:
+                    conditions.append(str(child))
+            
+            connector = " AND " if condition.connector == "AND" else " OR "
+            return connector.join(conditions)
+        
+        return str(condition)
+
+    def get_matcher_description(self, matcher) -> str:
+        """Generate a human-readable description of what the matcher does."""
+        if hasattr(matcher, 'ip_fields') and hasattr(matcher, 'vrf_field'):
+            # IP Network matcher
+            ip_fields_str = ", ".join(matcher.ip_fields)
+            if matcher.name.startswith('logical_ip_address_global_no_vrf'):
+                return f"Matches IP address {ip_fields_str} in global namespace (no VRF)"
+            elif matcher.name.startswith('logical_ip_address_within_vrf'):
+                return f"Matches IP address {ip_fields_str} within VRF"
+            elif matcher.name.startswith('logical_ip_range'):
+                return f"Matches IP range {ip_fields_str} within VRF context"
+        
+        # Standard field-based matcher
+        if hasattr(matcher, 'fields') and matcher.fields:
+            fields_str = ", ".join(matcher.fields)
+            if hasattr(matcher, 'condition') and matcher.condition:
+                condition_desc = self.extract_condition_description(matcher.condition)
+                return f"Matches on fields: {fields_str} where {condition_desc}"
+            else:
+                return f"Matches on fields: {fields_str}"
+        
+        return "Custom matcher"
+
+    def get_version_constraints(self, matcher) -> Optional[str]:
+        """Get version constraints as a string."""
+        constraints = []
+        if hasattr(matcher, 'min_version') and matcher.min_version:
+            constraints.append(f"≥{matcher.min_version}")
+        if hasattr(matcher, 'max_version') and matcher.max_version:
+            constraints.append(f"≤{matcher.max_version}")
+        
+        return " ".join(constraints) if constraints else None
+
+    def analyze_logical_matchers(self) -> Dict[str, List[MatcherInfo]]:
+        """Analyze the logical matchers and extract documentation information."""
+        documentation = {}
+        
+        for object_type, matcher_factory in _LOGICAL_MATCHERS.items():
+            matchers = matcher_factory()
+            matcher_infos = []
+            
+            for matcher in matchers:
+                info = MatcherInfo(
+                    name=matcher.name,
+                    fields=list(matcher.fields) if hasattr(matcher, 'fields') and matcher.fields else None,
+                    condition=self.extract_condition_description(matcher.condition) if hasattr(matcher, 'condition') else None,
+                    description=self.get_matcher_description(matcher),
+                    matcher_type=matcher.__class__.__name__,
+                    version_constraints=self.get_version_constraints(matcher)
+                )
+                matcher_infos.append(info)
+            
+            documentation[object_type] = matcher_infos
+        
+        return documentation
+
+    def generate_markdown_table(self, docs: Dict[str, List[MatcherInfo]]) -> str:
+        """Generate a markdown table from the documentation."""
+        markdown = []
+        markdown.append("# NetBox Diode Plugin - Object Matching Criteria")
+        markdown.append("")
+        markdown.append("This document describes how the Diode NetBox Plugin matches existing objects when applying changes.")
+        markdown.append("")
+        
+        # Sort object types for consistent output
+        sorted_object_types = sorted(docs.keys())
+        
+        for object_type in sorted_object_types:
+            matchers = docs[object_type]
+            
+            markdown.append(f"## {object_type}")
+            markdown.append("")
+            
+            if not matchers:
+                markdown.append("No specific matching criteria defined.")
+                markdown.append("")
+                continue
+            
+            # Create table header
+            markdown.append("| Matcher Name | Fields | Condition | Description | Version Constraints |")
+            markdown.append("|--------------|--------|-----------|-------------|-------------------|")
+            
+            for matcher in matchers:
+                fields_str = ", ".join(matcher.fields) if matcher.fields else "N/A"
+                condition_str = matcher.condition if matcher.condition and matcher.condition != "None" else "N/A"
+                version_str = matcher.version_constraints if matcher.version_constraints else "All versions"
+                
+                # Escape pipe characters in table cells
+                name = matcher.name.replace("|", "\\|")
+                fields_str = fields_str.replace("|", "\\|")
+                condition_str = condition_str.replace("|", "\\|")
+                description = matcher.description.replace("|", "\\|")
+                version_str = version_str.replace("|", "\\|")
+                
+                markdown.append(f"| {name} | {fields_str} | {condition_str} | {description} | {version_str} |")
+            
+            markdown.append("")
+        
+        return "\n".join(markdown)
+
+    def handle(self, *args, **options):
+        """Handle the command execution."""
+        self.stdout.write("Analyzing matching criteria...")
+        docs = self.analyze_logical_matchers()
+        
+        self.stdout.write("Generating markdown documentation...")
+        markdown_content = self.generate_markdown_table(docs)
+        
+        # Output to file or stdout
+        if options['output']:
+            with open(options['output'], 'w') as f:
+                f.write(markdown_content)
+            self.stdout.write(
+                self.style.SUCCESS(f"Documentation generated and saved to: {options['output']}")
+            )
+        else:
+            self.stdout.write(markdown_content) 

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -22,13 +22,6 @@ class MatcherInfo:
 class Command(BaseCommand):
     help = "Generate markdown documentation for NetBox Diode Plugin matching criteria"
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--output',
-            type=str,
-            help='Output file path (default: stdout)',
-        )
-
     def extract_condition_description(self, condition) -> str:
         """Extract a human-readable description of a Q condition."""
         if condition is None:
@@ -139,16 +132,12 @@ class Command(BaseCommand):
             markdown.append("|--------------|--------|-----------|-------------|-------------------|")
             
             for matcher in matchers:
-                fields_str = ", ".join(matcher.fields) if matcher.fields else "N/A"
-                condition_str = matcher.condition if matcher.condition and matcher.condition != "None" else "N/A"
-                version_str = matcher.version_constraints if matcher.version_constraints else "All versions"
-                
                 # Escape pipe characters in table cells
-                name = matcher.name.replace("|", "\\|")
-                fields_str = fields_str.replace("|", "\\|")
-                condition_str = condition_str.replace("|", "\\|")
-                description = matcher.description.replace("|", "\\|")
-                version_str = version_str.replace("|", "\\|")
+                name = matcher.name.replace("|", "\\|") if matcher.name else "N/A"
+                fields_str = ", ".join(matcher.fields).replace("|", "\\|") if matcher.fields else ""
+                condition_str = matcher.condition.replace("|", "\\|") if matcher.condition and matcher.condition != "None" else "N/A"
+                description = matcher.description.replace("|", "\\|") if matcher.description else "N/A"
+                version_str = matcher.version_constraints.replace("|", "\\|") if matcher.version_constraints else "All versions"
                 
                 markdown.append(f"| {name} | {fields_str} | {condition_str} | {description} | {version_str} |")
             

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -1,34 +1,38 @@
 #!/usr/bin/env python
 """Django management command to generate markdown documentation for NetBox Diode Plugin matching criteria."""
 
-from django.core.management.base import BaseCommand
-from typing import Dict, List, Optional
 from dataclasses import dataclass
+from typing import Optional
 
-from netbox_diode_plugin.api.matcher import _LOGICAL_MATCHERS, get_model_matchers
+from django.core.management.base import BaseCommand
+
 from netbox_diode_plugin.api.differ import SUPPORTED_MODELS
+from netbox_diode_plugin.api.matcher import _LOGICAL_MATCHERS, get_model_matchers
 
 
 @dataclass
 class MatcherInfo:
     """Information about a matcher for documentation."""
+
     name: str
-    fields: Optional[List[str]] = None
-    condition: Optional[str] = None
-    description: Optional[str] = None
+    fields: list[str] | None = None
+    condition: str | None = None
+    description: str | None = None
     matcher_type: str = "ObjectMatchCriteria"
-    version_constraints: Optional[str] = None
+    version_constraints: str | None = None
     matcher_source: str = "logical"  # "logical" or "builtin"
 
 
 class Command(BaseCommand):
+    """Django management command to generate markdown documentation for NetBox Diode Plugin matching criteria."""
+
     help = "Generate markdown documentation for NetBox Diode Plugin matching criteria"
 
     def extract_condition_description(self, condition) -> str:
         """Extract a human-readable description of a Q condition."""
         if condition is None:
             return "None"
-        
+
         # Handle simple conditions
         if hasattr(condition, 'children'):
             conditions = []
@@ -45,76 +49,74 @@ class Command(BaseCommand):
                         conditions.append(f"{field} = {value}")
                 else:
                     conditions.append(str(child))
-            
+
             connector = " AND " if condition.connector == "AND" else " OR "
             return connector.join(conditions)
-        
+
         return str(condition)
 
-    def get_matcher_description(self, matcher) -> str:
+    def get_matcher_description(self, matcher) -> str:  # noqa: C901
         """Generate a human-readable description of what the matcher does."""
         # Handle IP Network matchers
         if hasattr(matcher, 'ip_fields') and matcher.ip_fields and hasattr(matcher, 'vrf_field') and matcher.vrf_field:
             ip_fields_str = ", ".join(matcher.ip_fields)
             if matcher.name.startswith('logical_ip_address_global_no_vrf'):
                 return f"Matches IP address {ip_fields_str} in global namespace (no VRF)"
-            elif matcher.name.startswith('logical_ip_address_within_vrf'):
+            if matcher.name.startswith('logical_ip_address_within_vrf'):
                 return f"Matches IP address {ip_fields_str} within VRF"
-            elif matcher.name.startswith('logical_ip_range'):
+            if matcher.name.startswith('logical_ip_range'):
                 return f"Matches IP range {ip_fields_str} within VRF context"
-        
+
         # Handle CustomFieldMatcher
         if hasattr(matcher, 'custom_field') and matcher.custom_field:
             return f"Matches on unique custom field: {matcher.custom_field}"
-        
+
         # Handle AutoSlugMatcher
         if hasattr(matcher, 'slug_field') and matcher.slug_field:
             return f"Matches on auto-generated slug field: {matcher.slug_field}"
-        
+
         # Handle builtin unique field matchers
         if matcher.name.startswith('unique_') and hasattr(matcher, 'fields') and matcher.fields:
             field_name = matcher.fields[0] if len(matcher.fields) == 1 else ", ".join(matcher.fields)
             if matcher.name.startswith('unique_'):
                 return f"Matches on unique field(s): {field_name}"
-        
+
         # Handle builtin UniqueConstraint matchers
         if hasattr(matcher, 'fields') and matcher.fields and not matcher.name.startswith('logical_'):
             fields_str = ", ".join(matcher.fields)
             if hasattr(matcher, 'condition') and matcher.condition:
                 condition_desc = self.extract_condition_description(matcher.condition)
                 return f"Matches on unique constraint fields: {fields_str} where {condition_desc}"
-            else:
-                return f"Matches on unique constraint fields: {fields_str}"
-        
+            return f"Matches on unique constraint fields: {fields_str}"
+
         # Standard field-based matcher
         if hasattr(matcher, 'fields') and matcher.fields:
             fields_str = ", ".join(matcher.fields)
             if hasattr(matcher, 'condition') and matcher.condition:
                 condition_desc = self.extract_condition_description(matcher.condition)
                 return f"Matches on fields: {fields_str} where {condition_desc}"
-            else:
-                return f"Matches on fields: {fields_str}"
-        
+            return f"Matches on fields: {fields_str}"
+
         return "Custom matcher"
 
-    def get_version_constraints(self, matcher) -> Optional[str]:
+    def get_version_constraints(self, matcher) -> str | None:
         """Get version constraints as a string."""
         constraints = []
         if hasattr(matcher, 'min_version') and matcher.min_version:
             constraints.append(f"≥{matcher.min_version}")
         if hasattr(matcher, 'max_version') and matcher.max_version:
             constraints.append(f"≤{matcher.max_version}")
-        
+
         return " ".join(constraints) if constraints else None
 
-    def analyze_logical_matchers(self) -> Dict[str, List[MatcherInfo]]:
+    def analyze_logical_matchers(self) -> dict[str, list[MatcherInfo]]:
         """Analyze the logical matchers and extract documentation information."""
         documentation = {}
-        
+
         for object_type, matcher_factory in _LOGICAL_MATCHERS.items():
             matchers = matcher_factory()
             matcher_infos = []
-            
+
             for matcher in matchers:
                 info = MatcherInfo(
                     name=matcher.name,
@@ -126,25 +128,25 @@ class Command(BaseCommand):
                     matcher_source="logical"
                 )
                 matcher_infos.append(info)
-            
+
             documentation[object_type] = matcher_infos
-        
+
         return documentation
 
-    def analyze_builtin_matchers(self) -> Dict[str, List[MatcherInfo]]:
+    def analyze_builtin_matchers(self) -> dict[str, list[MatcherInfo]]:
         """Analyze the builtin matchers and extract documentation information."""
         documentation = {}
-        
+
         for object_type, model_info in SUPPORTED_MODELS.items():
             model_class = model_info["model"]
             matchers = get_model_matchers(model_class)
             matcher_infos = []
-            
+
             for matcher in matchers:
                 # Skip logical matchers as they're already handled
                 if matcher.name.startswith('logical_'):
                     continue
-                
+
                 # Extract fields for builtin matchers
                 fields = None
                 if hasattr(matcher, 'fields') and matcher.fields:
@@ -153,7 +155,7 @@ class Command(BaseCommand):
                     fields = [f"custom_fields.{matcher.custom_field}"]
                 elif hasattr(matcher, 'slug_field'):
                     fields = [matcher.slug_field]
-                
+
                 info = MatcherInfo(
                     name=matcher.name,
                     fields=fields,
@@ -164,66 +166,76 @@ class Command(BaseCommand):
                     matcher_source="builtin"
                 )
                 matcher_infos.append(info)
-            
+
             if matcher_infos:  # Only add if there are builtin matchers
                 documentation[object_type] = matcher_infos
-        
+
         return documentation
 
-    def combine_matchers(self, logical_docs: Dict[str, List[MatcherInfo]], builtin_docs: Dict[str, List[MatcherInfo]]) -> Dict[str, List[MatcherInfo]]:
+    def combine_matchers(
+        self,
+        logical_docs: dict[str, list[MatcherInfo]],
+        builtin_docs: dict[str, list[MatcherInfo]],
+    ) -> dict[str, list[MatcherInfo]]:
         """Combine logical and builtin matchers into a single documentation structure."""
         combined = {}
-        
+
         # Get all object types
         all_object_types = set(logical_docs.keys()) | set(builtin_docs.keys())
-        
+
         for object_type in all_object_types:
             matchers = []
-            
+
             # Add logical matchers
             if object_type in logical_docs:
                 matchers.extend(logical_docs[object_type])
-            
+
             # Add builtin matchers
             if object_type in builtin_docs:
                 matchers.extend(builtin_docs[object_type])
-            
+
             if matchers:
                 combined[object_type] = matchers
-        
+
         return combined
 
-    def generate_markdown_table(self, docs: Dict[str, List[MatcherInfo]]) -> str:
+    def generate_markdown_table(self, docs: dict[str, list[MatcherInfo]]) -> str:
         """Generate a markdown table from the documentation."""
         markdown = []
         markdown.append("# NetBox Diode Plugin - Object Matching Criteria")
         markdown.append("")
-        markdown.append("This document describes how the Diode NetBox Plugin matches existing objects when applying changes. The matchers will be applied in the order of their precedence, unttil one of them matches.")
+        markdown.append(
+            "This document describes how the Diode NetBox Plugin matches existing objects when applying changes. "
+            "The matchers will be applied in the order of their precedence, unttil one of them matches."
+        )
         markdown.append("")
         markdown.append("## Matcher Types")
         markdown.append("")
         markdown.append("- **Logical Matchers**: Custom matching criteria that represent likely user intent")
-        markdown.append("- **Builtin Matchers**: Automatically generated from NetBox model constraints (unique fields, unique constraints, custom fields, auto-slugs)")
+        markdown.append(
+            "- **Builtin Matchers**: Automatically generated from NetBox model constraints "
+            "(unique fields, unique constraints, custom fields, auto-slugs)"
+        )
         markdown.append("")
-        
+
         # Sort object types for consistent output
         sorted_object_types = sorted(docs.keys())
-        
+
         for object_type in sorted_object_types:
             matchers = docs[object_type]
-            
+
             markdown.append(f"## {object_type}")
             markdown.append("")
-            
+
             if not matchers:
                 markdown.append("No specific matching criteria defined.")
                 markdown.append("")
                 continue
-            
+
             # Create table header
             markdown.append("| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |")
             markdown.append("|--------------|---------------------|------|--------|-----------|-------------|---------------------|")
-            
+
             for precedence, matcher in enumerate(matchers, start=1):
                 # Escape pipe characters in table cells
                 name = matcher.name.replace("|", "\\|") if matcher.name else "N/A"
@@ -232,24 +244,26 @@ class Command(BaseCommand):
                 condition_str = matcher.condition.replace("|", "\\|") if matcher.condition and matcher.condition != "None" else "N/A"
                 description = matcher.description.replace("|", "\\|") if matcher.description else "N/A"
                 version_str = matcher.version_constraints.replace("|", "\\|") if matcher.version_constraints else "All versions"
-                
-                markdown.append(f"| {name} | {precedence} | {matcher_type} | {fields_str} | {condition_str} | {description} | {version_str} |")
-            
+
+                markdown.append(
+                    f"| {name} | {precedence} | {matcher_type} | {fields_str} | {condition_str} | {description} | {version_str} |"
+                )
+
             markdown.append("")
-        
+
         return "\n".join(markdown)
 
     def handle(self, *args, **options):
         """Handle the command execution."""
         self.stdout.write("Analyzing logical matching criteria...")
         logical_docs = self.analyze_logical_matchers()
-        
+
         self.stdout.write("Analyzing builtin matching criteria...")
         builtin_docs = self.analyze_builtin_matchers()
-        
+
         self.stdout.write("Combining matchers...")
         combined_docs = self.combine_matchers(logical_docs, builtin_docs)
-        
+
         self.stdout.write("Generating markdown documentation...")
-        markdown_content = self.generate_markdown_table(combined_docs)        
-        self.stdout.write(markdown_content) 
+        markdown_content = self.generate_markdown_table(combined_docs)
+        self.stdout.write(markdown_content)

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -5,7 +5,8 @@ from django.core.management.base import BaseCommand
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 
-from netbox_diode_plugin.api.matcher import _LOGICAL_MATCHERS
+from netbox_diode_plugin.api.matcher import _LOGICAL_MATCHERS, get_model_matchers
+from netbox_diode_plugin.api.differ import SUPPORTED_MODELS
 
 
 @dataclass
@@ -17,6 +18,7 @@ class MatcherInfo:
     description: Optional[str] = None
     matcher_type: str = "ObjectMatchCriteria"
     version_constraints: Optional[str] = None
+    matcher_source: str = "logical"  # "logical" or "builtin"
 
 
 class Command(BaseCommand):
@@ -51,8 +53,8 @@ class Command(BaseCommand):
 
     def get_matcher_description(self, matcher) -> str:
         """Generate a human-readable description of what the matcher does."""
-        if hasattr(matcher, 'ip_fields') and hasattr(matcher, 'vrf_field'):
-            # IP Network matcher
+        # Handle IP Network matchers
+        if hasattr(matcher, 'ip_fields') and matcher.ip_fields and hasattr(matcher, 'vrf_field') and matcher.vrf_field:
             ip_fields_str = ", ".join(matcher.ip_fields)
             if matcher.name.startswith('logical_ip_address_global_no_vrf'):
                 return f"Matches IP address {ip_fields_str} in global namespace (no VRF)"
@@ -60,6 +62,29 @@ class Command(BaseCommand):
                 return f"Matches IP address {ip_fields_str} within VRF"
             elif matcher.name.startswith('logical_ip_range'):
                 return f"Matches IP range {ip_fields_str} within VRF context"
+        
+        # Handle CustomFieldMatcher
+        if hasattr(matcher, 'custom_field') and matcher.custom_field:
+            return f"Matches on unique custom field: {matcher.custom_field}"
+        
+        # Handle AutoSlugMatcher
+        if hasattr(matcher, 'slug_field') and matcher.slug_field:
+            return f"Matches on auto-generated slug field: {matcher.slug_field}"
+        
+        # Handle builtin unique field matchers
+        if matcher.name.startswith('unique_') and hasattr(matcher, 'fields') and matcher.fields:
+            field_name = matcher.fields[0] if len(matcher.fields) == 1 else ", ".join(matcher.fields)
+            if matcher.name.startswith('unique_'):
+                return f"Matches on unique field(s): {field_name}"
+        
+        # Handle builtin UniqueConstraint matchers
+        if hasattr(matcher, 'fields') and matcher.fields and not matcher.name.startswith('logical_'):
+            fields_str = ", ".join(matcher.fields)
+            if hasattr(matcher, 'condition') and matcher.condition:
+                condition_desc = self.extract_condition_description(matcher.condition)
+                return f"Matches on unique constraint fields: {fields_str} where {condition_desc}"
+            else:
+                return f"Matches on unique constraint fields: {fields_str}"
         
         # Standard field-based matcher
         if hasattr(matcher, 'fields') and matcher.fields:
@@ -97,7 +122,8 @@ class Command(BaseCommand):
                     condition=self.extract_condition_description(matcher.condition) if hasattr(matcher, 'condition') else None,
                     description=self.get_matcher_description(matcher),
                     matcher_type=matcher.__class__.__name__,
-                    version_constraints=self.get_version_constraints(matcher)
+                    version_constraints=self.get_version_constraints(matcher),
+                    matcher_source="logical"
                 )
                 matcher_infos.append(info)
             
@@ -105,12 +131,79 @@ class Command(BaseCommand):
         
         return documentation
 
+    def analyze_builtin_matchers(self) -> Dict[str, List[MatcherInfo]]:
+        """Analyze the builtin matchers and extract documentation information."""
+        documentation = {}
+        
+        for object_type, model_info in SUPPORTED_MODELS.items():
+            model_class = model_info["model"]
+            matchers = get_model_matchers(model_class)
+            matcher_infos = []
+            
+            for matcher in matchers:
+                # Skip logical matchers as they're already handled
+                if matcher.name.startswith('logical_'):
+                    continue
+                
+                # Extract fields for builtin matchers
+                fields = None
+                if hasattr(matcher, 'fields') and matcher.fields:
+                    fields = list(matcher.fields)
+                elif hasattr(matcher, 'custom_field'):
+                    fields = [f"custom_fields.{matcher.custom_field}"]
+                elif hasattr(matcher, 'slug_field'):
+                    fields = [matcher.slug_field]
+                
+                info = MatcherInfo(
+                    name=matcher.name,
+                    fields=fields,
+                    condition=self.extract_condition_description(matcher.condition) if hasattr(matcher, 'condition') else None,
+                    description=self.get_matcher_description(matcher),
+                    matcher_type=matcher.__class__.__name__,
+                    version_constraints=self.get_version_constraints(matcher),
+                    matcher_source="builtin"
+                )
+                matcher_infos.append(info)
+            
+            if matcher_infos:  # Only add if there are builtin matchers
+                documentation[object_type] = matcher_infos
+        
+        return documentation
+
+    def combine_matchers(self, logical_docs: Dict[str, List[MatcherInfo]], builtin_docs: Dict[str, List[MatcherInfo]]) -> Dict[str, List[MatcherInfo]]:
+        """Combine logical and builtin matchers into a single documentation structure."""
+        combined = {}
+        
+        # Get all object types
+        all_object_types = set(logical_docs.keys()) | set(builtin_docs.keys())
+        
+        for object_type in all_object_types:
+            matchers = []
+            
+            # Add logical matchers
+            if object_type in logical_docs:
+                matchers.extend(logical_docs[object_type])
+            
+            # Add builtin matchers
+            if object_type in builtin_docs:
+                matchers.extend(builtin_docs[object_type])
+            
+            if matchers:
+                combined[object_type] = matchers
+        
+        return combined
+
     def generate_markdown_table(self, docs: Dict[str, List[MatcherInfo]]) -> str:
         """Generate a markdown table from the documentation."""
         markdown = []
         markdown.append("# NetBox Diode Plugin - Object Matching Criteria")
         markdown.append("")
         markdown.append("This document describes how the Diode NetBox Plugin matches existing objects when applying changes.")
+        markdown.append("")
+        markdown.append("## Matcher Types")
+        markdown.append("")
+        markdown.append("- **Logical Matchers**: Custom matching criteria that represent likely user intent")
+        markdown.append("- **Builtin Matchers**: Automatically generated from NetBox model constraints (unique fields, unique constraints, custom fields, auto-slugs)")
         markdown.append("")
         
         # Sort object types for consistent output
@@ -128,18 +221,19 @@ class Command(BaseCommand):
                 continue
             
             # Create table header
-            markdown.append("| Matcher Name | Fields | Condition | Description | Version Constraints |")
-            markdown.append("|--------------|--------|-----------|-------------|-------------------|")
+            markdown.append("| Matcher Name | Type | Fields | Condition | Description | Version Constraints |")
+            markdown.append("|--------------|------|--------|-----------|-------------|-------------------|")
             
             for matcher in matchers:
                 # Escape pipe characters in table cells
                 name = matcher.name.replace("|", "\\|") if matcher.name else "N/A"
+                matcher_type = matcher.matcher_source.replace("|", "\\|")
                 fields_str = ", ".join(matcher.fields).replace("|", "\\|") if matcher.fields else ""
                 condition_str = matcher.condition.replace("|", "\\|") if matcher.condition and matcher.condition != "None" else "N/A"
                 description = matcher.description.replace("|", "\\|") if matcher.description else "N/A"
                 version_str = matcher.version_constraints.replace("|", "\\|") if matcher.version_constraints else "All versions"
                 
-                markdown.append(f"| {name} | {fields_str} | {condition_str} | {description} | {version_str} |")
+                markdown.append(f"| {name} | {matcher_type} | {fields_str} | {condition_str} | {description} | {version_str} |")
             
             markdown.append("")
         
@@ -147,8 +241,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Handle the command execution."""
-        self.stdout.write("Analyzing matching criteria...")
-        docs = self.analyze_logical_matchers()
+        self.stdout.write("Analyzing logical matching criteria...")
+        logical_docs = self.analyze_logical_matchers()
+        
+        self.stdout.write("Analyzing builtin matching criteria...")
+        builtin_docs = self.analyze_builtin_matchers()
+        
+        self.stdout.write("Combining matchers...")
+        combined_docs = self.combine_matchers(logical_docs, builtin_docs)
+        
         self.stdout.write("Generating markdown documentation...")
-        markdown_content = self.generate_markdown_table(docs)        
+        markdown_content = self.generate_markdown_table(combined_docs)        
         self.stdout.write(markdown_content) 

--- a/netbox_diode_plugin/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/test_generate_matching_docs.py
@@ -12,6 +12,7 @@ from django.core.management.base import CommandError
 from django.db.models import Q
 from django.test import TestCase
 
+from netbox_diode_plugin.api.matcher import ObjectMatchCriteria
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
     Command,
     MatcherInfo,
@@ -130,32 +131,41 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
     def test_get_matcher_description_standard_fields(self):
         """Test getting matcher description for standard field-based matcher."""
-        mock_matcher = mock.MagicMock()
-        mock_matcher.fields = ["name", "site"]
-        mock_matcher.condition = None
+        matcher = ObjectMatchCriteria(
+            fields=["name", "site"],
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
         
-        result = self.command.get_matcher_description(mock_matcher)
+        result = self.command.get_matcher_description(matcher)
         self.assertEqual(result, "Matches on fields: name, site")
 
     def test_get_matcher_description_with_condition(self):
         """Test getting matcher description for matcher with condition."""
-        mock_matcher = mock.MagicMock()
-        mock_matcher.fields = ["name", "site"]
-        mock_matcher.condition = Q(site__isnull=False)
+        matcher = ObjectMatchCriteria(
+            fields=["name", "site"],
+            name="test_matcher",
+            model_class=None,
+            condition=Q(site__isnull=False)
+        )
         
         with mock.patch.object(self.command, 'extract_condition_description') as mock_extract:
             mock_extract.return_value = "site is NOT NULL"
-            result = self.command.get_matcher_description(mock_matcher)
+            result = self.command.get_matcher_description(matcher)
         
         self.assertEqual(result, "Matches on fields: name, site where site is NOT NULL")
 
     def test_get_matcher_description_custom(self):
         """Test getting matcher description for custom matcher."""
-        mock_matcher = mock.MagicMock()
-        # No special attributes
-        del mock_matcher.fields
+        matcher = ObjectMatchCriteria(
+            fields=None,
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
         
-        result = self.command.get_matcher_description(mock_matcher)
+        result = self.command.get_matcher_description(matcher)
         self.assertEqual(result, "Custom matcher")
 
     def test_get_version_constraints_none(self):
@@ -217,15 +227,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             ("dcim.site", lambda: [mock_matcher1, mock_matcher2])
         ]
         
-        with mock.patch.object(self.command, 'extract_condition_description') as mock_extract, \
-             mock.patch.object(self.command, 'get_matcher_description') as mock_desc, \
-             mock.patch.object(self.command, 'get_version_constraints') as mock_version:
-            
-            mock_extract.return_value = "site is NOT NULL"
-            mock_desc.return_value = "Test description"
-            mock_version.return_value = "≥4.3.0"
-            
-            result = self.command.analyze_logical_matchers()
+        result = self.command.analyze_logical_matchers()
         
         self.assertIn("dcim.site", result)
         self.assertEqual(len(result["dcim.site"]), 2)
@@ -242,7 +244,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         self.assertEqual(matcher2_info.name, "test_matcher_2")
         self.assertEqual(matcher2_info.fields, ["name", "site"])
         self.assertEqual(matcher2_info.condition, "site is NOT NULL")
-        self.assertEqual(matcher2_info.version_constraints, "≥4.3.0")
+        self.assertEqual(matcher2_info.version_constraints, "≤4.2.99")
 
     def test_generate_markdown_table_empty(self):
         """Test generating markdown table with empty documentation."""
@@ -351,116 +353,49 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         self.assertLess(device_index, site_index)
         self.assertLess(site_index, prefix_index)
 
-    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs._LOGICAL_MATCHERS')
-    def test_handle_success(self, mock_logical_matchers):
-        """Test successful command execution."""
-        # Mock the matcher factory to return empty list
-        mock_logical_matchers.items.return_value = []
-        
-        # Capture stdout
-        with patch('sys.stdout', new=io.StringIO()) as mock_stdout:
-            self.command.handle()
-            
-            output = mock_stdout.getvalue()
-            self.assertIn("Analyzing matching criteria...", output)
-            self.assertIn("Generating markdown documentation...", output)
-            self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", output)
-
-    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs._LOGICAL_MATCHERS')
-    def test_handle_with_output_file(self, mock_logical_matchers):
-        """Test command execution with output file."""
-        import tempfile
-        import os
-        
-        # Mock the matcher factory to return empty list
-        mock_logical_matchers.items.return_value = []
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
-            temp_file_path = temp_file.name
-        
-        try:
-            # Test with --output argument
-            with patch('sys.stdout', new=io.StringIO()):
-                self.command.handle(output=temp_file_path)
-            
-            # Check that file was created and contains expected content
-            with open(temp_file_path, 'r') as f:
-                content = f.read()
-                self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", content)
-        
-        finally:
-            # Clean up
-            if os.path.exists(temp_file_path):
-                os.unlink(temp_file_path)
-
-    def test_call_command_success(self):
-        """Test calling the command via call_command."""
-        with patch('sys.stdout', new=io.StringIO()) as mock_stdout:
-            call_command('generate_matching_docs')
-            
-            output = mock_stdout.getvalue()
-            self.assertIn("Analyzing matching criteria...", output)
-            self.assertIn("Generating markdown documentation...", output)
-            self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", output)
-
-    def test_call_command_with_output(self):
-        """Test calling the command with output file."""
-        import tempfile
-        import os
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
-            temp_file_path = temp_file.name
-        
-        try:
-            call_command('generate_matching_docs', output=temp_file_path)
-            
-            # Check that file was created and contains expected content
-            with open(temp_file_path, 'r') as f:
-                content = f.read()
-                self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", content)
-        
-        finally:
-            # Clean up
-            if os.path.exists(temp_file_path):
-                os.unlink(temp_file_path)
-
-    def test_condition_extraction_edge_cases(self):
+    def test_condition_extraction_with_none_Q_condition(self):
         """Test edge cases in condition extraction."""
         # Test with non-Q condition
         condition = "simple_string_condition"
         result = self.command.extract_condition_description(condition)
         self.assertEqual(result, "simple_string_condition")
         
+    def test_condition_extraction_with_Q_condition_with_no_children(self):
         # Test with Q condition that has no children
         condition = Q()
         result = self.command.extract_condition_description(condition)
-        self.assertEqual(result, "Q()")
+        self.assertEqual(result, "")
         
-        # Test with complex nested condition
+    def test_condition_extraction_with_Q_condition_with_children(self):
+        """Test with complex nested condition."""
         condition = Q(field1__isnull=True) & (Q(field2="value1") | Q(field2="value2"))
         result = self.command.extract_condition_description(condition)
-        # The exact format may vary, but it should contain the field names
-        self.assertIn("field1", result)
-        self.assertIn("field2", result)
+        self.assertEqual(result, "field1 is NULL AND (OR: ('field2', 'value1'), ('field2', 'value2'))")
 
     def test_matcher_description_edge_cases(self):
         """Test edge cases in matcher description generation."""
         # Test with matcher that has fields but no condition
-        mock_matcher = mock.MagicMock()
-        mock_matcher.fields = []
-        mock_matcher.condition = None
+        matcher = ObjectMatchCriteria(
+            fields=["name"],
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
         
-        result = self.command.get_matcher_description(mock_matcher)
-        self.assertEqual(result, "Matches on fields: ")
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Matches on fields: name")
         
         # Test with matcher that has condition but no fields
-        mock_matcher = mock.MagicMock()
-        mock_matcher.fields = None
-        mock_matcher.condition = Q(field1__isnull=True)
+        matcher = ObjectMatchCriteria(
+            fields=None,
+            name="test_matcher",
+            model_class=None,
+            condition=Q(field1__isnull=True)
+        )
         
         with mock.patch.object(self.command, 'extract_condition_description') as mock_extract:
             mock_extract.return_value = "field1 is NULL"
-            result = self.command.get_matcher_description(mock_matcher)
+            result = self.command.get_matcher_description(matcher)
         
         self.assertEqual(result, "Custom matcher")
 
@@ -472,7 +407,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher.max_version = ""
         
         result = self.command.get_version_constraints(mock_matcher)
-        self.assertEqual(result, "≥ ≤")
+        self.assertEqual(result, None)
         
         # Test with whitespace versions
         mock_matcher = mock.MagicMock()
@@ -482,7 +417,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         result = self.command.get_version_constraints(mock_matcher)
         self.assertEqual(result, "≥  4.3.0   ≤  4.3.99  ")
 
-    def test_markdown_table_edge_cases(self):
+    def test_markdown_table_with_empty_values(self):
         """Test edge cases in markdown table generation."""
         # Test with None values
         matcher_info = MatcherInfo(
@@ -500,9 +435,10 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         result = self.command.generate_markdown_table(docs)
         
         # Check that None values are handled gracefully
-        self.assertIn("| test_matcher | N/A | N/A | Custom matcher | All versions |", result)
+        self.assertIn("| test_matcher |  | N/A | N/A | All versions |", result)
         
-        # Test with empty fields list
+    def test_markdown_table_with_empty_fields(self):
+        """Test with empty fields list."""
         matcher_info = MatcherInfo(
             name="test_matcher",
             fields=[],

--- a/netbox_diode_plugin/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/test_generate_matching_docs.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python
+# Copyright 2025 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests for generate_matching_docs command."""
+
+import io
+import sys
+from unittest import mock
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db.models import Q
+from django.test import TestCase
+
+from netbox_diode_plugin.management.commands.generate_matching_docs import (
+    Command,
+    MatcherInfo,
+)
+
+
+class MatcherInfoTestCase(TestCase):
+    """Test case for MatcherInfo dataclass."""
+
+    def test_matcher_info_creation(self):
+        """Test creating MatcherInfo with all fields."""
+        info = MatcherInfo(
+            name="test_matcher",
+            fields=["field1", "field2"],
+            condition="field1 is NOT NULL",
+            description="Test matcher description",
+            matcher_type="ObjectMatchCriteria",
+            version_constraints="≥4.3.0"
+        )
+        
+        self.assertEqual(info.name, "test_matcher")
+        self.assertEqual(info.fields, ["field1", "field2"])
+        self.assertEqual(info.condition, "field1 is NOT NULL")
+        self.assertEqual(info.description, "Test matcher description")
+        self.assertEqual(info.matcher_type, "ObjectMatchCriteria")
+        self.assertEqual(info.version_constraints, "≥4.3.0")
+
+    def test_matcher_info_defaults(self):
+        """Test creating MatcherInfo with default values."""
+        info = MatcherInfo(name="test_matcher")
+        
+        self.assertEqual(info.name, "test_matcher")
+        self.assertIsNone(info.fields)
+        self.assertIsNone(info.condition)
+        self.assertIsNone(info.description)
+        self.assertEqual(info.matcher_type, "ObjectMatchCriteria")
+        self.assertIsNone(info.version_constraints)
+
+
+class GenerateMatchingDocsCommandTestCase(TestCase):
+    """Test case for the generate_matching_docs command."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.command = Command()
+        self.command.stdout = io.StringIO()
+        self.command.stderr = io.StringIO()
+
+    def test_add_arguments(self):
+        """Test that the command accepts the --output argument."""
+        from django.core.management.base import BaseCommand
+        from django.core.management import get_commands
+        
+        # Verify the command is registered
+        commands = get_commands()
+        self.assertIn('generate_matching_docs', commands)
+
+    def test_extract_condition_description_none(self):
+        """Test extracting condition description from None."""
+        result = self.command.extract_condition_description(None)
+        self.assertEqual(result, "None")
+
+    def test_extract_condition_description_simple(self):
+        """Test extracting condition description from a simple condition."""
+        condition = Q(field1__isnull=True)
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NULL")
+
+    def test_extract_condition_description_complex(self):
+        """Test extracting condition description from a complex condition."""
+        condition = Q(field1__isnull=True) & Q(field2="value")
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NULL AND field2 = value")
+
+    def test_extract_condition_description_or(self):
+        """Test extracting condition description with OR connector."""
+        condition = Q(field1="value1") | Q(field2="value2")
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 = value1 OR field2 = value2")
+
+    def test_extract_condition_description_not_null(self):
+        """Test extracting condition description for NOT NULL."""
+        condition = Q(field1__isnull=False)
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NOT NULL")
+
+    def test_get_matcher_description_ip_address_global(self):
+        """Test getting matcher description for IP address global matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_address_global_no_vrf"
+        mock_matcher.ip_fields = ["address"]
+        mock_matcher.vrf_field = "vrf"
+        
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP address address in global namespace (no VRF)")
+
+    def test_get_matcher_description_ip_address_vrf(self):
+        """Test getting matcher description for IP address VRF matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_address_within_vrf"
+        mock_matcher.ip_fields = ["address"]
+        mock_matcher.vrf_field = "vrf"
+        
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP address address within VRF")
+
+    def test_get_matcher_description_ip_range(self):
+        """Test getting matcher description for IP range matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_range_start_end_within_vrf"
+        mock_matcher.ip_fields = ["start_address", "end_address"]
+        mock_matcher.vrf_field = "vrf"
+        
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP range start_address, end_address within VRF context")
+
+    def test_get_matcher_description_standard_fields(self):
+        """Test getting matcher description for standard field-based matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.fields = ["name", "site"]
+        mock_matcher.condition = None
+        
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches on fields: name, site")
+
+    def test_get_matcher_description_with_condition(self):
+        """Test getting matcher description for matcher with condition."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.fields = ["name", "site"]
+        mock_matcher.condition = Q(site__isnull=False)
+        
+        with mock.patch.object(self.command, 'extract_condition_description') as mock_extract:
+            mock_extract.return_value = "site is NOT NULL"
+            result = self.command.get_matcher_description(mock_matcher)
+        
+        self.assertEqual(result, "Matches on fields: name, site where site is NOT NULL")
+
+    def test_get_matcher_description_custom(self):
+        """Test getting matcher description for custom matcher."""
+        mock_matcher = mock.MagicMock()
+        # No special attributes
+        del mock_matcher.fields
+        
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Custom matcher")
+
+    def test_get_version_constraints_none(self):
+        """Test getting version constraints when none are set."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = None
+        mock_matcher.max_version = None
+        
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertIsNone(result)
+
+    def test_get_version_constraints_min_only(self):
+        """Test getting version constraints with only min_version."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "4.3.0"
+        mock_matcher.max_version = None
+        
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥4.3.0")
+
+    def test_get_version_constraints_max_only(self):
+        """Test getting version constraints with only max_version."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = None
+        mock_matcher.max_version = "4.2.99"
+        
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≤4.2.99")
+
+    def test_get_version_constraints_both(self):
+        """Test getting version constraints with both min and max."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "4.3.0"
+        mock_matcher.max_version = "4.3.99"
+        
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥4.3.0 ≤4.3.99")
+
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs._LOGICAL_MATCHERS')
+    def test_analyze_logical_matchers(self, mock_logical_matchers):
+        """Test analyzing logical matchers."""
+        # Create mock matchers
+        mock_matcher1 = mock.MagicMock()
+        mock_matcher1.name = "test_matcher_1"
+        mock_matcher1.fields = ["name"]
+        mock_matcher1.condition = None
+        mock_matcher1.min_version = "4.3.0"
+        mock_matcher1.max_version = None
+        
+        mock_matcher2 = mock.MagicMock()
+        mock_matcher2.name = "test_matcher_2"
+        mock_matcher2.fields = ["name", "site"]
+        mock_matcher2.condition = Q(site__isnull=False)
+        mock_matcher2.min_version = None
+        mock_matcher2.max_version = "4.2.99"
+        
+        # Mock the matcher factory
+        mock_logical_matchers.items.return_value = [
+            ("dcim.site", lambda: [mock_matcher1, mock_matcher2])
+        ]
+        
+        with mock.patch.object(self.command, 'extract_condition_description') as mock_extract, \
+             mock.patch.object(self.command, 'get_matcher_description') as mock_desc, \
+             mock.patch.object(self.command, 'get_version_constraints') as mock_version:
+            
+            mock_extract.return_value = "site is NOT NULL"
+            mock_desc.return_value = "Test description"
+            mock_version.return_value = "≥4.3.0"
+            
+            result = self.command.analyze_logical_matchers()
+        
+        self.assertIn("dcim.site", result)
+        self.assertEqual(len(result["dcim.site"]), 2)
+        
+        # Check first matcher
+        matcher1_info = result["dcim.site"][0]
+        self.assertEqual(matcher1_info.name, "test_matcher_1")
+        self.assertEqual(matcher1_info.fields, ["name"])
+        self.assertEqual(matcher1_info.condition, "None")
+        self.assertEqual(matcher1_info.version_constraints, "≥4.3.0")
+        
+        # Check second matcher
+        matcher2_info = result["dcim.site"][1]
+        self.assertEqual(matcher2_info.name, "test_matcher_2")
+        self.assertEqual(matcher2_info.fields, ["name", "site"])
+        self.assertEqual(matcher2_info.condition, "site is NOT NULL")
+        self.assertEqual(matcher2_info.version_constraints, "≥4.3.0")
+
+    def test_generate_markdown_table_empty(self):
+        """Test generating markdown table with empty documentation."""
+        docs = {}
+        result = self.command.generate_markdown_table(docs)
+        
+        expected_lines = [
+            "# NetBox Diode Plugin - Object Matching Criteria",
+            "",
+            "This document describes how the Diode NetBox Plugin matches existing objects when applying changes.",
+            ""
+        ]
+        
+        for line in expected_lines:
+            self.assertIn(line, result)
+
+    def test_generate_markdown_table_with_matchers(self):
+        """Test generating markdown table with matchers."""
+        matcher_info1 = MatcherInfo(
+            name="test_matcher_1",
+            fields=["name"],
+            condition="N/A",
+            description="Test description 1",
+            version_constraints="All versions"
+        )
+        
+        matcher_info2 = MatcherInfo(
+            name="test_matcher_2",
+            fields=["name", "site"],
+            condition="site is NOT NULL",
+            description="Test description 2",
+            version_constraints="≥4.3.0"
+        )
+        
+        docs = {
+            "dcim.site": [matcher_info1, matcher_info2]
+        }
+        
+        result = self.command.generate_markdown_table(docs)
+        
+        # Check header
+        self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", result)
+        self.assertIn("## dcim.site", result)
+        
+        # Check table header
+        self.assertIn("| Matcher Name | Fields | Condition | Description | Version Constraints |", result)
+        self.assertIn("|--------------|--------|-----------|-------------|-------------------|", result)
+        
+        # Check table rows
+        self.assertIn("| test_matcher_1 | name | N/A | Test description 1 | All versions |", result)
+        self.assertIn("| test_matcher_2 | name, site | site is NOT NULL | Test description 2 | ≥4.3.0 |", result)
+
+    def test_generate_markdown_table_with_pipe_escaping(self):
+        """Test generating markdown table with pipe character escaping."""
+        matcher_info = MatcherInfo(
+            name="test|matcher",
+            fields=["field|1", "field|2"],
+            condition="field|1 is NOT NULL",
+            description="Test|description",
+            version_constraints="≥4.3.0|test"
+        )
+        
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+        
+        result = self.command.generate_markdown_table(docs)
+        
+        # Check that pipe characters are escaped
+        self.assertIn("| test\\|matcher | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |", result)
+
+    def test_generate_markdown_table_no_matchers(self):
+        """Test generating markdown table for object type with no matchers."""
+        docs = {
+            "dcim.site": []
+        }
+        
+        result = self.command.generate_markdown_table(docs)
+        
+        self.assertIn("## dcim.site", result)
+        self.assertIn("No specific matching criteria defined.", result)
+
+    def test_generate_markdown_table_sorted_object_types(self):
+        """Test that object types are sorted in the output."""
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=["name"],
+            condition="N/A",
+            description="Test description",
+            version_constraints="All versions"
+        )
+        
+        docs = {
+            "dcim.device": [matcher_info],
+            "dcim.site": [matcher_info],
+            "ipam.prefix": [matcher_info]
+        }
+        
+        result = self.command.generate_markdown_table(docs)
+        
+        # Check that sections appear in alphabetical order
+        site_index = result.find("## dcim.site")
+        device_index = result.find("## dcim.device")
+        prefix_index = result.find("## ipam.prefix")
+        
+        self.assertLess(device_index, site_index)
+        self.assertLess(site_index, prefix_index)
+
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs._LOGICAL_MATCHERS')
+    def test_handle_success(self, mock_logical_matchers):
+        """Test successful command execution."""
+        # Mock the matcher factory to return empty list
+        mock_logical_matchers.items.return_value = []
+        
+        # Capture stdout
+        with patch('sys.stdout', new=io.StringIO()) as mock_stdout:
+            self.command.handle()
+            
+            output = mock_stdout.getvalue()
+            self.assertIn("Analyzing matching criteria...", output)
+            self.assertIn("Generating markdown documentation...", output)
+            self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", output)
+
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs._LOGICAL_MATCHERS')
+    def test_handle_with_output_file(self, mock_logical_matchers):
+        """Test command execution with output file."""
+        import tempfile
+        import os
+        
+        # Mock the matcher factory to return empty list
+        mock_logical_matchers.items.return_value = []
+        
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            temp_file_path = temp_file.name
+        
+        try:
+            # Test with --output argument
+            with patch('sys.stdout', new=io.StringIO()):
+                self.command.handle(output=temp_file_path)
+            
+            # Check that file was created and contains expected content
+            with open(temp_file_path, 'r') as f:
+                content = f.read()
+                self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", content)
+        
+        finally:
+            # Clean up
+            if os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
+
+    def test_call_command_success(self):
+        """Test calling the command via call_command."""
+        with patch('sys.stdout', new=io.StringIO()) as mock_stdout:
+            call_command('generate_matching_docs')
+            
+            output = mock_stdout.getvalue()
+            self.assertIn("Analyzing matching criteria...", output)
+            self.assertIn("Generating markdown documentation...", output)
+            self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", output)
+
+    def test_call_command_with_output(self):
+        """Test calling the command with output file."""
+        import tempfile
+        import os
+        
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            temp_file_path = temp_file.name
+        
+        try:
+            call_command('generate_matching_docs', output=temp_file_path)
+            
+            # Check that file was created and contains expected content
+            with open(temp_file_path, 'r') as f:
+                content = f.read()
+                self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", content)
+        
+        finally:
+            # Clean up
+            if os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
+
+    def test_condition_extraction_edge_cases(self):
+        """Test edge cases in condition extraction."""
+        # Test with non-Q condition
+        condition = "simple_string_condition"
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "simple_string_condition")
+        
+        # Test with Q condition that has no children
+        condition = Q()
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "Q()")
+        
+        # Test with complex nested condition
+        condition = Q(field1__isnull=True) & (Q(field2="value1") | Q(field2="value2"))
+        result = self.command.extract_condition_description(condition)
+        # The exact format may vary, but it should contain the field names
+        self.assertIn("field1", result)
+        self.assertIn("field2", result)
+
+    def test_matcher_description_edge_cases(self):
+        """Test edge cases in matcher description generation."""
+        # Test with matcher that has fields but no condition
+        mock_matcher = mock.MagicMock()
+        mock_matcher.fields = []
+        mock_matcher.condition = None
+        
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches on fields: ")
+        
+        # Test with matcher that has condition but no fields
+        mock_matcher = mock.MagicMock()
+        mock_matcher.fields = None
+        mock_matcher.condition = Q(field1__isnull=True)
+        
+        with mock.patch.object(self.command, 'extract_condition_description') as mock_extract:
+            mock_extract.return_value = "field1 is NULL"
+            result = self.command.get_matcher_description(mock_matcher)
+        
+        self.assertEqual(result, "Custom matcher")
+
+    def test_version_constraints_edge_cases(self):
+        """Test edge cases in version constraints."""
+        # Test with empty string versions
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = ""
+        mock_matcher.max_version = ""
+        
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥ ≤")
+        
+        # Test with whitespace versions
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "  4.3.0  "
+        mock_matcher.max_version = "  4.3.99  "
+        
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥  4.3.0   ≤  4.3.99  ")
+
+    def test_markdown_table_edge_cases(self):
+        """Test edge cases in markdown table generation."""
+        # Test with None values
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=None,
+            condition=None,
+            description=None,
+            version_constraints=None
+        )
+        
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+        
+        result = self.command.generate_markdown_table(docs)
+        
+        # Check that None values are handled gracefully
+        self.assertIn("| test_matcher | N/A | N/A | Custom matcher | All versions |", result)
+        
+        # Test with empty fields list
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=[],
+            condition="N/A",
+            description="Test description",
+            version_constraints="All versions"
+        )
+        
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+        
+        result = self.command.generate_markdown_table(docs)
+        
+        # Check that empty fields list is handled
+        self.assertIn("| test_matcher |  | N/A | Test description | All versions |", result) 

--- a/netbox_diode_plugin/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/test_generate_matching_docs.py
@@ -32,7 +32,7 @@ class MatcherInfoTestCase(TestCase):
             matcher_type="ObjectMatchCriteria",
             version_constraints="≥4.3.0"
         )
-        
+
         self.assertEqual(info.name, "test_matcher")
         self.assertEqual(info.fields, ["field1", "field2"])
         self.assertEqual(info.condition, "field1 is NOT NULL")
@@ -43,7 +43,7 @@ class MatcherInfoTestCase(TestCase):
     def test_matcher_info_defaults(self):
         """Test creating MatcherInfo with default values."""
         info = MatcherInfo(name="test_matcher")
-        
+
         self.assertEqual(info.name, "test_matcher")
         self.assertIsNone(info.fields)
         self.assertIsNone(info.condition)
@@ -63,9 +63,9 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
     def test_add_arguments(self):
         """Test that the command accepts the --output argument."""
-        from django.core.management.base import BaseCommand
         from django.core.management import get_commands
-        
+        from django.core.management.base import BaseCommand
+
         # Verify the command is registered
         commands = get_commands()
         self.assertIn('generate_matching_docs', commands)
@@ -105,7 +105,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher.name = "logical_ip_address_global_no_vrf"
         mock_matcher.ip_fields = ["address"]
         mock_matcher.vrf_field = "vrf"
-        
+
         result = self.command.get_matcher_description(mock_matcher)
         self.assertEqual(result, "Matches IP address address in global namespace (no VRF)")
 
@@ -115,7 +115,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher.name = "logical_ip_address_within_vrf"
         mock_matcher.ip_fields = ["address"]
         mock_matcher.vrf_field = "vrf"
-        
+
         result = self.command.get_matcher_description(mock_matcher)
         self.assertEqual(result, "Matches IP address address within VRF")
 
@@ -125,7 +125,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher.name = "logical_ip_range_start_end_within_vrf"
         mock_matcher.ip_fields = ["start_address", "end_address"]
         mock_matcher.vrf_field = "vrf"
-        
+
         result = self.command.get_matcher_description(mock_matcher)
         self.assertEqual(result, "Matches IP range start_address, end_address within VRF context")
 
@@ -137,7 +137,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             model_class=None,
             condition=None
         )
-        
+
         result = self.command.get_matcher_description(matcher)
         self.assertEqual(result, "Matches on unique constraint fields: name, site")
 
@@ -149,7 +149,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             model_class=None,
             condition=Q(site__isnull=False)
         )
-        
+
         result = self.command.get_matcher_description(matcher)
         self.assertEqual(result, "Matches on unique constraint fields: name, site where site is NOT NULL")
 
@@ -161,7 +161,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             model_class=None,
             condition=None
         )
-        
+
         result = self.command.get_matcher_description(matcher)
         self.assertEqual(result, "Custom matcher")
 
@@ -170,7 +170,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher = mock.MagicMock()
         mock_matcher.min_version = None
         mock_matcher.max_version = None
-        
+
         result = self.command.get_version_constraints(mock_matcher)
         self.assertIsNone(result)
 
@@ -179,7 +179,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher = mock.MagicMock()
         mock_matcher.min_version = "4.3.0"
         mock_matcher.max_version = None
-        
+
         result = self.command.get_version_constraints(mock_matcher)
         self.assertEqual(result, "≥4.3.0")
 
@@ -188,7 +188,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher = mock.MagicMock()
         mock_matcher.min_version = None
         mock_matcher.max_version = "4.2.99"
-        
+
         result = self.command.get_version_constraints(mock_matcher)
         self.assertEqual(result, "≤4.2.99")
 
@@ -197,7 +197,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher = mock.MagicMock()
         mock_matcher.min_version = "4.3.0"
         mock_matcher.max_version = "4.3.99"
-        
+
         result = self.command.get_version_constraints(mock_matcher)
         self.assertEqual(result, "≥4.3.0 ≤4.3.99")
 
@@ -211,24 +211,24 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher1.condition = None
         mock_matcher1.min_version = "4.3.0"
         mock_matcher1.max_version = None
-        
+
         mock_matcher2 = mock.MagicMock()
         mock_matcher2.name = "test_matcher_2"
         mock_matcher2.fields = ["name", "site"]
         mock_matcher2.condition = Q(site__isnull=False)
         mock_matcher2.min_version = None
         mock_matcher2.max_version = "4.2.99"
-        
+
         # Mock the matcher factory
         mock_logical_matchers.items.return_value = [
             ("dcim.site", lambda: [mock_matcher1, mock_matcher2])
         ]
-        
+
         result = self.command.analyze_logical_matchers()
-        
+
         self.assertIn("dcim.site", result)
         self.assertEqual(len(result["dcim.site"]), 2)
-        
+
         # Check first matcher
         matcher1_info = result["dcim.site"][0]
         self.assertEqual(matcher1_info.name, "test_matcher_1")
@@ -236,7 +236,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         self.assertEqual(matcher1_info.condition, "None")
         self.assertEqual(matcher1_info.version_constraints, "≥4.3.0")
         self.assertEqual(matcher1_info.matcher_source, "logical")
-        
+
         # Check second matcher
         matcher2_info = result["dcim.site"][1]
         self.assertEqual(matcher2_info.name, "test_matcher_2")
@@ -252,7 +252,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         # Create mock model class
         mock_model_class = mock.MagicMock()
         mock_model_class.__name__ = "TestModel"
-        
+
         # Create mock builtin matchers
         mock_unique_matcher = mock.MagicMock()
         mock_unique_matcher.name = "unique_name"
@@ -260,14 +260,14 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_unique_matcher.condition = None
         mock_unique_matcher.min_version = None
         mock_unique_matcher.max_version = None
-        
+
         mock_constraint_matcher = mock.MagicMock()
         mock_constraint_matcher.name = "test_constraint"
         mock_constraint_matcher.fields = ["field1", "field2"]
         mock_constraint_matcher.condition = Q(field1__isnull=True)
         mock_constraint_matcher.min_version = None
         mock_constraint_matcher.max_version = None
-        
+
         # Mock logical matcher (should be skipped)
         mock_logical_matcher = mock.MagicMock()
         mock_logical_matcher.name = "logical_test"
@@ -275,7 +275,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_logical_matcher.condition = None
         mock_logical_matcher.min_version = None
         mock_logical_matcher.max_version = None
-        
+
         # Mock the supported models and get_model_matchers
         mock_supported_models.items.return_value = [
             ("dcim.site", {"model": mock_model_class})
@@ -285,18 +285,18 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             mock_constraint_matcher,
             mock_logical_matcher  # This should be skipped
         ]
-        
+
         result = self.command.analyze_builtin_matchers()
-        
+
         self.assertIn("dcim.site", result)
         self.assertEqual(len(result["dcim.site"]), 2)  # Should only include builtin matchers
-        
+
         # Check unique field matcher
         unique_matcher_info = result["dcim.site"][0]
         self.assertEqual(unique_matcher_info.name, "unique_name")
         self.assertEqual(unique_matcher_info.fields, ["name"])
         self.assertEqual(unique_matcher_info.matcher_source, "builtin")
-        
+
         # Check constraint matcher
         constraint_matcher_info = result["dcim.site"][1]
         self.assertEqual(constraint_matcher_info.name, "test_constraint")
@@ -314,7 +314,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             version_constraints="All versions",
             matcher_source="logical"
         )
-        
+
         # Create builtin matchers
         builtin_matcher = MatcherInfo(
             name="builtin_test",
@@ -324,38 +324,38 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             version_constraints="All versions",
             matcher_source="builtin"
         )
-        
+
         logical_docs = {
             "dcim.site": [logical_matcher],
             "dcim.device": [logical_matcher]
         }
-        
+
         builtin_docs = {
             "dcim.site": [builtin_matcher],
             "ipam.prefix": [builtin_matcher]
         }
-        
+
         result = self.command.combine_matchers(logical_docs, builtin_docs)
-        
+
         # Check that all object types are included
         self.assertIn("dcim.site", result)
         self.assertIn("dcim.device", result)
         self.assertIn("ipam.prefix", result)
-        
+
         # Check that dcim.site has both logical and builtin matchers
         site_matchers = result["dcim.site"]
         self.assertEqual(len(site_matchers), 2)
-        
+
         # Check that logical matcher comes first (as it was added first)
         self.assertEqual(site_matchers[0].name, "logical_test")
         self.assertEqual(site_matchers[0].matcher_source, "logical")
         self.assertEqual(site_matchers[1].name, "builtin_test")
         self.assertEqual(site_matchers[1].matcher_source, "builtin")
-        
+
         # Check that other object types have correct matchers
         self.assertEqual(len(result["dcim.device"]), 1)
         self.assertEqual(result["dcim.device"][0].matcher_source, "logical")
-        
+
         self.assertEqual(len(result["ipam.prefix"]), 1)
         self.assertEqual(result["ipam.prefix"][0].matcher_source, "builtin")
 
@@ -367,10 +367,10 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_custom_field_matcher.fields = None
         mock_custom_field_matcher.ip_fields = None
         mock_custom_field_matcher.vrf_field = None
-                
+
         result = self.command.get_matcher_description(mock_custom_field_matcher)
         self.assertEqual(result, "Matches on unique custom field: test_field")
-        
+
     def test_get_matcher_description_autoslug(self):
         """Test getting matcher description for AutoSlugMatcher."""
         # Test AutoSlugMatcher
@@ -379,10 +379,10 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             model_class=None,
             slug_field="slug"
         )
-        
+
         result = self.command.get_matcher_description(autoslug_matcher)
         self.assertEqual(result, "Matches on auto-generated slug field: slug")
-        
+
     def test_get_matcher_description_unique_field(self):
         """Test getting matcher description for unique field matcher."""
         # Test unique field matcher
@@ -393,10 +393,10 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_unique_matcher.vrf_field = None
         mock_unique_matcher.custom_field = None
         mock_unique_matcher.slug_field = None
-        
+
         result = self.command.get_matcher_description(mock_unique_matcher)
         self.assertEqual(result, "Matches on unique field(s): name")
-        
+
     def test_get_matcher_description_unique_constraint(self):
         """Test getting matcher description for unique constraint matcher."""
         # Test unique constraint matcher
@@ -406,7 +406,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_constraint_matcher.condition = None
         mock_constraint_matcher.custom_field = None
         mock_constraint_matcher.slug_field = None
-        
+
         result = self.command.get_matcher_description(mock_constraint_matcher)
         self.assertEqual(result, "Matches on unique constraint fields: field1, field2")
 
@@ -414,14 +414,14 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         """Test generating markdown table with empty documentation."""
         docs = {}
         result = self.command.generate_markdown_table(docs)
-        
+
         expected_lines = [
             "# NetBox Diode Plugin - Object Matching Criteria",
             "",
             "This document describes how the Diode NetBox Plugin matches existing objects when applying changes.",
             ""
         ]
-        
+
         for line in expected_lines:
             self.assertIn(line, result)
 
@@ -435,7 +435,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             version_constraints="All versions",
             matcher_source="logical"
         )
-        
+
         matcher_info2 = MatcherInfo(
             name="test_matcher_2",
             fields=["name", "site"],
@@ -444,21 +444,21 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             version_constraints="≥4.3.0",
             matcher_source="logical"
         )
-        
+
         docs = {
             "dcim.site": [matcher_info1, matcher_info2]
         }
-        
+
         result = self.command.generate_markdown_table(docs)
-        
+
         # Check header
         self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", result)
         self.assertIn("## dcim.site", result)
-        
+
         # Check table header
         self.assertIn("| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |", result)
         self.assertIn("|--------------|---------------------|------|--------|-----------|-------------|---------------------|", result)
-        
+
         # Check table rows
         self.assertIn("| test_matcher_1 | 1 | logical | name | N/A | Test description 1 | All versions |", result)
         self.assertIn("| test_matcher_2 | 2 | logical | name, site | site is NOT NULL | Test description 2 | ≥4.3.0 |", result)
@@ -473,24 +473,27 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             version_constraints="≥4.3.0|test",
             matcher_source="logical"
         )
-        
+
         docs = {
             "dcim.site": [matcher_info]
         }
-        
+
         result = self.command.generate_markdown_table(docs)
-        
+
         # Check that pipe characters are escaped
-        self.assertIn("| test\\|matcher | 1 | logical | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |", result)
+        self.assertIn(
+            "| test\\|matcher | 1 | logical | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |",
+            result,
+        )
 
     def test_generate_markdown_table_no_matchers(self):
         """Test generating markdown table for object type with no matchers."""
         docs = {
             "dcim.site": []
         }
-        
+
         result = self.command.generate_markdown_table(docs)
-        
+
         self.assertIn("## dcim.site", result)
         self.assertIn("No specific matching criteria defined.", result)
 
@@ -503,20 +506,20 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             description="Test description",
             version_constraints="All versions"
         )
-        
+
         docs = {
             "dcim.device": [matcher_info],
             "dcim.site": [matcher_info],
             "ipam.prefix": [matcher_info]
         }
-        
+
         result = self.command.generate_markdown_table(docs)
-        
+
         # Check that sections appear in alphabetical order
         site_index = result.find("## dcim.site")
         device_index = result.find("## dcim.device")
         prefix_index = result.find("## ipam.prefix")
-        
+
         self.assertLess(device_index, site_index)
         self.assertLess(site_index, prefix_index)
 
@@ -526,13 +529,13 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         condition = "simple_string_condition"
         result = self.command.extract_condition_description(condition)
         self.assertEqual(result, "simple_string_condition")
-        
+
     def test_condition_extraction_with_Q_condition_with_no_children(self):
-        # Test with Q condition that has no children
+        """Test with Q condition that has no children."""
         condition = Q()
         result = self.command.extract_condition_description(condition)
         self.assertEqual(result, "")
-        
+
     def test_condition_extraction_with_Q_condition_with_children(self):
         """Test with complex nested condition."""
         condition = Q(field1__isnull=True) & (Q(field2="value1") | Q(field2="value2"))
@@ -548,10 +551,10 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             model_class=None,
             condition=None
         )
-        
+
         result = self.command.get_matcher_description(matcher)
         self.assertEqual(result, "Matches on unique constraint fields: name")
-        
+
         # Test with matcher that has condition but no fields
         matcher = ObjectMatchCriteria(
             fields=None,
@@ -559,11 +562,11 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             model_class=None,
             condition=Q(field1__isnull=True)
         )
-        
+
         with mock.patch.object(self.command, 'extract_condition_description') as mock_extract:
             mock_extract.return_value = "field1 is NULL"
             result = self.command.get_matcher_description(matcher)
-        
+
         self.assertEqual(result, "Custom matcher")
 
     def test_version_constraints_edge_cases(self):
@@ -572,15 +575,15 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         mock_matcher = mock.MagicMock()
         mock_matcher.min_version = ""
         mock_matcher.max_version = ""
-        
+
         result = self.command.get_version_constraints(mock_matcher)
         self.assertEqual(result, None)
-        
+
         # Test with whitespace versions
         mock_matcher = mock.MagicMock()
         mock_matcher.min_version = "  4.3.0  "
         mock_matcher.max_version = "  4.3.99  "
-        
+
         result = self.command.get_version_constraints(mock_matcher)
         self.assertEqual(result, "≥  4.3.0   ≤  4.3.99  ")
 
@@ -595,16 +598,16 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             version_constraints=None,
             matcher_source="logical"
         )
-        
+
         docs = {
             "dcim.site": [matcher_info]
         }
-        
+
         result = self.command.generate_markdown_table(docs)
-        
+
         # Check that None values are handled gracefully
         self.assertIn("| test_matcher | 1 | logical |  | N/A | N/A | All versions |", result)
-        
+
     def test_markdown_table_with_empty_fields(self):
         """Test with empty fields list."""
         matcher_info = MatcherInfo(
@@ -615,12 +618,12 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             version_constraints="All versions",
             matcher_source="logical"
         )
-        
+
         docs = {
             "dcim.site": [matcher_info]
         }
-        
+
         result = self.command.generate_markdown_table(docs)
-        
+
         # Check that empty fields list is handled
-        self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result) 
+        self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result)

--- a/netbox_diode_plugin/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/test_generate_matching_docs.py
@@ -12,7 +12,7 @@ from django.core.management.base import CommandError
 from django.db.models import Q
 from django.test import TestCase
 
-from netbox_diode_plugin.api.matcher import ObjectMatchCriteria
+from netbox_diode_plugin.api.matcher import AutoSlugMatcher, ObjectMatchCriteria
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
     Command,
     MatcherInfo,
@@ -139,7 +139,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         )
         
         result = self.command.get_matcher_description(matcher)
-        self.assertEqual(result, "Matches on fields: name, site")
+        self.assertEqual(result, "Matches on unique constraint fields: name, site")
 
     def test_get_matcher_description_with_condition(self):
         """Test getting matcher description for matcher with condition."""
@@ -150,11 +150,8 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             condition=Q(site__isnull=False)
         )
         
-        with mock.patch.object(self.command, 'extract_condition_description') as mock_extract:
-            mock_extract.return_value = "site is NOT NULL"
-            result = self.command.get_matcher_description(matcher)
-        
-        self.assertEqual(result, "Matches on fields: name, site where site is NOT NULL")
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: name, site where site is NOT NULL")
 
     def test_get_matcher_description_custom(self):
         """Test getting matcher description for custom matcher."""
@@ -238,6 +235,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         self.assertEqual(matcher1_info.fields, ["name"])
         self.assertEqual(matcher1_info.condition, "None")
         self.assertEqual(matcher1_info.version_constraints, "≥4.3.0")
+        self.assertEqual(matcher1_info.matcher_source, "logical")
         
         # Check second matcher
         matcher2_info = result["dcim.site"][1]
@@ -245,6 +243,172 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         self.assertEqual(matcher2_info.fields, ["name", "site"])
         self.assertEqual(matcher2_info.condition, "site is NOT NULL")
         self.assertEqual(matcher2_info.version_constraints, "≤4.2.99")
+        self.assertEqual(matcher2_info.matcher_source, "logical")
+
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs.SUPPORTED_MODELS')
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs.get_model_matchers')
+    def test_analyze_builtin_matchers(self, mock_get_model_matchers, mock_supported_models):
+        """Test analyzing builtin matchers."""
+        # Create mock model class
+        mock_model_class = mock.MagicMock()
+        mock_model_class.__name__ = "TestModel"
+        
+        # Create mock builtin matchers
+        mock_unique_matcher = mock.MagicMock()
+        mock_unique_matcher.name = "unique_name"
+        mock_unique_matcher.fields = ["name"]
+        mock_unique_matcher.condition = None
+        mock_unique_matcher.min_version = None
+        mock_unique_matcher.max_version = None
+        
+        mock_constraint_matcher = mock.MagicMock()
+        mock_constraint_matcher.name = "test_constraint"
+        mock_constraint_matcher.fields = ["field1", "field2"]
+        mock_constraint_matcher.condition = Q(field1__isnull=True)
+        mock_constraint_matcher.min_version = None
+        mock_constraint_matcher.max_version = None
+        
+        # Mock logical matcher (should be skipped)
+        mock_logical_matcher = mock.MagicMock()
+        mock_logical_matcher.name = "logical_test"
+        mock_logical_matcher.fields = ["name"]
+        mock_logical_matcher.condition = None
+        mock_logical_matcher.min_version = None
+        mock_logical_matcher.max_version = None
+        
+        # Mock the supported models and get_model_matchers
+        mock_supported_models.items.return_value = [
+            ("dcim.site", {"model": mock_model_class})
+        ]
+        mock_get_model_matchers.return_value = [
+            mock_unique_matcher,
+            mock_constraint_matcher,
+            mock_logical_matcher  # This should be skipped
+        ]
+        
+        result = self.command.analyze_builtin_matchers()
+        
+        self.assertIn("dcim.site", result)
+        self.assertEqual(len(result["dcim.site"]), 2)  # Should only include builtin matchers
+        
+        # Check unique field matcher
+        unique_matcher_info = result["dcim.site"][0]
+        self.assertEqual(unique_matcher_info.name, "unique_name")
+        self.assertEqual(unique_matcher_info.fields, ["name"])
+        self.assertEqual(unique_matcher_info.matcher_source, "builtin")
+        
+        # Check constraint matcher
+        constraint_matcher_info = result["dcim.site"][1]
+        self.assertEqual(constraint_matcher_info.name, "test_constraint")
+        self.assertEqual(constraint_matcher_info.fields, ["field1", "field2"])
+        self.assertEqual(constraint_matcher_info.matcher_source, "builtin")
+
+    def test_combine_matchers(self):
+        """Test combining logical and builtin matchers."""
+        # Create logical matchers
+        logical_matcher = MatcherInfo(
+            name="logical_test",
+            fields=["name"],
+            condition="N/A",
+            description="Logical matcher",
+            version_constraints="All versions",
+            matcher_source="logical"
+        )
+        
+        # Create builtin matchers
+        builtin_matcher = MatcherInfo(
+            name="builtin_test",
+            fields=["name"],
+            condition="N/A",
+            description="Builtin matcher",
+            version_constraints="All versions",
+            matcher_source="builtin"
+        )
+        
+        logical_docs = {
+            "dcim.site": [logical_matcher],
+            "dcim.device": [logical_matcher]
+        }
+        
+        builtin_docs = {
+            "dcim.site": [builtin_matcher],
+            "ipam.prefix": [builtin_matcher]
+        }
+        
+        result = self.command.combine_matchers(logical_docs, builtin_docs)
+        
+        # Check that all object types are included
+        self.assertIn("dcim.site", result)
+        self.assertIn("dcim.device", result)
+        self.assertIn("ipam.prefix", result)
+        
+        # Check that dcim.site has both logical and builtin matchers
+        site_matchers = result["dcim.site"]
+        self.assertEqual(len(site_matchers), 2)
+        
+        # Check that logical matcher comes first (as it was added first)
+        self.assertEqual(site_matchers[0].name, "logical_test")
+        self.assertEqual(site_matchers[0].matcher_source, "logical")
+        self.assertEqual(site_matchers[1].name, "builtin_test")
+        self.assertEqual(site_matchers[1].matcher_source, "builtin")
+        
+        # Check that other object types have correct matchers
+        self.assertEqual(len(result["dcim.device"]), 1)
+        self.assertEqual(result["dcim.device"][0].matcher_source, "logical")
+        
+        self.assertEqual(len(result["ipam.prefix"]), 1)
+        self.assertEqual(result["ipam.prefix"][0].matcher_source, "builtin")
+
+    def test_get_matcher_description_builtin_types(self):
+        """Test getting matcher description for different builtin matcher types."""
+        # Test CustomFieldMatcher
+        mock_custom_field_matcher = mock.MagicMock()
+        mock_custom_field_matcher.custom_field = "test_field"
+        mock_custom_field_matcher.fields = None
+        mock_custom_field_matcher.ip_fields = None
+        mock_custom_field_matcher.vrf_field = None
+                
+        result = self.command.get_matcher_description(mock_custom_field_matcher)
+        self.assertEqual(result, "Matches on unique custom field: test_field")
+        
+    def test_get_matcher_description_autoslug(self):
+        """Test getting matcher description for AutoSlugMatcher."""
+        # Test AutoSlugMatcher
+        autoslug_matcher = AutoSlugMatcher(
+            name="test_autoslug",
+            model_class=None,
+            slug_field="slug"
+        )
+        
+        result = self.command.get_matcher_description(autoslug_matcher)
+        self.assertEqual(result, "Matches on auto-generated slug field: slug")
+        
+    def test_get_matcher_description_unique_field(self):
+        """Test getting matcher description for unique field matcher."""
+        # Test unique field matcher
+        mock_unique_matcher = mock.MagicMock()
+        mock_unique_matcher.name = "unique_name"
+        mock_unique_matcher.fields = ["name"]
+        mock_unique_matcher.ip_fields = None
+        mock_unique_matcher.vrf_field = None
+        mock_unique_matcher.custom_field = None
+        mock_unique_matcher.slug_field = None
+        
+        result = self.command.get_matcher_description(mock_unique_matcher)
+        self.assertEqual(result, "Matches on unique field(s): name")
+        
+    def test_get_matcher_description_unique_constraint(self):
+        """Test getting matcher description for unique constraint matcher."""
+        # Test unique constraint matcher
+        mock_constraint_matcher = mock.MagicMock()
+        mock_constraint_matcher.name = "test_constraint"
+        mock_constraint_matcher.fields = ["field1", "field2"]
+        mock_constraint_matcher.condition = None
+        mock_constraint_matcher.custom_field = None
+        mock_constraint_matcher.slug_field = None
+        
+        result = self.command.get_matcher_description(mock_constraint_matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: field1, field2")
 
     def test_generate_markdown_table_empty(self):
         """Test generating markdown table with empty documentation."""
@@ -268,7 +432,8 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             fields=["name"],
             condition="N/A",
             description="Test description 1",
-            version_constraints="All versions"
+            version_constraints="All versions",
+            matcher_source="logical"
         )
         
         matcher_info2 = MatcherInfo(
@@ -276,7 +441,8 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             fields=["name", "site"],
             condition="site is NOT NULL",
             description="Test description 2",
-            version_constraints="≥4.3.0"
+            version_constraints="≥4.3.0",
+            matcher_source="logical"
         )
         
         docs = {
@@ -290,12 +456,12 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         self.assertIn("## dcim.site", result)
         
         # Check table header
-        self.assertIn("| Matcher Name | Fields | Condition | Description | Version Constraints |", result)
-        self.assertIn("|--------------|--------|-----------|-------------|-------------------|", result)
+        self.assertIn("| Matcher Name | Type | Fields | Condition | Description | Version Constraints |", result)
+        self.assertIn("|--------------|------|--------|-----------|-------------|-------------------|", result)
         
         # Check table rows
-        self.assertIn("| test_matcher_1 | name | N/A | Test description 1 | All versions |", result)
-        self.assertIn("| test_matcher_2 | name, site | site is NOT NULL | Test description 2 | ≥4.3.0 |", result)
+        self.assertIn("| test_matcher_1 | logical | name | N/A | Test description 1 | All versions |", result)
+        self.assertIn("| test_matcher_2 | logical | name, site | site is NOT NULL | Test description 2 | ≥4.3.0 |", result)
 
     def test_generate_markdown_table_with_pipe_escaping(self):
         """Test generating markdown table with pipe character escaping."""
@@ -304,7 +470,8 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             fields=["field|1", "field|2"],
             condition="field|1 is NOT NULL",
             description="Test|description",
-            version_constraints="≥4.3.0|test"
+            version_constraints="≥4.3.0|test",
+            matcher_source="logical"
         )
         
         docs = {
@@ -314,7 +481,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         result = self.command.generate_markdown_table(docs)
         
         # Check that pipe characters are escaped
-        self.assertIn("| test\\|matcher | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |", result)
+        self.assertIn("| test\\|matcher | logical | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |", result)
 
     def test_generate_markdown_table_no_matchers(self):
         """Test generating markdown table for object type with no matchers."""
@@ -383,7 +550,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         )
         
         result = self.command.get_matcher_description(matcher)
-        self.assertEqual(result, "Matches on fields: name")
+        self.assertEqual(result, "Matches on unique constraint fields: name")
         
         # Test with matcher that has condition but no fields
         matcher = ObjectMatchCriteria(
@@ -425,7 +592,8 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             fields=None,
             condition=None,
             description=None,
-            version_constraints=None
+            version_constraints=None,
+            matcher_source="logical"
         )
         
         docs = {
@@ -435,7 +603,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         result = self.command.generate_markdown_table(docs)
         
         # Check that None values are handled gracefully
-        self.assertIn("| test_matcher |  | N/A | N/A | All versions |", result)
+        self.assertIn("| test_matcher | logical |  | N/A | N/A | All versions |", result)
         
     def test_markdown_table_with_empty_fields(self):
         """Test with empty fields list."""
@@ -444,7 +612,8 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
             fields=[],
             condition="N/A",
             description="Test description",
-            version_constraints="All versions"
+            version_constraints="All versions",
+            matcher_source="logical"
         )
         
         docs = {
@@ -454,4 +623,4 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         result = self.command.generate_markdown_table(docs)
         
         # Check that empty fields list is handled
-        self.assertIn("| test_matcher |  | N/A | Test description | All versions |", result) 
+        self.assertIn("| test_matcher | logical |  | N/A | Test description | All versions |", result) 

--- a/netbox_diode_plugin/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/test_generate_matching_docs.py
@@ -456,12 +456,12 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         self.assertIn("## dcim.site", result)
         
         # Check table header
-        self.assertIn("| Matcher Name | Type | Fields | Condition | Description | Version Constraints |", result)
-        self.assertIn("|--------------|------|--------|-----------|-------------|-------------------|", result)
+        self.assertIn("| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |", result)
+        self.assertIn("|--------------|---------------------|------|--------|-----------|-------------|---------------------|", result)
         
         # Check table rows
-        self.assertIn("| test_matcher_1 | logical | name | N/A | Test description 1 | All versions |", result)
-        self.assertIn("| test_matcher_2 | logical | name, site | site is NOT NULL | Test description 2 | ≥4.3.0 |", result)
+        self.assertIn("| test_matcher_1 | 1 | logical | name | N/A | Test description 1 | All versions |", result)
+        self.assertIn("| test_matcher_2 | 2 | logical | name, site | site is NOT NULL | Test description 2 | ≥4.3.0 |", result)
 
     def test_generate_markdown_table_with_pipe_escaping(self):
         """Test generating markdown table with pipe character escaping."""
@@ -481,7 +481,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         result = self.command.generate_markdown_table(docs)
         
         # Check that pipe characters are escaped
-        self.assertIn("| test\\|matcher | logical | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |", result)
+        self.assertIn("| test\\|matcher | 1 | logical | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |", result)
 
     def test_generate_markdown_table_no_matchers(self):
         """Test generating markdown table for object type with no matchers."""
@@ -603,7 +603,7 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         result = self.command.generate_markdown_table(docs)
         
         # Check that None values are handled gracefully
-        self.assertIn("| test_matcher | logical |  | N/A | N/A | All versions |", result)
+        self.assertIn("| test_matcher | 1 | logical |  | N/A | N/A | All versions |", result)
         
     def test_markdown_table_with_empty_fields(self):
         """Test with empty fields list."""
@@ -623,4 +623,4 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
         result = self.command.generate_markdown_table(docs)
         
         # Check that empty fields list is handled
-        self.assertIn("| test_matcher | logical |  | N/A | Test description | All versions |", result) 
+        self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result) 


### PR DESCRIPTION
This pull request introduces functionality to generate documentation for object matching criteria in the NetBox Diode Plugin. Key changes include the addition of a new Django management command, updates to the `Makefile` and `README.md`, and the creation of a documentation file. These changes aim to improve transparency and usability by providing detailed matching criteria for various object types.

### New functionality for generating documentation:

* [`netbox_diode_plugin/management/commands/generate_matching_docs.py`](diffhunk://#diff-7119e8c60e8ada57f5d5d1fc1c9aa387038833ffd4901c8dfe1328b1a4ac150dR1-R175): Added a Django management command to generate markdown documentation for object matching criteria. This includes analyzing logical matchers, extracting conditions, and generating a structured markdown table.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R24-R31): Added new targets `docker-compose-generate-matching-docs` and `docker-compose-migrate` to facilitate generating documentation and running migrations via Docker.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R107): Added instructions for generating documentation using the new `docker-compose-generate-matching-docs` command.
* [`docs/matching-criteria-documentation.md`](diffhunk://#diff-c994490b6a3b56e22f4b01f9333461d5235b3d6f766f7f9f8fdd0a3c0b7024fdR1-R149): Created a comprehensive markdown file describing how the plugin matches objects, including matcher names, fields, conditions, descriptions, and version constraints.

### Minor structural additions:

* [`netbox_diode_plugin/management/__init__.py`](diffhunk://#diff-5d4431c0a0677fdebc173d81ff236adee68cc71334a9b7ee60839f5f172943ffR1): Added a package-level docstring for the management package.
* [`netbox_diode_plugin/management/commands/__init__.py`](diffhunk://#diff-6e83ab7cf2f8a7537c3dc963239d284934a4265d18a3782efb377e25f07aef74R1): Added a module-level docstring for the management commands package.This pull request introduces new functionality for generating documentation related to diode entity matching and updates the `Makefile` and `README.md` accordingly. The changes include adding new `Makefile` targets and updating the documentation to guide users on how to use these features.

### New functionality for documentation generation:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R24-R31): Added two new targets, `docker-compose-generate-matching-docs` and `docker-compose-migrate`, to facilitate the generation of matching criteria documentation and database migrations.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R107): Updated to include instructions for generating matching criteria documentation using the new `docker-compose-generate-matching-docs` target.

## Example output
# NetBox Diode Plugin - Object Matching Criteria

This document describes how the Diode NetBox Plugin matches existing objects when applying changes. The matchers will be applied in the order of their precedence, unttil one of them matches.

## Matcher Types

- **Logical Matchers**: Custom matching criteria that represent likely user intent
- **Builtin Matchers**: Automatically generated from NetBox model constraints (unique fields, unique constraints, custom fields, auto-slugs)

## circuits.circuit

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| circuits_circuit_unique_provider_cid | 1 | builtin | provider, cid | N/A | Matches on unique constraint fields: provider, cid | All versions |
| circuits_circuit_unique_provideraccount_cid | 2 | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |

## circuits.circuitgroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## circuits.circuitgroupassignment

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| circuits_circuitgroupassignment_unique_member_group | 1 | builtin | member_type, member_id, group | N/A | Matches on unique constraint fields: member_type, member_id, group | All versions |

## circuits.circuittermination

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| circuits_circuittermination_unique_circuit_term_side | 1 | builtin | circuit, term_side | N/A | Matches on unique constraint fields: circuit, term_side | All versions |

## circuits.circuittype

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## circuits.provider

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## circuits.provideraccount

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| circuits_provideraccount_unique_provider_account | 1 | builtin | provider, account | N/A | Matches on unique constraint fields: provider, account | All versions |
| circuits_provideraccount_unique_provider_name | 2 | builtin | provider, name | name =  | Matches on unique constraint fields: provider, name where name =  | All versions |

## circuits.providernetwork

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| circuits_providernetwork_unique_provider_name | 1 | builtin | provider, name | N/A | Matches on unique constraint fields: provider, name | All versions |

## circuits.virtualcircuit

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| circuits_virtualcircuit_unique_provider_network_cid | 1 | builtin | provider_network, cid | N/A | Matches on unique constraint fields: provider_network, cid | All versions |
| circuits_virtualcircuit_unique_provideraccount_cid | 2 | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |

## circuits.virtualcircuittermination

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_interface | 1 | builtin | interface | N/A | Matches on unique field(s): interface | All versions |

## circuits.virtualcircuittype

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.cabletermination

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_cabletermination_unique_termination | 1 | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |

## dcim.consoleport

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_consoleport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |

## dcim.consoleporttemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_consoleporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
| dcim_consoleporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |

## dcim.consoleserverport

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_consoleserverport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |

## dcim.consoleserverporttemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_consoleserverporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
| dcim_consoleserverporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |

## dcim.device

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_asset_tag | 1 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
| unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
| unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
| unique_oob_ip | 4 | builtin | oob_ip | N/A | Matches on unique field(s): oob_ip | All versions |
| dcim_device_unique_name_site_tenant | 5 | builtin |  | N/A | Custom matcher | All versions |
| dcim_device_unique_name_site | 6 | builtin |  | tenant is NULL | Custom matcher | All versions |
| dcim_device_unique_rack_position_face | 7 | builtin | rack, position, face | N/A | Matches on unique constraint fields: rack, position, face | All versions |
| dcim_device_unique_virtual_chassis_vc_position | 8 | builtin | virtual_chassis, vc_position | N/A | Matches on unique constraint fields: virtual_chassis, vc_position | All versions |

## dcim.devicebay

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_installed_device | 1 | builtin | installed_device | N/A | Matches on unique field(s): installed_device | All versions |
| dcim_devicebay_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |

## dcim.devicebaytemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_devicebaytemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |

## dcim.devicerole

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_device_role_name_no_parent | 1 | logical | name | parent is NULL | Matches on fields: name where parent is NULL | ≥4.3.0 |
| logical_device_role_slug_no_parent | 2 | logical | slug | parent is NULL | Matches on fields: slug where parent is NULL | ≥4.3.0 |
| unique_name | 3 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 4 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.devicetype

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_devicetype_unique_manufacturer_model | 1 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
| dcim_devicetype_unique_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.frontport

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_frontport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
| dcim_frontport_unique_rear_port_position | 2 | builtin | rear_port, rear_port_position | N/A | Matches on unique constraint fields: rear_port, rear_port_position | All versions |

## dcim.frontporttemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_frontporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
| dcim_frontporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |
| dcim_frontporttemplate_unique_rear_port_position | 3 | builtin | rear_port, rear_port_position | N/A | Matches on unique constraint fields: rear_port, rear_port_position | All versions |

## dcim.interface

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
| dcim_interface_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |

## dcim.interfacetemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_interfacetemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
| dcim_interfacetemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |

## dcim.inventoryitem

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_inventory_item_name_on_device_no_parent | 1 | logical | name, device | parent is NULL | Matches on fields: name, device where parent is NULL | All versions |
| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
| dcim_inventoryitem_unique_device_parent_name | 3 | builtin | device, parent, name | N/A | Matches on unique constraint fields: device, parent, name | All versions |

## dcim.inventoryitemrole

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.inventoryitemtemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_inventoryitemtemplate_unique_device_type_parent_name | 1 | builtin | device_type, parent, name | N/A | Matches on unique constraint fields: device_type, parent, name | All versions |

## dcim.location

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_location_parent_name | 1 | builtin | site, parent, name | N/A | Matches on unique constraint fields: site, parent, name | All versions |
| dcim_location_name | 2 | builtin | site, name | parent is NULL | Matches on unique constraint fields: site, name where parent is NULL | All versions |
| dcim_location_parent_slug | 3 | builtin | site, parent, slug | N/A | Matches on unique constraint fields: site, parent, slug | All versions |
| dcim_location_slug | 4 | builtin | site, slug | parent is NULL | Matches on unique constraint fields: site, slug where parent is NULL | All versions |
| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.macaddress

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_mac_address_within_parent | 1 | logical | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NOT NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NOT NULL | All versions |
| logical_mac_address_within_parent | 2 | logical | mac_address, assigned_object_type, assigned_object_id | assigned_object_id is NULL | Matches on fields: mac_address, assigned_object_type, assigned_object_id where assigned_object_id is NULL | All versions |

## dcim.manufacturer

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.module

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_module_bay | 1 | builtin | module_bay | N/A | Matches on unique field(s): module_bay | All versions |
| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |

## dcim.modulebay

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_module_bay_name_on_device | 1 | logical | name, device | N/A | Matches on fields: name, device | All versions |
| dcim_modulebay_unique_device_module_name | 2 | builtin | device, module, name | N/A | Matches on unique constraint fields: device, module, name | All versions |

## dcim.modulebaytemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_modulebaytemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
| dcim_modulebaytemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |

## dcim.moduletype

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_moduletype_unique_manufacturer_model | 1 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |

## dcim.platform

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.powerfeed

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_powerfeed_unique_power_panel_name | 1 | builtin | power_panel, name | N/A | Matches on unique constraint fields: power_panel, name | All versions |

## dcim.poweroutlet

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_poweroutlet_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |

## dcim.poweroutlettemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_poweroutlettemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
| dcim_poweroutlettemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |

## dcim.powerpanel

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_powerpanel_unique_site_name | 1 | builtin | site, name | N/A | Matches on unique constraint fields: site, name | All versions |

## dcim.powerport

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_powerport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |

## dcim.powerporttemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_powerporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
| dcim_powerporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |

## dcim.rack

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_asset_tag | 1 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
| dcim_rack_unique_location_name | 2 | builtin | location, name | N/A | Matches on unique constraint fields: location, name | All versions |
| dcim_rack_unique_location_facility_id | 3 | builtin | location, facility_id | N/A | Matches on unique constraint fields: location, facility_id | All versions |

## dcim.rackrole

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.racktype

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_slug | 1 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| dcim_racktype_unique_manufacturer_model | 2 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
| dcim_racktype_unique_manufacturer_slug | 3 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.rearport

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_rearport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |

## dcim.rearporttemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_rearporttemplate_unique_device_type_name | 1 | builtin | device_type, name | N/A | Matches on unique constraint fields: device_type, name | All versions |
| dcim_rearporttemplate_unique_module_type_name | 2 | builtin | module_type, name | N/A | Matches on unique constraint fields: module_type, name | All versions |

## dcim.region

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_region_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
| dcim_region_name | 2 | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
| dcim_region_parent_slug | 3 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
| dcim_region_slug | 4 | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.site

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.sitegroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| dcim_sitegroup_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
| dcim_sitegroup_name | 2 | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
| dcim_sitegroup_parent_slug | 3 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
| dcim_sitegroup_slug | 4 | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## dcim.virtualchassis

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_master | 1 | builtin | master | N/A | Matches on unique field(s): master | All versions |

## dcim.virtualdevicecontext

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_primary_ip4 | 1 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
| unique_primary_ip6 | 2 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
| dcim_virtualdevicecontext_device_identifier | 3 | builtin | device, identifier | N/A | Matches on unique constraint fields: device, identifier | All versions |
| dcim_virtualdevicecontext_device_name | 4 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |

## extras.bookmark

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| extras_bookmark_unique_per_object_and_user | 1 | builtin | object_type, object_id, user | N/A | Matches on unique constraint fields: object_type, object_id, user | All versions |

## extras.configcontext

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## extras.customfield

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## extras.customfieldchoiceset

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## extras.customlink

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## extras.eventrule

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## extras.notificationgroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## extras.savedfilter

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## extras.script

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| extras_script_unique_name_module | 1 | builtin | name, module | N/A | Matches on unique constraint fields: name, module | All versions |

## extras.tag

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## extras.webhook

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## ipam.aggregate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_aggregate_prefix_no_rir | 1 | logical | prefix | rir is NULL | Matches on fields: prefix where rir is NULL | All versions |
| logical_aggregate_prefix_within_rir | 2 | logical | prefix, rir | rir is NOT NULL | Matches on fields: prefix, rir where rir is NOT NULL | All versions |

## ipam.asn

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_asn | 1 | builtin | asn | N/A | Matches on unique field(s): asn | All versions |

## ipam.asnrange

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## ipam.fhrpgroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_fhrp_group_id | 1 | logical | group_id | N/A | Matches on fields: group_id | All versions |

## ipam.fhrpgroupassignment

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| ipam_fhrpgroupassignment_unique_interface_group | 1 | builtin | interface_type, interface_id, group | N/A | Matches on unique constraint fields: interface_type, interface_id, group | All versions |

## ipam.ipaddress

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_ip_address_global_no_vrf | 1 | logical |  | N/A | Matches IP address address in global namespace (no VRF) | All versions |
| logical_ip_address_within_vrf | 2 | logical |  | N/A | Matches IP address address within VRF | All versions |

## ipam.iprange

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_ip_range_start_end_global_no_vrf | 1 | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
| logical_ip_range_start_end_within_vrf | 2 | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |

## ipam.prefix

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_prefix_global_no_vrf | 1 | logical | prefix | vrf is NULL | Matches on fields: prefix where vrf is NULL | All versions |
| logical_prefix_within_vrf | 2 | logical | prefix, vrf | vrf is NOT NULL | Matches on fields: prefix, vrf where vrf is NOT NULL | All versions |

## ipam.rir

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## ipam.role

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## ipam.routetarget

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## ipam.service

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_service_name_no_device_or_vm | 1 | logical | name | device is NULL AND virtual_machine is NULL | Matches on fields: name where device is NULL AND virtual_machine is NULL | ≤4.2.99 |
| logical_service_name_on_device | 2 | logical | name, device | device is NOT NULL | Matches on fields: name, device where device is NOT NULL | ≤4.2.99 |
| logical_service_name_on_vm | 3 | logical | name, virtual_machine | virtual_machine is NOT NULL | Matches on fields: name, virtual_machine where virtual_machine is NOT NULL | ≤4.2.99 |
| logical_service_name_on_parent | 4 | logical | name, parent_object_type, parent_object_id | parent_object_type is NOT NULL | Matches on fields: name, parent_object_type, parent_object_id where parent_object_type is NOT NULL | ≥4.3.0 |

## ipam.servicetemplate

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## ipam.vlan

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_vlan_vid_no_group_or_svlan | 1 | logical | vid | group is NULL AND qinq_svlan is NULL | Matches on fields: vid where group is NULL AND qinq_svlan is NULL | All versions |
| ipam_vlan_unique_group_vid | 2 | builtin | group, vid | N/A | Matches on unique constraint fields: group, vid | All versions |
| ipam_vlan_unique_group_name | 3 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
| ipam_vlan_unique_qinq_svlan_vid | 4 | builtin | qinq_svlan, vid | N/A | Matches on unique constraint fields: qinq_svlan, vid | All versions |
| ipam_vlan_unique_qinq_svlan_name | 5 | builtin | qinq_svlan, name | N/A | Matches on unique constraint fields: qinq_svlan, name | All versions |

## ipam.vlangroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_vlan_group_name_no_scope | 1 | logical | name | scope_type is NULL | Matches on fields: name where scope_type is NULL | All versions |
| ipam_vlangroup_unique_scope_name | 2 | builtin | scope_type, scope_id, name | N/A | Matches on unique constraint fields: scope_type, scope_id, name | All versions |
| ipam_vlangroup_unique_scope_slug | 3 | builtin | scope_type, scope_id, slug | N/A | Matches on unique constraint fields: scope_type, scope_id, slug | All versions |
| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## ipam.vlantranslationpolicy

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## ipam.vlantranslationrule

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| ipam_vlantranslationrule_unique_policy_local_vid | 1 | builtin | policy, local_vid | N/A | Matches on unique constraint fields: policy, local_vid | All versions |
| ipam_vlantranslationrule_unique_policy_remote_vid | 2 | builtin | policy, remote_vid | N/A | Matches on unique constraint fields: policy, remote_vid | All versions |

## ipam.vrf

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_rd | 1 | builtin | rd | N/A | Matches on unique field(s): rd | All versions |

## tenancy.contact

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_contact_name | 1 | logical | name | N/A | Matches on fields: name | ≥4.3.0 |
| tenancy_contact_unique_group_name | 2 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |

## tenancy.contactassignment

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| tenancy_contactassignment_unique_object_contact_role | 1 | builtin | object_type, object_id, contact, role | N/A | Matches on unique constraint fields: object_type, object_id, contact, role | All versions |

## tenancy.contactgroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| tenancy_contactgroup_unique_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
| unique_autoslug_slug | 2 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## tenancy.contactrole

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## tenancy.tenant

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| tenancy_tenant_unique_group_name | 1 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
| tenancy_tenant_unique_name | 2 | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
| tenancy_tenant_unique_group_slug | 3 | builtin | group, slug | N/A | Matches on unique constraint fields: group, slug | All versions |
| tenancy_tenant_unique_slug | 4 | builtin | slug | group is NULL | Matches on unique constraint fields: slug where group is NULL | All versions |
| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## tenancy.tenantgroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## virtualization.cluster

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_cluster_within_scope | 1 | logical | name, scope_type, scope_id | scope_type is NOT NULL | Matches on fields: name, scope_type, scope_id where scope_type is NOT NULL | All versions |
| logical_cluster_with_no_scope_or_group | 2 | logical | name | group is NULL AND scope_type is NULL | Matches on fields: name where group is NULL AND scope_type is NULL | All versions |
| virtualization_cluster_unique_group_name | 3 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
| virtualization_cluster_unique__site_name | 4 | builtin | _site, name | N/A | Matches on unique constraint fields: _site, name | All versions |

## virtualization.clustergroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## virtualization.clustertype

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## virtualization.virtualdisk

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| virtualization_virtualdisk_unique_virtual_machine_name | 1 | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |

## virtualization.virtualmachine

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_virtual_machine_name_no_cluster | 1 | logical | name | cluster is NULL | Matches on fields: name where cluster is NULL | All versions |
| unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
| unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
| virtualization_virtualmachine_unique_name_cluster_tenant | 4 | builtin |  | N/A | Custom matcher | All versions |
| virtualization_virtualmachine_unique_name_cluster | 5 | builtin |  | tenant is NULL | Custom matcher | All versions |

## virtualization.vminterface

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
| virtualization_vminterface_unique_virtual_machine_name | 2 | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |

## vpn.ikepolicy

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## vpn.ikeproposal

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## vpn.ipsecpolicy

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## vpn.ipsecprofile

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## vpn.ipsecproposal

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |

## vpn.l2vpn

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## vpn.l2vpntermination

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| vpn_l2vpntermination_assigned_object | 1 | builtin | assigned_object_type, assigned_object_id | N/A | Matches on unique constraint fields: assigned_object_type, assigned_object_id | All versions |

## vpn.tunnel

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| vpn_tunnel_group_name | 2 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
| vpn_tunnel_name | 3 | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |

## vpn.tunnelgroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## vpn.tunneltermination

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| vpn_tunneltermination_termination | 1 | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |

## wireless.wirelesslan

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| logical_wireless_lan_ssid_no_group_or_vlan | 1 | logical | ssid | group is NULL AND vlan is NULL | Matches on fields: ssid where group is NULL AND vlan is NULL | All versions |
| logical_wireless_lan_ssid_in_group | 2 | logical | ssid, group | group is NOT NULL | Matches on fields: ssid, group where group is NOT NULL | All versions |
| logical_wireless_lan_ssid_in_vlan | 3 | logical | ssid, vlan | vlan is NOT NULL | Matches on fields: ssid, vlan where vlan is NOT NULL | All versions |

## wireless.wirelesslangroup

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
| wireless_wirelesslangroup_unique_parent_name | 3 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |

## wireless.wirelesslink

| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
|--------------|------------|------|--------|-----------|-------------|---------------------|
| wireless_wirelesslink_unique_interfaces | 1 | builtin | interface_a, interface_b | N/A | Matches on unique constraint fields: interface_a, interface_b | All versions |

