### PR TITLE
feat: add /bulk-plan endpoint for batched entity diffing

### DIFF
--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -2,6 +2,7 @@
 # Copyright 2025 NetBox Labs Inc
 """Diode NetBox Plugin - API - Differ."""
 
+import contextvars
 import copy
 import datetime
 import logging
@@ -23,12 +24,24 @@ from .common import (
     harmonize_formats,
     sort_ints_first,
 )
+from .matcher import _get_active_branch_schema
 from .plugin_utils import get_primary_value, legal_fields
 from .profile import profiled
 from .supported_models import extract_supported_models
 from .transformer import cleanup_unresolved_references, set_custom_field_defaults, transform_proto_json
 
 logger = logging.getLogger(__name__)
+
+_prechange_cache = contextvars.ContextVar("diode_prechange_cache", default=None)
+
+
+def enter_prechange_cache():
+    return _prechange_cache.set({})
+
+
+def exit_prechange_cache(token):
+    _prechange_cache.reset(token)
+
 
 @profiled("prechange_data")
 def prechange_data_from_instance(instance) -> dict: # noqa: C901
@@ -40,6 +53,13 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
 
     model_class = instance.__class__
     object_type = f"{model_class._meta.app_label}.{model_class._meta.model_name}"
+
+    cache = _prechange_cache.get(None)
+    if cache is not None:
+        cache_key = (_get_active_branch_schema(), object_type, instance.pk)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return copy.deepcopy(cached)
 
     supported_models = extract_supported_models()
     model = supported_models.get(object_type)
@@ -92,6 +112,10 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
                 cfmap[cf.name] = serialized
         prechange_data["custom_fields"] = cfmap
     prechange_data = harmonize_formats(prechange_data)
+
+    if cache is not None:
+        cache[cache_key] = prechange_data
+        return copy.deepcopy(prechange_data)
 
     return prechange_data
 

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -36,10 +36,12 @@ _prechange_cache = contextvars.ContextVar("diode_prechange_cache", default=None)
 
 
 def enter_prechange_cache():
+    """Activate a request-scoped prechange data cache."""
     return _prechange_cache.set({})
 
 
 def exit_prechange_cache(token):
+    """Deactivate the request-scoped prechange data cache."""
     _prechange_cache.reset(token)
 
 

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -34,10 +34,12 @@ _NOT_FOUND_SENTINEL = object()
 
 
 def enter_request_obj_cache():
+    """Activate a request-scoped object lookup cache."""
     return _request_obj_cache.set({})
 
 
 def exit_request_obj_cache(token):
+    """Deactivate the request-scoped object lookup cache."""
     _request_obj_cache.reset(token)
 
 

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -2,6 +2,7 @@
 # Copyright 2025 NetBox Labs, Inc.
 """Diode NetBox Plugin - API - Object matching utilities."""
 
+import contextvars
 import hashlib
 import logging
 import time
@@ -27,6 +28,18 @@ from .plugin_utils import content_type_id, get_object_type, get_object_type_mode
 from .profile import get_profile_ctx
 
 logger = logging.getLogger(__name__)
+
+_request_obj_cache = contextvars.ContextVar("diode_request_obj_cache", default=None)
+_NOT_FOUND_SENTINEL = object()
+
+
+def enter_request_obj_cache():
+    return _request_obj_cache.set({})
+
+
+def exit_request_obj_cache(token):
+    _request_obj_cache.reset(token)
+
 
 def _get_find_obj_cache_ttl() -> int:
     return get_plugin_config("netbox_diode_plugin", "find_obj_cache_ttl")
@@ -982,6 +995,16 @@ def find_existing_object(data: dict, object_type: str): # noqa: C901
     cache_ttl = _get_find_obj_cache_ttl()
     cache_key = _find_obj_cache_key(data, object_type) if cache_ttl > 0 else None
 
+    req_cache = _request_obj_cache.get(None)
+    if req_cache is not None and cache_key is not None and cache_key in req_cache:
+        cached = req_cache[cache_key]
+        result = None if cached is _NOT_FOUND_SENTINEL else cached
+        if ctx:
+            ctx.record_timing("find_obj", (time.monotonic() - start) * 1000)
+            ctx.increment("find_obj_found" if result else "find_obj_not_found")
+            ctx.increment("find_obj_req_cache_hit")
+        return result
+
     if cache_key:
         cached_id = django_cache.get(cache_key)
         if cached_id is not None:
@@ -1009,6 +1032,9 @@ def find_existing_object(data: dict, object_type: str): # noqa: C901
         if cache_key and result is not None:
             django_cache.set(cache_key, result.id, cache_ttl)
             django_cache.set(_find_obj_rev_key(object_type, result.id), cache_key, cache_ttl)
+
+    if req_cache is not None and cache_key is not None:
+        req_cache[cache_key] = result if result is not None else _NOT_FOUND_SENTINEL
 
     if ctx:
         ctx.record_timing("find_obj", (time.monotonic() - start) * 1000)

--- a/netbox_diode_plugin/api/urls.py
+++ b/netbox_diode_plugin/api/urls.py
@@ -5,12 +5,13 @@
 from django.urls import include, path
 from netbox.api.routers import NetBoxRouter
 
-from .views import ApplyChangeSetView, GenerateDiffView, GetDefaultBranchView
+from .views import ApplyChangeSetView, BulkPlanView, GenerateDiffView, GetDefaultBranchView
 
 router = NetBoxRouter()
 
 urlpatterns = [
     path("apply-change-set/", ApplyChangeSetView.as_view()),
+    path("bulk-plan/", BulkPlanView.as_view()),
     path("generate-diff/", GenerateDiffView.as_view()),
     path("default-branch/", GetDefaultBranchView.as_view()),
     path("", include(router.urls)),

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -257,7 +257,12 @@ class BulkPlanView(views.APIView):
                 break
 
         if original_entity_data is None:
-            return {"change_set": None, "errors": {"entity": {entity_key: [f"No data found in expected entity key, got: {list(entity.keys())}"]}}}
+            return {
+                "change_set": None,
+                "errors": {"entity": {entity_key: [
+                    f"No data found in expected entity key, got: {list(entity.keys())}"
+                ]}},
+            }
 
         try:
             result = generate_changeset(original_entity_data, object_type)
@@ -267,7 +272,10 @@ class BulkPlanView(views.APIView):
             return ChangeSetResult(errors=e.errors).to_dict()
         except Exception:
             logger.exception("unexpected error in bulk-plan for entity %s", entry.get("id"))
-            return {"change_set": None, "errors": {"request": {"__all__": ["internal error processing entity"]}}}
+            return {
+                "change_set": None,
+                "errors": {"request": {"__all__": ["internal error processing entity"]}},
+            }
 
 
 class ApplyChangeSetView(views.APIView):

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -18,7 +18,7 @@ from .common import (
     ChangeSetException,
     ChangeSetResult,
 )
-from .differ import generate_changeset
+from .differ import enter_prechange_cache, exit_prechange_cache, generate_changeset
 from .matcher import enter_request_obj_cache, exit_request_obj_cache
 from .permissions import (
     SCOPE_NETBOX_READ,
@@ -191,7 +191,8 @@ class BulkPlanView(views.APIView):
 
         branch_schema_id = self._get_branch_schema_id(request)
 
-        token = enter_request_obj_cache()
+        obj_token = enter_request_obj_cache()
+        prechange_token = enter_prechange_cache()
         try:
             results = []
             for entry in entities:
@@ -200,7 +201,8 @@ class BulkPlanView(views.APIView):
                 result["id"] = entity_id
                 results.append(result)
         finally:
-            exit_request_obj_cache(token)
+            exit_prechange_cache(prechange_token)
+            exit_request_obj_cache(obj_token)
 
         return Response({"results": results})
 

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -29,6 +29,13 @@ from .permissions import (
 
 logger = logging.getLogger("netbox.diode_data")
 
+
+def _sanitize_for_log(value, max_len=200):
+    """Strip newlines/CR and bound length to make user-controlled values safe for logs."""
+    s = str(value) if value is not None else ""
+    return s.replace("\n", "").replace("\r", "")[:max_len]
+
+
 # Try to import Branch model at module level
 Branch = None
 try:
@@ -103,8 +110,10 @@ class GenerateDiffView(views.APIView):
                 branch = Branch.objects.get(schema_id=branch_schema_id)
                 result.change_set.branch = {"id": branch.schema_id, "name": branch.name}
             except Branch.DoesNotExist:
-                sanitized_branch_id = branch_schema_id.replace('\n', '').replace('\r', '')
-                logger.warning(f"Branch with ID {sanitized_branch_id} does not exist")
+                logger.warning(
+                    "Branch with ID %s does not exist",
+                    _sanitize_for_log(branch_schema_id),
+                )
 
     def _post(self, request, *args, **kwargs):
         entity = request.data.get("entity")
@@ -271,7 +280,10 @@ class BulkPlanView(views.APIView):
         except ChangeSetException as e:
             return ChangeSetResult(errors=e.errors).to_dict()
         except Exception:
-            logger.exception("unexpected error in bulk-plan for entity %s", entry.get("id"))
+            logger.exception(
+                "unexpected error in bulk-plan for entity %s",
+                _sanitize_for_log(entry.get("id")),
+            )
             return {
                 "change_set": None,
                 "errors": {"request": {"__all__": ["internal error processing entity"]}},

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -19,6 +19,7 @@ from .common import (
     ChangeSetResult,
 )
 from .differ import generate_changeset
+from .matcher import enter_request_obj_cache, exit_request_obj_cache
 from .permissions import (
     SCOPE_NETBOX_READ,
     SCOPE_NETBOX_WRITE,
@@ -190,12 +191,16 @@ class BulkPlanView(views.APIView):
 
         branch_schema_id = self._get_branch_schema_id(request)
 
-        results = []
-        for entry in entities:
-            entity_id = entry.get("id")
-            result = self._process_entity(entry, branch_schema_id)
-            result["id"] = entity_id
-            results.append(result)
+        token = enter_request_obj_cache()
+        try:
+            results = []
+            for entry in entities:
+                entity_id = entry.get("id")
+                result = self._process_entity(entry, branch_schema_id)
+                result["id"] = entity_id
+                results.append(result)
+        finally:
+            exit_request_obj_cache(token)
 
         return Response({"results": results})
 

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -6,7 +6,7 @@ import re
 
 from django.apps import apps
 from django.db import transaction
-from rest_framework import views
+from rest_framework import status, views
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
@@ -161,6 +161,106 @@ class GenerateDiffView(views.APIView):
         self._add_branch_to_result(result, branch_schema_id)
 
         return Response(result.to_dict(), status=result.get_status_code())
+
+
+class BulkPlanView(views.APIView):
+    """BulkPlan view — batch generate diffs for multiple entities in a single request."""
+
+    authentication_classes = [DiodeOAuth2Authentication]
+    permission_classes = [IsAuthenticated, require_scopes(SCOPE_NETBOX_READ)]
+
+    def post(self, request, *args, **kwargs):
+        """Generate diffs for a batch of entities."""
+        try:
+            return self._post(request, *args, **kwargs)
+        except Exception:
+            logger.exception("unexpected error in bulk-plan")
+            return Response(
+                {"errors": {"request": {"__all__": ["internal error"]}}},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    def _post(self, request, *args, **kwargs):
+        entities = request.data.get("entities")
+        if not isinstance(entities, list) or len(entities) == 0:
+            return Response(
+                {"errors": {"request": {"entities": ["a non-empty list of entities is required"]}}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        branch_schema_id = self._get_branch_schema_id(request)
+
+        results = []
+        for entry in entities:
+            entity_id = entry.get("id")
+            result = self._process_entity(entry, branch_schema_id)
+            result["id"] = entity_id
+            results.append(result)
+
+        return Response({"results": results})
+
+    def _get_branch_schema_id(self, request):
+        """Get branch schema ID from request header or settings."""
+        branch_schema_id = request.headers.get("X-NetBox-Branch")
+
+        if not branch_schema_id and Branch is not None:
+            try:
+                from netbox_diode_plugin.models import Setting
+                settings = Setting.objects.first()
+                if settings and settings.branch:
+                    branch_schema_id = settings.branch.schema_id
+            except Exception as e:
+                logger.warning(f"Could not retrieve default branch from settings: {e}")
+
+        return branch_schema_id
+
+    def _add_branch_to_result(self, result, branch_schema_id):
+        """Add branch information to the result if branch is available."""
+        if branch_schema_id and Branch is not None:
+            try:
+                branch = Branch.objects.get(schema_id=branch_schema_id)
+                result.change_set.branch = {"id": branch.schema_id, "name": branch.name}
+            except Branch.DoesNotExist:
+                pass
+
+    def _process_entity(self, entry, branch_schema_id):
+        """Process a single entity and return its result dict."""
+        entity = entry.get("entity")
+        object_type = entry.get("object_type")
+
+        if not entity:
+            return {"change_set": None, "errors": {"request": {"entity": ["entity is required"]}}}
+        if not object_type:
+            return {"change_set": None, "errors": {"request": {"object_type": ["object_type is required"]}}}
+
+        try:
+            app_label, model_name = object_type.split(".")
+        except ValueError:
+            return {"change_set": None, "errors": {"request": {"object_type": [f"invalid format: {object_type}"]}}}
+
+        try:
+            model_class = apps.get_model(app_label, model_name)
+        except LookupError:
+            return {"change_set": None, "errors": {"request": {"object_type": [f"{object_type} is not supported in this version."]}}}
+
+        original_entity_data = None
+        for entity_key in get_valid_entity_keys(model_class.__name__):
+            original_entity_data = entity.get(entity_key)
+            if original_entity_data:
+                break
+
+        if original_entity_data is None:
+            return {"change_set": None, "errors": {"entity": {entity_key: [f"No data found in expected entity key, got: {list(entity.keys())}"]}}}
+
+        try:
+            result = generate_changeset(original_entity_data, object_type)
+            self._add_branch_to_result(result, branch_schema_id)
+            return result.to_dict()
+        except ChangeSetException as e:
+            return ChangeSetResult(errors=e.errors).to_dict()
+        except Exception:
+            logger.exception("unexpected error in bulk-plan for entity %s", entry.get("id"))
+            return {"change_set": None, "errors": {"request": {"__all__": ["internal error processing entity"]}}}
 
 
 class ApplyChangeSetView(views.APIView):

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_bulk_plan.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_bulk_plan.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkPlan API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Site
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BulkPlanTestCase(APITestCase):
+    """BulkPlan endpoint test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Existing Site",
+            slug="existing-site",
+            comments="original comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, expected_status=status.HTTP_200_OK):
+        """Post the payload and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    def test_single_entity_create(self):
+        """Test bulk plan with a single new entity."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "New Site", "slug": "new-site"}},
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_type"], "create")
+        self.assertEqual(changes[0]["object_type"], "dcim.site")
+
+    def test_single_entity_update(self):
+        """Test bulk plan with a single existing entity that has changes."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "updated comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_type"], "update")
+        self.assertEqual(changes[0]["object_id"], self.site.pk)
+
+    def test_single_entity_no_changes(self):
+        """Test bulk plan with an entity that matches NetBox exactly — empty changes."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        cs = r.get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 0)
+
+    def test_multiple_entities_mixed(self):
+        """Test bulk plan with multiple entities — one create, one update, one no-change."""
+        payload = {
+            "entities": [
+                {
+                    "id": "create-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Brand New Site", "slug": "brand-new-site"}},
+                },
+                {
+                    "id": "update-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "changed",
+                        }
+                    },
+                },
+                {
+                    "id": "noop-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 3)
+
+        ids = {r["id"]: r for r in results}
+
+        create_r = ids["create-1"]
+        self.assertIsNone(create_r.get("errors"))
+        self.assertEqual(len(create_r["change_set"]["changes"]), 1)
+        self.assertEqual(create_r["change_set"]["changes"][0]["change_type"], "create")
+
+        update_r = ids["update-1"]
+        self.assertIsNone(update_r.get("errors"))
+        self.assertEqual(len(update_r["change_set"]["changes"]), 1)
+        self.assertEqual(update_r["change_set"]["changes"][0]["change_type"], "update")
+
+        noop_r = ids["noop-1"]
+        self.assertEqual(len(noop_r["change_set"]["changes"]), 0)
+
+    def test_entity_with_missing_entity_field(self):
+        """Test that a missing entity field returns per-entity error without failing the batch."""
+        payload = {
+            "entities": [
+                {
+                    "id": "good-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Good Site", "slug": "good-site"}},
+                },
+                {
+                    "id": "bad-1",
+                    "object_type": "dcim.site",
+                    "entity": None,
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 2)
+
+        ids = {r["id"]: r for r in results}
+
+        good = ids["good-1"]
+        self.assertIsNone(good.get("errors"))
+        self.assertIsNotNone(good.get("change_set"))
+
+        bad = ids["bad-1"]
+        self.assertIsNotNone(bad.get("errors"))
+        self.assertIn("entity", bad["errors"].get("request", {}))
+
+    def test_entity_with_missing_object_type(self):
+        """Test that a missing object_type returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "entity": {"site": {"name": "Some Site", "slug": "some-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+        self.assertIn("object_type", results[0]["errors"].get("request", {}))
+
+    def test_entity_with_unsupported_object_type(self):
+        """Test that an unsupported object_type returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+        self.assertIn("object_type", results[0]["errors"].get("request", {}))
+
+    def test_entity_with_invalid_object_type_format(self):
+        """Test that an invalid object_type format returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "nodotshere",
+                    "entity": {"nodotshere": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+
+    def test_empty_entities_list(self):
+        """Test that an empty entities list returns 400."""
+        payload = {"entities": []}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_entities_field(self):
+        """Test that a missing entities field returns 400."""
+        payload = {"something_else": "value"}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_entities_not_a_list(self):
+        """Test that entities as a non-list returns 400."""
+        payload = {"entities": "not a list"}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_id_correlation(self):
+        """Test that returned results preserve the entity IDs for correlation."""
+        payload = {
+            "entities": [
+                {
+                    "id": "aaa-111",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site A", "slug": "site-a"}},
+                },
+                {
+                    "id": "bbb-222",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site B", "slug": "site-b"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["id"], "aaa-111")
+        self.assertEqual(results[1]["id"], "bbb-222")
+
+    def test_entity_without_id(self):
+        """Test that an entity without an id field gets null id in the result."""
+        payload = {
+            "entities": [
+                {
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "No ID Site", "slug": "no-id-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["id"])
+        self.assertIsNone(results[0].get("errors"))

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_bulk_plan.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_bulk_plan.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkPlan API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Site
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BulkPlanTestCase(APITestCase):
+    """BulkPlan endpoint test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Existing Site",
+            slug="existing-site",
+            comments="original comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, expected_status=status.HTTP_200_OK):
+        """Post the payload and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    def test_single_entity_create(self):
+        """Test bulk plan with a single new entity."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "New Site", "slug": "new-site"}},
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_type"], "create")
+        self.assertEqual(changes[0]["object_type"], "dcim.site")
+
+    def test_single_entity_update(self):
+        """Test bulk plan with a single existing entity that has changes."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "updated comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_type"], "update")
+        self.assertEqual(changes[0]["object_id"], self.site.pk)
+
+    def test_single_entity_no_changes(self):
+        """Test bulk plan with an entity that matches NetBox exactly — empty changes."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        cs = r.get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 0)
+
+    def test_multiple_entities_mixed(self):
+        """Test bulk plan with multiple entities — one create, one update, one no-change."""
+        payload = {
+            "entities": [
+                {
+                    "id": "create-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Brand New Site", "slug": "brand-new-site"}},
+                },
+                {
+                    "id": "update-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "changed",
+                        }
+                    },
+                },
+                {
+                    "id": "noop-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 3)
+
+        ids = {r["id"]: r for r in results}
+
+        create_r = ids["create-1"]
+        self.assertIsNone(create_r.get("errors"))
+        self.assertEqual(len(create_r["change_set"]["changes"]), 1)
+        self.assertEqual(create_r["change_set"]["changes"][0]["change_type"], "create")
+
+        update_r = ids["update-1"]
+        self.assertIsNone(update_r.get("errors"))
+        self.assertEqual(len(update_r["change_set"]["changes"]), 1)
+        self.assertEqual(update_r["change_set"]["changes"][0]["change_type"], "update")
+
+        noop_r = ids["noop-1"]
+        self.assertEqual(len(noop_r["change_set"]["changes"]), 0)
+
+    def test_entity_with_missing_entity_field(self):
+        """Test that a missing entity field returns per-entity error without failing the batch."""
+        payload = {
+            "entities": [
+                {
+                    "id": "good-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Good Site", "slug": "good-site"}},
+                },
+                {
+                    "id": "bad-1",
+                    "object_type": "dcim.site",
+                    "entity": None,
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 2)
+
+        ids = {r["id"]: r for r in results}
+
+        good = ids["good-1"]
+        self.assertIsNone(good.get("errors"))
+        self.assertIsNotNone(good.get("change_set"))
+
+        bad = ids["bad-1"]
+        self.assertIsNotNone(bad.get("errors"))
+        self.assertIn("entity", bad["errors"].get("request", {}))
+
+    def test_entity_with_missing_object_type(self):
+        """Test that a missing object_type returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "entity": {"site": {"name": "Some Site", "slug": "some-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+        self.assertIn("object_type", results[0]["errors"].get("request", {}))
+
+    def test_entity_with_unsupported_object_type(self):
+        """Test that an unsupported object_type returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+        self.assertIn("object_type", results[0]["errors"].get("request", {}))
+
+    def test_entity_with_invalid_object_type_format(self):
+        """Test that an invalid object_type format returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "nodotshere",
+                    "entity": {"nodotshere": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+
+    def test_empty_entities_list(self):
+        """Test that an empty entities list returns 400."""
+        payload = {"entities": []}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_entities_field(self):
+        """Test that a missing entities field returns 400."""
+        payload = {"something_else": "value"}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_entities_not_a_list(self):
+        """Test that entities as a non-list returns 400."""
+        payload = {"entities": "not a list"}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_id_correlation(self):
+        """Test that returned results preserve the entity IDs for correlation."""
+        payload = {
+            "entities": [
+                {
+                    "id": "aaa-111",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site A", "slug": "site-a"}},
+                },
+                {
+                    "id": "bbb-222",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site B", "slug": "site-b"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["id"], "aaa-111")
+        self.assertEqual(results[1]["id"], "bbb-222")
+
+    def test_entity_without_id(self):
+        """Test that an entity without an id field gets null id in the result."""
+        payload = {
+            "entities": [
+                {
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "No ID Site", "slug": "no-id-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["id"])
+        self.assertIsNone(results[0].get("errors"))


### PR DESCRIPTION
## Summary

- Adds `POST /api/plugins/diode/bulk-plan/` endpoint that accepts `{"entities": [...]}` and generates diffs for all entities in a single HTTP request, replacing N individual `/generate-diff/` calls with one batched call
- Adds request-scoped caching for `find_existing_object()` lookups and `prechange_data` across entities in the batch, avoiding redundant DB queries for shared objects (e.g. site, manufacturer referenced by multiple devices)
- Fixes ruff D103 and E501 lint violations

### Performance impact

At batch sizes of 100-200 entities, the per-request overhead (auth, middleware, TLS, rate limiter slot) is paid once instead of per-entity. The request-scoped caches eliminate redundant DB lookups for objects shared across entities in the same batch.

## Test plan

- [x] `make docker-compose-netbox-plugin-test` — 325 tests pass
- [x] `ruff check netbox_diode_plugin/` — all checks passed