### PR TITLE
fix: client credentials model and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ at [https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in
 |    >= 4.2.3    |     1.1.0      |
 |    >= 4.2.3    |     1.2.0      |
 |    >= 4.4.0    |     1.4.0      |
+|    >= 4.4.0    |     1.4.1      |
 
 ## Installation
 

--- a/docker/Dockerfile-diode-netbox-plugin
+++ b/docker/Dockerfile-diode-netbox-plugin
@@ -1,4 +1,4 @@
-FROM netboxcommunity/netbox:v4.3.3-3.3.0
+FROM netboxcommunity/netbox:v4.4.2-3.4.1
 
 COPY ./netbox/configuration/ /etc/netbox/config/
 RUN chmod 755 /etc/netbox/config/* && \

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 name: diode-netbox-plugin
 services:
   netbox: &netbox
-    image: netboxcommunity/netbox:v4.3.3-3.3.0-diode-netbox-plugin
+    image: netboxcommunity/netbox:v4.4.2-3.4.1-diode-netbox-plugin
     build:
       context: .
       dockerfile: Dockerfile-diode-netbox-plugin

--- a/docker/requirements-diode-netbox-plugin.txt
+++ b/docker/requirements-diode-netbox-plugin.txt
@@ -4,4 +4,4 @@ coverage==7.6.0
 grpcio==1.62.1
 protobuf==5.29.5
 pytest==8.0.2
-netboxlabs-netbox-branching==0.6.0
+netboxlabs-netbox-branching==0.7.1

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -449,7 +449,11 @@ class ObjectMatchCriteria:
                 field = self.model_class._meta.get_field(field_name)
                 # special handling for object type -> content type id
                 if field.is_relation and hasattr(field, "related_model") and field.related_model == ContentType:
-                    prepared[field_name] = content_type_id(value)
+                    # Handle ManyToMany fields (list of object types) and ForeignKey fields (single object type)
+                    if isinstance(value, list):
+                        prepared[field_name] = [content_type_id(v) for v in value]
+                    else:
+                        prepared[field_name] = content_type_id(value)
                 else:
                     prepared[field_name] = value
 

--- a/netbox_diode_plugin/migrations/0006_clientcredentials_alter_setting_diode_target.py
+++ b/netbox_diode_plugin/migrations/0006_clientcredentials_alter_setting_diode_target.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# Copyright 2025 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Database migrations."""
+
+from django.db import migrations, models
+
+import netbox_diode_plugin.models
+
+
+class Migration(migrations.Migration):
+    """Create ClientCredentials model and alter Setting.diode_target field."""
+
+    dependencies = [
+        ("netbox_diode_plugin", "0001_squashed_0005"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ClientCredentials",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+            ],
+            options={
+                "permissions": (
+                    ("view_clientcredentials", "Can view Client Credentials"),
+                    (
+                        "add_clientcredentials",
+                        "Can perform actions on Client Credentials",
+                    ),
+                ),
+                "managed": False,
+                "default_permissions": (),
+            },
+        ),
+        migrations.AlterField(
+            model_name="setting",
+            name="diode_target",
+            field=models.CharField(
+                max_length=255,
+                validators=[netbox_diode_plugin.models.diode_target_validator],
+            ),
+        ),
+    ]

--- a/netbox_diode_plugin/models.py
+++ b/netbox_diode_plugin/models.py
@@ -41,8 +41,18 @@ class Setting(NetBoxModel):
         return reverse("plugins:netbox_diode_plugin:settings")
 
 
+class UnmanagedModelManager(models.Manager):
+    """Manager for unmanaged models that prevents database queries."""
+
+    def get_queryset(self):
+        """Return an empty queryset without hitting the database."""
+        return super().get_queryset().none()
+
+
 class ClientCredentials(models.Model):
     """Dummy model to allow for permissions, saved filters, etc.."""
+
+    objects = UnmanagedModelManager()
 
     class Meta:
         """Meta class."""


### PR DESCRIPTION
Fixes https://github.com/netboxlabs/diode-netbox-plugin/issues/136

---

This pull request updates the Diode NetBox plugin to support newer NetBox versions and improves compatibility, dependency management, and data handling. The most important changes include updating the base NetBox version, adding a new migration for the `ClientCredentials` model, enhancing the data preparation logic for relation fields, and updating dependencies.

**NetBox version and Docker updates:**
- Updated the base NetBox version in `Dockerfile-diode-netbox-plugin` and `docker-compose.yaml` from `v4.3.3-3.3.0` to `v4.4.2-3.4.1` to ensure compatibility with newer NetBox releases. [[1]](diffhunk://#diff-112ee4e06e4a556534c26208d1566b12ae5a6fcf415f8e9d465c6f5d78ebc4ebL1-R1) [[2]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L4-R4)
- Added a new plugin version (`1.4.1`) to the compatibility table in `README.md`.

**Database and model improvements:**
- Added a migration (`0006_clientcredentials_alter_setting_diode_target.py`) to create the `ClientCredentials` model (unmanaged, for permissions/saved filters) and altered the `Setting.diode_target` field to use a validator.
- Introduced `UnmanagedModelManager` for unmanaged models like `ClientCredentials`, preventing accidental database queries.

**Dependency updates:**
- Updated the `netboxlabs-netbox-branching` dependency from `0.6.0` to `0.7.1` in `requirements-diode-netbox-plugin.txt`.

**Data handling improvements:**
- Improved `_prepare_data` in `api/matcher.py` to handle both single and multiple related object types (ForeignKey and ManyToMany fields) by converting lists of objects to content type IDs.