### PR TITLE
feat: add support for optional introspection headers in authentication

### DIFF
--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -35,6 +35,10 @@ class NetBoxDiodePluginConfig(PluginConfig):
         # List of audiences to require for the diode-to-netbox token.
         # If empty, no audience is required.
         "required_token_audience": [],
+
+        # Headers to use for introspection requests.
+        # If empty, no headers are sent.
+        "introspection_headers": {},
     }
 
 

--- a/netbox_diode_plugin/api/authentication.py
+++ b/netbox_diode_plugin/api/authentication.py
@@ -61,7 +61,7 @@ class DiodeOAuth2Authentication(BaseAuthentication):
             introspection_headers = get_introspection_headers()
             if introspection_headers:
                 headers.update(introspection_headers)
-            
+
             response = requests.post(
                 introspect_url, headers=headers, timeout=5
             )

--- a/netbox_diode_plugin/api/authentication.py
+++ b/netbox_diode_plugin/api/authentication.py
@@ -14,6 +14,7 @@ from rest_framework.exceptions import AuthenticationFailed
 from netbox_diode_plugin.plugin_config import (
     get_diode_auth_introspect_url,
     get_diode_user,
+    get_introspection_headers,
     get_required_token_audience,
 )
 
@@ -56,8 +57,13 @@ class DiodeOAuth2Authentication(BaseAuthentication):
             return None
 
         try:
+            headers = {"Authorization": f"Bearer {token}"}
+            introspection_headers = get_introspection_headers()
+            if introspection_headers:
+                headers.update(introspection_headers)
+            
             response = requests.post(
-                introspect_url, headers={"Authorization": f"Bearer {token}"}, timeout=5
+                introspect_url, headers=headers, timeout=5
             )
             response.raise_for_status()
             data = response.json()

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -12,6 +12,7 @@ from netbox.plugins import get_plugin_config
 __all__ = (
     "get_diode_auth_introspect_url",
     "get_diode_user",
+    "get_introspection_headers",
 )
 
 User = get_user_model()
@@ -93,3 +94,7 @@ def get_diode_user():
 def get_required_token_audience():
     """Returns the require token audience."""
     return get_plugin_config("netbox_diode_plugin", "required_token_audience")
+
+def get_introspection_headers():
+    """Returns the introspection headers."""
+    return get_plugin_config("netbox_diode_plugin", "introspection_headers")

--- a/netbox_diode_plugin/tests/test_authentication.py
+++ b/netbox_diode_plugin/tests/test_authentication.py
@@ -55,6 +55,13 @@ class DiodeOAuth2AuthenticationTestCase(TestCase):
         )
         self.required_audience_mock = self.required_audience_patcher.start()
 
+        # Mock get_introspection_headers
+        self.introspection_headers_patcher = mock.patch(
+            'netbox_diode_plugin.api.authentication.get_introspection_headers',
+            return_value={}
+        )
+        self.introspection_headers_mock = self.introspection_headers_patcher.start()
+
     def tearDown(self):
         """Clean up after tests."""
         self.cache_patcher.stop()
@@ -62,6 +69,7 @@ class DiodeOAuth2AuthenticationTestCase(TestCase):
         self.requests_patcher.stop()
         self.introspect_url_patcher.stop()
         self.required_audience_patcher.stop()
+        self.introspection_headers_patcher.stop()
 
     def test_authenticate_no_auth_header(self):
         """Test authentication with no Authorization header."""
@@ -186,3 +194,59 @@ class DiodeOAuth2AuthenticationTestCase(TestCase):
 
         # The timeout should be 300 (default)
         self.assertEqual(call_args.kwargs['timeout'], 300)
+
+    def test_authenticate_with_no_introspection_headers(self):
+        """Test authentication with no introspection headers configured."""
+        self.cache_get_mock.return_value = None
+        self.introspection_headers_mock.return_value = {}
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write',
+            'exp': 1000,
+            'iat': 500
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.valid_token}')
+        
+        user, _ = self.auth.authenticate(request)
+        self.assertEqual(user, self.diode_user.user)
+        
+        # Verify that requests.post was called with only Authorization header
+        self.requests_mock.assert_called_once_with(
+            'http://localhost:8080/diode/auth/introspect',
+            headers={'Authorization': f'Bearer {self.valid_token}'},
+            timeout=5
+        )
+
+    def test_authenticate_with_introspection_headers(self):
+        """Test authentication with introspection headers configured."""
+        self.cache_get_mock.return_value = None
+        custom_headers = {
+            'X-Custom-Header': 'custom-value',
+            'Content-Type': 'application/json'
+        }
+        self.introspection_headers_mock.return_value = custom_headers
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write',
+            'exp': 1000,
+            'iat': 500
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.valid_token}')
+        
+        user, _ = self.auth.authenticate(request)
+        self.assertEqual(user, self.diode_user.user)
+        
+        # Verify that requests.post was called with merged headers
+        expected_headers = {
+            'Authorization': f'Bearer {self.valid_token}',
+            'X-Custom-Header': 'custom-value',
+            'Content-Type': 'application/json'
+        }
+        self.requests_mock.assert_called_once_with(
+            'http://localhost:8080/diode/auth/introspect',
+            headers=expected_headers,
+            timeout=5
+        )
+

--- a/netbox_diode_plugin/tests/test_authentication.py
+++ b/netbox_diode_plugin/tests/test_authentication.py
@@ -207,10 +207,10 @@ class DiodeOAuth2AuthenticationTestCase(TestCase):
         }
 
         request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.valid_token}')
-        
+
         user, _ = self.auth.authenticate(request)
         self.assertEqual(user, self.diode_user.user)
-        
+
         # Verify that requests.post was called with only Authorization header
         self.requests_mock.assert_called_once_with(
             'http://localhost:8080/diode/auth/introspect',
@@ -234,10 +234,10 @@ class DiodeOAuth2AuthenticationTestCase(TestCase):
         }
 
         request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.valid_token}')
-        
+
         user, _ = self.auth.authenticate(request)
         self.assertEqual(user, self.diode_user.user)
-        
+
         # Verify that requests.post was called with merged headers
         expected_headers = {
             'Authorization': f'Bearer {self.valid_token}',


### PR DESCRIPTION
This pull request introduces support for configurable introspection headers in the `netbox_diode_plugin`. The changes allow users to specify custom headers for token introspection requests, improving flexibility for integration with various authentication systems. Key updates include modifications to the plugin configuration, authentication logic, and corresponding test cases.

### Configuration Enhancements:
* Added a new `introspection_headers` configuration option in `PluginConfig` to specify custom headers for introspection requests. If left empty, no additional headers are sent (`netbox_diode_plugin/__init__.py`).

### Authentication Logic Updates:
* Updated the `_introspect_token` method to include the custom introspection headers, merging them with the default `Authorization` header (`netbox_diode_plugin/api/authentication.py`).
* Introduced a new helper function, `get_introspection_headers`, to retrieve the `introspection_headers` configuration value (`netbox_diode_plugin/plugin_config.py`).

### Test Suite Enhancements:
* Added mocks for `get_introspection_headers` in the test setup to simulate different configurations (`netbox_diode_plugin/tests/test_authentication.py`).
* Implemented two new test cases to validate authentication behavior with and without configured introspection headers:
  - [`test_authenticate_with_no_introspection_headers`](diffhunk://#diff-948442878a649efdad3684c0f96a393341d1112e37c6b2b92a60129d7608e82aR197-R252): Ensures only the `Authorization` header is sent when no custom headers are configured.
  - [`test_authenticate_with_introspection_headers`](diffhunk://#diff-948442878a649efdad3684c0f96a393341d1112e37c6b2b92a60129d7608e82aR197-R252): Verifies that custom headers are correctly merged with the `Authorization` header.