### PR TITLE
feat(api): /bulk-plan-apply endpoint

### DIFF
--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -67,6 +67,15 @@ class NetBoxDiodePluginConfig(PluginConfig):
         # provenance lives in the diode-side ChangeSet rows.
         "apply_bypass_counter_updates": False,
         "apply_bypass_change_logging": False,
+
+        # Per-entity retry on Postgres deadlock (SQLSTATE 40P01) during
+        # the apply phase of /bulk-plan-apply. Cross-batch concurrent
+        # writes for shared-lookup unique indexes (dcim_site_slug_key,
+        # dcim_devicerole_name, ...) occasionally deadlock under load;
+        # the deadlocked transaction is killed by Postgres and the
+        # entity would otherwise fail. Setting >0 retries the apply
+        # with small jittered backoff. Set to 0 to disable retries.
+        "apply_deadlock_max_retries": 2,
     }
 
 

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -71,9 +71,17 @@ class NetBoxDiodePluginConfig(PluginConfig):
         # built-in periodic reindex, so deployments enabling this must
         # schedule `manage.py reindex` (or a system_job) to keep the
         # search box current.
+        #
+        # apply_bypass_customfield_query_cache: install a process-level
+        # cache for CustomField.objects.get_for_model. NetBox's built-in
+        # cache is request-scoped and misses for models with no custom
+        # fields (empty-QuerySet truthiness bug), so under load every
+        # instance.clean()/save() re-queries extras_customfield. Cache
+        # is invalidated on CustomField post_save/post_delete signals.
         "apply_bypass_counter_updates": False,
         "apply_bypass_change_logging": False,
         "apply_bypass_search_indexing": False,
+        "apply_bypass_customfield_query_cache": False,
 
         # Per-entity retry on Postgres deadlock (SQLSTATE 40P01) during
         # the apply phase of /bulk-plan-apply. Cross-batch concurrent

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -41,8 +41,11 @@ class NetBoxDiodePluginConfig(PluginConfig):
         "required_token_audience": [],
 
         # TTL in seconds for caching find_existing_object results in Redis.
-        # Set to 0 to disable caching.
-        "find_obj_cache_ttl": 5,
+        # Cached entries are auto-invalidated when this plugin's apply path
+        # updates the same PK; the TTL bounds staleness for external
+        # mutations (UI edits, direct API writes, other tools). Set to 0 to
+        # disable caching.
+        "find_obj_cache_ttl": 30,
 
         # Override the displayed Diode target URL without affecting internal
         # communication (e.g. to show the external ingress address).

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -50,6 +50,23 @@ class NetBoxDiodePluginConfig(PluginConfig):
         # Override the displayed Diode target URL without affecting internal
         # communication (e.g. to show the external ingress address).
         "diode_target_display": None,
+
+        # Per-write side-effect bypasses applied during /bulk-plan-apply
+        # (and the per-changeset apply path it shares with the legacy
+        # /apply-change-set endpoint). Both default to False; enabling
+        # either trades NetBox-side correctness for ingest throughput
+        # and requires a worker restart to take effect.
+        #
+        # apply_bypass_counter_updates: skip the per-write parent counter
+        # UPDATE (Device.interface_count, DeviceType.device_count, ...).
+        # Counters drift; reconcile via utilities.counters.update_counts.
+        #
+        # apply_bypass_change_logging: skip the per-write ObjectChange
+        # row + post_save/m2m_changed signal handler chain. CREATE/UPDATE
+        # made via diode apply do not appear in the NetBox audit log;
+        # provenance lives in the diode-side ChangeSet rows.
+        "apply_bypass_counter_updates": False,
+        "apply_bypass_change_logging": False,
     }
 
 

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -65,8 +65,15 @@ class NetBoxDiodePluginConfig(PluginConfig):
         # row + post_save/m2m_changed signal handler chain. CREATE/UPDATE
         # made via diode apply do not appear in the NetBox audit log;
         # provenance lives in the diode-side ChangeSet rows.
+        #
+        # apply_bypass_search_indexing: skip the per-write CachedValue
+        # INSERTs that back NetBox's global search index. NetBox has no
+        # built-in periodic reindex, so deployments enabling this must
+        # schedule `manage.py reindex` (or a system_job) to keep the
+        # search box current.
         "apply_bypass_counter_updates": False,
         "apply_bypass_change_logging": False,
+        "apply_bypass_search_indexing": False,
 
         # Per-entity retry on Postgres deadlock (SQLSTATE 40P01) during
         # the apply phase of /bulk-plan-apply. Cross-batch concurrent

--- a/netbox_diode_plugin/api/change_log_bypass.py
+++ b/netbox_diode_plugin/api/change_log_bypass.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""
+Bypass NetBox's per-write ObjectChange (audit log) signal during diode applies.
+
+NetBox writes one row into core_objectchange per save() of every tracked
+model — a Device save fires post_save -> handle_changed_object ->
+to_objectchange() -> ObjectChange.save() — plus the same flow on every
+m2m_changed event. Under bulk auto-apply with N entities × ~6 changes
+each, this is hundreds of thousands of per-write audit INSERTs per
+batch, accumulating both Python signal-handler cost and a long tail of
+small Postgres INSERTs.
+
+This module disconnects the post_save and m2m_changed receivers for the
+duration of the apply. The pre_delete receiver is intentionally left
+connected: it also enforces protection-rule validation, which we must
+keep firing, and deletes are rare in the auto-apply path.
+
+Granian's WSGI workers serve one request per process at a time, so the
+disconnect/reconnect is scoped to this request — concurrent requests in
+the same process can't observe an unsignalled save.
+
+Operational note: this drops audit-log entries for CREATE/UPDATE made
+via diode-driven apply. Deployments that need a full audit trail for
+those operations need to record provenance some other way (e.g.,
+ChangeSet rows on the diode side already capture intended changes).
+"""
+
+from contextlib import contextmanager
+
+from core.signals import handle_changed_object
+from django.db.models.signals import m2m_changed, post_save
+
+
+@contextmanager
+def bypass_change_logging():
+    """Disable per-save ObjectChange creation for CREATE/UPDATE/M2M for the block."""
+    post_save.disconnect(handle_changed_object)
+    m2m_changed.disconnect(handle_changed_object)
+    try:
+        yield
+    finally:
+        post_save.connect(handle_changed_object)
+        m2m_changed.connect(handle_changed_object)

--- a/netbox_diode_plugin/api/change_log_bypass.py
+++ b/netbox_diode_plugin/api/change_log_bypass.py
@@ -11,14 +11,36 @@ each, this is hundreds of thousands of per-write audit INSERTs per
 batch, accumulating both Python signal-handler cost and a long tail of
 small Postgres INSERTs.
 
-This module disconnects the post_save and m2m_changed receivers for the
-duration of the apply. The pre_delete receiver is intentionally left
-connected: it also enforces protection-rule validation, which we must
-keep firing, and deletes are rare in the auto-apply path.
+The bypass is opt-in via the plugin setting
+``apply_bypass_change_logging`` (default False). When enabled, this
+module swaps NetBox's ObjectChange receiver out of the post_save and
+m2m_changed registries at import time and replaces it with a wrapper
+that consults a per-context flag (``contextvars.ContextVar``). When
+``bypass_change_logging()`` is active in the current execution
+context the wrapper returns immediately; otherwise it delegates to
+the original. The pre_delete receiver is intentionally left
+untouched: it also enforces protection-rule validation, which we
+must keep firing, and deletes are rare in the auto-apply path.
 
-Granian's WSGI workers serve one request per process at a time, so the
-disconnect/reconnect is scoped to this request — concurrent requests in
-the same process can't observe an unsignalled save.
+When the setting is False (the default), this module performs no
+mutation of the signal registry and ``bypass_change_logging()``
+becomes a no-op context manager — the plugin behaves exactly like
+upstream NetBox. Toggling the setting requires a worker restart.
+
+Why not disconnect/reconnect per request? WSGI runtimes that serve
+multiple requests per worker via a thread pool — granian (the one we
+run with) and uWSGI with ``--threads`` — race on the global signal
+registry. In practice we observed ~10% of disconnect calls return
+False because another thread had already removed the receiver, and
+reconnect() can leave duplicate or missing entries. The one-time swap
+below happens before any request is served and is not subject to
+that race.
+
+Why ``contextvars.ContextVar`` rather than ``threading.local``?
+ContextVar works correctly under plain threads, asyncio tasks, and
+modern (1.5+) gevent greenlets — the latter is relevant if anyone
+runs the plugin under ``uwsgi --gevent``, where threading.local would
+be shared across greenlets in the same OS thread.
 
 Operational note: this drops audit-log entries for CREATE/UPDATE made
 via diode-driven apply. Deployments that need a full audit trail for
@@ -27,18 +49,49 @@ ChangeSet rows on the diode side already capture intended changes).
 """
 
 from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
 
-from core.signals import handle_changed_object
+from core.signals import handle_changed_object as _original_handler
 from django.db.models.signals import m2m_changed, post_save
+from netbox.plugins import get_plugin_config
+
+_bypass_active: ContextVar[bool] = ContextVar("diode_change_log_bypass_active", default=False)
+
+_enabled = bool(get_plugin_config("netbox_diode_plugin", "apply_bypass_change_logging"))
+
+
+@wraps(_original_handler)
+def _guarded_handler(sender, instance, **kwargs):
+    if _bypass_active.get():
+        return None
+    return _original_handler(sender, instance, **kwargs)
+
+
+if _enabled:
+    # One-time swap of the connected receiver: do this at import in
+    # each granian worker process, before any request is served, so
+    # it is not subject to the concurrency hazard the per-request
+    # disconnect/reconnect approach hit. Keep a strong module-level
+    # reference to the wrapper so Django's weakref does not die.
+    post_save.disconnect(_original_handler)
+    m2m_changed.disconnect(_original_handler)
+    post_save.connect(_guarded_handler)
+    m2m_changed.connect(_guarded_handler)
 
 
 @contextmanager
 def bypass_change_logging():
-    """Disable per-save ObjectChange creation for CREATE/UPDATE/M2M for the block."""
-    post_save.disconnect(handle_changed_object)
-    m2m_changed.disconnect(handle_changed_object)
+    """
+    Suppress ObjectChange creation for CREATE/UPDATE/M2M in this context.
+
+    No-op when ``apply_bypass_change_logging`` is False.
+    """
+    if not _enabled:
+        yield
+        return
+    token = _bypass_active.set(True)
     try:
         yield
     finally:
-        post_save.connect(handle_changed_object)
-        m2m_changed.connect(handle_changed_object)
+        _bypass_active.reset(token)

--- a/netbox_diode_plugin/api/common.py
+++ b/netbox_diode_plugin/api/common.py
@@ -9,6 +9,7 @@ import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import lru_cache
 from zoneinfo import ZoneInfo
 
 import netaddr
@@ -18,6 +19,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.backends.postgresql.psycopg_any import NumericRange
+from django.db.models.signals import post_delete, post_save
 from extras.models import CustomField
 from netaddr.eui import EUI
 from rest_framework import status
@@ -25,6 +27,20 @@ from rest_framework import status
 logger = logging.getLogger("netbox.diode_data")
 
 NON_FIELD_ERRORS = "__all__"
+
+
+@lru_cache(maxsize=256)
+def _get_custom_fields_for_model(model) -> tuple:
+    """Cached wrapper for CustomField.objects.get_for_model()."""
+    return tuple(CustomField.objects.get_for_model(model))
+
+
+def _on_custom_field_change(**kwargs):
+    _get_custom_fields_for_model.cache_clear()
+
+
+post_save.connect(_on_custom_field_change, sender=CustomField)
+post_delete.connect(_on_custom_field_change, sender=CustomField)
 
 @dataclass
 class UnresolvedReference:
@@ -169,7 +185,7 @@ class ChangeSet:
 
     def _validate_custom_fields(self, data: dict, model: models.Model) -> None:
         custom_fields = {
-            cf.name: cf for cf in CustomField.objects.get_for_model(model)
+            cf.name: cf for cf in _get_custom_fields_for_model(model)
         }
 
         unknown_errors = []

--- a/netbox_diode_plugin/api/counter_bypass.py
+++ b/netbox_diode_plugin/api/counter_bypass.py
@@ -14,8 +14,32 @@ DeviceType all serialize on a row-level lock on that one DeviceType row.
 pg_stat_statements observed mean=2.9s per UPDATE and ~99% of pg total
 time in this one query.
 
-This module monkey-patches utilities.counters.update_counter to a no-op
-inside a context manager. Counters drift while the bypass is active.
+The bypass is opt-in via the plugin setting
+``apply_bypass_counter_updates`` (default False). When enabled, this
+module replaces ``utilities.counters.update_counter`` at import time
+with a wrapper that consults a per-context flag
+(``contextvars.ContextVar``). When ``bypass_counter_updates()`` is
+active in the current execution context the wrapper returns
+immediately; otherwise it delegates to the original. Counters drift
+while the bypass is active.
+
+When the setting is False (the default), this module performs no
+monkey-patch and ``bypass_counter_updates()`` becomes a no-op context
+manager — the plugin behaves exactly like upstream NetBox. Toggling
+the setting requires a worker restart.
+
+Why not patch and restore the module attribute per request? WSGI
+runtimes that serve multiple requests per worker via a thread pool —
+granian (the one we run with) and uWSGI with ``--threads`` — race on
+the module attribute. The classic save/restore pattern can leave the
+attribute pointing at the no-op after a concurrent enter/exit
+sequence, breaking counter updates for the rest of the worker's life.
+The one-time swap below happens before any request is served; the
+per-request toggle is a ContextVar with no shared state.
+
+ContextVar works correctly under plain threads, asyncio tasks, and
+modern (1.5+) gevent greenlets — the latter is relevant if anyone
+runs the plugin under ``uwsgi --gevent``.
 
 Operational note: deployments that rely on accurate counters in the UI
 should periodically run utilities.counters.update_counts(model, field,
@@ -25,28 +49,46 @@ between refreshes is bounded by ingest volume between refreshes.
 """
 
 from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
 
+from netbox.plugins import get_plugin_config
 from utilities import counters
 
+_bypass_active: ContextVar[bool] = ContextVar("diode_counter_bypass_active", default=False)
 
-def _noop(*_args, **_kwargs):
-    """Replacement for utilities.counters.update_counter that does nothing."""
-    return
+_enabled = bool(get_plugin_config("netbox_diode_plugin", "apply_bypass_counter_updates"))
+
+_original_update_counter = counters.update_counter
+
+
+@wraps(_original_update_counter)
+def _guarded_update_counter(*args, **kwargs):
+    if _bypass_active.get():
+        return None
+    return _original_update_counter(*args, **kwargs)
+
+
+if _enabled:
+    # One-time swap of the module attribute. Granian imports modules
+    # once per worker before serving traffic, so this is not subject
+    # to per-request races. Keep a module-level reference to the
+    # original so we can call it on the non-bypassed path.
+    counters.update_counter = _guarded_update_counter
 
 
 @contextmanager
 def bypass_counter_updates():
     """
-    Disable NetBox's per-write counter UPDATE for the duration of the block.
+    Suppress NetBox's per-write counter UPDATE in this context.
 
-    The patch is a module-attribute swap, so it affects only the current
-    granian worker process for the duration of the request. Granian's WSGI
-    interface serves one request per worker at a time, so the swap is
-    effectively scoped to this request.
+    No-op when ``apply_bypass_counter_updates`` is False.
     """
-    original = counters.update_counter
-    counters.update_counter = _noop
+    if not _enabled:
+        yield
+        return
+    token = _bypass_active.set(True)
     try:
         yield
     finally:
-        counters.update_counter = original
+        _bypass_active.reset(token)

--- a/netbox_diode_plugin/api/counter_bypass.py
+++ b/netbox_diode_plugin/api/counter_bypass.py
@@ -31,12 +31,13 @@ from utilities import counters
 
 def _noop(*_args, **_kwargs):
     """Replacement for utilities.counters.update_counter that does nothing."""
-    return None
+    return
 
 
 @contextmanager
 def bypass_counter_updates():
-    """Disable NetBox's per-write counter UPDATE for the duration of the block.
+    """
+    Disable NetBox's per-write counter UPDATE for the duration of the block.
 
     The patch is a module-attribute swap, so it affects only the current
     granian worker process for the duration of the request. Granian's WSGI

--- a/netbox_diode_plugin/api/counter_bypass.py
+++ b/netbox_diode_plugin/api/counter_bypass.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""
+Bypass NetBox's per-write denormalized counter UPDATE during diode applies.
+
+NetBox keeps cached counters on parent objects (Device.interface_count,
+DeviceType.device_count, ...) up-to-date via post_save signals on the
+child models. Each child write triggers a row-level UPDATE on the
+parent's counter (see utilities.counters.update_counter).
+
+Under concurrent auto-apply load this is a hot-row lock contention
+problem: dozens of granian workers writing Devices that share the same
+DeviceType all serialize on a row-level lock on that one DeviceType row.
+pg_stat_statements observed mean=2.9s per UPDATE and ~99% of pg total
+time in this one query.
+
+This module monkey-patches utilities.counters.update_counter to a no-op
+inside a context manager. Counters drift while the bypass is active.
+
+Operational note: deployments that rely on accurate counters in the UI
+should periodically run utilities.counters.update_counts(model, field,
+related_query) to reconcile, or apply a similar background refresh.
+Diode-driven writes are the primary source of bulk inserts so drift
+between refreshes is bounded by ingest volume between refreshes.
+"""
+
+from contextlib import contextmanager
+
+from utilities import counters
+
+
+def _noop(*_args, **_kwargs):
+    """Replacement for utilities.counters.update_counter that does nothing."""
+    return None
+
+
+@contextmanager
+def bypass_counter_updates():
+    """Disable NetBox's per-write counter UPDATE for the duration of the block.
+
+    The patch is a module-attribute swap, so it affects only the current
+    granian worker process for the duration of the request. Granian's WSGI
+    interface serves one request per worker at a time, so the swap is
+    effectively scoped to this request.
+    """
+    original = counters.update_counter
+    counters.update_counter = _noop
+    try:
+        yield
+    finally:
+        counters.update_counter = original

--- a/netbox_diode_plugin/api/customfield_cache.py
+++ b/netbox_diode_plugin/api/customfield_cache.py
@@ -62,7 +62,8 @@ _original_get_for_model = CustomField.objects.__class__.get_for_model
 
 
 def _cached_get_for_model(self, model):
-    """Process-level cached replacement for CustomFieldManager.get_for_model.
+    """
+    Process-level cached replacement for CustomFieldManager.get_for_model.
 
     Returns the same QuerySet object on cache hit, with its internal result
     cache pre-populated so iteration does not hit the DB.

--- a/netbox_diode_plugin/api/customfield_cache.py
+++ b/netbox_diode_plugin/api/customfield_cache.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""
+Process-level cache for ``CustomField.objects.get_for_model()``.
+
+NetBox ships a request-scoped cache for ``CustomFieldManager.get_for_model``
+in ``extras.models.customfields``, but the hit check uses Python's walrus
+operator with truthiness:
+
+    if custom_fields := cache['custom_fields'].get(model._meta.model):
+        return custom_fields
+
+An empty QuerySet (model with no custom fields defined) is **falsy**, so
+the cache hit branch is skipped and the DB query runs every time. For
+Diode bulk-apply workloads against NetBox deployments where most models
+have no custom fields, this re-queries ``extras_customfield`` on every
+``instance.clean()`` and ``instance.save()`` - observed at ~558 calls/sec
+returning ~0 rows/sec during sustained ``/bulk-plan-apply`` load on
+RDS Performance Insights.
+
+This module installs a process-level wrapper around
+``CustomFieldManager.get_for_model`` that:
+
+  - Caches the QuerySet object per ``model._meta.model`` for the lifetime
+    of the worker process (not per request).
+  - Force-evaluates the QuerySet inside the wrapper so its internal
+    ``_result_cache`` is populated before it enters the cache. Subsequent
+    iterations across requests use the in-memory cache, never the DB.
+  - Uses an explicit sentinel for the "not cached" check, so empty
+    QuerySets cache correctly (the bug above).
+  - Returns the same QuerySet object on every hit. Callers that chain
+    ``.filter()`` / ``.exclude()`` (e.g. ``matcher.py``) continue to work
+    unchanged - those chains create new QuerySets that hit the DB on
+    iteration, same as before.
+  - Invalidates the entire cache on ``post_save`` / ``post_delete`` of
+    CustomField, matching the per-call-site lru_cache pattern already
+    used by ``transformer.py``, ``matcher.py``, and ``common.py``.
+
+Opt-in via the plugin setting ``apply_bypass_customfield_query_cache``
+(default False). When False the module performs no method-table mutation.
+
+This is install-once-at-import (per worker process) like the other
+apply-path bypasses; threading.Lock guards concurrent first-fill from
+multiple worker threads within a single process.
+"""
+
+from threading import Lock
+
+from django.db.models.signals import post_delete, post_save
+from extras.models import CustomField
+from netbox.plugins import get_plugin_config
+
+_enabled = bool(get_plugin_config("netbox_diode_plugin", "apply_bypass_customfield_query_cache"))
+
+# Sentinel distinguishes "not yet cached" from "cached as empty QuerySet".
+_MISSING = object()
+
+_cache: dict = {}
+_cache_lock = Lock()
+
+_original_get_for_model = CustomField.objects.__class__.get_for_model
+
+
+def _cached_get_for_model(self, model):
+    """Process-level cached replacement for CustomFieldManager.get_for_model.
+
+    Returns the same QuerySet object on cache hit, with its internal result
+    cache pre-populated so iteration does not hit the DB.
+    """
+    model_class = model._meta.model
+    with _cache_lock:
+        cached = _cache.get(model_class, _MISSING)
+    if cached is not _MISSING:
+        return cached
+
+    queryset = _original_get_for_model(self, model)
+    # Force evaluation now so the QuerySet's _result_cache is populated
+    # before any other thread starts iterating it from the cache.
+    list(queryset)
+    with _cache_lock:
+        _cache[model_class] = queryset
+    return queryset
+
+
+def _invalidate(**kwargs):
+    with _cache_lock:
+        _cache.clear()
+
+
+if _enabled:
+    # One-time swap at import - done in each worker process before any
+    # request is served. The signal handlers stay connected for the
+    # process lifetime.
+    CustomField.objects.__class__.get_for_model = _cached_get_for_model
+    post_save.connect(_invalidate, sender=CustomField)
+    post_delete.connect(_invalidate, sender=CustomField)

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -104,10 +104,12 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
         # request. For /bulk-plan-apply touching dozens of unique models per batch,
         # that's still 30-50 extras_customfield queries per call. Use the
         # transformer-level lru_cache instead (process-wide, signal-invalidated)
-        # to make it once-per-process-per-model.
+        # to make it once-per-process-per-model. Inlined logic matches NetBox's
+        # get_custom_fields() exactly: raw JSON value -> field.deserialize() so
+        # callers see datetimes/object instances/etc. rather than primitives.
         cfmap = {}
         for cf in _get_custom_fields_for_model(instance._meta.model):
-            value = instance.custom_field_data.get(cf.name)
+            value = cf.deserialize(instance.custom_field_data.get(cf.name))
             if isinstance(value, datetime.datetime | datetime.date):
                 cfmap[cf.name] = value
             else:

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -28,7 +28,7 @@ from .matcher import _get_active_branch_schema
 from .plugin_utils import get_primary_value, legal_fields
 from .profile import profiled
 from .supported_models import extract_supported_models
-from .transformer import cleanup_unresolved_references, set_custom_field_defaults, transform_proto_json
+from .transformer import _get_custom_fields_for_model, cleanup_unresolved_references, set_custom_field_defaults, transform_proto_json
 
 logger = logging.getLogger(__name__)
 
@@ -99,9 +99,15 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
             prechange_data[field_name] = value
 
     if hasattr(instance, "get_custom_fields"):
-        custom_field_values = instance.get_custom_fields()
+        # NetBox's instance.get_custom_fields() calls CustomField.objects.get_for_model
+        # which uses a request-scoped query_cache - one DB hit per unique model per
+        # request. For /bulk-plan-apply touching dozens of unique models per batch,
+        # that's still 30-50 extras_customfield queries per call. Use the
+        # transformer-level lru_cache instead (process-wide, signal-invalidated)
+        # to make it once-per-process-per-model.
         cfmap = {}
-        for cf, value in custom_field_values.items():
+        for cf in _get_custom_fields_for_model(instance._meta.model):
+            value = instance.custom_field_data.get(cf.name)
             if isinstance(value, datetime.datetime | datetime.date):
                 cfmap[cf.name] = value
             else:

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -33,7 +33,8 @@ _request_obj_cache = contextvars.ContextVar("diode_request_obj_cache", default=N
 
 
 def enter_request_obj_cache():
-    """Activate a request-scoped object lookup cache.
+    """
+    Activate a request-scoped object lookup cache.
 
     Only positive (found-instance) results are stored. A miss is left
     uncached so that subsequent lookups against the same key correctly

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -30,11 +30,17 @@ from .profile import get_profile_ctx
 logger = logging.getLogger(__name__)
 
 _request_obj_cache = contextvars.ContextVar("diode_request_obj_cache", default=None)
-_NOT_FOUND_SENTINEL = object()
 
 
 def enter_request_obj_cache():
-    """Activate a request-scoped object lookup cache."""
+    """Activate a request-scoped object lookup cache.
+
+    Only positive (found-instance) results are stored. A miss is left
+    uncached so that subsequent lookups against the same key correctly
+    pick up a row another worker (or this request's apply phase) has
+    inserted in the meantime. This is what makes the cache safe to share
+    across plan and apply phases within the same request.
+    """
     return _request_obj_cache.set({})
 
 
@@ -1000,12 +1006,11 @@ def find_existing_object(data: dict, object_type: str): # noqa: C901
     req_cache = _request_obj_cache.get(None)
     if req_cache is not None and cache_key is not None and cache_key in req_cache:
         cached = req_cache[cache_key]
-        result = None if cached is _NOT_FOUND_SENTINEL else cached
         if ctx:
             ctx.record_timing("find_obj", (time.monotonic() - start) * 1000)
-            ctx.increment("find_obj_found" if result else "find_obj_not_found")
+            ctx.increment("find_obj_found")
             ctx.increment("find_obj_req_cache_hit")
-        return result
+        return cached
 
     if cache_key:
         cached_id = django_cache.get(cache_key)
@@ -1035,8 +1040,8 @@ def find_existing_object(data: dict, object_type: str): # noqa: C901
             django_cache.set(cache_key, result.id, cache_ttl)
             django_cache.set(_find_obj_rev_key(object_type, result.id), cache_key, cache_ttl)
 
-    if req_cache is not None and cache_key is not None:
-        req_cache[cache_key] = result if result is not None else _NOT_FOUND_SENTINEL
+    if req_cache is not None and cache_key is not None and result is not None:
+        req_cache[cache_key] = result
 
     if ctx:
         ctx.record_timing("find_obj", (time.monotonic() - start) * 1000)

--- a/netbox_diode_plugin/api/search_index_bypass.py
+++ b/netbox_diode_plugin/api/search_index_bypass.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""
+Bypass NetBox's per-write search-index caching signal during diode applies.
+
+NetBox maintains a global search index in ``extras_cachedvalue``: one
+row per indexed field per object. Every model save fires a post_save
+receiver — ``search_backend.caching_handler`` — that inserts a fresh
+batch of CachedValue rows for the saved instance. Under bulk
+auto-apply this is the second-largest write source on NetBox-postgres
+after the actual data tables (e.g. ~11% of pg total time at our
+benchmark profile, ~5 indexed fields per Interface × hundreds of
+thousands of inserts per bench run).
+
+NetBox does *not* periodically reindex on its own. The daily
+SystemHousekeepingJob runs prune/sessions/census tasks — no reindex.
+The only ways to repopulate ``extras_cachedvalue`` after enabling
+this bypass are:
+
+- ``manage.py reindex [app_label[.ModelName] ...]`` run as a cron or
+  k8s CronJob on whatever cadence matches the deployment's tolerance
+  for stale search results, or
+- a custom NetBox JobRunner registered via ``@system_job(interval=...)``
+  that calls ``search_backend.cache(...)`` on diode-touched models.
+
+This is opt-in via the plugin setting
+``apply_bypass_search_indexing`` (default False). When enabled the
+module swaps ``caching_handler`` out of the post_save registry once
+at import time and replaces it with a wrapper that consults a
+per-context flag (``contextvars.ContextVar``); when
+``bypass_search_indexing()`` is active in the current execution
+context the wrapper returns immediately. When the setting is False
+the module performs no signal-registry mutation and the context
+manager is a no-op. ``post_delete``'s ``removal_handler`` is
+intentionally left untouched: deletes are rare on the auto-apply
+path and removing stale CachedValue rows is correct.
+
+Same one-time-swap-plus-ContextVar shape as
+``change_log_bypass``/``counter_bypass`` — chosen for the same
+reasons: per-request disconnect/reconnect races on the global signal
+registry under granian/uwsgi worker thread pools, and
+``threading.local`` is not greenlet-safe under ``uwsgi --gevent``.
+
+Operational note: search index correctness is the user's
+responsibility while this bypass is active — schedule a periodic
+``manage.py reindex`` or accept stale search results.
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
+
+from django.db.models.signals import post_save
+from netbox.plugins import get_plugin_config
+from netbox.search.backends import search_backend
+
+_bypass_active: ContextVar[bool] = ContextVar("diode_search_index_bypass_active", default=False)
+
+_enabled = bool(get_plugin_config("netbox_diode_plugin", "apply_bypass_search_indexing"))
+
+# caching_handler is a bound method on the search_backend singleton.
+# Django's _make_id treats bound methods as (id(self), id(func)) so the
+# disconnect call below matches the receiver registered when
+# netbox.search.backends was imported.
+_original_handler = search_backend.caching_handler
+
+
+@wraps(_original_handler)
+def _guarded_handler(sender, instance, created, **kwargs):
+    if _bypass_active.get():
+        return None
+    return _original_handler(sender, instance, created, **kwargs)
+
+
+if _enabled:
+    # One-time swap of the connected receiver: done at import in each
+    # granian worker process, before any request is served, so it is
+    # not subject to the concurrency hazard the per-request
+    # disconnect/reconnect approach hit. Keep a module-level reference
+    # to the wrapper so Django's weakref does not die.
+    post_save.disconnect(_original_handler)
+    post_save.connect(_guarded_handler)
+
+
+@contextmanager
+def bypass_search_indexing():
+    """
+    Suppress NetBox's per-write search index UPDATE in this context.
+
+    No-op when ``apply_bypass_search_indexing`` is False.
+    """
+    if not _enabled:
+        yield
+        return
+    token = _bypass_active.set(True)
+    try:
+        yield
+    finally:
+        _bypass_active.reset(token)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -259,7 +259,20 @@ def _ensure_snake_case(proto_json: dict, object_type: str) -> dict:
 
 
 def _topo_sort(entities: list[dict]) -> list[dict]:
-    """Topologically sort entities by reference."""
+    """Topologically sort entities by reference.
+
+    Within each topological level, entities are visited in a deterministic
+    content-based order (object_type, primary identifier) so concurrent
+    workers process shared lookup rows — Site, Region, DeviceRole, ... — in
+    identical sequence. Without this, two workers can each insert a pair of
+    shared lookups in opposite orders and Postgres detects an A↔B lock cycle
+    on the unique index (e.g. dcim_devicerole_name), aborting one as a
+    deadlock.
+
+    graphlib.TopologicalSorter preserves insertion order at ties, so the
+    pre-sort propagates into the topological output.
+    """
+    entities = sorted(entities, key=_stable_topo_key)
     by_uuid = {e['_uuid']: e for e in entities}
     graph = defaultdict(set)
     for entity in entities:
@@ -276,6 +289,23 @@ def _topo_sort(entities: list[dict]) -> list[dict]:
                 NON_FIELD_ERRORS: "Unable to resolve circular reference in entities",
             }
         })
+
+
+# Fields tried in order to derive a stable, content-based sort key.
+# Covers the natural primary identifier for most NetBox object types.
+_STABLE_KEY_FIELDS = ("name", "slug", "model", "serial", "address", "mac_address")
+
+
+def _stable_topo_key(entity: dict) -> tuple:
+    """Deterministic content-based sort key for an entity at the same topo level."""
+    ot = entity.get("_object_type", "")
+    for k in _STABLE_KEY_FIELDS:
+        v = entity.get(k)
+        if isinstance(v, str):
+            return (ot, k, v)
+    # Last resort — UUIDs differ per request but at least within one request
+    # this gives a stable ordering for entities lacking the common id fields.
+    return (ot, "_uuid", entity.get("_uuid", ""))
 
 
 def _set_defaults(entities: list[dict], supported_models: dict):

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -259,7 +259,8 @@ def _ensure_snake_case(proto_json: dict, object_type: str) -> dict:
 
 
 def _topo_sort(entities: list[dict]) -> list[dict]:
-    """Topologically sort entities by reference.
+    """
+    Topologically sort entities by reference.
 
     Within each topological level, entities are visited in a deterministic
     content-based order (object_type, primary identifier) so concurrent

--- a/netbox_diode_plugin/api/urls.py
+++ b/netbox_diode_plugin/api/urls.py
@@ -8,6 +8,7 @@ from netbox.api.routers import NetBoxRouter
 from .views import (
     ApplyChangeSetView,
     BulkApplyView,
+    BulkPlanApplyView,
     BulkPlanView,
     GenerateDiffView,
     GetDefaultBranchView,
@@ -19,6 +20,7 @@ urlpatterns = [
     path("apply-change-set/", ApplyChangeSetView.as_view()),
     path("bulk-apply/", BulkApplyView.as_view()),
     path("bulk-plan/", BulkPlanView.as_view()),
+    path("bulk-plan-apply/", BulkPlanApplyView.as_view()),
     path("generate-diff/", GenerateDiffView.as_view()),
     path("default-branch/", GetDefaultBranchView.as_view()),
     path("", include(router.urls)),

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -466,16 +466,26 @@ class BulkPlanApplyView(views.APIView):
 
         branch_schema_id = _get_branch_schema_id(request)
 
-        # The per-request object cache is plan-phase only. Extending it into apply
-        # turns _create_or_find_instance's IntegrityError → re-lookup race recovery
-        # into a terminal error because the cached negative lookup hides the row
-        # another worker just inserted. Enter and exit around plan only.
-        results = []
-        for entry in entities:
-            entity_id = entry.get("id")
-            result = self._process_entity(entry, branch_schema_id, request)
-            result["id"] = entity_id
-            results.append(result)
+        # Share the object-lookup and prechange caches across all entities in
+        # the batch. Both caches are positive-only and request-scoped (single
+        # thread), so a hit reflects a row that genuinely exists; a row created
+        # by an earlier entity's apply is picked up by a subsequent entity's
+        # plan (cache miss → DB → found → cached). The cache extends across
+        # plan and apply within this batch — _create_or_find_instance's
+        # IntegrityError fallback still recovers correctly because the cache
+        # cannot return a stale "not found".
+        obj_token = enter_request_obj_cache()
+        prechange_token = enter_prechange_cache()
+        try:
+            results = []
+            for entry in entities:
+                entity_id = entry.get("id")
+                result = self._process_entity(entry, branch_schema_id, request)
+                result["id"] = entity_id
+                results.append(result)
+        finally:
+            exit_prechange_cache(prechange_token)
+            exit_request_obj_cache(obj_token)
 
         http_status = (
             status.HTTP_207_MULTI_STATUS
@@ -520,25 +530,19 @@ class BulkPlanApplyView(views.APIView):
 
     @staticmethod
     def _run_plan(entity_data, object_type, entry_id, branch_schema_id):
-        """Run the plan phase under a request-scoped object cache. Returns (result, error_dict)."""
-        obj_token = enter_request_obj_cache()
-        prechange_token = enter_prechange_cache()
+        """Run the plan phase. Object + prechange caches are managed by _post."""
         try:
-            try:
-                result = generate_changeset(entity_data, object_type)
-                _add_branch_to_result(result, branch_schema_id)
-                return result, None
-            except ChangeSetException as e:
-                return None, e.errors
-            except Exception:
-                logger.exception(
-                    "plan phase failed for entity %s",
-                    _sanitize_for_log(entry_id),
-                )
-                return None, {"request": {"__all__": ["internal error"]}}
-        finally:
-            exit_prechange_cache(prechange_token)
-            exit_request_obj_cache(obj_token)
+            result = generate_changeset(entity_data, object_type)
+            _add_branch_to_result(result, branch_schema_id)
+            return result, None
+        except ChangeSetException as e:
+            return None, e.errors
+        except Exception:
+            logger.exception(
+                "plan phase failed for entity %s",
+                _sanitize_for_log(entry_id),
+            )
+            return None, {"request": {"__all__": ["internal error"]}}
 
 
 class GetDefaultBranchView(views.APIView):

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -32,6 +32,7 @@ from .permissions import (
     IsAuthenticated,
     require_scopes,
 )
+from .search_index_bypass import bypass_search_indexing
 
 _PG_DEADLOCK_SQLSTATE = "40P01"
 
@@ -91,7 +92,9 @@ def _apply_one_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
     """
     Apply one changeset, returning a ChangeSetResult on success or on ChangeSetException.
 
-    The apply runs inside two side-effect bypasses:
+    The apply runs inside three opt-in side-effect bypasses (each gated
+    by its own plugin setting; all default to off so the plugin behaves
+    like upstream NetBox unless explicitly enabled):
 
     - ``bypass_counter_updates``: suppresses the per-write parent-counter
       UPDATE (Device.interface_count, DeviceType.device_count, ...) that
@@ -104,9 +107,19 @@ def _apply_one_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
       log; the ChangeSet rows on the diode side already capture intent.
       pre_delete is left connected so protection-rule validation keeps
       firing.
+    - ``bypass_search_indexing``: disconnects the post_save receiver
+      that maintains the global ``extras_cachedvalue`` search index.
+      NetBox has no built-in periodic reindex; deployments enabling
+      this bypass must schedule ``manage.py reindex`` (or a system_job)
+      to keep the UI search box current.
     """
     try:
-        with transaction.atomic(), bypass_counter_updates(), bypass_change_logging():
+        with (
+            transaction.atomic(),
+            bypass_counter_updates(),
+            bypass_change_logging(),
+            bypass_search_indexing(),
+        ):
             return apply_changeset(change_set, request)
     except ChangeSetException as e:
         logger.error(f"Error applying change set: {e}")

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from django.apps import apps
 from django.db import transaction
+from django.db.utils import OperationalError
 from rest_framework import status, views
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -521,8 +522,21 @@ class BulkPlanApplyView(views.APIView):
             return {"change_set": change_set_dict, "errors": None}
 
         # Apply phase — no obj_cache. Each entity gets its own transaction
-        # via _apply_one_changeset.
-        apply_result = _apply_one_changeset(plan_result.change_set, request)
+        # via _apply_one_changeset. Catch OperationalError (Postgres deadlock,
+        # serialization failure, etc.) here so a single contended entity
+        # fails alone with a per-entity error rather than bubbling out and
+        # turning the whole batch response into a 500 (which the reconciler
+        # client then retries 4x, amplifying NetBox CPU on every deadlock).
+        try:
+            apply_result = _apply_one_changeset(plan_result.change_set, request)
+        except OperationalError as e:
+            logger.warning(
+                "apply phase hit DB error for entity %s: %s",
+                _sanitize_for_log(entry.get("id")),
+                e,
+            )
+            return {"change_set": change_set_dict, "errors": {"apply": {"__all__": [str(e)]}}}
+
         if apply_result.errors:
             return {"change_set": change_set_dict, "errors": {"apply": apply_result.errors}}
 

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -51,6 +51,22 @@ def _extract_sqlstate(exc):
 def _is_deadlock(exc):
     return _extract_sqlstate(exc) == _PG_DEADLOCK_SQLSTATE
 
+
+def _db_error_code(exc):
+    """
+    Map a Django-wrapped DB OperationalError to a stable client-safe code.
+
+    Postgres deadlock detail (process IDs, transaction IDs, the index/relation
+    names, in-flight query context) is operational information we do not want
+    in the HTTP response body — it leaks internal state and trips CodeQL's
+    "information exposure through an exception" rule. The full exception is
+    still logged server-side by the caller; clients get a short stable tag
+    they can switch on without parsing free-form Postgres error text.
+    """
+    if _is_deadlock(exc):
+        return "db_deadlock_after_retries"
+    return "db_error"
+
 logger = logging.getLogger("netbox.diode_data")
 
 
@@ -623,7 +639,15 @@ class BulkPlanApplyView(views.APIView):
                 _sanitize_for_log(entry.get("id")),
                 e,
             )
-            return {"change_set": change_set_dict, "errors": {"apply": {"__all__": [str(e)]}}}
+            # Return a stable client-safe code, not str(e): the underlying
+            # Postgres deadlock detail (PIDs, txids, index/relation names,
+            # query context) is internal state that does not belong in the
+            # HTTP response. Server-side log line above retains the full
+            # message for operators.
+            return {
+                "change_set": change_set_dict,
+                "errors": {"apply": {"__all__": [_db_error_code(e)]}},
+            }
 
         if apply_result.errors:
             return {"change_set": change_set_dict, "errors": {"apply": apply_result.errors}}

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 
 from .applier import apply_changeset
 from .authentication import DiodeOAuth2Authentication
+from .change_log_bypass import bypass_change_logging
 from .counter_bypass import bypass_counter_updates
 from .common import (
     ChangeSet,
@@ -69,16 +70,22 @@ def get_valid_entity_keys(model_name):
 def _apply_one_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
     """Apply one changeset, returning a ChangeSetResult on success or on ChangeSetException.
 
-    The apply runs inside ``bypass_counter_updates``: NetBox's per-write
-    counter UPDATEs (Device.interface_count, DeviceType.device_count, ...)
-    are suppressed for the duration of the apply. These UPDATEs are
-    hot-row lock contention under concurrent auto-apply load and were
-    accounting for ~99% of NetBox-postgres time in pg_stat_statements.
-    Counters drift; expected to be reconciled by a periodic
-    ``update_counts`` background job.
+    The apply runs inside two side-effect bypasses:
+
+    - ``bypass_counter_updates``: suppresses the per-write parent-counter
+      UPDATE (Device.interface_count, DeviceType.device_count, ...) that
+      was consuming ~99% of NetBox-postgres time as hot-row lock
+      contention. Counters drift; a periodic ``update_counts`` background
+      job reconciles them.
+    - ``bypass_change_logging``: disconnects the post_save / m2m_changed
+      receiver that writes one core_objectchange row per save. CREATE /
+      UPDATE made via diode apply are not recorded in the NetBox audit
+      log; the ChangeSet rows on the diode side already capture intent.
+      pre_delete is left connected so protection-rule validation keeps
+      firing.
     """
     try:
-        with transaction.atomic(), bypass_counter_updates():
+        with transaction.atomic(), bypass_counter_updates(), bypass_change_logging():
             return apply_changeset(change_set, request)
     except ChangeSetException as e:
         logger.error(f"Error applying change set: {e}")

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -15,12 +15,12 @@ from rest_framework.response import Response
 from .applier import apply_changeset
 from .authentication import DiodeOAuth2Authentication
 from .change_log_bypass import bypass_change_logging
-from .counter_bypass import bypass_counter_updates
 from .common import (
     ChangeSet,
     ChangeSetException,
     ChangeSetResult,
 )
+from .counter_bypass import bypass_counter_updates
 from .differ import enter_prechange_cache, exit_prechange_cache, generate_changeset
 from .matcher import enter_request_obj_cache, exit_request_obj_cache
 from .permissions import (
@@ -68,7 +68,8 @@ def get_valid_entity_keys(model_name):
 
 
 def _apply_one_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
-    """Apply one changeset, returning a ChangeSetResult on success or on ChangeSetException.
+    """
+    Apply one changeset, returning a ChangeSetResult on success or on ChangeSetException.
 
     The apply runs inside two side-effect bypasses:
 

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -15,6 +15,7 @@ from rest_framework import status, views
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from . import customfield_cache  # noqa: F401 - imported for side-effect install at module load
 from .applier import apply_changeset
 from .authentication import DiodeOAuth2Authentication
 from .change_log_bypass import bypass_change_logging

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 
 from .applier import apply_changeset
 from .authentication import DiodeOAuth2Authentication
+from .counter_bypass import bypass_counter_updates
 from .common import (
     ChangeSet,
     ChangeSetException,
@@ -66,9 +67,18 @@ def get_valid_entity_keys(model_name):
 
 
 def _apply_one_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
-    """Apply one changeset, returning a ChangeSetResult on success or on ChangeSetException."""
+    """Apply one changeset, returning a ChangeSetResult on success or on ChangeSetException.
+
+    The apply runs inside ``bypass_counter_updates``: NetBox's per-write
+    counter UPDATEs (Device.interface_count, DeviceType.device_count, ...)
+    are suppressed for the duration of the apply. These UPDATEs are
+    hot-row lock contention under concurrent auto-apply load and were
+    accounting for ~99% of NetBox-postgres time in pg_stat_statements.
+    Counters drift; expected to be reconciled by a periodic
+    ``update_counts`` background job.
+    """
     try:
-        with transaction.atomic():
+        with transaction.atomic(), bypass_counter_updates():
             return apply_changeset(change_set, request)
     except ChangeSetException as e:
         logger.error(f"Error applying change set: {e}")

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -3,6 +3,7 @@
 """Diode NetBox Plugin - API Views."""
 import logging
 import re
+from dataclasses import dataclass
 
 from django.apps import apps
 from django.db import transaction
@@ -73,6 +74,91 @@ def _apply_one_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
         return ChangeSetResult(id=change_set.id, errors=e.errors)
 
 
+def _get_branch_schema_id(request):
+    """Return the branch schema ID from the X-NetBox-Branch header or plugin Setting fallback."""
+    branch_schema_id = request.headers.get("X-NetBox-Branch")
+
+    if not branch_schema_id and Branch is not None:
+        try:
+            from netbox_diode_plugin.models import Setting
+            settings = Setting.objects.first()
+            if settings and settings.branch:
+                branch_schema_id = settings.branch.schema_id
+                logger.debug(
+                    "Using default branch from settings: %s (%s)",
+                    settings.branch.name,
+                    branch_schema_id,
+                )
+        except Exception as e:
+            logger.warning("Could not retrieve default branch from settings: %s", e)
+
+    return branch_schema_id
+
+
+def _add_branch_to_result(result, branch_schema_id):
+    """Attach branch info to a ChangeSetResult's change_set when a branch is set."""
+    if not branch_schema_id or Branch is None or result.change_set is None:
+        return
+    try:
+        branch = Branch.objects.get(schema_id=branch_schema_id)
+        result.change_set.branch = {"id": branch.schema_id, "name": branch.name}
+    except Branch.DoesNotExist:
+        logger.warning(
+            "Branch with ID %s does not exist",
+            _sanitize_for_log(branch_schema_id),
+        )
+
+
+@dataclass
+class _ExtractedEntity:
+    """Result of validating and locating an entity's data within a bulk request entry."""
+
+    entity_data: dict | None = None
+    object_type: str | None = None
+    error: dict | None = None
+
+
+def _extract_entity_data(entry):
+    """
+    Validate a bulk-request entry and locate the inner entity dict by snake/camel key.
+
+    Returns an `_ExtractedEntity` with either `entity_data` + `object_type` populated
+    (success) or `error` populated with a plan-error dict (per-entity validation failure).
+    """
+    entity = entry.get("entity")
+    object_type = entry.get("object_type")
+
+    if not entity:
+        return _ExtractedEntity(error={"request": {"entity": ["entity is required"]}})
+    if not object_type:
+        return _ExtractedEntity(error={"request": {"object_type": ["object_type is required"]}})
+
+    try:
+        app_label, model_name = object_type.split(".")
+    except ValueError:
+        return _ExtractedEntity(error={"request": {"object_type": [f"invalid format: {object_type}"]}})
+
+    try:
+        model_class = apps.get_model(app_label, model_name)
+    except LookupError:
+        return _ExtractedEntity(
+            error={"request": {"object_type": [f"{object_type} is not supported in this version."]}}
+        )
+
+    last_key = None
+    for entity_key in get_valid_entity_keys(model_class.__name__):
+        last_key = entity_key
+        data = entity.get(entity_key)
+        if data:
+            return _ExtractedEntity(entity_data=data, object_type=object_type)
+
+    return _ExtractedEntity(
+        error={"entity": {last_key: [
+            f"No data found in expected entity key, got: {list(entity.keys())}"
+        ]}}
+    )
+
+
 class GenerateDiffView(views.APIView):
     """GenerateDiff view."""
 
@@ -92,37 +178,6 @@ class GenerateDiffView(views.APIView):
             import traceback
             traceback.print_exc()
             raise
-
-    def _get_branch_schema_id(self, request):
-        """Get branch schema ID from request header or settings."""
-        branch_schema_id = request.headers.get("X-NetBox-Branch")
-
-        # If no branch specified in header, check for default branch in settings
-        if not branch_schema_id and Branch is not None:
-            try:
-                from netbox_diode_plugin.models import Setting
-                settings = Setting.objects.first()
-                if settings and settings.branch:
-                    branch_schema_id = settings.branch.schema_id
-                    logger.debug(
-                        f"Using default branch from settings: {settings.branch.name} ({branch_schema_id})"
-                    )
-            except Exception as e:
-                logger.warning(f"Could not retrieve default branch from settings: {e}")
-
-        return branch_schema_id
-
-    def _add_branch_to_result(self, result, branch_schema_id):
-        """Add branch information to the result if branch is available."""
-        if branch_schema_id and Branch is not None:
-            try:
-                branch = Branch.objects.get(schema_id=branch_schema_id)
-                result.change_set.branch = {"id": branch.schema_id, "name": branch.name}
-            except Branch.DoesNotExist:
-                logger.warning(
-                    "Branch with ID %s does not exist",
-                    _sanitize_for_log(branch_schema_id),
-                )
 
     def _post(self, request, *args, **kwargs):
         entity = request.data.get("entity")
@@ -176,8 +231,8 @@ class GenerateDiffView(views.APIView):
             )
 
         result = generate_changeset(original_entity_data, object_type)
-        branch_schema_id = self._get_branch_schema_id(request)
-        self._add_branch_to_result(result, branch_schema_id)
+        branch_schema_id = _get_branch_schema_id(request)
+        _add_branch_to_result(result, branch_schema_id)
 
         return Response(result.to_dict(), status=result.get_status_code())
 
@@ -207,7 +262,7 @@ class BulkPlanView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        branch_schema_id = self._get_branch_schema_id(request)
+        branch_schema_id = _get_branch_schema_id(request)
 
         obj_token = enter_request_obj_cache()
         prechange_token = enter_prechange_cache()
@@ -223,30 +278,6 @@ class BulkPlanView(views.APIView):
             exit_request_obj_cache(obj_token)
 
         return Response({"results": results})
-
-    def _get_branch_schema_id(self, request):
-        """Get branch schema ID from request header or settings."""
-        branch_schema_id = request.headers.get("X-NetBox-Branch")
-
-        if not branch_schema_id and Branch is not None:
-            try:
-                from netbox_diode_plugin.models import Setting
-                settings = Setting.objects.first()
-                if settings and settings.branch:
-                    branch_schema_id = settings.branch.schema_id
-            except Exception as e:
-                logger.warning(f"Could not retrieve default branch from settings: {e}")
-
-        return branch_schema_id
-
-    def _add_branch_to_result(self, result, branch_schema_id):
-        """Add branch information to the result if branch is available."""
-        if branch_schema_id and Branch is not None:
-            try:
-                branch = Branch.objects.get(schema_id=branch_schema_id)
-                result.change_set.branch = {"id": branch.schema_id, "name": branch.name}
-            except Branch.DoesNotExist:
-                pass
 
     def _process_entity(self, entry, branch_schema_id):
         """Process a single entity and return its result dict."""
@@ -284,7 +315,7 @@ class BulkPlanView(views.APIView):
 
         try:
             result = generate_changeset(original_entity_data, object_type)
-            self._add_branch_to_result(result, branch_schema_id)
+            _add_branch_to_result(result, branch_schema_id)
             return result.to_dict()
         except ChangeSetException as e:
             return ChangeSetResult(errors=e.errors).to_dict()
@@ -382,6 +413,132 @@ class BulkApplyView(views.APIView):
             else status.HTTP_200_OK
         )
         return Response({"results": results}, status=http_status)
+
+
+class BulkPlanApplyView(views.APIView):
+    """
+    BulkPlanApply view — combined plan+apply per entity for the auto-apply fast path.
+
+    For each entity in the batch this view runs ``generate_changeset`` then, when
+    a non-empty change_set is produced, applies it via ``_apply_one_changeset``.
+    The returned change_set is always included in the response (when the plan
+    phase succeeded) so the reconciler can persist it for audit/retry regardless
+    of apply outcome. Plan failure short-circuits apply for that entity.
+
+    Each entity's apply gets its own ``transaction.atomic()`` (inherited from
+    ``_apply_one_changeset``); a failure in one entity does not affect the
+    others. Manual-review flows continue to use ``/bulk-plan`` + ``/bulk-apply``.
+
+    Request shape::
+
+        {"entities": [{"id": ..., "object_type": "dcim.site", "entity": {...}}, ...]}
+
+    Response shape::
+
+        {"results": [{"id": ..., "change_set": {...} | null,
+                      "errors": {"plan": {...} | null, "apply": {...} | null} | null}, ...]}
+
+    HTTP 200 if every entity succeeded both phases, 207 multi-status if any
+    entity hit a plan or apply error, 400 if the request envelope is invalid.
+    """
+
+    authentication_classes = [DiodeOAuth2Authentication]
+    permission_classes = [IsAuthenticated, require_scopes(SCOPE_NETBOX_WRITE)]
+
+    def post(self, request, *args, **kwargs):
+        """Plan and apply a batch of entities."""
+        try:
+            return self._post(request, *args, **kwargs)
+        except Exception:
+            logger.exception("unexpected error in bulk-plan-apply")
+            return Response(
+                {"errors": {"request": {"__all__": ["internal error"]}}},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    def _post(self, request, *args, **kwargs):
+        entities = request.data.get("entities")
+        if not isinstance(entities, list) or len(entities) == 0:
+            return Response(
+                {"errors": {"request": {"entities": ["a non-empty list of entities is required"]}}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        branch_schema_id = _get_branch_schema_id(request)
+
+        # The per-request object cache is plan-phase only. Extending it into apply
+        # turns _create_or_find_instance's IntegrityError → re-lookup race recovery
+        # into a terminal error because the cached negative lookup hides the row
+        # another worker just inserted. Enter and exit around plan only.
+        results = []
+        for entry in entities:
+            entity_id = entry.get("id")
+            result = self._process_entity(entry, branch_schema_id, request)
+            result["id"] = entity_id
+            results.append(result)
+
+        http_status = (
+            status.HTTP_207_MULTI_STATUS
+            if any(self._has_error(r) for r in results)
+            else status.HTTP_200_OK
+        )
+        return Response({"results": results}, status=http_status)
+
+    @staticmethod
+    def _has_error(result):
+        errors = result.get("errors") or {}
+        return bool(errors.get("plan") or errors.get("apply"))
+
+    def _process_entity(self, entry, branch_schema_id, request):
+        """Plan-then-apply one entity. Returns a dict with change_set + plan/apply errors."""
+        extracted = _extract_entity_data(entry)
+        if extracted.error is not None:
+            return {"change_set": None, "errors": {"plan": extracted.error}}
+
+        plan_result, plan_error = self._run_plan(
+            extracted.entity_data,
+            extracted.object_type,
+            entry.get("id"),
+            branch_schema_id,
+        )
+        if plan_error is not None:
+            return {"change_set": None, "errors": {"plan": plan_error}}
+
+        change_set_dict = plan_result.change_set.to_dict() if plan_result.change_set else None
+
+        # If plan produced no changes, there's nothing to apply.
+        if plan_result.change_set is None or not plan_result.change_set.changes:
+            return {"change_set": change_set_dict, "errors": None}
+
+        # Apply phase — no obj_cache. Each entity gets its own transaction
+        # via _apply_one_changeset.
+        apply_result = _apply_one_changeset(plan_result.change_set, request)
+        if apply_result.errors:
+            return {"change_set": change_set_dict, "errors": {"apply": apply_result.errors}}
+
+        return {"change_set": change_set_dict, "errors": None}
+
+    @staticmethod
+    def _run_plan(entity_data, object_type, entry_id, branch_schema_id):
+        """Run the plan phase under a request-scoped object cache. Returns (result, error_dict)."""
+        obj_token = enter_request_obj_cache()
+        prechange_token = enter_prechange_cache()
+        try:
+            try:
+                result = generate_changeset(entity_data, object_type)
+                _add_branch_to_result(result, branch_schema_id)
+                return result, None
+            except ChangeSetException as e:
+                return None, e.errors
+            except Exception:
+                logger.exception(
+                    "plan phase failed for entity %s",
+                    _sanitize_for_log(entry_id),
+                )
+                return None, {"request": {"__all__": ["internal error"]}}
+        finally:
+            exit_prechange_cache(prechange_token)
+            exit_request_obj_cache(obj_token)
 
 
 class GetDefaultBranchView(views.APIView):

--- a/netbox_diode_plugin/api/views.py
+++ b/netbox_diode_plugin/api/views.py
@@ -2,12 +2,15 @@
 # Copyright 2025 NetBox Labs, Inc.
 """Diode NetBox Plugin - API Views."""
 import logging
+import random
 import re
+import time
 from dataclasses import dataclass
 
 from django.apps import apps
 from django.db import transaction
 from django.db.utils import OperationalError
+from netbox.plugins import get_plugin_config
 from rest_framework import status, views
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -29,6 +32,23 @@ from .permissions import (
     IsAuthenticated,
     require_scopes,
 )
+
+_PG_DEADLOCK_SQLSTATE = "40P01"
+
+
+def _extract_sqlstate(exc):
+    """Pull SQLSTATE from a Django-wrapped OperationalError, psycopg2 or psycopg3."""
+    for candidate in (exc, getattr(exc, "__cause__", None)):
+        if candidate is None:
+            continue
+        code = getattr(candidate, "sqlstate", None) or getattr(candidate, "pgcode", None)
+        if code:
+            return code
+    return None
+
+
+def _is_deadlock(exc):
+    return _extract_sqlstate(exc) == _PG_DEADLOCK_SQLSTATE
 
 logger = logging.getLogger("netbox.diode_data")
 
@@ -91,6 +111,38 @@ def _apply_one_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
     except ChangeSetException as e:
         logger.error(f"Error applying change set: {e}")
         return ChangeSetResult(id=change_set.id, errors=e.errors)
+
+
+def _apply_one_changeset_with_retry(change_set: ChangeSet, request, entity_id) -> ChangeSetResult:
+    """
+    Apply with retries on Postgres deadlock (SQLSTATE 40P01).
+
+    The transaction.atomic() in _apply_one_changeset rolls back fully on
+    OperationalError, so a retry starts from a clean slate. The
+    request-scoped object cache is positive-only and remains valid across
+    retries — any row it contains genuinely existed at lookup time.
+    """
+    max_retries = get_plugin_config("netbox_diode_plugin", "apply_deadlock_max_retries") or 0
+    attempt = 0
+    while True:
+        try:
+            return _apply_one_changeset(change_set, request)
+        except OperationalError as e:
+            if attempt >= max_retries or not _is_deadlock(e):
+                raise
+            # Jittered backoff: 25–50ms on the first retry, 75–100ms on
+            # the second, etc. Small enough to stay well under the
+            # reconciler's per-call HTTP timeout, large enough to give
+            # the contending transaction time to commit.
+            delay = 0.025 * (attempt + 1) + random.uniform(0, 0.025)
+            logger.warning(
+                "deadlock on entity %s (attempt %d), retrying in %.3fs",
+                _sanitize_for_log(entity_id),
+                attempt + 1,
+                delay,
+            )
+            time.sleep(delay)
+            attempt += 1
 
 
 def _get_branch_schema_id(request):
@@ -545,8 +597,13 @@ class BulkPlanApplyView(views.APIView):
         # fails alone with a per-entity error rather than bubbling out and
         # turning the whole batch response into a 500 (which the reconciler
         # client then retries 4x, amplifying NetBox CPU on every deadlock).
+        # Retry on Postgres deadlock (SQLSTATE 40P01) with small jittered
+        # backoff: cross-batch concurrent inserts to shared-lookup unique
+        # indexes (dcim_site_slug_key, dcim_devicerole_name, ...) occasionally
+        # deadlock under load, and a second attempt almost always succeeds
+        # because the contending transaction has finished by then.
         try:
-            apply_result = _apply_one_changeset(plan_result.change_set, request)
+            apply_result = _apply_one_changeset_with_retry(plan_result.change_set, request, entry.get("id"))
         except OperationalError as e:
             logger.warning(
                 "apply phase hit DB error for entity %s: %s",

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_bulk_plan_apply.py
@@ -371,10 +371,10 @@ class BulkPlanApplyTestCase(APITestCase):
 
     # --- Auth/permissions ---
 
-    def test_unauthenticated_request_returns_401(self):
-        """Missing token returns 401."""
+    def test_unauthenticated_request_returns_403(self):
+        """Missing token returns 403 (DiodeOAuth2Authentication has no authenticate_header)."""
         response = self.client.post(self.url, data={"entities": []}, format="json")
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_insufficient_scope_returns_403(self):
         """Token with only read scope cannot call bulk-plan-apply (requires write)."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_bulk_plan_apply.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkPlanApply API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Site
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BulkPlanApplyTestCase(APITestCase):
+    """BulkPlanApply endpoint test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Existing Site",
+            slug="existing-site",
+            comments="original comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, expected_status=status.HTTP_200_OK):
+        """Post the payload and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    # --- Happy path: plan + apply both succeed ---
+
+    def test_single_entity_create_applies(self):
+        """Plan creates a new site and apply persists it to NetBox."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "New Site", "slug": "new-site"}},
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertIsNotNone(cs)
+        self.assertEqual(len(cs["changes"]), 1)
+        self.assertEqual(cs["changes"][0]["change_type"], "create")
+        # Site should exist after apply.
+        self.assertTrue(Site.objects.filter(slug="new-site").exists())
+
+    def test_single_entity_update_applies(self):
+        """Plan updates an existing site and apply persists the change."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "updated comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        r = results[0]
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertEqual(cs["changes"][0]["change_type"], "update")
+        self.site.refresh_from_db()
+        self.assertEqual(self.site.comments, "updated comments")
+
+    def test_single_entity_no_changes_skips_apply(self):
+        """Entity matching NetBox exactly produces empty change_set; apply is skipped."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        r = results[0]
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertEqual(len(cs["changes"]), 0)
+
+    # --- Plan failures short-circuit apply ---
+
+    def test_plan_failure_missing_entity_field(self):
+        """Missing entity field returns plan error per-entity; batch returns 207."""
+        payload = {
+            "entities": [
+                {
+                    "id": "good-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Good Site", "slug": "good-site"}},
+                },
+                {
+                    "id": "bad-1",
+                    "object_type": "dcim.site",
+                    "entity": None,
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        results = response.json().get("results", [])
+        ids = {r["id"]: r for r in results}
+
+        good = ids["good-1"]
+        self.assertIsNone(good.get("errors"))
+        self.assertIsNotNone(good.get("change_set"))
+        self.assertTrue(Site.objects.filter(slug="good-site").exists())
+
+        bad = ids["bad-1"]
+        self.assertIsNone(bad.get("change_set"))
+        self.assertIsNotNone(bad.get("errors"))
+        self.assertIn("plan", bad["errors"])
+        self.assertNotIn("apply", bad["errors"])
+
+    def test_plan_failure_unsupported_object_type(self):
+        """Unsupported object_type returns plan error, apply is skipped."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIsNone(r.get("change_set"))
+        self.assertIn("plan", r["errors"])
+        self.assertIn("object_type", r["errors"]["plan"].get("request", {}))
+
+    def test_plan_failure_invalid_object_type_format(self):
+        """Invalid object_type format returns plan error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "nodotshere",
+                    "entity": {"nodotshere": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIsNone(r.get("change_set"))
+        self.assertIn("plan", r["errors"])
+
+    def test_plan_failure_missing_object_type(self):
+        """Missing object_type returns plan error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "entity": {"site": {"name": "Site", "slug": "site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIn("plan", r["errors"])
+
+    # --- Apply failures: change_set still returned, apply error reported ---
+
+    def test_apply_failure_returns_change_set_and_apply_error(self):
+        """When _apply_one_changeset returns errors, the change_set is still in the response."""
+        from netbox_diode_plugin.api.common import ChangeSetResult
+
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Apply Fail Site", "slug": "apply-fail-site"}},
+                }
+            ]
+        }
+
+        with mock.patch(
+            "netbox_diode_plugin.api.views._apply_one_changeset",
+            return_value=ChangeSetResult(
+                id="cs-id",
+                errors={"dcim.site": {"slug": ["already exists"]}},
+            ),
+        ):
+            response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+
+        r = response.json()["results"][0]
+        self.assertIsNotNone(r.get("change_set"))
+        self.assertIsNotNone(r.get("errors"))
+        self.assertNotIn("plan", r["errors"])
+        self.assertIn("apply", r["errors"])
+        self.assertIn("dcim.site", r["errors"]["apply"])
+
+    def test_mixed_batch_plan_ok_plan_fail_apply_fail(self):
+        """Mixed batch: one ok, one plan-fail, one apply-fail. Order preserved, 207 returned."""
+        from netbox_diode_plugin.api.common import ChangeSetResult
+
+        payload = {
+            "entities": [
+                {
+                    "id": "ok-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "OK Site", "slug": "ok-site"}},
+                },
+                {
+                    "id": "plan-fail-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "fake"}},
+                },
+                {
+                    "id": "apply-fail-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Apply Fail", "slug": "apply-fail"}},
+                },
+            ]
+        }
+
+        # Only fail the third entity's apply. The first uses the real applier.
+        original_apply = None
+        call_count = {"n": 0}
+
+        def fake_apply(change_set, request):
+            call_count["n"] += 1
+            # First call (ok-1) — delegate to real applier.
+            # Second call would be for apply-fail-1 (plan-fail-1 short-circuits).
+            if call_count["n"] == 1:
+                return original_apply(change_set, request)
+            return ChangeSetResult(
+                id=change_set.id,
+                errors={"dcim.site": {"slug": ["already exists"]}},
+            )
+
+        # Capture the real _apply_one_changeset for the first call to delegate to.
+        from netbox_diode_plugin.api import views as views_module
+        original_apply = views_module._apply_one_changeset
+
+        with mock.patch.object(views_module, "_apply_one_changeset", side_effect=fake_apply):
+            response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 3)
+        ids = [r["id"] for r in results]
+        self.assertEqual(ids, ["ok-1", "plan-fail-1", "apply-fail-1"])
+
+        ok = results[0]
+        self.assertIsNone(ok.get("errors"))
+        self.assertIsNotNone(ok.get("change_set"))
+
+        plan_fail = results[1]
+        self.assertIsNone(plan_fail.get("change_set"))
+        self.assertIn("plan", plan_fail["errors"])
+
+        apply_fail = results[2]
+        self.assertIsNotNone(apply_fail.get("change_set"))
+        self.assertIn("apply", apply_fail["errors"])
+
+    # --- Envelope validation ---
+
+    def test_empty_entities_list(self):
+        """Empty entities list returns 400."""
+        self.send_request({"entities": []}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_entities_field(self):
+        """Missing entities field returns 400."""
+        self.send_request({"something_else": "value"}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_entities_not_a_list(self):
+        """Non-list entities returns 400."""
+        self.send_request({"entities": "not a list"}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    # --- ID correlation ---
+
+    def test_id_correlation_preserved(self):
+        """Result IDs match input IDs in order."""
+        payload = {
+            "entities": [
+                {
+                    "id": "aaa-111",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site A", "slug": "site-a"}},
+                },
+                {
+                    "id": "bbb-222",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site B", "slug": "site-b"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual([r["id"] for r in results], ["aaa-111", "bbb-222"])
+
+    def test_entity_without_id(self):
+        """Entity without an id field gets null id in result."""
+        payload = {
+            "entities": [
+                {
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "No ID Site", "slug": "no-id-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["id"])
+        self.assertIsNone(results[0].get("errors"))
+
+    # --- Auth/permissions ---
+
+    def test_unauthenticated_request_returns_401(self):
+        """Missing token returns 401."""
+        response = self.client.post(self.url, data={"entities": []}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_insufficient_scope_returns_403(self):
+        """Token with only read scope cannot call bulk-plan-apply (requires write)."""
+        read_only_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read"],
+            token_data={"scope": "netbox:read"},
+        )
+        with mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=read_only_user
+        ):
+            response = self.client.post(
+                self.url,
+                data={"entities": [{"id": "x", "object_type": "dcim.site",
+                                    "entity": {"site": {"name": "x", "slug": "x"}}}]},
+                format="json",
+                **self.authorization_header,
+            )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_bulk_plan_apply.py
@@ -371,10 +371,10 @@ class BulkPlanApplyTestCase(APITestCase):
 
     # --- Auth/permissions ---
 
-    def test_unauthenticated_request_returns_401(self):
-        """Missing token returns 401."""
+    def test_unauthenticated_request_returns_403(self):
+        """Missing token returns 403 (DiodeOAuth2Authentication has no authenticate_header)."""
         response = self.client.post(self.url, data={"entities": []}, format="json")
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_insufficient_scope_returns_403(self):
         """Token with only read scope cannot call bulk-plan-apply (requires write)."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_bulk_plan_apply.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkPlanApply API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Site
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BulkPlanApplyTestCase(APITestCase):
+    """BulkPlanApply endpoint test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Existing Site",
+            slug="existing-site",
+            comments="original comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, expected_status=status.HTTP_200_OK):
+        """Post the payload and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    # --- Happy path: plan + apply both succeed ---
+
+    def test_single_entity_create_applies(self):
+        """Plan creates a new site and apply persists it to NetBox."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "New Site", "slug": "new-site"}},
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertIsNotNone(cs)
+        self.assertEqual(len(cs["changes"]), 1)
+        self.assertEqual(cs["changes"][0]["change_type"], "create")
+        # Site should exist after apply.
+        self.assertTrue(Site.objects.filter(slug="new-site").exists())
+
+    def test_single_entity_update_applies(self):
+        """Plan updates an existing site and apply persists the change."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "updated comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        r = results[0]
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertEqual(cs["changes"][0]["change_type"], "update")
+        self.site.refresh_from_db()
+        self.assertEqual(self.site.comments, "updated comments")
+
+    def test_single_entity_no_changes_skips_apply(self):
+        """Entity matching NetBox exactly produces empty change_set; apply is skipped."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        r = results[0]
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertEqual(len(cs["changes"]), 0)
+
+    # --- Plan failures short-circuit apply ---
+
+    def test_plan_failure_missing_entity_field(self):
+        """Missing entity field returns plan error per-entity; batch returns 207."""
+        payload = {
+            "entities": [
+                {
+                    "id": "good-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Good Site", "slug": "good-site"}},
+                },
+                {
+                    "id": "bad-1",
+                    "object_type": "dcim.site",
+                    "entity": None,
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        results = response.json().get("results", [])
+        ids = {r["id"]: r for r in results}
+
+        good = ids["good-1"]
+        self.assertIsNone(good.get("errors"))
+        self.assertIsNotNone(good.get("change_set"))
+        self.assertTrue(Site.objects.filter(slug="good-site").exists())
+
+        bad = ids["bad-1"]
+        self.assertIsNone(bad.get("change_set"))
+        self.assertIsNotNone(bad.get("errors"))
+        self.assertIn("plan", bad["errors"])
+        self.assertNotIn("apply", bad["errors"])
+
+    def test_plan_failure_unsupported_object_type(self):
+        """Unsupported object_type returns plan error, apply is skipped."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIsNone(r.get("change_set"))
+        self.assertIn("plan", r["errors"])
+        self.assertIn("object_type", r["errors"]["plan"].get("request", {}))
+
+    def test_plan_failure_invalid_object_type_format(self):
+        """Invalid object_type format returns plan error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "nodotshere",
+                    "entity": {"nodotshere": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIsNone(r.get("change_set"))
+        self.assertIn("plan", r["errors"])
+
+    def test_plan_failure_missing_object_type(self):
+        """Missing object_type returns plan error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "entity": {"site": {"name": "Site", "slug": "site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIn("plan", r["errors"])
+
+    # --- Apply failures: change_set still returned, apply error reported ---
+
+    def test_apply_failure_returns_change_set_and_apply_error(self):
+        """When _apply_one_changeset returns errors, the change_set is still in the response."""
+        from netbox_diode_plugin.api.common import ChangeSetResult
+
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Apply Fail Site", "slug": "apply-fail-site"}},
+                }
+            ]
+        }
+
+        with mock.patch(
+            "netbox_diode_plugin.api.views._apply_one_changeset",
+            return_value=ChangeSetResult(
+                id="cs-id",
+                errors={"dcim.site": {"slug": ["already exists"]}},
+            ),
+        ):
+            response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+
+        r = response.json()["results"][0]
+        self.assertIsNotNone(r.get("change_set"))
+        self.assertIsNotNone(r.get("errors"))
+        self.assertNotIn("plan", r["errors"])
+        self.assertIn("apply", r["errors"])
+        self.assertIn("dcim.site", r["errors"]["apply"])
+
+    def test_mixed_batch_plan_ok_plan_fail_apply_fail(self):
+        """Mixed batch: one ok, one plan-fail, one apply-fail. Order preserved, 207 returned."""
+        from netbox_diode_plugin.api.common import ChangeSetResult
+
+        payload = {
+            "entities": [
+                {
+                    "id": "ok-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "OK Site", "slug": "ok-site"}},
+                },
+                {
+                    "id": "plan-fail-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "fake"}},
+                },
+                {
+                    "id": "apply-fail-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Apply Fail", "slug": "apply-fail"}},
+                },
+            ]
+        }
+
+        # Only fail the third entity's apply. The first uses the real applier.
+        original_apply = None
+        call_count = {"n": 0}
+
+        def fake_apply(change_set, request):
+            call_count["n"] += 1
+            # First call (ok-1) — delegate to real applier.
+            # Second call would be for apply-fail-1 (plan-fail-1 short-circuits).
+            if call_count["n"] == 1:
+                return original_apply(change_set, request)
+            return ChangeSetResult(
+                id=change_set.id,
+                errors={"dcim.site": {"slug": ["already exists"]}},
+            )
+
+        # Capture the real _apply_one_changeset for the first call to delegate to.
+        from netbox_diode_plugin.api import views as views_module
+        original_apply = views_module._apply_one_changeset
+
+        with mock.patch.object(views_module, "_apply_one_changeset", side_effect=fake_apply):
+            response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 3)
+        ids = [r["id"] for r in results]
+        self.assertEqual(ids, ["ok-1", "plan-fail-1", "apply-fail-1"])
+
+        ok = results[0]
+        self.assertIsNone(ok.get("errors"))
+        self.assertIsNotNone(ok.get("change_set"))
+
+        plan_fail = results[1]
+        self.assertIsNone(plan_fail.get("change_set"))
+        self.assertIn("plan", plan_fail["errors"])
+
+        apply_fail = results[2]
+        self.assertIsNotNone(apply_fail.get("change_set"))
+        self.assertIn("apply", apply_fail["errors"])
+
+    # --- Envelope validation ---
+
+    def test_empty_entities_list(self):
+        """Empty entities list returns 400."""
+        self.send_request({"entities": []}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_entities_field(self):
+        """Missing entities field returns 400."""
+        self.send_request({"something_else": "value"}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_entities_not_a_list(self):
+        """Non-list entities returns 400."""
+        self.send_request({"entities": "not a list"}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    # --- ID correlation ---
+
+    def test_id_correlation_preserved(self):
+        """Result IDs match input IDs in order."""
+        payload = {
+            "entities": [
+                {
+                    "id": "aaa-111",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site A", "slug": "site-a"}},
+                },
+                {
+                    "id": "bbb-222",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site B", "slug": "site-b"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual([r["id"] for r in results], ["aaa-111", "bbb-222"])
+
+    def test_entity_without_id(self):
+        """Entity without an id field gets null id in result."""
+        payload = {
+            "entities": [
+                {
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "No ID Site", "slug": "no-id-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["id"])
+        self.assertIsNone(results[0].get("errors"))
+
+    # --- Auth/permissions ---
+
+    def test_unauthenticated_request_returns_401(self):
+        """Missing token returns 401."""
+        response = self.client.post(self.url, data={"entities": []}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_insufficient_scope_returns_403(self):
+        """Token with only read scope cannot call bulk-plan-apply (requires write)."""
+        read_only_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read"],
+            token_data={"scope": "netbox:read"},
+        )
+        with mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=read_only_user
+        ):
+            response = self.client.post(
+                self.url,
+                data={"entities": [{"id": "x", "object_type": "dcim.site",
+                                    "entity": {"site": {"name": "x", "slug": "x"}}}]},
+                format="json",
+                **self.authorization_header,
+            )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_bulk_plan_apply.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkPlanApply API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Site
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BulkPlanApplyTestCase(APITestCase):
+    """BulkPlanApply endpoint test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Existing Site",
+            slug="existing-site",
+            comments="original comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, expected_status=status.HTTP_200_OK):
+        """Post the payload and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    # --- Happy path: plan + apply both succeed ---
+
+    def test_single_entity_create_applies(self):
+        """Plan creates a new site and apply persists it to NetBox."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "New Site", "slug": "new-site"}},
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertIsNotNone(cs)
+        self.assertEqual(len(cs["changes"]), 1)
+        self.assertEqual(cs["changes"][0]["change_type"], "create")
+        # Site should exist after apply.
+        self.assertTrue(Site.objects.filter(slug="new-site").exists())
+
+    def test_single_entity_update_applies(self):
+        """Plan updates an existing site and apply persists the change."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "updated comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        r = results[0]
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertEqual(cs["changes"][0]["change_type"], "update")
+        self.site.refresh_from_db()
+        self.assertEqual(self.site.comments, "updated comments")
+
+    def test_single_entity_no_changes_skips_apply(self):
+        """Entity matching NetBox exactly produces empty change_set; apply is skipped."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        r = results[0]
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertEqual(len(cs["changes"]), 0)
+
+    # --- Plan failures short-circuit apply ---
+
+    def test_plan_failure_missing_entity_field(self):
+        """Missing entity field returns plan error per-entity; batch returns 207."""
+        payload = {
+            "entities": [
+                {
+                    "id": "good-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Good Site", "slug": "good-site"}},
+                },
+                {
+                    "id": "bad-1",
+                    "object_type": "dcim.site",
+                    "entity": None,
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        results = response.json().get("results", [])
+        ids = {r["id"]: r for r in results}
+
+        good = ids["good-1"]
+        self.assertIsNone(good.get("errors"))
+        self.assertIsNotNone(good.get("change_set"))
+        self.assertTrue(Site.objects.filter(slug="good-site").exists())
+
+        bad = ids["bad-1"]
+        self.assertIsNone(bad.get("change_set"))
+        self.assertIsNotNone(bad.get("errors"))
+        self.assertIn("plan", bad["errors"])
+        self.assertNotIn("apply", bad["errors"])
+
+    def test_plan_failure_unsupported_object_type(self):
+        """Unsupported object_type returns plan error, apply is skipped."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIsNone(r.get("change_set"))
+        self.assertIn("plan", r["errors"])
+        self.assertIn("object_type", r["errors"]["plan"].get("request", {}))
+
+    def test_plan_failure_invalid_object_type_format(self):
+        """Invalid object_type format returns plan error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "nodotshere",
+                    "entity": {"nodotshere": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIsNone(r.get("change_set"))
+        self.assertIn("plan", r["errors"])
+
+    def test_plan_failure_missing_object_type(self):
+        """Missing object_type returns plan error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "entity": {"site": {"name": "Site", "slug": "site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIn("plan", r["errors"])
+
+    # --- Apply failures: change_set still returned, apply error reported ---
+
+    def test_apply_failure_returns_change_set_and_apply_error(self):
+        """When _apply_one_changeset returns errors, the change_set is still in the response."""
+        from netbox_diode_plugin.api.common import ChangeSetResult
+
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Apply Fail Site", "slug": "apply-fail-site"}},
+                }
+            ]
+        }
+
+        with mock.patch(
+            "netbox_diode_plugin.api.views._apply_one_changeset",
+            return_value=ChangeSetResult(
+                id="cs-id",
+                errors={"dcim.site": {"slug": ["already exists"]}},
+            ),
+        ):
+            response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+
+        r = response.json()["results"][0]
+        self.assertIsNotNone(r.get("change_set"))
+        self.assertIsNotNone(r.get("errors"))
+        self.assertNotIn("plan", r["errors"])
+        self.assertIn("apply", r["errors"])
+        self.assertIn("dcim.site", r["errors"]["apply"])
+
+    def test_mixed_batch_plan_ok_plan_fail_apply_fail(self):
+        """Mixed batch: one ok, one plan-fail, one apply-fail. Order preserved, 207 returned."""
+        from netbox_diode_plugin.api.common import ChangeSetResult
+
+        payload = {
+            "entities": [
+                {
+                    "id": "ok-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "OK Site", "slug": "ok-site"}},
+                },
+                {
+                    "id": "plan-fail-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "fake"}},
+                },
+                {
+                    "id": "apply-fail-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Apply Fail", "slug": "apply-fail"}},
+                },
+            ]
+        }
+
+        # Only fail the third entity's apply. The first uses the real applier.
+        original_apply = None
+        call_count = {"n": 0}
+
+        def fake_apply(change_set, request):
+            call_count["n"] += 1
+            # First call (ok-1) — delegate to real applier.
+            # Second call would be for apply-fail-1 (plan-fail-1 short-circuits).
+            if call_count["n"] == 1:
+                return original_apply(change_set, request)
+            return ChangeSetResult(
+                id=change_set.id,
+                errors={"dcim.site": {"slug": ["already exists"]}},
+            )
+
+        # Capture the real _apply_one_changeset for the first call to delegate to.
+        from netbox_diode_plugin.api import views as views_module
+        original_apply = views_module._apply_one_changeset
+
+        with mock.patch.object(views_module, "_apply_one_changeset", side_effect=fake_apply):
+            response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 3)
+        ids = [r["id"] for r in results]
+        self.assertEqual(ids, ["ok-1", "plan-fail-1", "apply-fail-1"])
+
+        ok = results[0]
+        self.assertIsNone(ok.get("errors"))
+        self.assertIsNotNone(ok.get("change_set"))
+
+        plan_fail = results[1]
+        self.assertIsNone(plan_fail.get("change_set"))
+        self.assertIn("plan", plan_fail["errors"])
+
+        apply_fail = results[2]
+        self.assertIsNotNone(apply_fail.get("change_set"))
+        self.assertIn("apply", apply_fail["errors"])
+
+    # --- Envelope validation ---
+
+    def test_empty_entities_list(self):
+        """Empty entities list returns 400."""
+        self.send_request({"entities": []}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_entities_field(self):
+        """Missing entities field returns 400."""
+        self.send_request({"something_else": "value"}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_entities_not_a_list(self):
+        """Non-list entities returns 400."""
+        self.send_request({"entities": "not a list"}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    # --- ID correlation ---
+
+    def test_id_correlation_preserved(self):
+        """Result IDs match input IDs in order."""
+        payload = {
+            "entities": [
+                {
+                    "id": "aaa-111",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site A", "slug": "site-a"}},
+                },
+                {
+                    "id": "bbb-222",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site B", "slug": "site-b"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual([r["id"] for r in results], ["aaa-111", "bbb-222"])
+
+    def test_entity_without_id(self):
+        """Entity without an id field gets null id in result."""
+        payload = {
+            "entities": [
+                {
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "No ID Site", "slug": "no-id-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["id"])
+        self.assertIsNone(results[0].get("errors"))
+
+    # --- Auth/permissions ---
+
+    def test_unauthenticated_request_returns_403(self):
+        """Missing token returns 403 (DiodeOAuth2Authentication has no authenticate_header)."""
+        response = self.client.post(self.url, data={"entities": []}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_insufficient_scope_returns_403(self):
+        """Token with only read scope cannot call bulk-plan-apply (requires write)."""
+        read_only_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read"],
+            token_data={"scope": "netbox:read"},
+        )
+        with mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=read_only_user
+        ):
+            response = self.client.post(
+                self.url,
+                data={"entities": [{"id": "x", "object_type": "dcim.site",
+                                    "entity": {"site": {"name": "x", "slug": "x"}}}]},
+                format="json",
+                **self.authorization_header,
+            )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
## Summary

A new combined plan-and-apply endpoint plus four opt-in performance settings that let deployments trade specific NetBox-side correctness guarantees for substantially higher ingest throughput on the auto-apply path. All bypasses default off - out-of-the-box behaviour is unchanged.

## What changes

### New endpoint

``POST /api/plugins/diode/bulk-plan-apply/`` - single HTTP call that plans and applies each entity in a batch. Architecturally distinct from ``/bulk-plan/`` (diff-only) and ``/bulk-apply/`` (apply-only): this is the auto-apply fast path, where the plan and apply phases share a request-scoped object lookup cache and prechange cache.

Per-entity outcomes:

- plan failed → state ``FAILED``, failure-placeholder ``change_set`` persisted
- plan ok, no changes → state ``NO_CHANGES``, no ``change_set`` persisted
- plan ok, apply ok → state ``APPLIED``, ``change_set`` persisted
- plan ok, apply failed → state ``FAILED``, ``change_set`` persisted for audit / retry

A failure in one entity does not roll back its siblings (``transaction.atomic()`` is scoped per entity). Returns HTTP 200 on all-success, HTTP 207 on partial failure.

### New opt-in settings (all default ``False``)

- ``apply_bypass_counter_updates`` - no-op ``utilities.counters.update_counter`` for the request. Eliminates the row-level UPDATE on parent counters (``DeviceType.device_count``, ``Device.interface_count``, …). Counters drift while enabled; reconcile via ``utilities.counters.update_counts``.
- ``apply_bypass_change_logging`` - swap ``core.signals.handle_changed_object`` out of ``post_save`` + ``m2m_changed``. Suppresses ``core_objectchange`` INSERTs + the prechange/postchange serializer pipeline. CREATE/UPDATE made via diode apply will not appear in the NetBox audit log; ``pre_delete`` is left connected so protection-rule validation still fires.
- ``apply_bypass_search_indexing`` - swap ``search_backend.caching_handler`` out of ``post_save``. Suppresses ``extras_cachedvalue`` INSERTs. NetBox has no built-in periodic reindex - deployments enabling this must schedule ``manage.py reindex`` (or a ``@system_job``) on their own cadence to keep the global search current. ``removal_handler`` is left connected.
- ``apply_bypass_customfield_query_cache`` - install a process-level cache for ``CustomField.objects.get_for_model()`` (monkey-patches ``CustomFieldManager.get_for_model``). NetBox ships its own request-scoped cache for the same call, but the hit check uses Python truthiness on a QuerySet (``if custom_fields := cache[…].get(model)``); an empty QuerySet (model with no custom fields defined) is falsy, so the cache hit branch is skipped and the DB query runs every time. Observed at ~558 calls/sec returning ~0 rows/sec on ``extras_customfield`` during sustained ``/bulk-plan-apply`` load against deployments where most models have no custom fields. The wrapper uses an explicit sentinel for the not-cached check (so empty QuerySets cache correctly), force-evaluates the QuerySet inside the wrapper so its internal ``_result_cache`` is populated before it enters the cache, and invalidates the entire cache on ``CustomField`` ``post_save`` / ``post_delete`` signals. Process-level (not per-request); takes effect after a worker restart.

The first three bypasses are implemented as a **one-time receiver / module-attribute swap at module import** plus a ``contextvars.ContextVar`` toggle per request. The earlier per-request disconnect-and-restore approach was unsafe under WSGI thread pools (granian, uwsgi ``--threads``) - a sibling thread could re-register the receiver while another was inside the bypass block. The current shape is race-free across plain threads, asyncio tasks, and modern gevent (1.5+) greenlets. The fourth bypass (``apply_bypass_customfield_query_cache``) is unconditional once enabled: the monkey-patch is installed at module import and stays active for the lifetime of the worker process, with a ``threading.Lock`` guarding concurrent first-fill from multiple worker threads.

### Correctness improvements

- **Deterministic intra-batch ordering.** ``transformer._stable_topo_key`` pre-sorts entities so concurrent workers process shared lookup rows (Site, Region, DeviceRole, …) in identical sequence. Eliminates intra-batch unique-index lock cycles on those shared lookups.
- **Per-entity deadlock retry.** ``_apply_one_changeset_with_retry`` catches ``OperationalError`` with SQLSTATE 40P01 and retries with small jittered backoff. Tunable via ``apply_deadlock_max_retries`` (default 2). Absorbs cross-batch deadlocks that the intra-batch topo-sort cannot prevent.
- **Per-entity error containment.** ``OperationalError`` is caught at the per-entity level so a single contended entity fails alone with a per-entity error rather than bubbling out and turning the whole batch response into a 500.

### Smaller items

- ``find_obj_cache_ttl`` default raised from 5s to 30s - the request-scoped object cache is positive-only (cache hits reflect rows that actually exist), so a longer TTL is safe and reduces redundant lookups across plan+apply in the combined endpoint.

## Test plan

- [x] ``ruff check netbox_diode_plugin`` clean
- [x] ``make docker-compose-netbox-plugin-test`` - 341/341 pass
- [x] Manual: ``/bulk-plan-apply`` under load against a local stack (granian with multiple worker threads) - verified each bypass setting independently flips on/off cleanly and the per-entity error path returns 207 not 500