### PR TITLE
feat: logical VRF name match when RD is null (no-tenant + within-tenant)

### DIFF
--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -485,8 +485,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| logical_vrf_name_no_rd_no_tenant | 1 | logical | name | rd is NULL AND tenant is NULL | Matches on fields: name where rd is NULL AND tenant is NULL | All versions |
-| logical_vrf_name_no_rd_within_tenant | 2 | logical | name, tenant | rd is NULL AND tenant is NOT NULL | Matches on fields: name, tenant where rd is NULL AND tenant is NOT NULL | All versions |
+| logical_vrf_name_no_tenant | 1 | logical | name | rd is NULL AND tenant is NULL | Matches on fields: name where rd is NULL AND tenant is NULL | All versions |
+| logical_vrf_name_within_tenant | 2 | logical | name, tenant | rd is NULL AND tenant is NOT NULL | Matches on fields: name, tenant where rd is NULL AND tenant is NOT NULL | All versions |
 | unique_rd | 3 | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
 
 ## tenancy.contact

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -485,7 +485,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_rd | 1 | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
+| logical_vrf_name_no_rd | 1 | logical | name | rd is NULL | Matches on fields: name where rd is NULL | All versions |
+| unique_rd | 2 | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
 
 ## tenancy.contact
 

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -485,8 +485,9 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| logical_vrf_name_no_rd | 1 | logical | name | rd is NULL | Matches on fields: name where rd is NULL | All versions |
-| unique_rd | 2 | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
+| logical_vrf_name_no_rd_no_tenant | 1 | logical | name | rd is NULL AND tenant is NULL | Matches on fields: name where rd is NULL AND tenant is NULL | All versions |
+| logical_vrf_name_no_rd_within_tenant | 2 | logical | name, tenant | rd is NULL AND tenant is NOT NULL | Matches on fields: name, tenant where rd is NULL AND tenant is NOT NULL | All versions |
+| unique_rd | 3 | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
 
 ## tenancy.contact
 

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -179,13 +179,13 @@ _LOGICAL_MATCHERS = {
     "ipam.vrf": lambda: [
         ObjectMatchCriteria(
             fields=("name",),
-            name="logical_vrf_name_no_rd_no_tenant",
+            name="logical_vrf_name_no_tenant",
             model_class=get_object_type_model("ipam.vrf"),
             condition=Q(rd__isnull=True, tenant__isnull=True),
         ),
         ObjectMatchCriteria(
             fields=("name", "tenant"),
-            name="logical_vrf_name_no_rd_within_tenant",
+            name="logical_vrf_name_within_tenant",
             model_class=get_object_type_model("ipam.vrf"),
             condition=Q(rd__isnull=True, tenant__isnull=False),
         ),

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -179,9 +179,15 @@ _LOGICAL_MATCHERS = {
     "ipam.vrf": lambda: [
         ObjectMatchCriteria(
             fields=("name",),
-            name="logical_vrf_name_no_rd",
+            name="logical_vrf_name_no_rd_no_tenant",
             model_class=get_object_type_model("ipam.vrf"),
-            condition=Q(rd__isnull=True),
+            condition=Q(rd__isnull=True, tenant__isnull=True),
+        ),
+        ObjectMatchCriteria(
+            fields=("name", "tenant"),
+            name="logical_vrf_name_no_rd_within_tenant",
+            model_class=get_object_type_model("ipam.vrf"),
+            condition=Q(rd__isnull=True, tenant__isnull=False),
         ),
     ],
     "wireless.wirelesslan": lambda: [

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -176,6 +176,14 @@ _LOGICAL_MATCHERS = {
             condition=Q(scope_type__isnull=True),
         ),
     ],
+    "ipam.vrf": lambda: [
+        ObjectMatchCriteria(
+            fields=("name",),
+            name="logical_vrf_name_no_rd",
+            model_class=get_object_type_model("ipam.vrf"),
+            condition=Q(rd__isnull=True),
+        ),
+    ],
     "wireless.wirelesslan": lambda: [
         ObjectMatchCriteria(
             fields=("ssid",),

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_diff_and_apply.py
@@ -960,7 +960,7 @@ class GenerateDiffAndApplyTestCase(APITestCase):
             "object_type": "ipam.vrf",
             "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
         })
-        # Second diff must be a no-op — proves logical_vrf_name_no_rd_within_tenant matched.
+        # Second diff must be a no-op — proves logical_vrf_name_within_tenant matched.
         response = self.client.post(self.diff_url, data={
             "timestamp": 2,
             "object_type": "ipam.vrf",

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_diff_and_apply.py
@@ -953,6 +953,56 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         self.assertEqual(vrfs.count(), 1)
         self.assertEqual(vrfs.first().description, "second")
 
+    def test_generate_diff_and_apply_vrf_no_rd_within_tenant_dedup(self):
+        """Re-ingesting an RD-less VRF within the same tenant resolves to the existing row."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
+        })
+        # Second diff must be a no-op — proves logical_vrf_name_no_rd_within_tenant matched.
+        response = self.client.post(self.diff_url, data={
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
+        }, format="json", **self.authorization_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+        self.assertEqual(VRF.objects.filter(name="VRF-E").count(), 1)
+
+    def test_generate_diff_and_apply_vrf_no_rd_no_cross_tenant_collapse(self):
+        """Two RD-less VRFs with the same name in different tenants must remain distinct."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-F", "tenant": {"name": "Tenant F1"}}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-F", "tenant": {"name": "Tenant F2"}}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-F").select_related("tenant").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual({v.tenant.name for v in vrfs}, {"Tenant F1", "Tenant F2"})
+
+    def test_generate_diff_and_apply_vrf_no_rd_no_tenant_does_not_match_tenant_vrf(self):
+        """A no-tenant RD-less ingest must not collapse into a same-name VRF that has a tenant."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-G", "tenant": {"name": "Tenant G"}}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-G"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-G").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual(vrfs[0].tenant.name, "Tenant G")
+        self.assertIsNone(vrfs[1].tenant)
+
     def test_generate_diff_and_apply_ip_address_with_assigned_object_interface(self):
         """Test ip."""
         payload = {

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_diff_and_apply.py
@@ -16,7 +16,7 @@ from core.models import ObjectType
 from dcim.models import Device, Interface, ModuleBay, Site
 from extras.models import CustomField
 from extras.models.customfields import CustomFieldChoiceSet, CustomFieldChoiceSetBaseChoices, CustomFieldTypeChoices
-from ipam.models import IPAddress, VLANGroup
+from ipam.models import VRF, IPAddress, VLANGroup
 from rest_framework import status
 from utilities.testing import APITestCase
 from virtualization.models import Cluster, VMInterface
@@ -880,6 +880,78 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         self.assertEqual(new_vlan_group.vid_ranges[0].upper, 10)
         self.assertEqual(new_vlan_group.vid_ranges[1].lower, 12)
         self.assertEqual(new_vlan_group.vid_ranges[1].upper, 21)
+
+    def test_generate_diff_and_apply_vrf_no_rd_dedup(self):
+        """Re-ingesting an RD-less VRF resolves to the existing row (empty diff on second pass)."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {
+                "vrf": {
+                    "name": "VRF-A",
+                },
+            },
+        }
+        self.diff_and_apply(payload)
+        # Second diff must be a no-op — proves the matcher resolved to the existing VRF.
+        response = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+        vrfs = VRF.objects.filter(name="VRF-A")
+        self.assertEqual(vrfs.count(), 1)
+        self.assertIsNone(vrfs.first().rd)
+
+    def test_generate_diff_and_apply_vrf_no_rd_does_not_match_rd_vrf(self):
+        """An RD-less ingest must not collapse into an existing RD'd VRF with the same name."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-B", "rd": "65000:1"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-B"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-B").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual(vrfs[0].rd, "65000:1")
+        self.assertIsNone(vrfs[1].rd)
+
+    def test_generate_diff_and_apply_vrf_rd_after_no_rd_does_not_collapse(self):
+        """An RD'd ingest after a no-RD ingest with the same name should create a new VRF."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-C"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-C", "rd": "65000:2"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-C").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertIsNone(vrfs[0].rd)
+        self.assertEqual(vrfs[1].rd, "65000:2")
+
+    def test_generate_diff_and_apply_vrf_no_rd_update(self):
+        """Repeat no-RD ingest with a different field value should update the same VRF, not duplicate."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-D", "description": "first"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-D", "description": "second"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-D")
+        self.assertEqual(vrfs.count(), 1)
+        self.assertEqual(vrfs.first().description, "second")
 
     def test_generate_diff_and_apply_ip_address_with_assigned_object_interface(self):
         """Test ip."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_diff_and_apply.py
@@ -961,7 +961,7 @@ class GenerateDiffAndApplyTestCase(APITestCase):
             "object_type": "ipam.vrf",
             "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
         })
-        # Second diff must be a no-op — proves logical_vrf_name_no_rd_within_tenant matched.
+        # Second diff must be a no-op — proves logical_vrf_name_within_tenant matched.
         response = self.client.post(self.diff_url, data={
             "timestamp": 2,
             "object_type": "ipam.vrf",

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_diff_and_apply.py
@@ -16,7 +16,7 @@ from core.models import ObjectType
 from dcim.models import Device, FrontPort, Interface, ModuleBay, RearPort, Site
 from extras.models import CustomField
 from extras.models.customfields import CustomFieldChoiceSet, CustomFieldChoiceSetBaseChoices, CustomFieldTypeChoices
-from ipam.models import ASN, IPAddress, VLANGroup, VLANTranslationPolicy
+from ipam.models import ASN, VRF, IPAddress, VLANGroup, VLANTranslationPolicy
 from rest_framework import status
 from users.models import Owner, OwnerGroup
 from utilities.testing import APITestCase
@@ -881,6 +881,78 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         self.assertEqual(new_vlan_group.vid_ranges[0].upper, 10)
         self.assertEqual(new_vlan_group.vid_ranges[1].lower, 12)
         self.assertEqual(new_vlan_group.vid_ranges[1].upper, 21)
+
+    def test_generate_diff_and_apply_vrf_no_rd_dedup(self):
+        """Re-ingesting an RD-less VRF resolves to the existing row (empty diff on second pass)."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {
+                "vrf": {
+                    "name": "VRF-A",
+                },
+            },
+        }
+        self.diff_and_apply(payload)
+        # Second diff must be a no-op — proves the matcher resolved to the existing VRF.
+        response = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+        vrfs = VRF.objects.filter(name="VRF-A")
+        self.assertEqual(vrfs.count(), 1)
+        self.assertIsNone(vrfs.first().rd)
+
+    def test_generate_diff_and_apply_vrf_no_rd_does_not_match_rd_vrf(self):
+        """An RD-less ingest must not collapse into an existing RD'd VRF with the same name."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-B", "rd": "65000:1"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-B"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-B").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual(vrfs[0].rd, "65000:1")
+        self.assertIsNone(vrfs[1].rd)
+
+    def test_generate_diff_and_apply_vrf_rd_after_no_rd_does_not_collapse(self):
+        """An RD'd ingest after a no-RD ingest with the same name should create a new VRF."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-C"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-C", "rd": "65000:2"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-C").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertIsNone(vrfs[0].rd)
+        self.assertEqual(vrfs[1].rd, "65000:2")
+
+    def test_generate_diff_and_apply_vrf_no_rd_update(self):
+        """Repeat no-RD ingest with a different field value should update the same VRF, not duplicate."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-D", "description": "first"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-D", "description": "second"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-D")
+        self.assertEqual(vrfs.count(), 1)
+        self.assertEqual(vrfs.first().description, "second")
 
     def test_generate_diff_and_apply_ip_address_with_assigned_object_interface(self):
         """Test ip."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_diff_and_apply.py
@@ -954,6 +954,56 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         self.assertEqual(vrfs.count(), 1)
         self.assertEqual(vrfs.first().description, "second")
 
+    def test_generate_diff_and_apply_vrf_no_rd_within_tenant_dedup(self):
+        """Re-ingesting an RD-less VRF within the same tenant resolves to the existing row."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
+        })
+        # Second diff must be a no-op — proves logical_vrf_name_no_rd_within_tenant matched.
+        response = self.client.post(self.diff_url, data={
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
+        }, format="json", **self.authorization_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+        self.assertEqual(VRF.objects.filter(name="VRF-E").count(), 1)
+
+    def test_generate_diff_and_apply_vrf_no_rd_no_cross_tenant_collapse(self):
+        """Two RD-less VRFs with the same name in different tenants must remain distinct."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-F", "tenant": {"name": "Tenant F1"}}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-F", "tenant": {"name": "Tenant F2"}}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-F").select_related("tenant").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual({v.tenant.name for v in vrfs}, {"Tenant F1", "Tenant F2"})
+
+    def test_generate_diff_and_apply_vrf_no_rd_no_tenant_does_not_match_tenant_vrf(self):
+        """A no-tenant RD-less ingest must not collapse into a same-name VRF that has a tenant."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-G", "tenant": {"name": "Tenant G"}}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-G"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-G").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual(vrfs[0].tenant.name, "Tenant G")
+        self.assertIsNone(vrfs[1].tenant)
+
     def test_generate_diff_and_apply_ip_address_with_assigned_object_interface(self):
         """Test ip."""
         payload = {


### PR DESCRIPTION
## Summary
- Add tenant-aware logical matching for VRFs without a Route Distinguisher. Previously every RD-less VRF ingest created a duplicate row.
- Two matchers, mirroring the prefix global-vs-VRF pattern:
  - `logical_vrf_name_no_tenant` — match on `name` when `rd IS NULL` AND `tenant IS NULL`.
  - `logical_vrf_name_within_tenant` — match on `(name, tenant)` when `rd IS NULL` AND `tenant IS NOT NULL`.
- When incoming data has an `rd`, both new matchers' conditions reject and we fall through to the existing `unique_rd` builtin matcher — no behavior change for RD'd VRFs.
- Splitting the matcher (rather than a single name-only one) avoids silent cross-tenant collapse: VRF "MGMT" in tenant Acme stays distinct from VRF "MGMT" in tenant Beta and from a tenant-less "MGMT".
- Naming follows the established convention in [matcher.py](netbox_diode_plugin/api/matcher.py): the `rd IS NULL` precondition is implicit (just as `group IS NULL` / `qinq_svlan IS NULL` are implicit in `logical_vlan_in_site`), and only the discriminating axis (tenant) is encoded in the matcher name.

## Test plan
- [x] `test_generate_diff_and_apply_vrf_no_rd_dedup` — re-ingesting an identical RD-less, no-tenant payload produces an empty diff.
- [x] `test_generate_diff_and_apply_vrf_no_rd_does_not_match_rd_vrf` — RD-less ingest does not collapse into an existing RD'd VRF with the same name.
- [x] `test_generate_diff_and_apply_vrf_rd_after_no_rd_does_not_collapse` — RD'd ingest after an RD-less ingest with the same name creates a new VRF.
- [x] `test_generate_diff_and_apply_vrf_no_rd_update` — repeated RD-less ingest with a changed field updates the same VRF (no duplicate).
- [x] `test_generate_diff_and_apply_vrf_no_rd_within_tenant_dedup` — re-ingesting an RD-less VRF within the same tenant resolves to the existing row.
- [x] `test_generate_diff_and_apply_vrf_no_rd_no_cross_tenant_collapse` — two RD-less VRFs with the same name in different tenants stay distinct.
- [x] `test_generate_diff_and_apply_vrf_no_rd_no_tenant_does_not_match_tenant_vrf` — a no-tenant ingest does not collapse into a same-name tenant-set VRF.
- [x] Full v4.5 suite passes locally (303 tests).
- [ ] CI to validate v4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)