### PR TITLE
perf(plugin): per-batch atomic Postgres write optimisations for bulk-apply

### DIFF
--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -47,6 +47,12 @@ class NetBoxDiodePluginConfig(PluginConfig):
         # Override the displayed Diode target URL without affecting internal
         # communication (e.g. to show the external ingress address).
         "diode_target_display": None,
+
+        # Max number of retries when the batch apply endpoint hits a
+        # Postgres deadlock (40P01) or serialization failure (40001).
+        # 0 disables retries; default 3 means up to three retries after
+        # the initial attempt (4 attempts total).
+        "batch_apply_deadlock_retry_max_count": 3,
     }
 
 

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -5,9 +5,11 @@
 
 import logging
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
 from django.db.utils import IntegrityError
+from extras.models import Tag
 from rest_framework.exceptions import ValidationError as ValidationError
 
 from .common import NON_FIELD_ERRORS, Change, ChangeSet, ChangeSetException, ChangeSetResult, ChangeType, error_from_validation_error
@@ -23,6 +25,7 @@ logger = logging.getLogger(__name__)
 def apply_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
     """Apply a change set."""
     _validate_change_set(change_set)
+    _preload_changeset_cache(change_set, request)
 
     created = {}
     for change in change_set.changes:
@@ -55,6 +58,63 @@ def apply_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
     return ChangeSetResult(
         id=change_set.id,
     )
+
+def _preload_changeset_cache(change_set: ChangeSet, request) -> dict:
+    """
+    Warm Django's ContentType cache and prefetch tag IDs once per changeset.
+
+    Without this, every per-change `ContentType.objects.get_for_model(...)` and
+    every `Tag.objects.get(slug=...)` issues its own SQL. Stashing the result on
+    `request._diode_preload` lets later code paths (PR 4 bulk-tag write) reuse
+    it without re-querying.
+    """
+    models_to_warm: dict[str, models.Model] = {}
+    tag_slugs: set[str] = set()
+
+    for change in change_set.changes:
+        if change.change_type == ChangeType.NOOP:
+            continue
+        ot = change.object_type
+        if ot and ot not in models_to_warm:
+            try:
+                models_to_warm[ot] = get_object_type_model(ot)
+            except Exception:
+                # Unknown model — let the main apply path raise the proper error.
+                continue
+        for slug in _iter_tag_slugs(change):
+            tag_slugs.add(slug)
+
+    if models_to_warm:
+        # Populates Django's per-process ContentType cache in a single query.
+        ContentType.objects.get_for_models(*models_to_warm.values())
+
+    tag_ids_by_slug: dict[str, int] = {}
+    if tag_slugs:
+        for tag_id, slug in Tag.objects.filter(slug__in=tag_slugs).values_list("id", "slug"):
+            tag_ids_by_slug[slug] = tag_id
+
+    preload = {
+        "tag_ids_by_slug": tag_ids_by_slug,
+        "models_by_object_type": models_to_warm,
+    }
+    if request is not None:
+        request._diode_preload = preload
+    return preload
+
+
+def _iter_tag_slugs(change: Change):
+    """Yield string tag slugs from a change.data['tags'] list."""
+    if not change.data:
+        return
+    tags = change.data.get("tags")
+    if not isinstance(tags, list):
+        return
+    for t in tags:
+        if isinstance(t, str):
+            yield t
+        elif isinstance(t, dict) and isinstance(t.get("slug"), str):
+            yield t["slug"]
+
 
 def _is_auto_created_component(object_type: str) -> bool:
     """Check if the object type is auto-created from templates."""

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -12,6 +12,7 @@ from django.db.utils import IntegrityError
 from extras.models import Tag
 from rest_framework.exceptions import ValidationError as ValidationError
 
+from .bulk_tags import apply_tags_bulk, supports_tags
 from .common import NON_FIELD_ERRORS, Change, ChangeSet, ChangeSetException, ChangeSetResult, ChangeType, error_from_validation_error
 from .matcher import find_existing_object, invalidate_find_obj_entry
 from .plugin_utils import get_object_type_model, legal_fields
@@ -26,6 +27,11 @@ def apply_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
     """Apply a change set."""
     _validate_change_set(change_set)
     _preload_changeset_cache(change_set, request)
+
+    # Collect (instance, tag_input) pairs as we apply changes; flushed via
+    # apply_tags_bulk after the main loop so we issue one DELETE+bulk INSERT
+    # for the whole changeset instead of per-instance m2m_changed re-fires.
+    request._diode_tag_pairs = []
 
     created = {}
     for change in change_set.changes:
@@ -54,6 +60,10 @@ def apply_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
         except IntegrityError as e:
             logger.error(f"Integrity error {object_type}: {e} {data}")
             raise _err(f"created a conflict with an existing {object_type}", object_type, "__all__")
+
+    # Flush deferred tag writes in one bulk pass.
+    apply_tags_bulk(request._diode_tag_pairs, request)
+    request._diode_tag_pairs = []
 
     return ChangeSetResult(
         id=change_set.id,
@@ -163,14 +173,23 @@ def _create_or_find_instance(data: dict, object_type: str, serializer_class, req
 
 
 def _apply_change(data: dict, model_class: models.Model, change: Change, created: dict, request):
+    # Pull tags out of `data` BEFORE serializer.save() so the serializer's
+    # `tag.set([...])` side effect — which fires m2m_changed and triggers a
+    # duplicate ObjectChange + a re-run of serialize_for_event — does not run.
+    # We buffer (instance, tag_input) and flush via apply_tags_bulk after the
+    # main apply_changeset loop.
+    deferred_tags = None
+    if supports_tags(model_class) and isinstance(data.get("tags"), list):
+        deferred_tags = data.pop("tags")
+
     serializer_class = get_serializer_for_model(model_class)
     change_type = change.change_type
+    instance = None
 
     if change_type == ChangeType.CREATE:
         # For component types that may be auto-created from e.g. DeviceType or ModuleType templates,
         # try to find existing object first before attempting to create.
         # This prevents duplicates when components are instantiated during Device/Module save()
-        instance = None
         if _is_auto_created_component(change.object_type):
             instance = _try_find_and_update_existing_instance(data, change.object_type, serializer_class, request)
 
@@ -194,6 +213,10 @@ def _apply_change(data: dict, model_class: models.Model, change: Change, created
             serializer.is_valid(raise_exception=True)
             serializer.save()
             invalidate_find_obj_entry(change.object_type, instance.id)
+
+    if deferred_tags is not None and instance is not None:
+        request._diode_tag_pairs.append((instance, deferred_tags))
+
 
 def _set_path(data, path, value):
     path = path.split(".")

--- a/netbox_diode_plugin/api/bulk_tags.py
+++ b/netbox_diode_plugin/api/bulk_tags.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""
+Bulk TaggedItem writes for diode apply paths.
+
+PR 4 of BULK-ORM Sprint 1.
+
+NetBox's `instance.tags.set([...])` triggers `m2m_changed` (post_clear +
+post_add) per instance. The signal handler re-fires
+`handle_changed_object`, which (a) writes another ObjectChange UPDATE and
+(b) calls `enqueue_event` again — that re-runs the expensive
+`serialize_for_event(instance)`. Multiplied by every tagged object in a
+changeset this dominates the apply path.
+
+This module bypasses the through-table m2m signal by writing
+`extras_taggeditem` rows directly via `bulk_create` and re-emitting a
+single `enqueue_event` per instance to refresh the queued payload with
+the post-tag state. PR 3's `deferred_changelog` already collapses the
+ObjectChange side; this module collapses the TaggedItem side.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+from core.events import OBJECT_UPDATED
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+from extras.events import enqueue_event
+from extras.models import Tag, TaggedItem
+from netbox.context import events_queue
+from netbox.models.features import TagsMixin
+
+logger = logging.getLogger(__name__)
+
+
+def supports_tags(model_or_instance) -> bool:
+    """Return True if the model (or instance's class) inherits from TagsMixin."""
+    cls = model_or_instance if isinstance(model_or_instance, type) else type(model_or_instance)
+    return issubclass(cls, TagsMixin)
+
+
+def apply_tags_bulk(instance_tag_pairs: list[tuple[Any, list]], request) -> None:
+    """
+    Write tags for a list of (instance, tag_input) pairs via bulk_create.
+
+    `tag_input` may be a list of slug strings, a list of integer tag IDs, or
+    a list of dicts with a "slug" key (the same shapes the serializer accepts).
+    Tags listed for an instance fully replace its existing tag set, mirroring
+    `instance.tags.set([...])` semantics — but without the m2m_changed re-fire.
+    """
+    if not instance_tag_pairs:
+        return
+
+    preload = getattr(request, "_diode_preload", None) or {}
+    tag_ids_by_slug: dict[str, int] = preload.get("tag_ids_by_slug", {}) or {}
+    _backfill_missing_tag_ids(instance_tag_pairs, tag_ids_by_slug)
+
+    rows, target_keys, instances_to_event = _build_rows(
+        instance_tag_pairs, tag_ids_by_slug,
+    )
+
+    _replace_existing(target_keys)
+    if rows:
+        TaggedItem.objects.bulk_create(rows, ignore_conflicts=True, batch_size=500)
+    _re_emit_events(instances_to_event, request)
+
+
+def _backfill_missing_tag_ids(pairs, tag_ids_by_slug: dict[str, int]) -> None:
+    missing: set[str] = set()
+    for _instance, tag_input in pairs:
+        for raw in tag_input or []:
+            slug = _slug_from(raw)
+            if slug and slug not in tag_ids_by_slug:
+                missing.add(slug)
+    if missing:
+        for tag_id, slug in Tag.objects.filter(slug__in=missing).values_list("id", "slug"):
+            tag_ids_by_slug[slug] = tag_id
+
+
+def _build_rows(pairs, tag_ids_by_slug: dict[str, int]):
+    ct_by_model: dict[type, ContentType] = {}
+    rows: list[TaggedItem] = []
+    target_keys: dict[int, set[int]] = defaultdict(set)
+    instances_to_event: list[Any] = []
+
+    for instance, tag_input in pairs:
+        if instance is None or instance.pk is None:
+            continue
+        ct = _ct_for(instance, ct_by_model)
+        target_keys[ct.id].add(instance.pk)
+        instances_to_event.append(instance)
+        for raw in tag_input or []:
+            tag_id = _resolve_tag_id(raw, tag_ids_by_slug)
+            if tag_id is None:
+                logger.warning("apply_tags_bulk: could not resolve tag %r for %s", raw, instance)
+                continue
+            rows.append(TaggedItem(content_type_id=ct.id, object_id=instance.pk, tag_id=tag_id))
+
+    return rows, target_keys, instances_to_event
+
+
+def _ct_for(instance, ct_by_model: dict[type, ContentType]) -> ContentType:
+    model = type(instance)
+    ct = ct_by_model.get(model)
+    if ct is None:
+        ct = ContentType.objects.get_for_model(model)
+        ct_by_model[model] = ct
+    return ct
+
+
+def _replace_existing(target_keys: dict[int, set[int]]) -> None:
+    if not target_keys:
+        return
+    q = Q()
+    for ct_id, obj_ids in target_keys.items():
+        q |= Q(content_type_id=ct_id, object_id__in=obj_ids)
+    TaggedItem.objects.filter(q).delete()
+
+
+def _re_emit_events(instances, request) -> None:
+    if not instances:
+        return
+    queue = events_queue.get()
+    for instance in instances:
+        try:
+            enqueue_event(queue, instance, request, OBJECT_UPDATED)
+        except Exception as e:
+            logger.warning("apply_tags_bulk: enqueue_event failed for %s: %s", instance, e)
+    events_queue.set(queue)
+
+
+def _slug_from(raw) -> str | None:
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, dict):
+        s = raw.get("slug")
+        return s if isinstance(s, str) else None
+    return None
+
+
+def _resolve_tag_id(raw, tag_ids_by_slug: dict[str, int]) -> int | None:
+    if isinstance(raw, int):
+        return raw
+    slug = _slug_from(raw)
+    if slug is not None:
+        return tag_ids_by_slug.get(slug)
+    return None

--- a/netbox_diode_plugin/api/deferred_changelog.py
+++ b/netbox_diode_plugin/api/deferred_changelog.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""
+Deferred ObjectChange writes for diode apply paths.
+
+PR 3 of BULK-ORM Sprint 1, with the V3 atomicity fix layered on top.
+
+NetBox's ``core.signals.handle_changed_object`` fires per-instance on
+``post_save`` / ``m2m_changed`` and persists each ``ObjectChange`` row
+with its own INSERT. For a multi-thousand-entity changeset that's the
+dominant write cost.
+
+This module installs a module-level monkey-patch on
+``core.models.ObjectChange.save`` that, when a thread-local flag is
+active, buffers the instance instead of writing it. The
+``deferred_changelog()`` context manager activates the flag and yields
+a ``_Deferred`` accumulator with three methods:
+
+* ``commit_pending()`` — promote the per-changeset *pending* buffer
+  into the cross-changeset *batch* buffer. Called after a changeset's
+  inner ``transaction.atomic()`` block completes successfully.
+* ``rollback_pending()`` — discard the per-changeset *pending* buffer.
+  Called when a changeset's inner atomic block raises and its writes
+  are rolled back. Without this the buffered ``ObjectChange`` rows
+  would still get flushed, leaking audit-log entries pointing at
+  rolled-back data.
+* ``flush()`` — issue ``ObjectChange.objects.bulk_create()`` for the
+  accumulated batch buffer. Caller invokes this once at the end of
+  the loop, **inside** the outer ``transaction.atomic()`` so a flush
+  failure rolls back the whole batch.
+
+m2m merge dedup is preserved by ``(content_type_id, object_id,
+request_id)`` keys spanning both buffers: a follow-up m2m_changed
+fire collapses onto whichever buffer holds the prior row, yielding
+a single audit row per object regardless of when within the batch
+the dedup happens.
+
+Nested usage is a no-op (outer wins).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from contextlib import contextmanager
+
+from core.models import ObjectChange
+
+logger = logging.getLogger(__name__)
+
+_state = threading.local()
+_BATCH_SIZE = 500
+
+
+def _is_active() -> bool:
+    return getattr(_state, "active", False)
+
+
+def _get_deferred():
+    return getattr(_state, "deferred", None)
+
+
+class _Deferred:
+    """Per-window accumulator for buffered ``ObjectChange`` writes."""
+
+    def __init__(self) -> None:
+        self.pending_buffer: list[ObjectChange] = []
+        self.pending_index: dict[tuple, int] = {}
+        self.batch_buffer: list[ObjectChange] = []
+        self.batch_index: dict[tuple, int] = {}
+
+    def _add(self, obj: ObjectChange) -> None:
+        """Buffer ``obj`` into pending; merge onto pending or batch on dedup."""
+        key = (
+            obj.changed_object_type_id,
+            obj.changed_object_id,
+            str(obj.request_id) if obj.request_id is not None else None,
+        )
+        pos = self.pending_index.get(key)
+        if pos is not None:
+            self.pending_buffer[pos].postchange_data = obj.postchange_data
+            return
+        batch_pos = self.batch_index.get(key)
+        if batch_pos is not None:
+            self.batch_buffer[batch_pos].postchange_data = obj.postchange_data
+            return
+        self.pending_index[key] = len(self.pending_buffer)
+        self.pending_buffer.append(obj)
+
+    def commit_pending(self) -> None:
+        """Promote pending entries onto the batch buffer; clear pending."""
+        for key, pos in self.pending_index.items():
+            obj = self.pending_buffer[pos]
+            existing = self.batch_index.get(key)
+            if existing is not None:
+                self.batch_buffer[existing].postchange_data = obj.postchange_data
+            else:
+                self.batch_index[key] = len(self.batch_buffer)
+                self.batch_buffer.append(obj)
+        self.pending_buffer = []
+        self.pending_index = {}
+
+    def rollback_pending(self) -> None:
+        """Discard the pending buffer (e.g. after a savepoint rollback)."""
+        self.pending_buffer = []
+        self.pending_index = {}
+
+    def flush(self) -> None:
+        """Drain pending into batch, then bulk-insert and clear the batch buffer.
+
+        Calling ``flush()`` without first calling ``commit_pending()`` is the
+        legacy single-window pattern (``with deferred_changelog(): ...`` with
+        no per-changeset accumulator). It commits any leftover pending entries
+        before issuing the INSERT so callers that don't use the V3 lifecycle
+        API still get a single bulk_create.
+        """
+        if self.pending_buffer:
+            self.commit_pending()
+        if self.batch_buffer:
+            ObjectChange.objects.bulk_create(self.batch_buffer, batch_size=_BATCH_SIZE)
+        self.batch_buffer = []
+        self.batch_index = {}
+
+
+_original_save = ObjectChange.save
+
+
+def _patched_save(self, *args, **kwargs):
+    """ObjectChange.save replacement: buffers when deferred_changelog() is active."""
+    if not _is_active():
+        return _original_save(self, *args, **kwargs)
+
+    deferred = _get_deferred()
+    if deferred is None:
+        return _original_save(self, *args, **kwargs)
+
+    if self.pk is not None:
+        # Already in DB (e.g. m2m post_clear updating an externally-saved
+        # change row). Fall back to the real save for correctness.
+        return _original_save(self, *args, **kwargs)
+
+    if not self.user_name and getattr(self, "user_id", None):
+        self.user_name = self.user.username
+    if not self.object_repr:
+        try:
+            self.object_repr = str(self.changed_object) if self.changed_object_id else ""
+        except Exception:
+            self.object_repr = ""
+
+    deferred._add(self)
+    return None
+
+
+# Install the monkey-patch at import time; views.py imports this module.
+ObjectChange.save = _patched_save
+
+
+@contextmanager
+def deferred_changelog():
+    """
+    Activate deferred ``ObjectChange`` persistence; yield a ``_Deferred``.
+
+    Two usage modes are supported:
+
+    * Legacy (single-window) — ``with deferred_changelog(): ...``. All saves
+      go to the pending buffer; on clean context exit the manager auto-calls
+      ``flush()``, draining pending into batch and issuing one
+      ``bulk_create``. If the body raises, no flush happens, so an unhandled
+      exception cannot leak audit-log rows.
+
+    * V3 (per-changeset accumulator) — ``with deferred_changelog() as defc:``
+      with explicit ``defc.commit_pending()`` / ``defc.rollback_pending()``
+      after each savepoint and ``defc.flush()`` once at the end inside the
+      outer ``transaction.atomic()``. The auto-flush at clean context exit
+      is a no-op because ``flush()`` already cleared the buffers.
+
+    Nested invocation is a no-op (outer wins).
+    """
+    if _is_active():
+        yield _get_deferred()
+        return
+
+    deferred = _Deferred()
+    _state.active = True
+    _state.deferred = deferred
+    raised = False
+    try:
+        yield deferred
+    except Exception:
+        raised = True
+        raise
+    finally:
+        _state.active = False
+        _state.deferred = None
+        if not raised:
+            deferred.flush()

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -17,6 +17,7 @@ from .common import (
     ChangeSetException,
     ChangeSetResult,
 )
+from .deferred_changelog import deferred_changelog
 from .differ import enter_prechange_cache, exit_prechange_cache, generate_changeset
 from .matcher import enter_request_obj_cache, exit_request_obj_cache
 from .permissions import (
@@ -317,7 +318,16 @@ class ApplyChangeSetView(views.APIView):
 
     def _post(self, request, *args, **kwargs):
         change_set = ChangeSet.from_dict(request.data)
-        result = _apply_one_changeset(change_set, request)
+        # Outer transaction.atomic() makes the changeset's data writes,
+        # tag-link writes, and audit-log bulk_create commit together to
+        # readers. _apply_one_changeset's inner atomic becomes a savepoint.
+        with deferred_changelog() as defc, transaction.atomic():
+            result = _apply_one_changeset(change_set, request)
+            if result.errors:
+                defc.rollback_pending()
+            else:
+                defc.commit_pending()
+            defc.flush()
         return Response(result.to_dict(), status=result.get_status_code())
 
 
@@ -358,23 +368,36 @@ class BulkApplyView(views.APIView):
             raise ValidationError({"change_sets": ["change_sets must not be empty"]})
 
         results = []
-        for entry in change_sets:
-            if not isinstance(entry, dict):
-                results.append(
-                    ChangeSetResult(
-                        errors={"request": {"change_set": ["change_set must be an object"]}}
+        # Outer transaction.atomic() makes the whole batch atomic to readers:
+        # data writes + tag-link writes + audit-log bulk_create commit together.
+        # _apply_one_changeset's inner transaction.atomic() becomes a savepoint
+        # (Django nests nested atomics), so a single failed changeset rolls
+        # back its own writes without aborting the whole batch.
+        with deferred_changelog() as defc, transaction.atomic():
+            for entry in change_sets:
+                if not isinstance(entry, dict):
+                    results.append(
+                        ChangeSetResult(
+                            errors={"request": {"change_set": ["change_set must be an object"]}}
+                        ).to_dict()
+                    )
+                    continue
+                try:
+                    change_set = ChangeSet.from_dict(entry)
+                    cs_result = _apply_one_changeset(change_set, request)
+                    if cs_result.errors:
+                        defc.rollback_pending()
+                    else:
+                        defc.commit_pending()
+                    result = cs_result.to_dict()
+                except Exception as e:
+                    logger.error(f"Error parsing batch entry: {e}")
+                    defc.rollback_pending()
+                    result = ChangeSetResult(
+                        errors={"request": {"change_set": [f"invalid change_set: {e}"]}}
                     ).to_dict()
-                )
-                continue
-            try:
-                change_set = ChangeSet.from_dict(entry)
-                result = _apply_one_changeset(change_set, request).to_dict()
-            except Exception as e:
-                logger.error(f"Error parsing batch entry: {e}")
-                result = ChangeSetResult(
-                    errors={"request": {"change_set": [f"invalid change_set: {e}"]}}
-                ).to_dict()
-            results.append(result)
+                results.append(result)
+            defc.flush()
 
         http_status = (
             status.HTTP_207_MULTI_STATUS

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -2,14 +2,18 @@
 # Copyright 2025 NetBox Labs, Inc.
 """Diode NetBox Plugin - API Views."""
 import logging
+import random
 import re
+import time
 
 from django.apps import apps
 from django.db import transaction
+from django.db.utils import OperationalError
 from rest_framework import status, views
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from ..plugin_config import get_batch_apply_deadlock_retry_max_count
 from .applier import apply_changeset
 from .authentication import DiodeOAuth2Authentication
 from .common import (
@@ -26,6 +30,20 @@ from .permissions import (
     IsAuthenticated,
     require_scopes,
 )
+
+# Postgres SQLSTATEs we retry on. 40P01 is deadlock_detected; 40001 is
+# serialization_failure (can show up on the SERIALIZABLE isolation
+# level path, harmless to retry the same way).
+_DEADLOCK_PGCODES = ("40P01", "40001")
+
+
+def _extract_pgcode(exc: OperationalError) -> str | None:
+    """Return the Postgres SQLSTATE on a wrapped Django OperationalError, or None."""
+    inner = exc.__cause__
+    pgcode = getattr(inner, "pgcode", None)
+    if pgcode is None:
+        pgcode = getattr(exc, "pgcode", None)
+    return pgcode
 
 logger = logging.getLogger("netbox.diode_data")
 
@@ -367,6 +385,46 @@ class BulkApplyView(views.APIView):
         if len(change_sets) == 0:
             raise ValidationError({"change_sets": ["change_sets must not be empty"]})
 
+        max_retries = int(get_batch_apply_deadlock_retry_max_count() or 0)
+        attempt = 0
+        while True:
+            try:
+                results = self._apply_batch(change_sets, request)
+                break
+            except OperationalError as exc:
+                pgcode = _extract_pgcode(exc)
+                if pgcode not in _DEADLOCK_PGCODES:
+                    raise
+                if attempt >= max_retries:
+                    logger.error(
+                        "batch apply: deadlock retries exhausted "
+                        "(attempts=%d, pgcode=%s)",
+                        attempt + 1, pgcode,
+                    )
+                    raise
+                # Jittered exponential backoff: 50ms * 2^attempt * U(0.5, 1.5)
+                sleep_s = 0.05 * (2 ** attempt) * (0.5 + random.random())
+                logger.warning(
+                    "batch apply: %s, retrying "
+                    "(attempt=%d/%d, sleep=%.3fs)",
+                    "deadlock" if pgcode == "40P01" else "serialization failure",
+                    attempt + 1, max_retries + 1, sleep_s,
+                )
+                time.sleep(sleep_s)
+                attempt += 1
+
+        http_status = (
+            status.HTTP_207_MULTI_STATUS
+            if any(r.get("errors") for r in results)
+            else status.HTTP_200_OK
+        )
+        resp = Response({"results": results}, status=http_status)
+        if attempt > 0:
+            resp["X-Diode-Batch-Retries"] = str(attempt)
+        return resp
+
+    def _apply_batch(self, change_sets, request):
+        """Apply all changesets in one outer transaction; caller wraps for retries."""
         results = []
         # Outer transaction.atomic() makes the whole batch atomic to readers:
         # data writes + tag-link writes + audit-log bulk_create commit together.
@@ -398,13 +456,7 @@ class BulkApplyView(views.APIView):
                     ).to_dict()
                 results.append(result)
             defc.flush()
-
-        http_status = (
-            status.HTTP_207_MULTI_STATUS
-            if any(r.get("errors") for r in results)
-            else status.HTTP_200_OK
-        )
-        return Response({"results": results}, status=http_status)
+        return results
 
 
 class GetDefaultBranchView(views.APIView):

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from netbox.plugins import get_plugin_config
 
 __all__ = (
+    "get_batch_apply_deadlock_retry_max_count",
     "get_diode_auth_introspect_url",
     "get_diode_user",
 )
@@ -99,3 +100,9 @@ def get_diode_user():
 def get_required_token_audience():
     """Returns the require token audience."""
     return get_plugin_config("netbox_diode_plugin", "required_token_audience")
+
+def get_batch_apply_deadlock_retry_max_count():
+    """Max retries on Postgres deadlock for the batch apply endpoint."""
+    return get_plugin_config(
+        "netbox_diode_plugin", "batch_apply_deadlock_retry_max_count"
+    )

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_bulk_tags.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_bulk_tags.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - PR 4 bulk TaggedItem tests."""
+
+import uuid
+from types import SimpleNamespace
+
+from core.models import ObjectChange
+from dcim.models import Site
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+from django.test import RequestFactory, TestCase
+from django.test.utils import CaptureQueriesContext
+from extras.models import Tag, TaggedItem
+from netbox.context import current_request, events_queue
+
+from netbox_diode_plugin.api.bulk_tags import apply_tags_bulk
+from netbox_diode_plugin.api.deferred_changelog import deferred_changelog
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+def _make_request():
+    rf = RequestFactory()
+    req = rf.post("/x")
+    req.id = uuid.uuid4()
+    req.user = get_diode_user()
+    return req
+
+
+class BulkTaggedItemTestCase(TestCase):
+    """Verifies apply_tags_bulk (PR 4)."""
+
+    def setUp(self):
+        """Create K distinct tags + N untagged sites."""
+        self.tags = [Tag.objects.create(name=f"t{i}", slug=f"t{i}") for i in range(3)]
+        self.sites = [Site.objects.create(name=f"S{i}", slug=f"s{i}") for i in range(4)]
+
+    def test_n_objects_one_bulk_insert(self):
+        """N tagged objects produce 1 INSERT INTO extras_taggeditem (modulo batches)."""
+        req = _make_request()
+        # Mimic preload contract from PR 2.
+        req._diode_preload = {
+            "tag_ids_by_slug": {t.slug: t.id for t in self.tags},
+        }
+        token = current_request.set(req)
+        try:
+            pairs = [(s, [t.slug for t in self.tags]) for s in self.sites]
+            with CaptureQueriesContext(connection) as ctx:
+                apply_tags_bulk(pairs, req)
+            inserts = [
+                q for q in ctx.captured_queries
+                if "INSERT INTO" in q["sql"] and '"extras_taggeditem"' in q["sql"]
+            ]
+            assert len(inserts) == 1, [q["sql"] for q in inserts]
+        finally:
+            current_request.reset(token)
+
+    def test_tag_set_per_object_matches_baseline(self):
+        """Final tag set per instance equals what `instance.tags.set([...])` would produce."""
+        req = _make_request()
+        req._diode_preload = {
+            "tag_ids_by_slug": {t.slug: t.id for t in self.tags},
+        }
+        token = current_request.set(req)
+        try:
+            pairs = [(self.sites[0], ["t0", "t1"]), (self.sites[1], ["t2"])]
+            apply_tags_bulk(pairs, req)
+            ct = ContentType.objects.get_for_model(Site)
+
+            for site, expected_slugs in [(self.sites[0], {"t0", "t1"}), (self.sites[1], {"t2"})]:
+                got = set(
+                    Tag.objects.filter(
+                        id__in=TaggedItem.objects.filter(
+                            content_type=ct, object_id=site.pk
+                        ).values_list("tag_id", flat=True)
+                    ).values_list("slug", flat=True)
+                )
+                assert got == expected_slugs, (site, got, expected_slugs)
+        finally:
+            current_request.reset(token)
+
+    def test_no_extra_audit_row_per_tagged_object(self):
+        """N audit rows for N tagged-only updates — no doubled rows from m2m re-fire."""
+        req = _make_request()
+        req._diode_preload = {
+            "tag_ids_by_slug": {t.slug: t.id for t in self.tags},
+        }
+        token = current_request.set(req)
+        try:
+            ObjectChange.objects.all().delete()
+            with deferred_changelog():
+                # Touch each instance once via a normal save, then bulk-tag.
+                for s in self.sites:
+                    s.description = "touched"
+                    s.save()
+                apply_tags_bulk([(s, ["t0"]) for s in self.sites], req)
+
+            ct = ContentType.objects.get_for_model(Site)
+            row_count = ObjectChange.objects.filter(
+                changed_object_type=ct,
+                changed_object_id__in=[s.pk for s in self.sites],
+            ).count()
+            assert row_count == len(self.sites), row_count
+        finally:
+            current_request.reset(token)
+
+    def test_events_queue_populated_with_post_tag_state(self):
+        """events_queue has one entry per tagged instance, with key matching baseline format."""
+        req = _make_request()
+        req._diode_preload = {
+            "tag_ids_by_slug": {t.slug: t.id for t in self.tags},
+        }
+        token = current_request.set(req)
+        # Reset events queue.
+        q_token = events_queue.set({})
+        try:
+            apply_tags_bulk([(self.sites[0], ["t0"])], req)
+            queued = events_queue.get()
+            expected_key = f"dcim.site:{self.sites[0].pk}"
+            assert expected_key in queued, list(queued.keys())
+        finally:
+            events_queue.reset(q_token)
+            current_request.reset(token)
+
+    def test_empty_pairs_is_noop(self):
+        """No pairs -> no INSERT, no DELETE."""
+        req = _make_request()
+        req._diode_preload = {"tag_ids_by_slug": {}}
+        with CaptureQueriesContext(connection) as ctx:
+            apply_tags_bulk([], req)
+        # An empty input may still touch a tx savepoint, but must not write taggeditem.
+        for q in ctx.captured_queries:
+            assert '"extras_taggeditem"' not in q["sql"], q["sql"]

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_deferred_changelog.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_deferred_changelog.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - PR 3 deferred changelog tests."""
+
+import uuid
+
+from core.models import ObjectChange
+from dcim.models import Site
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+from django.test import RequestFactory, TestCase
+from django.test.utils import CaptureQueriesContext
+from netbox.context import current_request
+
+from netbox_diode_plugin.api.deferred_changelog import deferred_changelog
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+def _make_request():
+    """Build a minimal request with a fresh request_id, attached to current_request."""
+    rf = RequestFactory()
+    req = rf.post("/x")
+    req.id = uuid.uuid4()
+    req.user = get_diode_user()
+    return req
+
+
+class DeferredChangelogTestCase(TestCase):
+    """Verifies deferred_changelog (PR 3)."""
+
+    def test_n_changes_one_bulk_insert(self):
+        """N saves inside the context produce ONE bulk INSERT, not N."""
+        req = _make_request()
+        token = current_request.set(req)
+        try:
+            ObjectChange.objects.all().delete()
+            with CaptureQueriesContext(connection) as ctx, deferred_changelog():
+                for i in range(5):
+                    Site.objects.create(name=f"S-{i}", slug=f"s-{i}")
+
+            insert_stmts = [
+                q for q in ctx.captured_queries
+                if "INSERT INTO" in q["sql"] and '"core_objectchange"' in q["sql"]
+            ]
+            assert len(insert_stmts) == 1, [q["sql"] for q in insert_stmts]
+            assert ObjectChange.objects.count() == 5
+        finally:
+            current_request.reset(token)
+
+    def test_audit_row_content_matches_baseline(self):
+        """Buffered audit rows carry the same fields as the per-save baseline."""
+        req = _make_request()
+        token = current_request.set(req)
+        try:
+            ObjectChange.objects.all().delete()
+            with deferred_changelog():
+                Site.objects.create(name="Deferred S", slug="deferred-s")
+            deferred_row = ObjectChange.objects.get(object_repr="Deferred S")
+
+            ObjectChange.objects.all().delete()
+            req2 = _make_request()
+            token2 = current_request.set(req2)
+            try:
+                Site.objects.create(name="Baseline S", slug="baseline-s")
+            finally:
+                current_request.reset(token2)
+            baseline_row = ObjectChange.objects.get(object_repr="Baseline S")
+
+            for field in ("action", "user_name", "changed_object_type_id",
+                          "postchange_data"):
+                assert getattr(deferred_row, field) == getattr(baseline_row, field), field
+        finally:
+            current_request.reset(token)
+
+    def test_nested_context_is_noop(self):
+        """An inner deferred_changelog must not flush — outer wins."""
+        req = _make_request()
+        token = current_request.set(req)
+        try:
+            ObjectChange.objects.all().delete()
+            with deferred_changelog():
+                with deferred_changelog():
+                    Site.objects.create(name="N-1", slug="n-1")
+                # If inner had flushed, this row would already exist.
+                assert ObjectChange.objects.filter(object_repr="N-1").count() == 0
+                Site.objects.create(name="N-2", slug="n-2")
+
+            assert ObjectChange.objects.filter(object_repr__in=["N-1", "N-2"]).count() == 2
+        finally:
+            current_request.reset(token)
+
+    def test_m2m_merge_dedup_single_row(self):
+        """An UPDATE that re-fires via m2m_changed merges into one buffered row."""
+        from extras.models import Tag
+
+        tag = Tag.objects.create(name="net", slug="net")
+        site = Site.objects.create(name="MM", slug="mm")  # outside the window
+
+        req = _make_request()
+        token = current_request.set(req)
+        try:
+            ObjectChange.objects.all().delete()
+            with deferred_changelog():
+                site.description = "updated"
+                site.save()  # post_save → ObjectChange #1
+                site.tags.set([tag])  # m2m_changed → would normally update the prior row
+
+            ct = ContentType.objects.get_for_model(Site)
+            rows = list(ObjectChange.objects.filter(
+                changed_object_type=ct,
+                changed_object_id=site.pk,
+                request_id=req.id,
+            ))
+            assert len(rows) == 1, [r.postchange_data for r in rows]
+            assert rows[0].postchange_data.get("tags") == [tag.id]
+        finally:
+            current_request.reset(token)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_preload_cache.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_preload_cache.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - PR 2 preload cache tests."""
+
+from types import SimpleNamespace
+
+from dcim.models import Site
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from extras.models import Tag
+
+from netbox_diode_plugin.api.applier import _preload_changeset_cache
+from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeType
+
+
+class PreloadChangesetCacheTestCase(TestCase):
+    """Verifies _preload_changeset_cache (PR 2)."""
+
+    def setUp(self):
+        """Create two tags + a 3-change changeset (one NOOP) for the assertions below."""
+        self.tag_a = Tag.objects.create(name="alpha", slug="alpha")
+        self.tag_b = Tag.objects.create(name="beta", slug="beta")
+
+        self.change_set = ChangeSet(
+            id="11111111-1111-1111-1111-111111111111",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE.value,
+                    object_type="dcim.site",
+                    ref_id="r1",
+                    data={"name": "S1", "slug": "s1", "tags": ["alpha", "beta"]},
+                ),
+                Change(
+                    change_type=ChangeType.CREATE.value,
+                    object_type="dcim.site",
+                    ref_id="r2",
+                    # repeated tag — must dedup
+                    data={"name": "S2", "slug": "s2", "tags": ["alpha"]},
+                ),
+                Change(
+                    change_type=ChangeType.NOOP.value,
+                    object_type="dcim.site",
+                    ref_id="r3",
+                    data={"tags": ["ignored"]},
+                ),
+            ],
+        )
+
+    def test_contenttype_cache_hit_after_preload(self):
+        """get_for_model on a preloaded model issues 0 queries."""
+        ContentType.objects.clear_cache()
+        request = SimpleNamespace()
+        _preload_changeset_cache(self.change_set, request)
+
+        with CaptureQueriesContext(connection) as ctx:
+            ContentType.objects.get_for_model(Site)
+        assert len(ctx.captured_queries) == 0, ctx.captured_queries
+
+    def test_tag_ids_collected_in_at_most_two_queries(self):
+        """Preload should resolve tag slugs in <= 2 queries total (1 ContentType + 1 Tag)."""
+        ContentType.objects.clear_cache()
+        request = SimpleNamespace()
+        with CaptureQueriesContext(connection) as ctx:
+            preload = _preload_changeset_cache(self.change_set, request)
+        # NOOP changes are skipped, so "ignored" tag should NOT be loaded.
+        assert preload["tag_ids_by_slug"] == {
+            "alpha": self.tag_a.id,
+            "beta": self.tag_b.id,
+        }
+        # 1 query for ContentType warm-up + 1 query for Tag.filter(...). Allow
+        # a small slack in case Django prefers to issue a savepoint.
+        assert len(ctx.captured_queries) <= 2, ctx.captured_queries
+        assert request._diode_preload is preload


### PR DESCRIPTION
[claude]

## Summary

Three Postgres-side optimisations stacked on top of the `bulk-apply` endpoint, plus a configurable retry on Postgres deadlock. All writes happen inside the batch's outer `transaction.atomic()`, so the batch remains atomic from a concurrent reader's perspective.

Draft PR — not for merge yet.

## Status: NOT tested after rebase

**This branch has not been exercised end-to-end against `develop`'s code.** The optimisations were originally developed and benchmarked on a separate branch (`perf/bulk-orm-no-ttl-bump`) that pre-dated develop's own `/bulk-apply/` endpoint. To produce this PR, the branch was rebased onto the current `develop` and re-targeted at `BulkApplyView` instead of the older `ApplyChangeSetBatchView`.

The rebased branch has only been:
- Syntax-checked (`python ast.parse`)
- Linted (`ruff` clean on changed files)
- Verified logically against the pre-rebase branch (each optimisation behaves the same; per-batch reader-atomicity preserved)

It has **NOT** been:
- Run against a real NetBox instance
- Exercised by any unit / integration test suite on this base
- Benchmarked

Anyone using this branch for local performance testing should run the plugin's test suite as a first sanity check, then run their own end-to-end ingest before drawing conclusions. The bench numbers below were measured on the pre-rebase branch — they should hold (the optimisations are structurally identical) but a fresh sweep is the right thing to confirm.

## Single-changeset endpoint also changes — drop or test before merge

In addition to the batch endpoint, this PR also modifies the existing **single-changeset endpoint** (`ApplyChangeSetView` at `/apply-change-set/`). Before this PR, that endpoint just did:

```python
change_set = ChangeSet.from_dict(request.data)
result = _apply_one_changeset(change_set, request)
return Response(result.to_dict(), status=result.get_status_code())
```

After this PR, it does:

```python
with deferred_changelog() as defc, transaction.atomic():
    result = _apply_one_changeset(change_set, request)
    if result.errors:
        defc.rollback_pending()
    else:
        defc.commit_pending()
    defc.flush()
return Response(result.to_dict(), status=result.get_status_code())
```

So the single-changeset endpoint also picks up:
- **Bulk audit-log INSERT** for that one changeset's ObjectChange rows (was: many small INSERTs as the signal handler fired per-save; now: one `bulk_create` at the end inside the same atomic).
- **Per-changeset bulk TaggedItem write** (applied via `apply_tags_bulk` from `applier.py`).
- **Preload** of ContentType + Tag IDs (also from `applier.py`).
- **Atomic data + audit + tags commit** — same atomicity story as the batch endpoint, just for a single changeset.

It does **NOT** pick up the deadlock retry (that's only on `BulkApplyView`).

These changes were not the explicit target of the original optimisation work — they came along because `applier.py` is shared and because audit-log buffering had to be wired into both endpoints to be self-consistent. They have a few risks:

- **Production hot path.** The single-changeset endpoint is on the regular ingest path for older / non-batched callers. A subtle change in audit-log row ordering or m2m-signal suppression could affect downstream consumers (event subscribers, webhook receivers) in ways the batch path doesn't.
- **No targeted test coverage.** The bench work measured the batch endpoint only. The single-changeset endpoint has only been syntax/lint-checked here.
- **Tag-write semantics.** `apply_tags_bulk` issues a `DELETE` + bulk `INSERT` (replace-set semantics, matching `instance.tags.set([...])`). On a single-changeset call this is functionally the same as the prior path, but the SQL shape is different (one transaction wrapping one DELETE + one INSERT, instead of multiple `m2m_changed` triggers). Anything monitoring `extras_taggeditem` mutations via signals will see a different pattern.

**Recommendation before merge: pick one of**

1. **Drop the single-changeset endpoint changes** — leave `ApplyChangeSetView._post` unchanged from develop, scope this PR strictly to the batch endpoint. Lower risk, narrower change surface, matches what was actually benchmarked. The plugin code in `applier.py` and `deferred_changelog.py` is shared, but the calling convention from the single-changeset view can stay outside the new wrapper.
2. **Thoroughly test the single-changeset endpoint** — run the plugin's existing test suite for `ApplyChangeSetView`, plus add coverage for the new audit-log / tag-write paths under that endpoint. Check for any downstream consumer (webhooks, event subscribers, observers) that depends on the old per-save audit-row pattern.

Option 1 is the cheaper / lower-risk path if the only goal is the bench win on the batch endpoint. Option 2 is the right path if you want the optimisations to also apply to single-changeset callers (smaller absolute win, but the per-changeset CPU drop should still help).

## What changed, in simple words

### 1. Preload ContentType + tag IDs once per changeset
Before: every entity save did one or more small `SELECT` queries to look up "what's the integer ID for this model type?" and "what's the integer ID for the `diode` tag?". With many entities, that's hundreds of small round-trips to Postgres.
After: at the start of each changeset, the plugin runs **one** `SELECT * FROM django_content_type` and **one** `SELECT * FROM extras_tag`, caches the results in a Python dict on the request, and every subsequent ID lookup inside the changeset is an in-memory dict access instead of a Postgres call.

### 2. Batch-wide single bulk `INSERT` of NetBox audit-log rows
Before: every time an entity is saved, NetBox's signal handler inserts one row into `core_objectchange` (the audit log). For a 100-changeset batch with ~280 entities each, that's ~28,000 individual INSERTs into the audit-log table.
After: a thread-local buffer collects `ObjectChange` rows in memory across all changesets in the batch. At the very end of the batch, the buffer is flushed with **one** `ObjectChange.objects.bulk_create(...)`. ~28,000 small INSERTs become 1 batched INSERT.

A failed-changeset accumulator (pending vs committed buffers) makes sure that if changeset N rolls back via its savepoint, its pending audit rows are discarded — they don't leak into the final bulk_create. So audit-log consistency is preserved: a row exists in the audit log only if the data it audits was actually committed.

### 3. Per-changeset bulk `INSERT` of `TaggedItem` rows + suppress redundant signal
Before: every `device.tags.add(...)` issued one `INSERT INTO extras_taggeditem` per tag. For ~280 entities × ~3 tags each, that's ~840 small INSERTs per changeset, and NetBox's `m2m_changed` handler also fires one extra `ObjectChange` audit row per tag attachment (~840 extra audit rows per changeset on top).
After: tag-link rows are accumulated in memory per changeset and written in **one** `TaggedItem.objects.bulk_create(...)` at the end of each changeset. The redundant `m2m_changed` audit-row fire is suppressed, so a tag attachment no longer doubles the audit-log volume.

## Measured impact (pre-rebase numbers)

Workload: `meraki-x10.yaml` (28,310 entities), single host, RPS=100, `APPLY_BATCH_SIZE=100`, `USE_BATCH_APPLY=true`, `AUTO_APPLY_CHANGESETS=false`. Three runs each cell, mean vs mean:

| metric | baseline | optimised | drop |
|---|---:|---:|---:|
| NetBox container CPU-seconds | 512.8 | 388.1 | **−24.3 %** |
| NetBox-postgres container CPU-seconds | 146.2 | 106.9 | **−26.9 %** |
| wall-clock (apply window) | 44.2 min | 32.9 min | **−25.5 %** |

Range no-overlap on all three metrics: every optimised run was faster, less CPU-busy, and easier on Postgres than every baseline run. CV around 7–8% on both cells over the three runs.

These numbers were taken on the pre-rebase branch and measured **only the batch endpoint**. They have **not** been re-measured after the rebase, and they do **not** speak to the single-changeset endpoint's behaviour (see Status section).

## Rare deadlock risk: concurrent batches modifying the same entities in different order

Because the whole batch runs inside one outer `transaction.atomic()`, every row this batch writes stays row-locked in Postgres until the outer commit (which can take seconds, depending on batch size). That trade-off is the cost of giving readers a consistent per-batch view, and it opens up a rare but real deadlock scenario.

**The scenario.** Two different ingest requests are handled by two separate reconciler workers in parallel. The two resulting batch-API calls happen to touch the same entities, but in a different order. For example:

- batch X (worker 1): modifies entity A first, then entity B.
- batch Y (worker 2): modifies entity B first, then entity A.

X takes the row lock on A; Y takes the row lock on B. Then X tries to write B (blocked, Y has it) and Y tries to write A (blocked, X has it). Each is waiting for the other to release. This is the classic A-B / B-A deadlock pattern.

**Postgres auto-resolves this.** When Postgres detects the wait-cycle (default `deadlock_timeout` = 1 second), it picks one of the two transactions as the "victim" and aborts it with SQLSTATE `40P01` (`deadlock_detected`). The other transaction proceeds to commit normally. So the system doesn't hang — but **this should be tested empirically**. The above reasoning was assisted by AI analysis and **should not be trusted blindly** — please verify the actual behaviour in your local test setup before relying on it for capacity planning.

**Mitigation (implemented in this PR).** The aborted batch raises Django's `OperationalError` with `pgcode='40P01'`. The plugin catches this and retries the whole batch with jittered exponential backoff. Max retries is configurable:

```python
PLUGINS_CONFIG = {
    "netbox_diode_plugin": {
        # ... existing settings ...
        "batch_apply_deadlock_retry_max_count": 3,  # default
    }
}
```

- Default `3` retries (so up to 4 attempts total).
- `0` disables retries entirely.
- Bigger values raise the retry budget for deadlock-prone deployments; smaller values fail faster.

On success after retry, the response carries an `X-Diode-Batch-Retries: <n>` header so it shows up in the caller's logs.

The deadlock retry is implemented **only on the batch endpoint**. The single-changeset endpoint inherits the outer atomic + audit-buffer wrapping but does not retry on deadlock; a deadlock there bubbles up to the caller as a 500 (as it does today on develop).

**Alternative: client-side retry on `40P01`.** The reconciler client could in principle catch the deadlock error code on the gRPC/HTTP response and retry the call from its side. That would work, but it's more complicated than retrying on the server side: the reconciler has to re-encode the gRPC request, re-burn rate-limiter budget, re-traverse the network, and the visibility of "which batch is being retried" gets harder to correlate across logs. Doing it inside the plugin keeps the retry cheap (milliseconds), local, and observable via a single response header.

## Effect on concurrent NetBox UI users during a batch

The same row-level locking that enables per-batch atomicity also means that any concurrent NetBox UI user (or any other writer) **will block** if they try to modify an entity that the in-flight batch has already locked. The block lasts until the outer transaction commits — which, depending on batch size, can be **a few seconds** for typical workloads. Plain UI reads (list pages, filter views, detail pages) are not blocked — under Postgres's default MVCC, readers see the pre-batch snapshot and never wait on writers.

So during a heavy ingest, a user who happens to be editing a device that the ingest is also touching will see a multi-second hang on "Save". For most workloads this is invisible (no overlap), but it's a real behaviour worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)