### PR TITLE
fix: preserve explicit empty values and null refs in update changesets

### DIFF
--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -140,6 +140,11 @@ def diff_to_change(
     if prior_id is None:
         ref_id = postchange_data.pop("id", None)
 
+    # For updates, preserve explicitly-provided empty values (empty strings, None)
+    # so that the apply changeset endpoint can clear fields the user intended to reset.
+    # For creates, strip empty values to avoid sending noise — the serializer handles defaults.
+    preserve_empty = change_type == ChangeType.UPDATE
+
     change = Change(
         change_type=change_type,
         before=_tidy(prechange_data),
@@ -152,12 +157,12 @@ def diff_to_change(
     )
 
     if change_type != ChangeType.NOOP:
-        change.data = _tidy(postchange_data)
+        change.data = _tidy(postchange_data, exclude_empty_values=not preserve_empty)
 
     return change
 
-def _tidy(data: dict) -> dict:
-    return sort_dict_recursively(clean_diff_data(data))
+def _tidy(data: dict, exclude_empty_values: bool = True) -> dict:
+    return sort_dict_recursively(clean_diff_data(data, exclude_empty_values=exclude_empty_values))
 
 def sort_dict_recursively(d):
     """Recursively sorts a dictionary by keys."""

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -194,6 +194,26 @@ def _transform_proto_json_1(proto_json: dict, object_type: str, supported_models
             node[field_name + "_type"] = ref_info.object_type
             field_name = field_name + "_id"
 
+        # Explicitly null reference — means "clear this FK".
+        # An empty dict {} comes from protojson when the SDK sets a message field
+        # to an empty message (e.g. Tenant{}) to signal "clear this field".
+        if value is None or (isinstance(value, dict) and len(value) == 0):
+            if ref_info.is_generic:
+                node[ref_info.field_name + "_type"] = None
+            if is_circular:
+                if post_create is None:
+                    post_create = {
+                        "_uuid": str(uuid4()),
+                        "_object_type": object_type,
+                        "_refs": set(),
+                        "_instance": node['_uuid'],
+                        "_is_post_create": True,
+                    }
+                post_create[field_name] = None
+            else:
+                node[field_name] = None
+            continue
+
         refs = []
         ref_value = None
         if isinstance(value, list):

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_generate_diff.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_generate_diff.py
@@ -9,9 +9,11 @@ from unittest import mock
 from uuid import uuid4
 
 from core.models import ObjectType
-from dcim.models import Manufacturer, RackType, Site
+from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, RackType, Site
 from extras.models import CustomField
 from extras.models.customfields import CustomFieldTypeChoices
+from ipam.models import IPAddress
+from tenancy.models import Tenant
 from rest_framework import status
 from utilities.testing import APITestCase
 
@@ -419,3 +421,464 @@ class GenerateDiffTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status_code)
         return response
+
+
+class ExplicitFieldClearingTestCase(APITestCase):
+    """Test that explicitly-provided empty values in updates produce changesets that clear fields."""
+
+    def setUp(self):
+        """Set up test fixtures with a site that has populated optional fields."""
+        self.url = "/netbox/api/plugins/diode/generate-diff/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Clear Fields Site",
+            slug="clear-fields-site",
+            facility="Bravo",
+            description="A description to be cleared",
+            physical_address="456 Real Ave",
+            shipping_address="789 Ship Blvd",
+            comments="Some comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_explicit_empty_string_clears_description(self):
+        """Setting description to '' on an existing site should produce an update with description=''."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+
+        data = change.get("data", {})
+        # description must be present and empty — this is the explicit clear
+        self.assertIn("description", data)
+        self.assertEqual(data["description"], "")
+
+    def test_omitted_field_leaves_existing_value_untouched(self):
+        """Not sending description at all should NOT include it in the changeset data."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "comments": "Updated comments",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("comments"), "Updated comments")
+        # description was not in the payload, so it should not be in the changeset data
+        self.assertNotIn("description", data)
+
+    def test_noop_when_existing_and_incoming_both_empty(self):
+        """If a field is already empty and the user sends empty, no change should be detected."""
+        self.site.description = ""
+        self.site.save()
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        if len(changes) > 0:
+            site_changes = [c for c in changes if c["object_type"] == "dcim.site"]
+            for change in site_changes:
+                self.assertEqual(change.get("change_type"), "noop")
+
+    def test_clear_multiple_fields_at_once(self):
+        """Setting multiple optional fields to '' should produce an update with all of them cleared."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "",
+                    "comments": "",
+                    "facility": "",
+                    "physical_address": "",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+
+        data = change.get("data", {})
+        self.assertIn("description", data)
+        self.assertEqual(data["description"], "")
+        self.assertIn("comments", data)
+        self.assertEqual(data["comments"], "")
+        self.assertIn("facility", data)
+        self.assertEqual(data["facility"], "")
+        self.assertIn("physical_address", data)
+        self.assertEqual(data["physical_address"], "")
+
+    def test_set_nonempty_value_still_works(self):
+        """Setting a field to a non-empty value still produces the correct update."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "New description",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+
+        data = change.get("data", {})
+        self.assertEqual(data["description"], "New description")
+
+    def test_clear_field_and_update_field_simultaneously(self):
+        """Clearing one field while updating another should both appear in the changeset."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "",
+                    "comments": "Brand new comment",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+
+        data = change.get("data", {})
+        self.assertIn("description", data)
+        self.assertEqual(data["description"], "")
+        self.assertEqual(data["comments"], "Brand new comment")
+
+    def test_create_with_empty_string_does_not_include_empty_fields(self):
+        """On create, empty string fields should still be excluded (no noise)."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Brand New Site",
+                    "slug": "brand-new-site",
+                    "description": "",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "create")
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("name"), "Brand New Site")
+        self.assertEqual(data.get("slug"), "brand-new-site")
+        # For creates, empty string fields should be stripped (current behavior preserved)
+        self.assertNotIn("description", data)
+
+
+class NullNestedEntityClearingTestCase(APITestCase):
+    """Test clearing nullable FK / generic FK fields by setting nested entities to null."""
+
+    def setUp(self):
+        """Set up test fixtures with objects that have nullable FK fields populated."""
+        self.url = "/netbox/api/plugins/diode/generate-diff/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        # Create tenant + site with tenant assigned
+        self.tenant = Tenant.objects.create(name="Test Tenant", slug="test-tenant")
+        self.site = Site.objects.create(
+            name="FK Clear Site",
+            slug="fk-clear-site",
+            tenant=self.tenant,
+            description="Site with tenant",
+        )
+
+        # Create device + interface + IP address with assigned_object
+        self.manufacturer = Manufacturer.objects.create(name="FK Test Mfg", slug="fk-test-mfg")
+        self.device_type = DeviceType.objects.create(
+            manufacturer=self.manufacturer, model="FK Test Type", slug="fk-test-type"
+        )
+        self.role = DeviceRole.objects.create(name="FK Test Role", slug="fk-test-role", color="ff0000")
+        self.device = Device.objects.create(
+            name="FK Test Device",
+            device_type=self.device_type,
+            role=self.role,
+            site=self.site,
+        )
+        self.interface = Interface.objects.create(
+            device=self.device, name="eth0", type="virtual"
+        )
+        self.ip_address = IPAddress.objects.create(
+            address="10.0.0.1/24",
+            assigned_object=self.interface,
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_null_tenant_clears_fk_on_site(self):
+        """Setting tenant to null on a site that has a tenant should produce an update clearing it."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "FK Clear Site",
+                    "slug": "fk-clear-site",
+                    "tenant": None,
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        site_changes = [c for c in changes if c["object_type"] == "dcim.site"]
+        self.assertEqual(len(site_changes), 1)
+        change = site_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+
+        data = change.get("data", {})
+        self.assertIn("tenant", data)
+        self.assertIsNone(data["tenant"])
+
+    def test_omitted_tenant_leaves_fk_unchanged(self):
+        """Not providing tenant at all should not include it in the changeset."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "FK Clear Site",
+                    "slug": "fk-clear-site",
+                    "description": "Updated description",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        site_changes = [c for c in changes if c["object_type"] == "dcim.site"]
+        self.assertEqual(len(site_changes), 1)
+        change = site_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+
+        data = change.get("data", {})
+        # tenant was not in the payload — must not appear in changeset
+        self.assertNotIn("tenant", data)
+
+    def test_null_assigned_object_interface_clears_generic_fk(self):
+        """Setting assigned_object_interface to null on an IP with an interface should clear it."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "10.0.0.1/24",
+                    "assigned_object_interface": None,
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        ip_changes = [c for c in changes if c["object_type"] == "ipam.ipaddress"]
+        self.assertEqual(len(ip_changes), 1)
+        change = ip_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.ip_address.id)
+
+        data = change.get("data", {})
+        self.assertIn("assigned_object_id", data)
+        self.assertIsNone(data["assigned_object_id"])
+        self.assertIn("assigned_object_type", data)
+        self.assertIsNone(data["assigned_object_type"])
+
+    def test_omitted_assigned_object_leaves_generic_fk_unchanged(self):
+        """Not providing assigned_object at all should not include it in the changeset."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "10.0.0.1/24",
+                    "description": "Updated description",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        ip_changes = [c for c in changes if c["object_type"] == "ipam.ipaddress"]
+        self.assertEqual(len(ip_changes), 1)
+        change = ip_changes[0]
+
+        data = change.get("data", {})
+        # assigned_object was not in payload — must not appear in changeset
+        self.assertNotIn("assigned_object_id", data)
+        self.assertNotIn("assigned_object_type", data)
+
+    def test_empty_dict_tenant_clears_fk_on_site(self):
+        """Setting tenant to {} (protojson for empty message) should clear it, same as null."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "FK Clear Site",
+                    "slug": "fk-clear-site",
+                    "tenant": {},
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        site_changes = [c for c in changes if c["object_type"] == "dcim.site"]
+        self.assertEqual(len(site_changes), 1)
+        change = site_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+
+        data = change.get("data", {})
+        self.assertIn("tenant", data)
+        self.assertIsNone(data["tenant"])
+
+    def test_empty_dict_assigned_object_clears_generic_fk(self):
+        """Setting assigned_object_interface to {} should clear the GFK, same as null."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "10.0.0.1/24",
+                    "assigned_object_interface": {},
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        ip_changes = [c for c in changes if c["object_type"] == "ipam.ipaddress"]
+        self.assertEqual(len(ip_changes), 1)
+        change = ip_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.ip_address.id)
+
+        data = change.get("data", {})
+        self.assertIn("assigned_object_id", data)
+        self.assertIsNone(data["assigned_object_id"])
+        self.assertIn("assigned_object_type", data)
+        self.assertIsNone(data["assigned_object_type"])

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_generate_diff.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_generate_diff.py
@@ -13,8 +13,8 @@ from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer,
 from extras.models import CustomField
 from extras.models.customfields import CustomFieldTypeChoices
 from ipam.models import IPAddress
-from tenancy.models import Tenant
 from rest_framework import status
+from tenancy.models import Tenant
 from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_generate_diff.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_generate_diff.py
@@ -13,8 +13,8 @@ from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer,
 from extras.models import CustomField
 from extras.models.customfields import CustomFieldTypeChoices
 from ipam.models import IPAddress
-from tenancy.models import Tenant
 from rest_framework import status
+from tenancy.models import Tenant
 from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_generate_diff.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_generate_diff.py
@@ -12,6 +12,8 @@ from core.models import ObjectType
 from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, RackType, Site
 from extras.models import CustomField
 from extras.models.customfields import CustomFieldTypeChoices
+from ipam.models import IPAddress
+from tenancy.models import Tenant
 from rest_framework import status
 from utilities.testing import APITestCase
 
@@ -419,6 +421,470 @@ class GenerateDiffTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status_code)
         return response
+
+
+class ExplicitFieldClearingTestCase(APITestCase):
+    """Test that explicitly-provided empty values in updates produce changesets that clear fields."""
+
+    def setUp(self):
+        """Set up test fixtures with a site that has populated optional fields."""
+        self.url = "/netbox/api/plugins/diode/generate-diff/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Clear Fields Site",
+            slug="clear-fields-site",
+            facility="Bravo",
+            description="A description to be cleared",
+            physical_address="456 Real Ave",
+            shipping_address="789 Ship Blvd",
+            comments="Some comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_explicit_empty_string_clears_description(self):
+        """Setting description to '' on an existing site should produce an update with description=''."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+
+        data = change.get("data", {})
+        # description must be present and empty — this is the explicit clear
+        self.assertIn("description", data)
+        self.assertEqual(data["description"], "")
+
+    def test_omitted_field_leaves_existing_value_untouched(self):
+        """Not sending description at all should NOT include it in the changeset data."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "comments": "Updated comments",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("comments"), "Updated comments")
+        # description was not in the payload, so it should not be in the changeset data —
+        # only fields the user actually sent should appear
+        self.assertNotIn("description", data)
+
+    def test_noop_when_existing_and_incoming_both_empty(self):
+        """If a field is already empty and the user sends empty, no change should be detected."""
+        # First clear the description via DB
+        self.site.description = ""
+        self.site.save()
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        # shallow_compare_dict sees no difference, so either noop or no changes
+        if len(changes) > 0:
+            site_changes = [c for c in changes if c["object_type"] == "dcim.site"]
+            for change in site_changes:
+                self.assertEqual(change.get("change_type"), "noop")
+
+    def test_clear_multiple_fields_at_once(self):
+        """Setting multiple optional fields to '' should produce an update with all of them cleared."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "",
+                    "comments": "",
+                    "facility": "",
+                    "physical_address": "",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+
+        data = change.get("data", {})
+        self.assertIn("description", data)
+        self.assertEqual(data["description"], "")
+        self.assertIn("comments", data)
+        self.assertEqual(data["comments"], "")
+        self.assertIn("facility", data)
+        self.assertEqual(data["facility"], "")
+        self.assertIn("physical_address", data)
+        self.assertEqual(data["physical_address"], "")
+
+    def test_set_nonempty_value_still_works(self):
+        """Setting a field to a non-empty value still produces the correct update."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "New description",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+
+        data = change.get("data", {})
+        self.assertEqual(data["description"], "New description")
+
+    def test_clear_field_and_update_field_simultaneously(self):
+        """Clearing one field while updating another should both appear in the changeset."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Clear Fields Site",
+                    "slug": "clear-fields-site",
+                    "description": "",
+                    "comments": "Brand new comment",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+
+        data = change.get("data", {})
+        self.assertIn("description", data)
+        self.assertEqual(data["description"], "")
+        self.assertEqual(data["comments"], "Brand new comment")
+
+    def test_create_with_empty_string_does_not_include_empty_fields(self):
+        """On create, empty string fields should still be excluded (no noise)."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Brand New Site",
+                    "slug": "brand-new-site",
+                    "description": "",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("change_type"), "create")
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("name"), "Brand New Site")
+        self.assertEqual(data.get("slug"), "brand-new-site")
+        # For creates, empty string fields should be stripped (current behavior preserved)
+        self.assertNotIn("description", data)
+
+
+class NullNestedEntityClearingTestCase(APITestCase):
+    """Test clearing nullable FK / generic FK fields by setting nested entities to null."""
+
+    def setUp(self):
+        """Set up test fixtures with objects that have nullable FK fields populated."""
+        self.url = "/netbox/api/plugins/diode/generate-diff/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        # Create tenant + site with tenant assigned
+        self.tenant = Tenant.objects.create(name="Test Tenant", slug="test-tenant")
+        self.site = Site.objects.create(
+            name="FK Clear Site",
+            slug="fk-clear-site",
+            tenant=self.tenant,
+            description="Site with tenant",
+        )
+
+        # Create device + interface + IP address with assigned_object
+        self.manufacturer = Manufacturer.objects.create(name="FK Test Mfg", slug="fk-test-mfg")
+        self.device_type = DeviceType.objects.create(
+            manufacturer=self.manufacturer, model="FK Test Type", slug="fk-test-type"
+        )
+        self.role = DeviceRole.objects.create(name="FK Test Role", slug="fk-test-role", color="ff0000")
+        self.device = Device.objects.create(
+            name="FK Test Device",
+            device_type=self.device_type,
+            role=self.role,
+            site=self.site,
+        )
+        self.interface = Interface.objects.create(
+            device=self.device, name="eth0", type="virtual"
+        )
+        self.ip_address = IPAddress.objects.create(
+            address="10.0.0.1/24",
+            assigned_object=self.interface,
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_null_tenant_clears_fk_on_site(self):
+        """Setting tenant to null on a site that has a tenant should produce an update clearing it."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "FK Clear Site",
+                    "slug": "fk-clear-site",
+                    "tenant": None,
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        site_changes = [c for c in changes if c["object_type"] == "dcim.site"]
+        self.assertEqual(len(site_changes), 1)
+        change = site_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+
+        data = change.get("data", {})
+        self.assertIn("tenant", data)
+        self.assertIsNone(data["tenant"])
+
+    def test_omitted_tenant_leaves_fk_unchanged(self):
+        """Not providing tenant at all should not include it in the changeset."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "FK Clear Site",
+                    "slug": "fk-clear-site",
+                    "description": "Updated description",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        site_changes = [c for c in changes if c["object_type"] == "dcim.site"]
+        self.assertEqual(len(site_changes), 1)
+        change = site_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+
+        data = change.get("data", {})
+        # tenant was not in the payload — must not appear in changeset
+        self.assertNotIn("tenant", data)
+
+    def test_null_assigned_object_interface_clears_generic_fk(self):
+        """Setting assigned_object_interface to null on an IP with an interface should clear it."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "10.0.0.1/24",
+                    "assigned_object_interface": None,
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        ip_changes = [c for c in changes if c["object_type"] == "ipam.ipaddress"]
+        self.assertEqual(len(ip_changes), 1)
+        change = ip_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.ip_address.id)
+
+        data = change.get("data", {})
+        self.assertIn("assigned_object_id", data)
+        self.assertIsNone(data["assigned_object_id"])
+        self.assertIn("assigned_object_type", data)
+        self.assertIsNone(data["assigned_object_type"])
+
+    def test_omitted_assigned_object_leaves_generic_fk_unchanged(self):
+        """Not providing assigned_object at all should not include it in the changeset."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "10.0.0.1/24",
+                    "description": "Updated description",
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        ip_changes = [c for c in changes if c["object_type"] == "ipam.ipaddress"]
+        self.assertEqual(len(ip_changes), 1)
+        change = ip_changes[0]
+
+        data = change.get("data", {})
+        # assigned_object was not in payload — must not appear in changeset
+        self.assertNotIn("assigned_object_id", data)
+        self.assertNotIn("assigned_object_type", data)
+
+    def test_empty_dict_tenant_clears_fk_on_site(self):
+        """Setting tenant to {} (protojson for empty message) should clear it, same as null."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "FK Clear Site",
+                    "slug": "fk-clear-site",
+                    "tenant": {},
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        site_changes = [c for c in changes if c["object_type"] == "dcim.site"]
+        self.assertEqual(len(site_changes), 1)
+        change = site_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+
+        data = change.get("data", {})
+        self.assertIn("tenant", data)
+        self.assertIsNone(data["tenant"])
+
+    def test_empty_dict_assigned_object_clears_generic_fk(self):
+        """Setting assigned_object_interface to {} should clear the GFK, same as null."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "10.0.0.1/24",
+                    "assigned_object_interface": {},
+                },
+            },
+        }
+
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        ip_changes = [c for c in changes if c["object_type"] == "ipam.ipaddress"]
+        self.assertEqual(len(ip_changes), 1)
+        change = ip_changes[0]
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.ip_address.id)
+
+        data = change.get("data", {})
+        self.assertIn("assigned_object_id", data)
+        self.assertIsNone(data["assigned_object_id"])
+        self.assertIn("assigned_object_type", data)
+        self.assertIsNone(data["assigned_object_type"])
 
 
 class PKBasedMatchingTestCase(APITestCase):


### PR DESCRIPTION
## Summary

Related to https://github.com/netboxlabs/diode/issues/421

- **Differ**: for UPDATE changesets, stop stripping empty strings (`""`) and `None` values from changeset `data`. This allows users to explicitly clear optional fields (e.g. reset `description` to `""` or remove a `tenant` assignment) via diode ingestion. CREATE changesets retain existing behavior (strip empty values to avoid noise).
- **Transformer**: handle `null` and `{}` (empty dict) values for reference fields. An empty dict comes from `protojson` when the SDK sets a message field to an empty message (e.g. `Tenant{}`) to signal "clear this field". Both are treated as "clear this FK" for regular FKs, generic FKs (e.g. `assigned_object`), and circular reference fields.

### Background

Previously, `clean_diff_data()` stripped empty strings, `None`, empty lists, and empty dicts unconditionally. This made three scenarios indistinguishable:

| User intent | Proto / JSON representation | Previous behavior | New behavior |
|---|---|---|---|
| Leave field unchanged | Key absent from JSON | Correct (not in changeset) | Correct (unchanged) |
| Clear string field | `"description": ""` | **Stripped** — treated as "leave unchanged" | Preserved in update `data` |
| Clear FK reference | `"tenant": null` or `"tenant": {}` | **Stripped** or crash | Converted to `None`, preserved |

A companion test in `diode-server` ([branch `test/protojson-field-presence-behavior`](https://github.com/netboxlabs/diode/tree/test/protojson-field-presence-behavior)) confirms that `protoToJSON()` already emits the correct signals — no Go server changes needed:
- `optional string` not set → omitted; set to `""` → `"description": ""`
- `optional Tenant` nil → omitted; set to `Tenant{}` → `"tenant": {}`
- `oneof` not set → all variants omitted; set to `Interface{}` → `"assigned_object_interface": {}`

## Test plan

- [x] 297 tests pass (291 existing + 15 new covering all field-clearing scenarios)
- [x] Verify with a real diode ingestion flow (SDK → server → plugin) that clearing a field works end-to-end
- [ ] SDK changes to document/support the empty-message convention for clearing FKs (separate PR)