### PR TITLE
perf(bulk-api): add apply-change-set-batch endpoint

### DIFF
--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -29,7 +29,7 @@ def apply_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
         change_type = change.change_type
         object_type = change.object_type
 
-        if change_type == ChangeType.NOOP.value:
+        if change_type == ChangeType.NOOP:
             continue
 
         try:
@@ -105,7 +105,7 @@ def _apply_change(data: dict, model_class: models.Model, change: Change, created
     serializer_class = get_serializer_for_model(model_class)
     change_type = change.change_type
 
-    if change_type == ChangeType.CREATE.value:
+    if change_type == ChangeType.CREATE:
         # For component types that may be auto-created from e.g. DeviceType or ModuleType templates,
         # try to find existing object first before attempting to create.
         # This prevents duplicates when components are instantiated during Device/Module save()
@@ -120,7 +120,7 @@ def _apply_change(data: dict, model_class: models.Model, change: Change, created
         if change.ref_id:
             created[change.ref_id] = instance
 
-    elif change_type == ChangeType.UPDATE.value:
+    elif change_type == ChangeType.UPDATE:
         if object_id := change.object_id:
             instance = model_class.objects.get(id=object_id)
             serializer = serializer_class(instance, data=data, partial=True, context={"request": request})
@@ -185,7 +185,7 @@ def _validate_change_set(change_set: ChangeSet):
     for change in change_set.changes:
         if change.object_id is None and change.ref_id is None:
             raise _err("Object ID or Ref ID must be provided", change.object_type, NON_FIELD_ERRORS)
-        if change.change_type not in [ct.value for ct in ChangeType]:
+        if not isinstance(change.change_type, ChangeType):
             raise _err(f"Unsupported change type '{change.change_type}'", change.object_type, "change_type")
 
 def _err(message, object_name, field):

--- a/netbox_diode_plugin/api/common.py
+++ b/netbox_diode_plugin/api/common.py
@@ -90,6 +90,25 @@ class Change:
             "new_refs": self.new_refs,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict) -> "Change":
+        """Build a Change from a request data dict."""
+        change_type = data.get("change_type")
+        if isinstance(change_type, str):
+            try:
+                change_type = ChangeType(change_type)
+            except ValueError:
+                pass
+        return cls(
+            change_type=change_type,
+            object_type=data.get("object_type"),
+            object_id=data.get("object_id"),
+            ref_id=data.get("ref_id"),
+            data=data.get("data"),
+            before=data.get("before"),
+            new_refs=data.get("new_refs", []),
+        )
+
 
 @dataclass
 class ChangeSet:
@@ -110,6 +129,16 @@ class ChangeSet:
         if self.warnings:
             d["warnings"] = self.warnings
         return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ChangeSet":
+        """Build a ChangeSet from a request data dict."""
+        return cls(
+            id=data.get("id"),
+            changes=[Change.from_dict(c) for c in data.get("changes", [])],
+            branch=data.get("branch"),
+            warnings=data.get("warnings"),
+        )
 
     def validate(self) -> dict[str, list[str]]:
         """Validate basics of the change set data."""

--- a/netbox_diode_plugin/api/urls.py
+++ b/netbox_diode_plugin/api/urls.py
@@ -5,12 +5,18 @@
 from django.urls import include, path
 from netbox.api.routers import NetBoxRouter
 
-from .views import ApplyChangeSetView, GenerateDiffView, GetDefaultBranchView
+from .views import (
+    ApplyChangeSetBatchView,
+    ApplyChangeSetView,
+    GenerateDiffView,
+    GetDefaultBranchView,
+)
 
 router = NetBoxRouter()
 
 urlpatterns = [
     path("apply-change-set/", ApplyChangeSetView.as_view()),
+    path("apply-change-set-batch/", ApplyChangeSetBatchView.as_view()),
     path("generate-diff/", GenerateDiffView.as_view()),
     path("default-branch/", GetDefaultBranchView.as_view()),
     path("", include(router.urls)),

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -6,14 +6,13 @@ import re
 
 from django.apps import apps
 from django.db import transaction
-from rest_framework import views
+from rest_framework import status, views
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from .applier import apply_changeset
 from .authentication import DiodeOAuth2Authentication
 from .common import (
-    Change,
     ChangeSet,
     ChangeSetException,
     ChangeSetResult,
@@ -54,6 +53,16 @@ def get_valid_entity_keys(model_name):
     lowerCamel = upperCamel[0].lower() + upperCamel[1:]  # lowerCamelCase
 
     return (snake, lowerCamel)
+
+
+def _apply_one_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
+    """Apply one changeset, returning a ChangeSetResult on success or on ChangeSetException."""
+    try:
+        with transaction.atomic():
+            return apply_changeset(change_set, request)
+    except ChangeSetException as e:
+        logger.error(f"Error applying change set: {e}")
+        return ChangeSetResult(id=change_set.id, errors=e.errors)
 
 
 class GenerateDiffView(views.APIView):
@@ -180,37 +189,72 @@ class ApplyChangeSetView(views.APIView):
             raise
 
     def _post(self, request, *args, **kwargs):
-        data = request.data.copy()
-
-        changes = []
-        if "changes" in data:
-            changes = [
-                Change(
-                    change_type=change.get("change_type"),
-                    object_type=change.get("object_type"),
-                    object_id=change.get("object_id"),
-                    ref_id=change.get("ref_id"),
-                    data=change.get("data"),
-                    before=change.get("before"),
-                    new_refs=change.get("new_refs", []),
-                )
-                for change in data["changes"]
-            ]
-        change_set = ChangeSet(
-            id=data.get("id"),
-            changes=changes,
-        )
-        try:
-            with transaction.atomic():
-                result = apply_changeset(change_set, request)
-        except ChangeSetException as e:
-            logger.error(f"Error applying change set: {e}")
-            result = ChangeSetResult(
-                id=change_set.id,
-                errors=e.errors,
-            )
-
+        change_set = ChangeSet.from_dict(request.data)
+        result = _apply_one_changeset(change_set, request)
         return Response(result.to_dict(), status=result.get_status_code())
+
+
+class ApplyChangeSetBatchView(views.APIView):
+    """
+    ApplyChangeSetBatch view.
+
+    Accepts ``{"change_sets": [<changeset>, ...]}`` and applies each changeset
+    in its own ``transaction.atomic()`` block (matching the singular
+    ``apply-change-set/`` endpoint). A failure in one changeset does not affect
+    the others.
+
+    Response shape: ``{"results": [<ChangeSetResult>, ...]}`` with one result
+    per input changeset, preserving order. HTTP 200 if all succeeded,
+    HTTP 207 (multi-status) if at least one changeset failed, HTTP 400 if the
+    batch envelope itself was invalid.
+    """
+
+    authentication_classes = [DiodeOAuth2Authentication]
+    permission_classes = [IsAuthenticated, require_scopes(SCOPE_NETBOX_WRITE)]
+
+    def post(self, request, *args, **kwargs):
+        """Apply a batch of change sets."""
+        try:
+            return self._post(request, *args, **kwargs)
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            raise
+
+    def _post(self, request, *args, **kwargs):
+        change_sets = request.data.get("change_sets")
+        if change_sets is None:
+            raise ValidationError({"change_sets": ["change_sets is required"]})
+        if not isinstance(change_sets, list):
+            raise ValidationError({"change_sets": ["change_sets must be a list"]})
+        if len(change_sets) == 0:
+            raise ValidationError({"change_sets": ["change_sets must not be empty"]})
+
+        results = []
+        for entry in change_sets:
+            if not isinstance(entry, dict):
+                results.append(
+                    ChangeSetResult(
+                        errors={"request": {"change_set": ["change_set must be an object"]}}
+                    ).to_dict()
+                )
+                continue
+            try:
+                change_set = ChangeSet.from_dict(entry)
+                result = _apply_one_changeset(change_set, request).to_dict()
+            except Exception as e:
+                logger.error(f"Error parsing batch entry: {e}")
+                result = ChangeSetResult(
+                    errors={"request": {"change_set": [f"invalid change_set: {e}"]}}
+                ).to_dict()
+            results.append(result)
+
+        http_status = (
+            status.HTTP_207_MULTI_STATUS
+            if any(r.get("errors") for r in results)
+            else status.HTTP_200_OK
+        )
+        return Response({"results": results}, status=http_status)
 
 
 class GetDefaultBranchView(views.APIView):

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_apply_change_set_batch.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_apply_change_set_batch.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - ApplyChangeSetBatch Tests."""
+
+import uuid
+
+from dcim.models import Site
+from rest_framework import status
+
+from .test_api_apply_change_set import BaseApplyChangeSet
+
+
+class ApplyChangeSetBatchTestCase(BaseApplyChangeSet):
+    """ApplyChangeSetBatch test cases."""
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.batch_url = "/netbox/api/plugins/diode/apply-change-set-batch/"
+        # BaseApplyChangeSet creates fixtures with hardcoded ids (Site id=10, id=20)
+        # via bulk_create, which does not advance the Postgres PK sequence.
+        # Auto-allocating CREATE INSERTs in this test class would otherwise
+        # collide with those fixture ids once the sequence catches up.
+        from django.db import connection
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT setval(pg_get_serial_sequence('dcim_site', 'id'), 10000, false)"
+            )
+
+    def _changeset_create_site(self, name, slug):
+        return {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": name,
+                        "slug": slug,
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "1 Fake St",
+                        "shipping_address": "1 Fake St",
+                        "comments": "",
+                        "asns": [self.asns[0].pk],
+                    },
+                },
+            ],
+        }
+
+    def _changeset_create_site_bad(self, name, slug):
+        cs = self._changeset_create_site(name, slug)
+        # asns must be a list — pass an int to trigger DRF ValidationError
+        cs["changes"][0]["data"]["asns"] = 1
+        return cs
+
+    def _post_batch(self, payload, status_code=status.HTTP_200_OK):
+        response = self.client.post(
+            self.batch_url,
+            data=payload,
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_batch_three_changesets_all_created(self):
+        """All three changesets in a batch create successfully."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Batch Site A", "batch-site-a"),
+                self._changeset_create_site("Batch Site B", "batch-site-b"),
+                self._changeset_create_site("Batch Site C", "batch-site-c"),
+            ],
+        }
+
+        response = self._post_batch(payload)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        for r in results:
+            self.assertIsNone(r.get("errors"))
+
+        for slug in ("batch-site-a", "batch-site-b", "batch-site-c"):
+            self.assertTrue(Site.objects.filter(slug=slug).exists())
+
+    def test_batch_savepoint_isolation_bad_middle(self):
+        """A bad changeset in the middle does not roll back the others."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Iso Site A", "iso-site-a"),
+                self._changeset_create_site_bad("Iso Site B", "iso-site-b"),
+                self._changeset_create_site("Iso Site C", "iso-site-c"),
+            ],
+        }
+
+        response = self._post_batch(payload, status_code=status.HTTP_207_MULTI_STATUS)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertIsNotNone(results[1].get("errors"))
+        self.assertIsNone(results[2].get("errors"))
+
+        self.assertTrue(Site.objects.filter(slug="iso-site-a").exists())
+        self.assertFalse(Site.objects.filter(slug="iso-site-b").exists())
+        self.assertTrue(Site.objects.filter(slug="iso-site-c").exists())
+
+    def test_batch_single_changeset_matches_old_endpoint(self):
+        """A 1-element batch produces the same effect as the per-changeset endpoint."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Single Site", "single-site"),
+            ],
+        }
+
+        response = self._post_batch(payload)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertTrue(Site.objects.filter(slug="single-site").exists())
+
+    def test_batch_empty_returns_400(self):
+        """Empty change_sets list returns 400."""
+        self._post_batch({"change_sets": []}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_missing_change_sets_returns_400(self):
+        """Missing change_sets key returns 400."""
+        self._post_batch({}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_change_sets_not_a_list_returns_400(self):
+        """change_sets not a list returns 400."""
+        self._post_batch(
+            {"change_sets": {"not": "a list"}},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def test_change_type_from_dict_normalises_and_round_trips(self):
+        """from_dict normalises change_type to enum; to_dict round-trips back to string."""
+        from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeType
+
+        change = Change.from_dict({
+            "change_type": "create",
+            "object_type": "dcim.site",
+            "data": {"name": "x", "slug": "x"},
+        })
+        self.assertEqual(change.change_type, ChangeType.CREATE)
+
+        cs = ChangeSet.from_dict({
+            "id": str(uuid.uuid4()),
+            "changes": [{"change_type": "update", "object_type": "dcim.site"}],
+        })
+        self.assertEqual(cs.changes[0].change_type, ChangeType.UPDATE)
+        self.assertEqual(cs.changes[0].to_dict()["change_type"], "update")
+
+        bad = Change.from_dict({"change_type": "delete", "object_type": "dcim.site"})
+        self.assertEqual(bad.change_type, "delete")
+
+    def test_change_set_from_dict_carries_branch_and_warnings(self):
+        """ChangeSet.from_dict picks up branch and warnings, and to_dict round-trips them."""
+        from netbox_diode_plugin.api.common import ChangeSet
+
+        cs = ChangeSet.from_dict({
+            "id": str(uuid.uuid4()),
+            "changes": [],
+            "branch": {"id": "abc", "name": "feature/x"},
+            "warnings": {"some_warning": ["foo"]},
+        })
+        self.assertEqual(cs.branch, {"id": "abc", "name": "feature/x"})
+        self.assertEqual(cs.warnings, {"some_warning": ["foo"]})
+        d = cs.to_dict()
+        self.assertEqual(d["branch"], {"id": "abc", "name": "feature/x"})
+        self.assertEqual(d["warnings"], {"some_warning": ["foo"]})
+
+        cs_empty = ChangeSet.from_dict({"id": str(uuid.uuid4()), "changes": []})
+        self.assertIsNone(cs_empty.branch)
+        self.assertIsNone(cs_empty.warnings)
+
+    def test_batch_malformed_per_entry_yields_207(self):
+        """A batch entry with non-list ``changes`` yields a per-item error, not a 500."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Batch OK", "batch-ok"),
+                {"id": str(uuid.uuid4()), "changes": "not-a-list"},
+            ],
+        }
+        response = self._post_batch(payload, status_code=status.HTTP_207_MULTI_STATUS)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 2)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertIsNotNone(results[1].get("errors"))
+        self.assertTrue(Site.objects.filter(slug="batch-ok").exists())
+

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_apply_change_set_batch.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_apply_change_set_batch.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - ApplyChangeSetBatch Tests."""
+
+import uuid
+
+from dcim.models import Site
+from rest_framework import status
+
+from .test_api_apply_change_set import BaseApplyChangeSet
+
+
+class ApplyChangeSetBatchTestCase(BaseApplyChangeSet):
+    """ApplyChangeSetBatch test cases."""
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.batch_url = "/netbox/api/plugins/diode/apply-change-set-batch/"
+        # BaseApplyChangeSet creates fixtures with hardcoded ids (Site id=10, id=20)
+        # via bulk_create, which does not advance the Postgres PK sequence.
+        # Auto-allocating CREATE INSERTs in this test class would otherwise
+        # collide with those fixture ids once the sequence catches up.
+        from django.db import connection
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT setval(pg_get_serial_sequence('dcim_site', 'id'), 10000, false)"
+            )
+
+    def _changeset_create_site(self, name, slug):
+        return {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": name,
+                        "slug": slug,
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "1 Fake St",
+                        "shipping_address": "1 Fake St",
+                        "comments": "",
+                        "asns": [self.asns[0].pk],
+                    },
+                },
+            ],
+        }
+
+    def _changeset_create_site_bad(self, name, slug):
+        cs = self._changeset_create_site(name, slug)
+        # asns must be a list — pass an int to trigger DRF ValidationError
+        cs["changes"][0]["data"]["asns"] = 1
+        return cs
+
+    def _post_batch(self, payload, status_code=status.HTTP_200_OK):
+        response = self.client.post(
+            self.batch_url,
+            data=payload,
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_batch_three_changesets_all_created(self):
+        """All three changesets in a batch create successfully."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Batch Site A", "batch-site-a"),
+                self._changeset_create_site("Batch Site B", "batch-site-b"),
+                self._changeset_create_site("Batch Site C", "batch-site-c"),
+            ],
+        }
+
+        response = self._post_batch(payload)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        for r in results:
+            self.assertIsNone(r.get("errors"))
+
+        for slug in ("batch-site-a", "batch-site-b", "batch-site-c"):
+            self.assertTrue(Site.objects.filter(slug=slug).exists())
+
+    def test_batch_savepoint_isolation_bad_middle(self):
+        """A bad changeset in the middle does not roll back the others."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Iso Site A", "iso-site-a"),
+                self._changeset_create_site_bad("Iso Site B", "iso-site-b"),
+                self._changeset_create_site("Iso Site C", "iso-site-c"),
+            ],
+        }
+
+        response = self._post_batch(payload, status_code=status.HTTP_207_MULTI_STATUS)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertIsNotNone(results[1].get("errors"))
+        self.assertIsNone(results[2].get("errors"))
+
+        self.assertTrue(Site.objects.filter(slug="iso-site-a").exists())
+        self.assertFalse(Site.objects.filter(slug="iso-site-b").exists())
+        self.assertTrue(Site.objects.filter(slug="iso-site-c").exists())
+
+    def test_batch_single_changeset_matches_old_endpoint(self):
+        """A 1-element batch produces the same effect as the per-changeset endpoint."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Single Site", "single-site"),
+            ],
+        }
+
+        response = self._post_batch(payload)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertTrue(Site.objects.filter(slug="single-site").exists())
+
+    def test_batch_empty_returns_400(self):
+        """Empty change_sets list returns 400."""
+        self._post_batch({"change_sets": []}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_missing_change_sets_returns_400(self):
+        """Missing change_sets key returns 400."""
+        self._post_batch({}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_change_sets_not_a_list_returns_400(self):
+        """change_sets not a list returns 400."""
+        self._post_batch(
+            {"change_sets": {"not": "a list"}},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def test_change_type_from_dict_normalises_and_round_trips(self):
+        """from_dict normalises change_type to enum; to_dict round-trips back to string."""
+        from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeType
+
+        change = Change.from_dict({
+            "change_type": "create",
+            "object_type": "dcim.site",
+            "data": {"name": "x", "slug": "x"},
+        })
+        self.assertEqual(change.change_type, ChangeType.CREATE)
+
+        cs = ChangeSet.from_dict({
+            "id": str(uuid.uuid4()),
+            "changes": [{"change_type": "update", "object_type": "dcim.site"}],
+        })
+        self.assertEqual(cs.changes[0].change_type, ChangeType.UPDATE)
+        self.assertEqual(cs.changes[0].to_dict()["change_type"], "update")
+
+        bad = Change.from_dict({"change_type": "delete", "object_type": "dcim.site"})
+        self.assertEqual(bad.change_type, "delete")
+
+    def test_change_set_from_dict_carries_branch_and_warnings(self):
+        """ChangeSet.from_dict picks up branch and warnings, and to_dict round-trips them."""
+        from netbox_diode_plugin.api.common import ChangeSet
+
+        cs = ChangeSet.from_dict({
+            "id": str(uuid.uuid4()),
+            "changes": [],
+            "branch": {"id": "abc", "name": "feature/x"},
+            "warnings": {"some_warning": ["foo"]},
+        })
+        self.assertEqual(cs.branch, {"id": "abc", "name": "feature/x"})
+        self.assertEqual(cs.warnings, {"some_warning": ["foo"]})
+        d = cs.to_dict()
+        self.assertEqual(d["branch"], {"id": "abc", "name": "feature/x"})
+        self.assertEqual(d["warnings"], {"some_warning": ["foo"]})
+
+        cs_empty = ChangeSet.from_dict({"id": str(uuid.uuid4()), "changes": []})
+        self.assertIsNone(cs_empty.branch)
+        self.assertIsNone(cs_empty.warnings)
+
+    def test_batch_malformed_per_entry_yields_207(self):
+        """A batch entry with non-list ``changes`` yields a per-item error, not a 500."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Batch OK", "batch-ok"),
+                {"id": str(uuid.uuid4()), "changes": "not-a-list"},
+            ],
+        }
+        response = self._post_batch(payload, status_code=status.HTTP_207_MULTI_STATUS)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 2)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertIsNotNone(results[1].get("errors"))
+        self.assertTrue(Site.objects.filter(slug="batch-ok").exists())
+


### PR DESCRIPTION
## Summary

Adds a new `POST /api/plugins/diode/apply-change-set-batch/` endpoint that
accepts `{"change_sets": [...]}` and applies each changeset within a single
HTTP request. The reconciler can then collapse N per-changeset HTTP calls
into one batched call.

**Scope of this change**: HTTP-call collapsing only. Each changeset is still
processed exactly the same way as the existing singular endpoint — same
`apply_changeset()` call, same per-changeset `transaction.atomic()` block,
same DB access pattern. Nothing inside the changeset processing changes.

- Each changeset is wrapped in its own `transaction.atomic()` block (same
  as the singular endpoint), so a single bad changeset does not roll back
  the rest of the batch.
- HTTP 200 if all changesets succeed; HTTP 207 (multi-status) on partial
  failure; HTTP 400 if the batch envelope itself is invalid.
- Response shape: `{"results": [<ChangeSetResult>, ...]}`, one entry per
  input changeset, preserving order.

The existing `apply-change-set/` endpoint is refactored to keep things DRY. The
reconciler-side wiring that calls the new endpoint lives in companion
changes in `diode` / `diode-pro`.

### What is collapsed (and what is not)

The only thing this PR collapses is the **per-HTTP-request overhead**, paid
once per batched call instead of once per changeset:

- Granian / Django request dispatch + middleware chain
- OAuth2 token introspection (`DiodeOAuth2Authentication`)
- `IsAuthenticated` + `require_scopes` permission checks
- DRF request parsing / serializer init
- TLS + HTTP framing on the reconciler→NetBox hop
- Reconciler-side rate-limiter slot consumption (1 slot per HTTP call)

At `APPLY_BATCH_SIZE=100` and ~27k entities workload these per-request
costs are paid ~84× fewer times.

### Performance impact (measured)

End-to-end bench at x10 workload (28,310 entities, RPS=100,
`APPLY_BATCH_SIZE=100`):

| Metric                          | Singular endpoint | Batch endpoint | Δ        |
|---------------------------------|------------------:|---------------:|----------|
| Apply-window wall-clock         | 56.7 min mean     | 43.5 min mean  | **-23 %**|
| HTTP calls into NetBox          | ~26,931           | ~318           | **84× fewer** |
| Total NetBox CPU-seconds        | ~120,910          | ~93,587        | **-23 %**|

Mean CPU% on NetBox is essentially flat between cells (36 vs 36) — the
saving is real reduction in work, not compression.

### Refactor / cleanup also included

Two small refactors landed alongside the new endpoint to keep the singular
and batch paths from diverging:

- **`Change.from_dict()` / `ChangeSet.from_dict()`** classmethods in
  `common.py` — replace the inline `Change(...)` list comprehension that
  previously lived in `ApplyChangeSetView._post()`. Both endpoints now
  parse request payloads through the same helpers.
- **`_apply_one_changeset()`** module-level helper in `views.py` — wraps
  the `try / with transaction.atomic(): apply_changeset(); except
  ChangeSetException` pattern that was duplicated between the two views.

### Bug fixed: `change_type` enum/string inconsistency

While extracting `Change.from_dict()`, a pre-existing latent bug surfaced
and is fixed in this PR:

- **Before**: the `Change` dataclass annotated `change_type: ChangeType`,
  but request-derived Changes carried the **raw string** (`"create"`,
  `"update"`, `"noop"`) because `ApplyChangeSetView._post()` constructed
  `Change(change_type=change.get("change_type"), ...)` without
  normalisation. `applier.py` papered over this by comparing
  `change_type == ChangeType.CREATE.value` (string-vs-string), while
  `differ.py` and `Change.to_dict()` assumed the enum and called
  `.value`. Calling `Change.to_dict()` on a request-derived Change
  would have crashed (latent only because the apply path doesn't include
  `change_set` in its response).
- **After**:
  - `Change.from_dict()` normalises `change_type` to the `ChangeType`
    enum (with a `ValueError` fallthrough that leaves the raw string in
    place for the existing "Unsupported change type" rejection in
    `_validate_change_set`).
  - `applier.py` compares against enum members directly:
    `change_type == ChangeType.NOOP/CREATE/UPDATE` (no more `.value`),
    and the validation loop uses
    `isinstance(change.change_type, ChangeType)`.
  - `Change.to_dict()` now round-trips for both producers
    (`differ.generate_changeset` and request-derived `Change.from_dict`).
  - The dataclass type annotation `change_type: ChangeType` is now true
    at runtime.

Existing singular-endpoint tests
(`tests/v4.{4,5}.x/tests/test_api_apply_change_set.py`) continue to pass
because they post string `change_type` over HTTP, which now gets
normalised at the plugin boundary.

## Test plan

- `pytest netbox_diode_plugin/tests/v4.5.x/tests/test_api_apply_change_set_batch.py` (new file — covers all-success / partial-failure / invalid-envelope / per-entry-malformed / round-trip scenarios)
- `pytest netbox_diode_plugin/tests/v4.4.x/tests/test_api_apply_change_set_batch.py` (mirror)
- `pytest netbox_diode_plugin/tests/v4.5.x/tests/test_api_apply_change_set.py` (singular endpoint regression net — must continue to pass under the new enum-normalised `change_type` path)
- `ruff check netbox_diode_plugin/`
- Confirm singular `apply-change-set/` endpoint behaviour is unchanged externally (only its internal construction site routes through `ChangeSet.from_dict` + `_apply_one_changeset`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)