### PR TITLE
feat: display-only diode_target_display plugin config setting

### DIFF
--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -43,6 +43,10 @@ class NetBoxDiodePluginConfig(PluginConfig):
         # TTL in seconds for caching find_existing_object results in Redis.
         # Set to 0 to disable caching.
         "find_obj_cache_ttl": 5,
+
+        # Override the displayed Diode target URL without affecting internal
+        # communication (e.g. to show the external ingress address).
+        "diode_target_display": None,
     }
 
 

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_views.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_views.py
@@ -76,6 +76,53 @@ class SettingsViewTestCase(TestCase):
             self.assertIn("grpc://localhost:8080/diode", str(response.content))
 
 
+    def test_settings_display_with_diode_target_display(self):
+        """Test that diode_target_display overrides the displayed target."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        def mock_get_plugin_config(plugin, key):
+            if key == "diode_target_display":
+                return "grpcs://external.example.com/diode"
+            if key == "diode_target_override":
+                return None
+            if key == "diode_target":
+                return "grpc://localhost:8080/diode"
+            return None
+
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config",
+            side_effect=mock_get_plugin_config,
+        ):
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpcs://external.example.com/diode", str(response.content))
+            self.assertNotIn("grpc://localhost:8080/diode", str(response.content))
+
+    def test_diode_target_display_takes_precedence_over_override(self):
+        """Test that diode_target_display takes precedence over diode_target_override for display."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        def mock_get_plugin_config(plugin, key):
+            if key == "diode_target_display":
+                return "grpcs://external.example.com/diode"
+            if key == "diode_target_override":
+                return "grpc://internal-override:8080/diode"
+            if key == "diode_target":
+                return "grpc://localhost:8080/diode"
+            return None
+
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config",
+            side_effect=mock_get_plugin_config,
+        ):
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpcs://external.example.com/diode", str(response.content))
+            self.assertNotIn("grpc://internal-override:8080/diode", str(response.content))
+
+
 class SettingsEditViewTestCase(TestCase):
     """Test case for the SettingsEditView."""
 

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_views.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_views.py
@@ -76,6 +76,53 @@ class SettingsViewTestCase(TestCase):
             self.assertIn("grpc://localhost:8080/diode", str(response.content))
 
 
+    def test_settings_display_with_diode_target_display(self):
+        """Test that diode_target_display overrides the displayed target."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        def mock_get_plugin_config(plugin, key):
+            if key == "diode_target_display":
+                return "grpcs://external.example.com/diode"
+            if key == "diode_target_override":
+                return None
+            if key == "diode_target":
+                return "grpc://localhost:8080/diode"
+            return None
+
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config",
+            side_effect=mock_get_plugin_config,
+        ):
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpcs://external.example.com/diode", str(response.content))
+            self.assertNotIn("grpc://localhost:8080/diode", str(response.content))
+
+    def test_diode_target_display_takes_precedence_over_override(self):
+        """Test that diode_target_display takes precedence over diode_target_override for display."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        def mock_get_plugin_config(plugin, key):
+            if key == "diode_target_display":
+                return "grpcs://external.example.com/diode"
+            if key == "diode_target_override":
+                return "grpc://internal-override:8080/diode"
+            if key == "diode_target":
+                return "grpc://localhost:8080/diode"
+            return None
+
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config",
+            side_effect=mock_get_plugin_config,
+        ):
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpcs://external.example.com/diode", str(response.content))
+            self.assertNotIn("grpc://internal-override:8080/diode", str(response.content))
+
+
 class SettingsEditViewTestCase(TestCase):
     """Test case for the SettingsEditView."""
 

--- a/netbox_diode_plugin/views.py
+++ b/netbox_diode_plugin/views.py
@@ -147,6 +147,9 @@ class SettingsView(BaseDiodeView):
         diode_target_override = get_plugin_config(
             "netbox_diode_plugin", "diode_target_override"
         )
+        diode_target_display = get_plugin_config(
+            "netbox_diode_plugin", "diode_target_display"
+        )
 
         try:
             settings = Setting.objects.get()
@@ -158,7 +161,11 @@ class SettingsView(BaseDiodeView):
                 diode_target=diode_target_override or default_diode_target
             )
 
-        diode_target = diode_target_override or settings.diode_target
+        diode_target = (
+            diode_target_display
+            or diode_target_override
+            or settings.diode_target
+        )
 
         # Check if branching plugin is available
         from django.conf import settings as django_settings
@@ -166,7 +173,10 @@ class SettingsView(BaseDiodeView):
 
         context = {
             "diode_target": diode_target,
-            "is_diode_target_overridden": diode_target_override is not None,
+            "is_diode_target_overridden": (
+                diode_target_override is not None
+                or diode_target_display is not None
+            ),
             "branch": settings.branch if has_branching_plugin else None,
             "has_branching_plugin": has_branching_plugin,
         }


### PR DESCRIPTION
## Summary
- Adds a new `diode_target_display` plugin config setting that overrides the Diode Target URL shown on the Settings page without affecting internal auth communication
- When set, takes precedence over both `diode_target_override` and the DB-stored target for display purposes only
- Allows showing the correct external ingress address so users know where to point their gRPC clients

## Test plan
- [x] New tests for `diode_target_display` overriding the displayed target
- [x] New tests for `diode_target_display` taking precedence over `diode_target_override`
- [x] All 286 existing tests pass
- [x] Ruff lint clean

Closes OBS-1821