### PR TITLE
fix: handle IntegrityError race in concurrent changeset applies

### DIFF
--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -6,7 +6,7 @@
 import logging
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import models
+from django.db import models, transaction
 from django.db.utils import IntegrityError
 from rest_framework.exceptions import ValidationError as ValidationError
 
@@ -93,8 +93,9 @@ def _create_or_find_instance(data: dict, object_type: str, serializer_class, req
     serializer = serializer_class(data=data, context={"request": request})
     try:
         serializer.is_valid(raise_exception=True)
-        return serializer.save()
-    except ValidationError as e:
+        with transaction.atomic():
+            return serializer.save()
+    except (ValidationError, IntegrityError) as e:
         instance = find_existing_object(data, object_type)
         if not instance:
             raise e


### PR DESCRIPTION
## Summary

- Wraps `serializer.save()` in `transaction.atomic()` savepoint in `_create_or_find_instance`
- Catches `IntegrityError` alongside `ValidationError`, falling back to `find_existing_object()`
- Fixes TOCTOU race where concurrent applies hit DB unique constraints between `is_valid()` and `save()`

## Context

Under concurrent changeset applies, `is_valid()` passes (no duplicate exists at validation time), but another request inserts the same object before `save()` executes — hitting a DB unique constraint. PostgreSQL aborts the entire transaction on `IntegrityError`. The `transaction.atomic()` block creates a savepoint so only the failed statement rolls back, allowing the subsequent `find_existing_object()` query to execute.

## Test plan

- [x] Existing test suite passes (296/296)
- [x] Bench with auto-apply at concurrency=50: zero apply failures

Linear: OBS-2857