### PR TITLE
fix: disable tags in Setting model 

### DIFF
--- a/netbox_diode_plugin/models.py
+++ b/netbox_diode_plugin/models.py
@@ -24,6 +24,7 @@ class Setting(NetBoxModel):
     """Setting model."""
 
     diode_target = models.CharField(max_length=255, validators=[diode_target_validator])
+    tags = None
 
     class Meta:
         """Meta class."""

--- a/netbox_diode_plugin/tests/test_models.py
+++ b/netbox_diode_plugin/tests/test_models.py
@@ -28,3 +28,8 @@ class SettingModelTestCase(TestCase):
         """Check Setting model absolute URL."""
         setting = Setting()
         self.assertEqual(setting.get_absolute_url(), "/netbox/plugins/diode/settings/")
+
+    def test_tags_disabled(self):
+        """Check Setting model has tags disabled."""
+        setting = Setting()
+        self.assertIsNone(setting.tags)

--- a/netbox_diode_plugin/tests/test_models.py
+++ b/netbox_diode_plugin/tests/test_models.py
@@ -31,5 +31,5 @@ class SettingModelTestCase(TestCase):
 
     def test_tags_disabled(self):
         """Check Setting model has tags disabled."""
-        setting = Setting()
+        setting = Setting(diode_target="http://localhost:8080")
         self.assertIsNone(setting.tags)


### PR DESCRIPTION
This pull request makes a small change to the `Setting` model in the `netbox_diode_plugin` by explicitly disabling the `tags` attribute, and adds a corresponding test to ensure this behavior. Tags are not needed in this model (which extends `NetBoxModel`) and cause reverse accessor conflicts with other Setting models (e.g. defined in other NetBox plugins)

Testing improvements:

* Added a new test `test_tags_disabled` in `netbox_diode_plugin/tests/test_models.py` to verify that the `tags` attribute on the `Setting` model is disabled (set to `None`).

Model update:

* Explicitly set the `tags` attribute to `None` in the `Setting` model within `netbox_diode_plugin/models.py` to disable tagging for this model.