### PR TITLE
feat: NetBox 4.6.x support

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Default NetBox version used for coverage reporting
-  DEFAULT_NETBOX_VERSION: "v4.5.5"
+  DEFAULT_NETBOX_VERSION: "v4.6.0"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python: [ "3.10" ]
-        netbox: [ "v4.5.5", "v4.4.10" ]
+        netbox: [ "v4.6.0", "v4.5.5", "v4.4.10" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ at [https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in
 |    >= 4.4.0     |     1.4.1      |
 |    >= 4.4.10    |     1.7.0      |
 |    >= 4.5.0     |     1.7.0      |
+|    >= 4.6.0     |     TBD        |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ at [https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in
 |    >= 4.4.0     |     1.4.1      |
 |    >= 4.4.10    |     1.7.0      |
 |    >= 4.5.0     |     1.7.0      |
-|    >= 4.6.0     |     TBD        |
+|    >= 4.6.0     |     1.12.0     |
 
 ## Installation
 

--- a/docker/v4.6.x/Dockerfile
+++ b/docker/v4.6.x/Dockerfile
@@ -1,0 +1,14 @@
+ARG NETBOX_VERSION=v4.6.0-5.0.1
+FROM netboxcommunity/netbox:${NETBOX_VERSION}
+
+COPY common/netbox/configuration/ /etc/netbox/config/
+RUN chmod 755 /etc/netbox/config/* && \
+    chown netbox:root /etc/netbox/config/*
+
+COPY common/netbox/local_settings.py /opt/netbox/netbox/netbox/local_settings.py
+RUN chmod 755 /opt/netbox/netbox/netbox/local_settings.py && \
+    chown netbox:root /opt/netbox/netbox/netbox/local_settings.py
+
+COPY v4.6.x/requirements-diode-netbox-plugin.txt /opt/netbox/
+ENV VIRTUAL_ENV=/opt/netbox/venv
+RUN /usr/local/bin/uv pip install -r /opt/netbox/requirements-diode-netbox-plugin.txt

--- a/docker/v4.6.x/docker-compose.override.yaml
+++ b/docker/v4.6.x/docker-compose.override.yaml
@@ -1,0 +1,5 @@
+services:
+  netbox:
+    volumes:
+      - ./netbox/launch-netbox.sh:/opt/netbox/launch-netbox.sh:z,ro
+      - ./netbox/granian.py:/opt/netbox/netbox/netbox/granian.py:z,ro

--- a/docker/v4.6.x/requirements-diode-netbox-plugin.txt
+++ b/docker/v4.6.x/requirements-diode-netbox-plugin.txt
@@ -1,0 +1,8 @@
+Brotli==1.2.0
+certifi==2024.7.4
+coverage==7.6.0
+grpcio==1.76.0
+protobuf==5.29.6
+pytest==9.0.3
+netboxlabs-netbox-branching==1.0.3
+granian[reload]

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -586,6 +586,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
 | virtualization_virtualmachine_unique_name_cluster_tenant | 4 | builtin |  | N/A | Custom matcher | All versions |
 | virtualization_virtualmachine_unique_name_cluster | 5 | builtin |  | tenant is NULL | Custom matcher | All versions |
+| virtualization_virtualmachine_unique_name_device_tenant | 6 | builtin |  | cluster is NULL AND device is NOT NULL | Custom matcher | All versions |
+| virtualization_virtualmachine_unique_name_device | 7 | builtin |  | cluster is NULL AND device is NOT NULL AND tenant is NULL | Custom matcher | All versions |
 
 ## virtualization.vminterface
 

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -16,7 +16,7 @@ class NetBoxDiodePluginConfig(PluginConfig):
     version = version_semver()
     base_url = "diode"
     min_version = "4.4.10"
-    max_version = "4.5.99"
+    max_version = "4.6.99"
     middleware = [
         "netbox_diode_plugin.api.profile.DiodeProfileMiddleware",
     ]

--- a/netbox_diode_plugin/api/plugin_utils.py
+++ b/netbox_diode_plugin/api/plugin_utils.py
@@ -1,7 +1,8 @@
 """Diode plugin helpers."""
 
 # Generated code. DO NOT EDIT.
-# Timestamp: 2026-01-12 17:44:14Z
+# Source: NetBox v4.6.0
+# Timestamp: 2026-05-14 16:54:23Z
 
 from dataclasses import dataclass
 import datetime
@@ -68,9 +69,6 @@ _JSON_REF_INFO = {
         ),
         "cable_path": RefInfo(
             object_type="dcim.cablepath", field_name="object", is_generic=True
-        ),
-        "cable_termination": RefInfo(
-            object_type="dcim.cabletermination", field_name="object", is_generic=True
         ),
         "circuit": RefInfo(
             object_type="circuits.circuit", field_name="object", is_generic=True
@@ -351,6 +349,20 @@ _JSON_REF_INFO = {
         "owner_group": RefInfo(
             object_type="users.ownergroup", field_name="object", is_generic=True
         ),
+        "cable_bundle": RefInfo(
+            object_type="dcim.cablebundle", field_name="object", is_generic=True
+        ),
+        "rack_group": RefInfo(
+            object_type="dcim.rackgroup", field_name="object", is_generic=True
+        ),
+        "script_module": RefInfo(
+            object_type="core.managedfile", field_name="object", is_generic=True
+        ),
+        "virtual_machine_type": RefInfo(
+            object_type="virtualization.virtualmachinetype",
+            field_name="object",
+            is_generic=True,
+        ),
     },
     "circuits.circuit": {
         "assignments": RefInfo(
@@ -449,43 +461,14 @@ _JSON_REF_INFO = {
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "dcim.cable": {
+        "bundle": RefInfo(object_type="dcim.cablebundle", field_name="bundle"),
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
         "tenant": RefInfo(object_type="tenancy.tenant", field_name="tenant"),
     },
-    "dcim.cabletermination": {
-        "cable": RefInfo(object_type="dcim.cable", field_name="cable"),
-        "termination_circuit_termination": RefInfo(
-            object_type="circuits.circuittermination",
-            field_name="termination",
-            is_generic=True,
-        ),
-        "termination_console_port": RefInfo(
-            object_type="dcim.consoleport", field_name="termination", is_generic=True
-        ),
-        "termination_console_server_port": RefInfo(
-            object_type="dcim.consoleserverport",
-            field_name="termination",
-            is_generic=True,
-        ),
-        "termination_front_port": RefInfo(
-            object_type="dcim.frontport", field_name="termination", is_generic=True
-        ),
-        "termination_interface": RefInfo(
-            object_type="dcim.interface", field_name="termination", is_generic=True
-        ),
-        "termination_power_feed": RefInfo(
-            object_type="dcim.powerfeed", field_name="termination", is_generic=True
-        ),
-        "termination_power_outlet": RefInfo(
-            object_type="dcim.poweroutlet", field_name="termination", is_generic=True
-        ),
-        "termination_power_port": RefInfo(
-            object_type="dcim.powerport", field_name="termination", is_generic=True
-        ),
-        "termination_rear_port": RefInfo(
-            object_type="dcim.rearport", field_name="termination", is_generic=True
-        ),
+    "dcim.cablebundle": {
+        "owner": RefInfo(object_type="users.owner", field_name="owner"),
+        "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "dcim.consoleport": {
         "device": RefInfo(object_type="dcim.device", field_name="device"),
@@ -698,6 +681,7 @@ _JSON_REF_INFO = {
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "dcim.rack": {
+        "group": RefInfo(object_type="dcim.rackgroup", field_name="group"),
         "location": RefInfo(object_type="dcim.location", field_name="location"),
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
         "rack_type": RefInfo(object_type="dcim.racktype", field_name="rack_type"),
@@ -705,6 +689,10 @@ _JSON_REF_INFO = {
         "site": RefInfo(object_type="dcim.site", field_name="site"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
         "tenant": RefInfo(object_type="tenancy.tenant", field_name="tenant"),
+    },
+    "dcim.rackgroup": {
+        "owner": RefInfo(object_type="users.owner", field_name="owner"),
+        "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "dcim.rackreservation": {
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
@@ -787,11 +775,6 @@ _JSON_REF_INFO = {
         ),
         "assigned_object_cable_path": RefInfo(
             object_type="dcim.cablepath", field_name="assigned_object", is_generic=True
-        ),
-        "assigned_object_cable_termination": RefInfo(
-            object_type="dcim.cabletermination",
-            field_name="assigned_object",
-            is_generic=True,
         ),
         "assigned_object_circuit": RefInfo(
             object_type="circuits.circuit",
@@ -1154,6 +1137,24 @@ _JSON_REF_INFO = {
             field_name="assigned_object",
             is_generic=True,
         ),
+        "assigned_object_cable_bundle": RefInfo(
+            object_type="dcim.cablebundle",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_rack_group": RefInfo(
+            object_type="dcim.rackgroup", field_name="assigned_object", is_generic=True
+        ),
+        "assigned_object_script_module": RefInfo(
+            object_type="core.managedfile",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_virtual_machine_type": RefInfo(
+            object_type="virtualization.virtualmachinetype",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "ipam.aggregate": {
@@ -1165,6 +1166,7 @@ _JSON_REF_INFO = {
     "ipam.asn": {
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
         "rir": RefInfo(object_type="ipam.rir", field_name="rir"),
+        "role": RefInfo(object_type="ipam.role", field_name="role"),
         "sites": RefInfo(object_type="dcim.site", field_name="sites", is_many=True),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
         "tenant": RefInfo(object_type="tenancy.tenant", field_name="tenant"),
@@ -1195,9 +1197,6 @@ _JSON_REF_INFO = {
         ),
         "interface_cable_path": RefInfo(
             object_type="dcim.cablepath", field_name="interface", is_generic=True
-        ),
-        "interface_cable_termination": RefInfo(
-            object_type="dcim.cabletermination", field_name="interface", is_generic=True
         ),
         "interface_circuit": RefInfo(
             object_type="circuits.circuit", field_name="interface", is_generic=True
@@ -1512,6 +1511,20 @@ _JSON_REF_INFO = {
         "interface_owner_group": RefInfo(
             object_type="users.ownergroup", field_name="interface", is_generic=True
         ),
+        "interface_cable_bundle": RefInfo(
+            object_type="dcim.cablebundle", field_name="interface", is_generic=True
+        ),
+        "interface_rack_group": RefInfo(
+            object_type="dcim.rackgroup", field_name="interface", is_generic=True
+        ),
+        "interface_script_module": RefInfo(
+            object_type="core.managedfile", field_name="interface", is_generic=True
+        ),
+        "interface_virtual_machine_type": RefInfo(
+            object_type="virtualization.virtualmachinetype",
+            field_name="interface",
+            is_generic=True,
+        ),
     },
     "ipam.ipaddress": {
         "assigned_object_fhrp_group": RefInfo(
@@ -1627,6 +1640,9 @@ _JSON_REF_INFO = {
         "scope_site_group": RefInfo(
             object_type="dcim.sitegroup", field_name="scope", is_generic=True
         ),
+        "scope_rack_group": RefInfo(
+            object_type="dcim.rackgroup", field_name="scope", is_generic=True
+        ),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
         "tenant": RefInfo(object_type="tenancy.tenant", field_name="tenant"),
     },
@@ -1673,9 +1689,6 @@ _JSON_REF_INFO = {
         ),
         "object_cable_path": RefInfo(
             object_type="dcim.cablepath", field_name="object", is_generic=True
-        ),
-        "object_cable_termination": RefInfo(
-            object_type="dcim.cabletermination", field_name="object", is_generic=True
         ),
         "object_circuit": RefInfo(
             object_type="circuits.circuit", field_name="object", is_generic=True
@@ -1972,6 +1985,20 @@ _JSON_REF_INFO = {
         "object_owner_group": RefInfo(
             object_type="users.ownergroup", field_name="object", is_generic=True
         ),
+        "object_cable_bundle": RefInfo(
+            object_type="dcim.cablebundle", field_name="object", is_generic=True
+        ),
+        "object_rack_group": RefInfo(
+            object_type="dcim.rackgroup", field_name="object", is_generic=True
+        ),
+        "object_script_module": RefInfo(
+            object_type="core.managedfile", field_name="object", is_generic=True
+        ),
+        "object_virtual_machine_type": RefInfo(
+            object_type="virtualization.virtualmachinetype",
+            field_name="object",
+            is_generic=True,
+        ),
         "role": RefInfo(object_type="tenancy.contactrole", field_name="role"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
@@ -2042,6 +2069,17 @@ _JSON_REF_INFO = {
         "site": RefInfo(object_type="dcim.site", field_name="site"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
         "tenant": RefInfo(object_type="tenancy.tenant", field_name="tenant"),
+        "virtual_machine_type": RefInfo(
+            object_type="virtualization.virtualmachinetype",
+            field_name="virtual_machine_type",
+        ),
+    },
+    "virtualization.virtualmachinetype": {
+        "default_platform": RefInfo(
+            object_type="dcim.platform", field_name="default_platform"
+        ),
+        "owner": RefInfo(object_type="users.owner", field_name="owner"),
+        "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "virtualization.vminterface": {
         "bridge": RefInfo(
@@ -2136,11 +2174,6 @@ _JSON_REF_INFO = {
         ),
         "assigned_object_cable_path": RefInfo(
             object_type="dcim.cablepath", field_name="assigned_object", is_generic=True
-        ),
-        "assigned_object_cable_termination": RefInfo(
-            object_type="dcim.cabletermination",
-            field_name="assigned_object",
-            is_generic=True,
         ),
         "assigned_object_circuit": RefInfo(
             object_type="circuits.circuit",
@@ -2492,6 +2525,24 @@ _JSON_REF_INFO = {
             field_name="assigned_object",
             is_generic=True,
         ),
+        "assigned_object_cable_bundle": RefInfo(
+            object_type="dcim.cablebundle",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_rack_group": RefInfo(
+            object_type="dcim.rackgroup", field_name="assigned_object", is_generic=True
+        ),
+        "assigned_object_script_module": RefInfo(
+            object_type="core.managedfile",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_virtual_machine_type": RefInfo(
+            object_type="virtualization.virtualmachinetype",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
         "l2vpn": RefInfo(object_type="vpn.l2vpn", field_name="l2vpn"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
@@ -2525,11 +2576,6 @@ _JSON_REF_INFO = {
         ),
         "termination_cable_path": RefInfo(
             object_type="dcim.cablepath", field_name="termination", is_generic=True
-        ),
-        "termination_cable_termination": RefInfo(
-            object_type="dcim.cabletermination",
-            field_name="termination",
-            is_generic=True,
         ),
         "termination_circuit": RefInfo(
             object_type="circuits.circuit", field_name="termination", is_generic=True
@@ -2860,6 +2906,20 @@ _JSON_REF_INFO = {
         "termination_owner_group": RefInfo(
             object_type="users.ownergroup", field_name="termination", is_generic=True
         ),
+        "termination_cable_bundle": RefInfo(
+            object_type="dcim.cablebundle", field_name="termination", is_generic=True
+        ),
+        "termination_rack_group": RefInfo(
+            object_type="dcim.rackgroup", field_name="termination", is_generic=True
+        ),
+        "termination_script_module": RefInfo(
+            object_type="core.managedfile", field_name="termination", is_generic=True
+        ),
+        "termination_virtual_machine_type": RefInfo(
+            object_type="virtualization.virtualmachinetype",
+            field_name="termination",
+            is_generic=True,
+        ),
         "tunnel": RefInfo(object_type="vpn.tunnel", field_name="tunnel"),
     },
     "wireless.wirelesslan": {
@@ -3036,10 +3096,12 @@ _LEGAL_FIELDS = {
             "tags",
         ]
     ),
+    "core.managedfile": frozenset(["file"]),
     "dcim.cable": frozenset(
         [
             "a_terminations",
             "b_terminations",
+            "bundle",
             "color",
             "comments",
             "custom_fields",
@@ -3055,10 +3117,10 @@ _LEGAL_FIELDS = {
             "type",
         ]
     ),
-    "dcim.cablepath": frozenset(["is_active", "is_complete", "is_split"]),
-    "dcim.cabletermination": frozenset(
-        ["cable", "cable_end", "termination_id", "termination_type"]
+    "dcim.cablebundle": frozenset(
+        ["comments", "custom_fields", "description", "name", "owner", "tags"]
     ),
+    "dcim.cablepath": frozenset(["is_active", "is_complete", "is_split"]),
     "dcim.consoleport": frozenset(
         [
             "custom_fields",
@@ -3126,6 +3188,7 @@ _LEGAL_FIELDS = {
             "custom_fields",
             "description",
             "device",
+            "enabled",
             "installed_device",
             "label",
             "name",
@@ -3291,6 +3354,7 @@ _LEGAL_FIELDS = {
     ),
     "dcim.module": frozenset(
         [
+            "adopt_components",
             "asset_tag",
             "comments",
             "custom_fields",
@@ -3299,6 +3363,7 @@ _LEGAL_FIELDS = {
             "module_bay",
             "module_type",
             "owner",
+            "replicate_components",
             "serial",
             "status",
             "tags",
@@ -3309,6 +3374,7 @@ _LEGAL_FIELDS = {
             "custom_fields",
             "description",
             "device",
+            "enabled",
             "installed_module",
             "label",
             "module",
@@ -3428,6 +3494,7 @@ _LEGAL_FIELDS = {
             "description",
             "facility_id",
             "form_factor",
+            "group",
             "location",
             "max_weight",
             "mounting_depth",
@@ -3450,6 +3517,9 @@ _LEGAL_FIELDS = {
             "weight_unit",
             "width",
         ]
+    ),
+    "dcim.rackgroup": frozenset(
+        ["comments", "custom_fields", "description", "name", "owner", "slug", "tags"]
     ),
     "dcim.rackreservation": frozenset(
         [
@@ -3615,12 +3685,14 @@ _LEGAL_FIELDS = {
             "validation_maximum",
             "validation_minimum",
             "validation_regex",
+            "validation_schema",
             "weight",
         ]
     ),
     "extras.customfieldchoiceset": frozenset(
         [
             "base_choices",
+            "choice_colors",
             "description",
             "extra_choices",
             "name",
@@ -3676,6 +3748,7 @@ _LEGAL_FIELDS = {
             "description",
             "owner",
             "rir",
+            "role",
             "sites",
             "tags",
             "tenant",
@@ -3989,6 +4062,21 @@ _LEGAL_FIELDS = {
             "tags",
             "tenant",
             "vcpus",
+            "virtual_machine_type",
+        ]
+    ),
+    "virtualization.virtualmachinetype": frozenset(
+        [
+            "comments",
+            "custom_fields",
+            "default_memory",
+            "default_platform",
+            "default_vcpus",
+            "description",
+            "name",
+            "owner",
+            "slug",
+            "tags",
         ]
     ),
     "virtualization.vminterface": frozenset(
@@ -4382,9 +4470,11 @@ _FORMAT_TRANSFORMATIONS = {
         "search_weight": int_from_int64string,
         "validation_maximum": transform_float_to_decimal,
         "validation_minimum": transform_float_to_decimal,
+        "validation_schema": parse_json,
         "weight": int_from_int64string,
     },
     "extras.customfieldchoiceset": {
+        "choice_colors": parse_json,
         "extra_choices": lambda v: delimited_tuples(v, 2, ":", False, False, None),
     },
     "extras.customlink": {
@@ -4445,6 +4535,10 @@ _FORMAT_TRANSFORMATIONS = {
         "disk": int_from_int64string,
         "memory": int_from_int64string,
         "vcpus": transform_float_to_decimal,
+    },
+    "virtualization.virtualmachinetype": {
+        "default_memory": int_from_int64string,
+        "default_vcpus": transform_float_to_decimal,
     },
     "virtualization.vminterface": {
         "mtu": int_from_int64string,

--- a/netbox_diode_plugin/api/plugin_utils.py
+++ b/netbox_diode_plugin/api/plugin_utils.py
@@ -2,7 +2,7 @@
 
 # Generated code. DO NOT EDIT.
 # Source: NetBox v4.6.0
-# Timestamp: 2026-05-14 16:54:23Z
+# Timestamp: 2026-05-14 20:30:15Z
 
 from dataclasses import dataclass
 import datetime

--- a/netbox_diode_plugin/tests/v4.6.x/tests/__init__.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_apply_change_set.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_apply_change_set.py
@@ -1,0 +1,1136 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Rack, Site
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from ipam.models import ASN, RIR, IPAddress, Prefix
+from netaddr import IPNetwork
+from rest_framework import status
+from utilities.testing import APITestCase
+from virtualization.models import Cluster, ClusterType, VirtualMachine
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+User = get_user_model()
+
+def _get_error(response, object_name, field):
+    return response.json().get("errors", {}).get(object_name, {}).get(field, [])
+
+class BaseApplyChangeSet(APITestCase):
+    """Base ApplyChangeSet test case."""
+
+    def setUp(self):
+        """Set up test."""
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+        rir = RIR.objects.create(name="RFC 6996", is_private=True)
+        self.asns = [ASN(asn=65000 + i, rir=rir) for i in range(8)]
+        ASN.objects.bulk_create(self.asns)
+
+        self.sites = (
+            Site(
+                id=10,
+                name="Site 1",
+                slug="site-1",
+                facility="Alpha",
+                description="First test site",
+                physical_address="123 Fake St Lincoln NE 68588",
+                shipping_address="123 Fake St Lincoln NE 68588",
+                comments="Lorem ipsum etcetera",
+            ),
+            Site(
+                id=20,
+                name="Site 2",
+                slug="site-2",
+                facility="Bravo",
+                description="Second test site",
+                physical_address="725 Cyrus Valleys Suite 761 Douglasfort NE 57761",
+                shipping_address="725 Cyrus Valleys Suite 761 Douglasfort NE 57761",
+                comments="Lorem ipsum etcetera",
+            ),
+        )
+        Site.objects.bulk_create(self.sites)
+
+        self.racks = (
+            Rack(name="Rack 1", site=self.sites[0]),
+            Rack(name="Rack 2", site=self.sites[1]),
+        )
+        Rack.objects.bulk_create(self.racks)
+
+        manufacturer = Manufacturer.objects.create(
+            name="Manufacturer 1", slug="manufacturer-1"
+        )
+
+        self.device_types = (
+            DeviceType(
+                manufacturer=manufacturer, model="Device Type 1", slug="device-type-1"
+            ),
+            DeviceType(
+                manufacturer=manufacturer,
+                model="Device Type 2",
+                slug="device-type-2",
+                u_height=2,
+            ),
+        )
+        DeviceType.objects.bulk_create(self.device_types)
+
+        # bulk create is wierd due to mptt
+        self.roles = [
+            DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ff0000"),
+            DeviceRole.objects.create(name="Device Role 2", slug="device-role-2", color="00ff00"),
+        ]
+
+        cluster_type = ClusterType.objects.create(
+            name="Cluster Type 1", slug="cluster-type-1"
+        )
+
+        self.cluster_types = (cluster_type,)
+
+        site_content_type = ContentType.objects.get_for_model(Site)
+
+        self.clusters = (
+            Cluster(name="Cluster 1", type=cluster_type, scope_type=site_content_type, scope_id=self.sites[0].id),
+            Cluster(name="Cluster 2", type=cluster_type, scope_type=site_content_type, scope_id=self.sites[0].id),
+        )
+        Cluster.objects.bulk_create(self.clusters)
+
+        self.devices = (
+            Device(
+                id=10,
+                device_type=self.device_types[0],
+                role=self.roles[0],
+                name="Device 1",
+                site=self.sites[0],
+                rack=self.racks[0],
+                cluster=self.clusters[0],
+                local_context_data={"A": 1},
+            ),
+            Device(
+                id=20,
+                device_type=self.device_types[0],
+                role=self.roles[0],
+                name="Device 2",
+                site=self.sites[0],
+                rack=self.racks[0],
+                cluster=self.clusters[0],
+                local_context_data={"B": 2},
+            ),
+        )
+        Device.objects.bulk_create(self.devices)
+
+        self.interfaces = (
+            Interface(name="Interface 1", device=self.devices[0], type="1000baset"),
+            Interface(name="Interface 2", device=self.devices[0], type="1000baset"),
+            Interface(name="Interface 3", device=self.devices[0], type="1000baset"),
+            Interface(name="Interface 4", device=self.devices[0], type="1000baset"),
+            Interface(name="Interface 5", device=self.devices[0], type="1000baset"),
+        )
+        Interface.objects.bulk_create(self.interfaces)
+
+        self.ip_addresses = (
+            IPAddress(
+                address=IPNetwork("10.0.0.1/24"), assigned_object=self.interfaces[0]
+            ),
+            IPAddress(
+                address=IPNetwork("192.0.2.1/24"), assigned_object=self.interfaces[1]
+            ),
+        )
+        IPAddress.objects.bulk_create(self.ip_addresses)
+
+        self.virtual_machines = (
+            VirtualMachine(name="Virtual Machine 1"),
+            VirtualMachine(name="Virtual Machine 2"),
+        )
+        VirtualMachine.objects.bulk_create(self.virtual_machines)
+
+        self.url = "/netbox/api/plugins/diode/apply-change-set/"
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url,
+            data=payload,
+            format="json",
+            **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+
+class ApplyChangeSetTestCase(BaseApplyChangeSet):
+    """ApplyChangeSet test cases."""
+
+    @staticmethod
+    def get_change_id(payload, index):
+        """Get change_id from payload."""
+        return payload.get("changes")[index].get("change_id")
+
+    def test_change_type_create_return_200(self):
+        """Test create change_type with successful."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.interface",
+                    "object_id": None,
+                    "ref_id": "2",
+                    "data": {
+                        "name": "Interface 1",
+                        "device": self.devices[1].pk,
+                        "type": "other",
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "ipam.ipaddress",
+                    "object_id": None,
+                    "ref_id": "3",
+                    "data": {
+                        "address": "192.163.2.1/24",
+                        "assigned_object_type": "dcim.interface",
+                        "assigned_object_id": self.interfaces[2].pk
+                    },
+                },
+            ],
+        }
+
+        _ = self.send_request(payload)
+
+    def test_change_type_update_return_200(self):
+        """Test update change_type with successful."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+            ],
+        }
+
+        _ = self.client.post(
+            self.url, payload, format="json", **self.authorization_header
+        )
+
+        site_updated = Site.objects.get(id=20)
+
+        self.assertEqual(site_updated.name, "Site A")
+
+    def test_change_type_create_with_error_return_400(self):
+        """Test create change_type with wrong payload."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+        site_created = Site.objects.filter(name="Site A")
+
+        self.assertIn(
+            'Expected a list of items but got type "int".',
+            _get_error(response, "dcim.site", "asns"),
+        )
+        self.assertFalse(site_created.exists())
+
+    def test_change_type_update_with_error_return_400(self):
+        """Test update change_type with wrong payload."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        site_updated = Site.objects.get(id=20)
+        self.assertIn(
+            'Expected a list of items but got type "int".',
+            _get_error(response, "dcim.site", "asns")
+        )
+        self.assertEqual(site_updated.name, "Site 2")
+
+    def test_change_type_create_with_multiples_objects_return_200(self):
+        """Test create change type with two objects."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site Z",
+                        "slug": "site-z",
+                        "facility": "Omega",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "2",
+                    "data": {
+                        "device_type": self.device_types[1].pk,
+                        "role": self.roles[1].pk,
+                        "name": "Test Device 500",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+            ],
+        }
+
+        _ = self.send_request(payload)
+
+    def test_change_type_update_with_multiples_objects_return_200(self):
+        """Test update change type with two objects."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": 10,
+                    "data": {
+                        "device_type": self.device_types[1].pk,
+                        "role": self.roles[1].pk,
+                        "name": "Test Device 3",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+            ],
+        }
+
+        _ = self.send_request(payload)
+
+        site_updated = Site.objects.get(id=20)
+        device_updated = Device.objects.get(id=10)
+
+        self.assertEqual(site_updated.name, "Site A")
+        self.assertEqual(device_updated.name, "Test Device 3")
+
+    def test_change_type_create_and_update_with_error_in_one_object_return_400(self):
+        """Test create and update change type with one object with error."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site Z",
+                        "slug": "site-z",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": 10,
+                    "data": {
+                        "device_type": 3,
+                        "role": self.roles[1].pk,
+                        "name": "Test Device 4",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        site_created = Site.objects.filter(name="Site Z")
+        device_created = Device.objects.filter(name="Test Device 4")
+
+        self.assertIn(
+            "Related object not found using the provided numeric ID: 3",
+            _get_error(response, "dcim.device", "device_type"),
+        )
+        self.assertFalse(site_created.exists())
+        self.assertFalse(device_created.exists())
+
+    def test_multiples_create_type_error_in_two_objects_return_400(self):
+        """Test create with error in two objects."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site Z",
+                        "slug": "site-z",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "2",
+                    "data": {
+                        "device_type": 3,
+                        "role": self.roles[1].pk,
+                        "name": "Test Device 4",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "3",
+                    "data": {
+                        "device_type": 100,
+                        "role": 10,
+                        "name": "Test Device 40",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        site_created = Site.objects.filter(name="Site Z")
+        device_created = Device.objects.filter(name="Test Device 4")
+
+        self.assertIn(
+            "Related object not found using the provided numeric ID: 3",
+            _get_error(response, "dcim.device", "device_type"),
+        )
+
+        self.assertFalse(site_created.exists())
+        self.assertFalse(device_created.exists())
+
+    def test_change_type_update_with_object_id_not_exist_return_400(self):
+        """Test update object with nonexistent object_id."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 30,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.client.post(
+            self.url, payload, format="json", **self.authorization_header
+        )
+
+        site_updated = Site.objects.get(id=20)
+
+        self.assertIn(
+            "dcim.site with id 30 does not exist",
+            _get_error(response, "dcim.site", "object_id"),
+        )
+        self.assertEqual(site_updated.name, "Site 2")
+
+    def test_change_set_id_field_not_provided_return_400(self):
+        """Test update object with change_set_id incorrect."""
+        payload = {
+            "id": None,
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        self.assertIsNone(response.json().get("errors", {}).get("change_id", None))
+        self.assertIn(
+            "Change set ID is required",
+            _get_error(response, "changeset", "id"),
+        )
+
+    def test_change_type_field_not_provided_return_400(
+        self,
+    ):
+        """Test update object with change_type incorrect."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn(
+            "Unsupported change type ''",
+            _get_error(response, "dcim.site", "change_type"),
+        )
+
+    def test_change_set_id_field_and_change_set_not_provided_return_400(self):
+        """Test update object with change_set_id and change_set incorrect."""
+        payload = {
+            "id": "",
+            "changes": [],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn(
+            "Change set ID is required",
+            _get_error(response, "changeset", "id"),
+        )
+
+    def test_change_type_and_object_type_provided_return_400(
+        self,
+    ):
+        """Test change_type and object_type incorrect."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": None,
+                    "object_version": None,
+                    "object_type": "",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "2",
+                    "data": {
+                        "name": "Site Z",
+                        "slug": "site-z",
+                        "facility": "Betha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn(
+            "Unsupported change type 'None'",
+            _get_error(response, "__all__", "change_type"),
+        )
+
+    def test_create_ip_address_return_200(self):
+        """Test create ip_address with successful."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "ipam.ipaddress",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "address": "192.161.3.1/24",
+                        "assigned_object_id": self.interfaces[3].pk,
+                        "assigned_object_type": "dcim.interface",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload)
+
+    def test_add_primary_ip_address_to_device(self):
+        """Add primary ip address to device."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": self.devices[0].pk,
+                    "data": {
+                        "name": self.devices[0].name,
+                        "site": {"name": self.sites[0].name},
+                        "primary_ip4": self.ip_addresses[0].pk
+                    },
+                },
+            ],
+        }
+
+        _ = self.send_request(payload)
+        device_updated = Device.objects.get(id=10)
+
+        self.assertEqual(device_updated.name, self.devices[0].name)
+        self.assertEqual(device_updated.primary_ip4, self.ip_addresses[0])
+
+    def test_create_prefix_with_site_stored_as_scope(self):
+        """Test create prefix with site stored as scope."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "ipam.prefix",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "prefix": "192.168.0.0/24",
+                        "scope_id": self.sites[0].pk,
+                        "scope_type": "dcim.site",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload)
+        self.assertEqual(Prefix.objects.get(prefix="192.168.0.0/24").scope, self.sites[0])
+
+    def test_create_prefix_with_unknown_site_fails(self):
+        """Test create prefix with unknown site fails."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "ipam.prefix",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "prefix": "192.168.0.0/24",
+                        "scope_id": 99,
+                        "scope_type": "dcim.site",
+                    },
+                },
+            ],
+        }
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+        print(response.json())
+        self.assertIn(
+            'Related object not found using the provided value: 99.',
+            _get_error(response, "ipam.prefix", "scope_id"),
+        )
+        self.assertFalse(Prefix.objects.filter(prefix="192.168.0.0/24").exists())
+
+    def test_create_virtualization_cluster_with_site_stored_as_scope(self):
+        """Test create cluster with site stored as scope."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "virtualization.cluster",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Cluster 3",
+                        "type": {
+                            "name": self.cluster_types[0].name,
+                        },
+                        "scope_id": self.sites[0].pk,
+                        "scope_type": "dcim.site",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload)
+        self.assertEqual(Cluster.objects.get(name="Cluster 3").scope, self.sites[0])
+
+    def test_create_virtualmachine_with_cluster_site_stored_as_scope(self):
+        """Test create virtualmachine with cluster site stored as scope."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "virtualization.cluster",
+                    "object_id": self.clusters[0].pk,
+                    "data": {
+                        "scope_id": self.sites[0].pk,
+                        "scope_type": "dcim.site",
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "virtualization.virtualmachine",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "VM foobar",
+                        "site": self.sites[0].pk,
+                        "cluster": self.clusters[0].pk
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload)
+        self.assertEqual(VirtualMachine.objects.get(name="VM foobar", site_id=self.sites[0].id).cluster.scope, self.sites[0])
+
+    def test_apply_two_changes_that_create_the_same_object_return_200(self):
+        """Test apply two changes that create the same object return 200."""
+        site_name = uuid.uuid4()
+        payload1 = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": f"Site {site_name}",
+                        "slug": f"site-{site_name}",
+                        "comments": "comment 1",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload1)
+
+        payload2 = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": f"Site {site_name}",
+                        "slug": f"site-{site_name}",
+                        "comments": "comment 1",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload2)
+
+    def test_module_bay_from_template_no_duplicate(self):
+        """Test that module bays created from templates are reused and updated, not duplicated."""
+        from dcim.models import Module, ModuleBay, ModuleBayTemplate, ModuleType
+
+        # Create a device type with a module bay template
+        device_type = DeviceType.objects.create(
+            manufacturer=Manufacturer.objects.first(),
+            model="Device with Module Bay Template",
+            slug="device-with-module-bay-template",
+        )
+
+        # Create module bay template
+        ModuleBayTemplate.objects.create(
+            device_type=device_type,
+            name="Tray",
+        )
+
+        # Create module type
+        module_type = ModuleType.objects.create(
+            manufacturer=Manufacturer.objects.first(),
+            model="Test Module Type",
+        )
+
+        # Step 1: Create a device - this will auto-create module bay "Tray" from template
+        device_payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "device-1",
+                    "data": {
+                        "name": "Test Device with Module Bay",
+                        "device_type": device_type.id,
+                        "role": self.roles[0].id,
+                        "site": self.sites[0].id,
+                    },
+                },
+            ],
+        }
+        self.send_request(device_payload)
+
+        # Verify device was created
+        device = Device.objects.get(name="Test Device with Module Bay")
+
+        # Verify module bay was auto-created from template
+        module_bays_before = ModuleBay.objects.filter(device=device, name="Tray")
+        self.assertEqual(module_bays_before.count(), 1)
+        module_bay = module_bays_before.first()
+        self.assertIsNone(module_bay.module)  # No module installed yet
+        self.assertEqual(module_bay.description, "")  # Template has no description
+
+        # Step 2: Create a module with the module bay - should reuse existing bay and update it
+        module_payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.modulebay",
+                    "object_id": None,
+                    "ref_id": "modulebay-1",
+                    "data": {
+                        "name": "Tray",
+                        "device": device.id,
+                        "description": "Ingested module bay",
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.module",
+                    "object_id": None,
+                    "ref_id": "module-1",
+                    "new_refs": ["module_bay"],
+                    "data": {
+                        "device": device.id,
+                        "module_bay": "modulebay-1",
+                        "module_type": module_type.id,
+                        "description": "Ingested module",
+                    },
+                },
+            ],
+        }
+        self.send_request(module_payload)
+
+        # Verify NO duplicate module bays were created
+        module_bays_after = ModuleBay.objects.filter(device=device, name="Tray")
+        self.assertEqual(
+            module_bays_after.count(),
+            1,
+            "Module bay should be reused, not duplicated"
+        )
+
+        # Verify the module bay was updated with the description
+        module_bay.refresh_from_db()
+        self.assertEqual(
+            module_bay.description,
+            "Ingested module bay",
+            "Module bay should be updated with ingested data"
+        )
+
+        # Verify module was created successfully
+        modules = Module.objects.filter(device=device, module_bay=module_bay)
+        self.assertEqual(modules.count(), 1)
+        module = modules.first()
+        self.assertEqual(module.module_type, module_type)
+        self.assertEqual(module.description, "Ingested module")
+
+    def test_interface_from_template_no_duplicate(self):
+        """Test that interfaces created from templates are reused and updated, not duplicated."""
+        from dcim.models import InterfaceTemplate
+
+        # Create a device type with an interface template
+        device_type = DeviceType.objects.create(
+            manufacturer=Manufacturer.objects.first(),
+            model="Device with Interface Template",
+            slug="device-with-interface-template",
+        )
+
+        # Create interface template
+        InterfaceTemplate.objects.create(
+            device_type=device_type,
+            name="eth0",
+            type="1000base-t",
+        )
+
+        # Step 1: Create a device - this will auto-create interface "eth0" from template
+        device_payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "device-1",
+                    "data": {
+                        "name": "Test Device with Interface",
+                        "device_type": device_type.id,
+                        "role": self.roles[0].id,
+                        "site": self.sites[0].id,
+                    },
+                },
+            ],
+        }
+        self.send_request(device_payload)
+
+        # Verify device was created
+        device = Device.objects.get(name="Test Device with Interface")
+
+        # Verify interface was auto-created from template
+        interfaces_before = Interface.objects.filter(device=device, name="eth0")
+        self.assertEqual(interfaces_before.count(), 1)
+        interface = interfaces_before.first()
+        self.assertEqual(interface.description, "")  # Template has no description
+
+        # Step 2: Try to create the same interface with additional data - should reuse and update
+        interface_payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.interface",
+                    "object_id": None,
+                    "ref_id": "interface-1",
+                    "data": {
+                        "name": "eth0",
+                        "device": device.id,
+                        "type": "1000base-t",
+                        "description": "Ingested interface",
+                        "enabled": True,
+                    },
+                },
+            ],
+        }
+        self.send_request(interface_payload)
+
+        # Verify NO duplicate interfaces were created
+        interfaces_after = Interface.objects.filter(device=device, name="eth0")
+        self.assertEqual(
+            interfaces_after.count(),
+            1,
+            "Interface should be reused, not duplicated"
+        )
+
+        # Verify the interface was updated with the description
+        interface.refresh_from_db()
+        self.assertEqual(
+            interface.description,
+            "Ingested interface",
+            "Interface should be updated with ingested data"
+        )
+        self.assertTrue(interface.enabled)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_bulk_apply.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_bulk_apply.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkApply Tests."""
+
+import uuid
+
+from dcim.models import Site
+from rest_framework import status
+
+from .test_api_apply_change_set import BaseApplyChangeSet
+
+
+class BulkApplyTestCase(BaseApplyChangeSet):
+    """BulkApply test cases."""
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.batch_url = "/netbox/api/plugins/diode/bulk-apply/"
+        # BaseApplyChangeSet creates fixtures with hardcoded ids (Site id=10, id=20)
+        # via bulk_create, which does not advance the Postgres PK sequence.
+        # Auto-allocating CREATE INSERTs in this test class would otherwise
+        # collide with those fixture ids once the sequence catches up.
+        from django.db import connection
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT setval(pg_get_serial_sequence('dcim_site', 'id'), 10000, false)"
+            )
+
+    def _changeset_create_site(self, name, slug):
+        return {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": name,
+                        "slug": slug,
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "1 Fake St",
+                        "shipping_address": "1 Fake St",
+                        "comments": "",
+                        "asns": [self.asns[0].pk],
+                    },
+                },
+            ],
+        }
+
+    def _changeset_create_site_bad(self, name, slug):
+        cs = self._changeset_create_site(name, slug)
+        # asns must be a list — pass an int to trigger DRF ValidationError
+        cs["changes"][0]["data"]["asns"] = 1
+        return cs
+
+    def _post_batch(self, payload, status_code=status.HTTP_200_OK):
+        response = self.client.post(
+            self.batch_url,
+            data=payload,
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_batch_three_changesets_all_created(self):
+        """All three changesets in a batch create successfully."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Batch Site A", "batch-site-a"),
+                self._changeset_create_site("Batch Site B", "batch-site-b"),
+                self._changeset_create_site("Batch Site C", "batch-site-c"),
+            ],
+        }
+
+        response = self._post_batch(payload)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        for r in results:
+            self.assertIsNone(r.get("errors"))
+
+        for slug in ("batch-site-a", "batch-site-b", "batch-site-c"):
+            self.assertTrue(Site.objects.filter(slug=slug).exists())
+
+    def test_batch_savepoint_isolation_bad_middle(self):
+        """A bad changeset in the middle does not roll back the others."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Iso Site A", "iso-site-a"),
+                self._changeset_create_site_bad("Iso Site B", "iso-site-b"),
+                self._changeset_create_site("Iso Site C", "iso-site-c"),
+            ],
+        }
+
+        response = self._post_batch(payload, status_code=status.HTTP_207_MULTI_STATUS)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertIsNotNone(results[1].get("errors"))
+        self.assertIsNone(results[2].get("errors"))
+
+        self.assertTrue(Site.objects.filter(slug="iso-site-a").exists())
+        self.assertFalse(Site.objects.filter(slug="iso-site-b").exists())
+        self.assertTrue(Site.objects.filter(slug="iso-site-c").exists())
+
+    def test_batch_single_changeset_matches_old_endpoint(self):
+        """A 1-element batch produces the same effect as the per-changeset endpoint."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Single Site", "single-site"),
+            ],
+        }
+
+        response = self._post_batch(payload)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertTrue(Site.objects.filter(slug="single-site").exists())
+
+    def test_batch_empty_returns_400(self):
+        """Empty change_sets list returns 400."""
+        self._post_batch({"change_sets": []}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_missing_change_sets_returns_400(self):
+        """Missing change_sets key returns 400."""
+        self._post_batch({}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_change_sets_not_a_list_returns_400(self):
+        """change_sets not a list returns 400."""
+        self._post_batch(
+            {"change_sets": {"not": "a list"}},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def test_change_type_from_dict_normalises_and_round_trips(self):
+        """from_dict normalises change_type to enum; to_dict round-trips back to string."""
+        from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeType
+
+        change = Change.from_dict({
+            "change_type": "create",
+            "object_type": "dcim.site",
+            "data": {"name": "x", "slug": "x"},
+        })
+        self.assertEqual(change.change_type, ChangeType.CREATE)
+
+        cs = ChangeSet.from_dict({
+            "id": str(uuid.uuid4()),
+            "changes": [{"change_type": "update", "object_type": "dcim.site"}],
+        })
+        self.assertEqual(cs.changes[0].change_type, ChangeType.UPDATE)
+        self.assertEqual(cs.changes[0].to_dict()["change_type"], "update")
+
+        bad = Change.from_dict({"change_type": "delete", "object_type": "dcim.site"})
+        self.assertEqual(bad.change_type, "delete")
+
+    def test_change_set_from_dict_carries_branch_and_warnings(self):
+        """ChangeSet.from_dict picks up branch and warnings, and to_dict round-trips them."""
+        from netbox_diode_plugin.api.common import ChangeSet
+
+        cs = ChangeSet.from_dict({
+            "id": str(uuid.uuid4()),
+            "changes": [],
+            "branch": {"id": "abc", "name": "feature/x"},
+            "warnings": {"some_warning": ["foo"]},
+        })
+        self.assertEqual(cs.branch, {"id": "abc", "name": "feature/x"})
+        self.assertEqual(cs.warnings, {"some_warning": ["foo"]})
+        d = cs.to_dict()
+        self.assertEqual(d["branch"], {"id": "abc", "name": "feature/x"})
+        self.assertEqual(d["warnings"], {"some_warning": ["foo"]})
+
+        cs_empty = ChangeSet.from_dict({"id": str(uuid.uuid4()), "changes": []})
+        self.assertIsNone(cs_empty.branch)
+        self.assertIsNone(cs_empty.warnings)
+
+    def test_batch_malformed_per_entry_yields_207(self):
+        """A batch entry with non-list ``changes`` yields a per-item error, not a 500."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Batch OK", "batch-ok"),
+                {"id": str(uuid.uuid4()), "changes": "not-a-list"},
+            ],
+        }
+        response = self._post_batch(payload, status_code=status.HTTP_207_MULTI_STATUS)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 2)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertIsNotNone(results[1].get("errors"))
+        self.assertTrue(Site.objects.filter(slug="batch-ok").exists())
+

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_bulk_plan.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_bulk_plan.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkPlan API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Site
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BulkPlanTestCase(APITestCase):
+    """BulkPlan endpoint test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Existing Site",
+            slug="existing-site",
+            comments="original comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, expected_status=status.HTTP_200_OK):
+        """Post the payload and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    def test_single_entity_create(self):
+        """Test bulk plan with a single new entity."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "New Site", "slug": "new-site"}},
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_type"], "create")
+        self.assertEqual(changes[0]["object_type"], "dcim.site")
+
+    def test_single_entity_update(self):
+        """Test bulk plan with a single existing entity that has changes."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "updated comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_type"], "update")
+        self.assertEqual(changes[0]["object_id"], self.site.pk)
+
+    def test_single_entity_no_changes(self):
+        """Test bulk plan with an entity that matches NetBox exactly — empty changes."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        cs = r.get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 0)
+
+    def test_multiple_entities_mixed(self):
+        """Test bulk plan with multiple entities — one create, one update, one no-change."""
+        payload = {
+            "entities": [
+                {
+                    "id": "create-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Brand New Site", "slug": "brand-new-site"}},
+                },
+                {
+                    "id": "update-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "changed",
+                        }
+                    },
+                },
+                {
+                    "id": "noop-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 3)
+
+        ids = {r["id"]: r for r in results}
+
+        create_r = ids["create-1"]
+        self.assertIsNone(create_r.get("errors"))
+        self.assertEqual(len(create_r["change_set"]["changes"]), 1)
+        self.assertEqual(create_r["change_set"]["changes"][0]["change_type"], "create")
+
+        update_r = ids["update-1"]
+        self.assertIsNone(update_r.get("errors"))
+        self.assertEqual(len(update_r["change_set"]["changes"]), 1)
+        self.assertEqual(update_r["change_set"]["changes"][0]["change_type"], "update")
+
+        noop_r = ids["noop-1"]
+        self.assertEqual(len(noop_r["change_set"]["changes"]), 0)
+
+    def test_entity_with_missing_entity_field(self):
+        """Test that a missing entity field returns per-entity error without failing the batch."""
+        payload = {
+            "entities": [
+                {
+                    "id": "good-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Good Site", "slug": "good-site"}},
+                },
+                {
+                    "id": "bad-1",
+                    "object_type": "dcim.site",
+                    "entity": None,
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 2)
+
+        ids = {r["id"]: r for r in results}
+
+        good = ids["good-1"]
+        self.assertIsNone(good.get("errors"))
+        self.assertIsNotNone(good.get("change_set"))
+
+        bad = ids["bad-1"]
+        self.assertIsNotNone(bad.get("errors"))
+        self.assertIn("entity", bad["errors"].get("request", {}))
+
+    def test_entity_with_missing_object_type(self):
+        """Test that a missing object_type returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "entity": {"site": {"name": "Some Site", "slug": "some-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+        self.assertIn("object_type", results[0]["errors"].get("request", {}))
+
+    def test_entity_with_unsupported_object_type(self):
+        """Test that an unsupported object_type returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+        self.assertIn("object_type", results[0]["errors"].get("request", {}))
+
+    def test_entity_with_invalid_object_type_format(self):
+        """Test that an invalid object_type format returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "nodotshere",
+                    "entity": {"nodotshere": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+
+    def test_empty_entities_list(self):
+        """Test that an empty entities list returns 400."""
+        payload = {"entities": []}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_entities_field(self):
+        """Test that a missing entities field returns 400."""
+        payload = {"something_else": "value"}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_entities_not_a_list(self):
+        """Test that entities as a non-list returns 400."""
+        payload = {"entities": "not a list"}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_id_correlation(self):
+        """Test that returned results preserve the entity IDs for correlation."""
+        payload = {
+            "entities": [
+                {
+                    "id": "aaa-111",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site A", "slug": "site-a"}},
+                },
+                {
+                    "id": "bbb-222",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site B", "slug": "site-b"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["id"], "aaa-111")
+        self.assertEqual(results[1]["id"], "bbb-222")
+
+    def test_entity_without_id(self):
+        """Test that an entity without an id field gets null id in the result."""
+        payload = {
+            "entities": [
+                {
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "No ID Site", "slug": "no-id-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["id"])
+        self.assertIsNone(results[0].get("errors"))

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_diff_and_apply.py
@@ -1,0 +1,2049 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+import copy
+import datetime
+import decimal
+import logging
+from types import SimpleNamespace
+from unittest import mock
+from uuid import uuid4
+
+import netaddr
+from circuits.models import Circuit, Provider
+from core.models import ObjectType
+from dcim.models import Device, FrontPort, Interface, ModuleBay, RearPort, Site
+from extras.models import CustomField
+from extras.models.customfields import CustomFieldChoiceSet, CustomFieldChoiceSetBaseChoices, CustomFieldTypeChoices
+from ipam.models import ASN, VRF, IPAddress, VLANGroup, VLANTranslationPolicy
+from rest_framework import status
+from users.models import Owner, OwnerGroup
+from utilities.testing import APITestCase
+from virtualization.models import Cluster, VMInterface
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+def _get_error(response, object_name, field):
+    return response.json().get("errors", {}).get(object_name, {}).get(field, [])
+
+class GenerateDiffAndApplyTestCase(APITestCase):
+    """GenerateDiff -> ApplyChangeSet test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+        self.object_type = ObjectType.objects.get_for_model(Site)
+
+        self.uuid_field = CustomField.objects.create(
+            name='myuuid',
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            required=False,
+            unique=True,
+        )
+        self.uuid_field.object_types.set([self.object_type])
+        self.uuid_field.save()
+
+        self.json_field = CustomField.objects.create(
+            name='some_json',
+            type=CustomFieldTypeChoices.TYPE_JSON,
+            required=False,
+            unique=False,
+        )
+        self.json_field.object_types.set([self.object_type])
+        self.json_field.save()
+
+        self.datetime_field = CustomField.objects.create(
+            name='mydatetime',
+            type=CustomFieldTypeChoices.TYPE_DATETIME,
+            required=False,
+            unique=False,
+        )
+        self.datetime_field.object_types.set([self.object_type])
+        self.datetime_field.save()
+
+        self.date_field = CustomField.objects.create(
+            name='mydate',
+            type=CustomFieldTypeChoices.TYPE_DATE,
+            required=False,
+            unique=False,
+        )
+        self.date_field.object_types.set([self.object_type])
+        self.date_field.save()
+
+        self.decimal_field = CustomField.objects.create(
+            name='mydecimal',
+            type=CustomFieldTypeChoices.TYPE_DECIMAL,
+            required=False,
+            unique=False,
+        )
+        self.decimal_field.object_types.set([self.object_type])
+        self.decimal_field.save()
+
+        self.long_text_field = CustomField.objects.create(
+            name='my_long_text',
+            type=CustomFieldTypeChoices.TYPE_LONGTEXT,
+            required=False,
+            unique=False,
+        )
+        self.long_text_field.object_types.set([self.object_type])
+        self.long_text_field.save()
+
+        choices = CustomFieldChoiceSet.objects.create(
+            name='my_choices',
+            base_choices=CustomFieldChoiceSetBaseChoices.IATA,
+        )
+        self.selection_field = CustomField.objects.create(
+            name='my_selection',
+            type=CustomFieldTypeChoices.TYPE_SELECT,
+            required=False,
+            unique=False,
+            choice_set=choices,
+        )
+        self.selection_field.object_types.set([self.object_type])
+        self.selection_field.save()
+
+        self.multiple_selection_field = CustomField.objects.create(
+            name='my_multiple_selection',
+            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
+            required=False,
+            unique=False,
+            choice_set=choices,
+        )
+        self.multiple_selection_field.object_types.set([self.object_type])
+        self.multiple_selection_field.save()
+
+        self.object_field = CustomField.objects.create(
+            name='my_object',
+            type=CustomFieldTypeChoices.TYPE_OBJECT,
+            required=False,
+            unique=False,
+            related_object_type=self.object_type,
+        )
+        self.object_field.object_types.set([self.object_type])
+        self.object_field.save()
+
+        self.multiple_objects_field = CustomField.objects.create(
+            name='my_multiple_objects',
+            type=CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            required=False,
+            unique=False,
+            related_object_type=self.object_type,
+        )
+        self.multiple_objects_field.object_types.set([self.object_type])
+        self.multiple_objects_field.save()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def test_generate_diff_and_apply_create_interface_with_tags(self):
+        """Test generate diff and apply create interface with tags."""
+        interface_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.interface",
+            "entity": {
+                "interface": {
+                    "name": f"Interface {interface_uuid}",
+                    "mtu": "1500",
+                    "mode": "access",
+                    "tags": [
+                        {"name": "tag 1"}
+                    ],
+                    "type": "1000base-t",
+                    "device": {
+                        "name": f"Device {uuid4()}",
+                        "device_type": {
+                            "model": f"Device Type {uuid4()}",
+                            "manufacturer": {
+                                "name": f"Manufacturer {uuid4()}"
+                            }
+                        },
+                        "role": {
+                            "name": f"Role {uuid4()}"
+                        },
+                        "site": {
+                            "name": f"Site {uuid4()}"
+                        }
+                    },
+                    "enabled": True,
+                    "description": "Physical interface"
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_interface = Interface.objects.get(name=f"Interface {interface_uuid}")
+        self.assertEqual(new_interface.tags.count(), 1)
+        self.assertEqual(new_interface.tags.first().name, "tag 1")
+
+
+    def test_generate_diff_and_apply_create_and_update_device_role(self):
+        """Test generate diff and apply create and update device role."""
+        device_uuid = str(uuid4())
+        role_1_uuid = str(uuid4())
+        role_2_uuid = str(uuid4())
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "device_type": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {role_1_uuid}"
+                    },
+                    "site": {
+                        "name": f"Site {site_uuid}"
+                    }
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(new_device.site.name, f"Site {site_uuid}")
+        self.assertEqual(new_device.role.name, f"Role {role_1_uuid}")
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "deviceType": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {role_2_uuid}"
+                    },
+                    "site": {
+                        "name": f"Site {site_uuid}"
+                    }
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.site.name, f"Site {site_uuid}")
+        self.assertEqual(device.role.name, f"Role {role_2_uuid}")
+
+
+    def test_generate_diff_and_apply_create_site_autoslug(self):
+        """Test generate diff and apply create site."""
+        """Test generate diff create site."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.slug, f"site-{site_uuid}")
+
+    def test_generate_diff_and_apply_tags_merged(self):
+        """Test generate diff and apply merges tags."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "tags": [
+                        {"name": "tag 1"},
+                        {"name": "tag 2"},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.tags.count(), 2)
+        tag_names = [tag.name for tag in new_site.tags.all()]
+        self.assertIn("tag 1", tag_names)
+        self.assertIn("tag 2", tag_names)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "tags": [
+                        {"name": "tag 3"},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.tags.count(), 3)
+        tag_names = [tag.name for tag in new_site.tags.all()]
+        self.assertIn("tag 1", tag_names)
+        self.assertIn("tag 2", tag_names)
+        self.assertIn("tag 3", tag_names)
+
+    def test_generate_diff_and_apply_refs_not_merged(self):
+        """Test generate diff and apply does not merge reference lists."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "asns": [
+                        {"asn": "1", "rir": {"name": "RIR 1"}},
+                        {"asn": "2", "rir": {"name": "RIR 1"}},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.asns.count(), 2)
+        asns = [asn.asn for asn in new_site.asns.all()]
+        self.assertIn(1, asns)
+        self.assertIn(2, asns)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "asns": [
+                        {"asn": "3", "rir": {"name": "RIR 1"}},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.asns.count(), 1)
+        asns = [asn.asn for asn in new_site.asns.all()]
+        self.assertNotIn(1, asns)
+        self.assertNotIn(2, asns)
+        self.assertIn(3, asns)
+
+
+    def test_generate_diff_and_apply_create_interface_with_primay_mac_address(self):
+        """Test generate diff and apply create interface with primary mac address."""
+        interface_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.interface",
+            "entity": {
+                "interface": {
+                    "name": f"Interface {interface_uuid}",
+                    "type": "1000base-t",
+                    "device": {
+                        "name": f"Device {uuid4()}",
+                        "role": {
+                            "Name": f"Role {uuid4()}",
+                        },
+                        "site": {
+                            "Name": f"Site {uuid4()}",
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "Name": f"Manufacturer {uuid4()}",
+                            },
+                            "model": f"Device Type {uuid4()}",
+                        },
+                    },
+                    "primary_mac_address": {
+                        "mac_address": "00:00:00:00:00:01",
+                    },
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_interface = Interface.objects.get(name=f"Interface {interface_uuid}")
+        self.assertEqual(new_interface.primary_mac_address.mac_address, "00:00:00:00:00:01")
+
+    def test_generate_diff_and_apply_create_device_with_primary_ip4_camel_case(self):
+        """Test generate diff and apply create device with primary ip4 (camel case)."""
+        device_uuid = str(uuid4())
+        interface_uuid = str(uuid4())
+        addr = "192.168.1.1"
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ipAddress": {
+                    "address": addr,
+                    "assignedObjectInterface": {
+                        "name": f"Interface {interface_uuid}",
+                        "type": "1000base-t",
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "role": {
+                                "name": f"Role {uuid4()}",
+                            },
+                            "site": {
+                                "name": f"Site {uuid4()}",
+                            },
+                            "deviceType": {
+                                "manufacturer": {
+                                    "name": f"Manufacturer {uuid4()}",
+                                },
+                                "model": f"Device Type {uuid4()}",
+                            },
+                            "primaryIp4": {
+                                "address": addr,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_ipaddress = IPAddress.objects.get(address=addr)
+        self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.primary_ip4.pk, new_ipaddress.pk)
+
+    def test_generate_diff_and_apply_create_device_with_primary_ip4(self):
+        """Test generate diff and apply create device with primary ip4."""
+        device_uuid = str(uuid4())
+        interface_uuid = str(uuid4())
+        addr = "192.168.1.1"
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": addr,
+                    "assigned_object_interface": {
+                        "name": f"Interface {interface_uuid}",
+                        "type": "1000base-t",
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "role": {
+                                "name": f"Role {uuid4()}",
+                            },
+                            "site": {
+                                "name": f"Site {uuid4()}",
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": f"Manufacturer {uuid4()}",
+                                },
+                                "model": f"Device Type {uuid4()}",
+                            },
+                            "primary_ip4": {
+                                "address": addr,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_ipaddress = IPAddress.objects.get(address=addr)
+        self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.primary_ip4.pk, new_ipaddress.pk)
+
+    def test_generate_diff_and_apply_create_device_with_primary_ip6(self):
+        """Test generate diff and apply create device with primary ip6."""
+        device_uuid = str(uuid4())
+        interface_uuid = str(uuid4())
+        addr = "2001:db8::1"
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": addr,
+                    "assigned_object_interface": {
+                        "name": f"Interface {interface_uuid}",
+                        "type": "1000base-t",
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "role": {
+                                "name": f"Role {uuid4()}",
+                            },
+                            "site": {
+                                "name": f"Site {uuid4()}",
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": f"Manufacturer {uuid4()}",
+                                },
+                                "model": f"Device Type {uuid4()}",
+                            },
+                            "primary_ip6": {
+                                "address": addr,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_ipaddress = IPAddress.objects.get(address=addr)
+        self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.primary_ip6.pk, new_ipaddress.pk)
+
+    def test_generate_diff_and_apply_create_device_with_oob_ip(self):
+        """Test generate diff and apply create device with oob ip."""
+        device_uuid = str(uuid4())
+        interface_uuid = str(uuid4())
+        addr = "192.168.1.1/24"
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": addr,
+                    "assigned_object_interface": {
+                        "name": f"Interface {interface_uuid}",
+                        "type": "1000base-t",
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "role": {
+                                "name": f"Role {uuid4()}",
+                            },
+                            "site": {
+                                "name": f"Site {uuid4()}",
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": f"Manufacturer {uuid4()}",
+                                },
+                                "model": f"Device Type {uuid4()}",
+                            },
+                            "oob_ip": {
+                                "address": addr,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_ipaddress = IPAddress.objects.get(address=addr)
+        self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.oob_ip.pk, new_ipaddress.pk)
+
+    def test_generate_diff_and_apply_create_and_update_site_with_custom_field(self):
+        """Test generate diff and apply create and update site with custom field."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "A New Custom Site",
+                    "slug": "a-new-custom-site",
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": site_uuid,
+                        },
+                        "mydecimal": {
+                            "decimal": 1234.567,
+                        },
+                        "some_json": {
+                            "json": '{"some_key": 9876543210}',
+                        },
+                        "my_long_text": {
+                            "long_text": "This is a long text",
+                        },
+                        "my_selection": {
+                            "selection": "LAX",
+                        },
+                        "my_multiple_selection": {
+                            "multiple_selection": ["JFK", "LAX"],
+                        },
+                        "my_object": {
+                            "object": {
+                                "site": {
+                                    "name": "Custom Object Site Ref 1",
+                                }
+                            },
+                        },
+                        "my_multiple_objects": {
+                            "multiple_objects": [
+                                {
+                                    "site": {
+                                        "name": "Custom Object Site Ref 2",
+                                    }
+                                },
+                                {
+                                    "site": {
+                                        "name": "Custom Object Site Ref 3",
+                                    }
+                                },
+                            ],
+                        },
+                    },
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name="A New Custom Site")
+        self.assertEqual(new_site.custom_field_data[self.uuid_field.name], site_uuid)
+        self.assertEqual(new_site.custom_field_data[self.json_field.name], {"some_key": 9876543210})
+        self.assertEqual(new_site.custom_field_data[self.decimal_field.name], 1234.567)
+        self.assertEqual(new_site.custom_field_data[self.long_text_field.name], "This is a long text")
+        self.assertEqual(new_site.custom_field_data[self.selection_field.name], "LAX")
+        self.assertEqual(new_site.custom_field_data[self.multiple_selection_field.name], ["JFK", "LAX"])
+
+        siteRef1 = Site.objects.get(name="Custom Object Site Ref 1")
+        self.assertIsNotNone(siteRef1)
+        self.assertEqual(new_site.custom_field_data[self.object_field.name], siteRef1.pk)
+        siteRef2 = Site.objects.get(name="Custom Object Site Ref 2")
+        self.assertIsNotNone(siteRef2)
+        self.assertEqual(new_site.custom_field_data[self.multiple_objects_field.name][0], siteRef2.pk)
+        siteRef3 = Site.objects.get(name="Custom Object Site Ref 3")
+        self.assertIsNotNone(siteRef3)
+        self.assertEqual(new_site.custom_field_data[self.multiple_objects_field.name][1], siteRef3.pk)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "comments": "An updated comment",
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": site_uuid,
+                        },
+                        "some_json": {
+                            "json": '{"some_key": 1234567890}',
+                        },
+                        "mydatetime": {
+                            "datetime": "2026-01-01T09:00:00Z",
+                        },
+                        "mydate": {
+                            "date": "2026-01-01T00:00:00Z",
+                        },
+                    },
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name="A New Custom Site")
+        self.assertEqual(new_site.cf[self.uuid_field.name], site_uuid)
+        self.assertEqual(new_site.cf[self.json_field.name], {"some_key": 1234567890})
+        self.assertEqual(new_site.cf[self.datetime_field.name], datetime.datetime(2026, 1, 1, 9, 0, 0, tzinfo=datetime.timezone.utc))
+        self.assertEqual(new_site.cf[self.date_field.name], datetime.date(2026, 1, 1))
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": site_uuid,
+                        },
+                        "mydatetime": {
+                            "datetime": "2026-01-01T10:00:00Z",
+                        },
+                        "mydate": {
+                            "date": "2026-01-02T00:00:00Z",
+                        },
+                        "my_multiple_objects": {
+                            "multiple_objects": [
+                                {
+                                    "site": {
+                                        "name": "Custom Object Site Ref 2",
+                                    }
+                                },
+                                {
+                                    "site": {
+                                        "name": "Custom Object Site Ref 4",
+                                    }
+                                },
+                            ],
+                        },
+
+                    },
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name="A New Custom Site")
+        self.assertEqual(new_site.cf[self.uuid_field.name], site_uuid)
+        self.assertEqual(new_site.cf[self.json_field.name], {"some_key": 1234567890})
+        self.assertEqual(new_site.cf[self.datetime_field.name], datetime.datetime(2026, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc))
+        self.assertEqual(new_site.cf[self.date_field.name], datetime.date(2026, 1, 2))
+
+        self.assertEqual(len(new_site.custom_field_data[self.multiple_objects_field.name]), 2)
+        siteRef2 = Site.objects.get(name="Custom Object Site Ref 2")
+        self.assertIsNotNone(siteRef2)
+        self.assertEqual(new_site.custom_field_data[self.multiple_objects_field.name][0], siteRef2.pk)
+        siteRef4 = Site.objects.get(name="Custom Object Site Ref 4")
+        self.assertIsNotNone(siteRef3)
+        self.assertEqual(new_site.custom_field_data[self.multiple_objects_field.name][1], siteRef4.pk)
+
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": site_uuid,
+                        },
+                        "mydatetime": {
+                            "datetime": "2026-01-01T10:00:00Z",
+                        },
+                        "mydate": {
+                            "date": "2026-01-02T00:00:00Z",
+                        },
+                    },
+                },
+            }
+        }
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+    def test_generate_diff_and_apply_circuit_with_install_date(self):
+        """Test generate diff and apply circuit with date."""
+        circuit_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "circuits.circuit",
+            "entity": {
+                "circuit": {
+                    "cid": f"Circuit {circuit_uuid}",
+                    "install_date": "2026-01-01T00:00:00Z",
+                    "provider": {
+                        "name": f"Provider {uuid4()}",
+                    },
+                    "type": {
+                        "name": f"Ciruit Type {uuid4()}",
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_circuit = Circuit.objects.get(cid=f"Circuit {circuit_uuid}")
+        self.assertEqual(new_circuit.install_date, datetime.date(2026, 1, 1))
+
+    def test_generate_diff_and_apply_site_with_lat_lon(self):
+        """Test generate diff and apply site with lat and lon."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "latitude":  23.456,
+                    "longitude": 78.910,
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.latitude, decimal.Decimal("23.456"))
+        self.assertEqual(new_site.longitude, decimal.Decimal("78.910"))
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "latitude":  23.456,
+                    "longitude": 78.910,
+                },
+            },
+        }
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+    def test_generate_diff_and_apply_wrong_type_date(self):
+        """Test generate diff and apply wrong type date."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Site Generate Diff 1",
+                    "slug": "site-generate-diff-1",
+                    "custom_fields": {
+                        "mydate": {
+                            "date": 12,
+                        },
+                    },
+                },
+            }
+        }
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+
+        diff = response1.json().get("change_set", {})
+
+        response2 = self.client.post(
+            self.apply_url, data=diff, format="json", **self.authorization_header
+        )
+        self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_generate_diff_and_apply_vlan_group_with_vid_ranges(self):
+        """Test generate diff and apply vlan group vid ranges."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vlangroup",
+            "entity": {
+                "vlan_group": {
+                    "name": "VLAN Group 1",
+                    "vid_ranges": [1,5,10,15],
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_vlan_group = VLANGroup.objects.get(name="VLAN Group 1")
+        self.assertEqual(new_vlan_group.vid_ranges[0].lower, 1)
+        self.assertEqual(new_vlan_group.vid_ranges[0].upper, 6)
+        self.assertEqual(new_vlan_group.vid_ranges[1].lower, 10)
+        self.assertEqual(new_vlan_group.vid_ranges[1].upper, 16)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vlangroup",
+            "entity": {
+                "vlan_group": {
+                    "name": "VLAN Group 1",
+                    "vid_ranges": [3,9,12,20],
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_vlan_group = VLANGroup.objects.get(name="VLAN Group 1")
+        self.assertEqual(new_vlan_group.vid_ranges[0].lower, 3)
+        self.assertEqual(new_vlan_group.vid_ranges[0].upper, 10)
+        self.assertEqual(new_vlan_group.vid_ranges[1].lower, 12)
+        self.assertEqual(new_vlan_group.vid_ranges[1].upper, 21)
+
+    def test_generate_diff_and_apply_vrf_no_rd_dedup(self):
+        """Re-ingesting an RD-less VRF resolves to the existing row (empty diff on second pass)."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {
+                "vrf": {
+                    "name": "VRF-A",
+                },
+            },
+        }
+        self.diff_and_apply(payload)
+        # Second diff must be a no-op — proves the matcher resolved to the existing VRF.
+        response = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+        vrfs = VRF.objects.filter(name="VRF-A")
+        self.assertEqual(vrfs.count(), 1)
+        self.assertIsNone(vrfs.first().rd)
+
+    def test_generate_diff_and_apply_vrf_no_rd_does_not_match_rd_vrf(self):
+        """An RD-less ingest must not collapse into an existing RD'd VRF with the same name."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-B", "rd": "65000:1"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-B"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-B").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual(vrfs[0].rd, "65000:1")
+        self.assertIsNone(vrfs[1].rd)
+
+    def test_generate_diff_and_apply_vrf_rd_after_no_rd_does_not_collapse(self):
+        """An RD'd ingest after a no-RD ingest with the same name should create a new VRF."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-C"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-C", "rd": "65000:2"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-C").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertIsNone(vrfs[0].rd)
+        self.assertEqual(vrfs[1].rd, "65000:2")
+
+    def test_generate_diff_and_apply_vrf_no_rd_update(self):
+        """Repeat no-RD ingest with a different field value should update the same VRF, not duplicate."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-D", "description": "first"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-D", "description": "second"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-D")
+        self.assertEqual(vrfs.count(), 1)
+        self.assertEqual(vrfs.first().description, "second")
+
+    def test_generate_diff_and_apply_vrf_no_rd_within_tenant_dedup(self):
+        """Re-ingesting an RD-less VRF within the same tenant resolves to the existing row."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
+        })
+        # Second diff must be a no-op — proves logical_vrf_name_within_tenant matched.
+        response = self.client.post(self.diff_url, data={
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
+        }, format="json", **self.authorization_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+        self.assertEqual(VRF.objects.filter(name="VRF-E").count(), 1)
+
+    def test_generate_diff_and_apply_vrf_no_rd_no_cross_tenant_collapse(self):
+        """Two RD-less VRFs with the same name in different tenants must remain distinct."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-F", "tenant": {"name": "Tenant F1"}}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-F", "tenant": {"name": "Tenant F2"}}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-F").select_related("tenant").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual({v.tenant.name for v in vrfs}, {"Tenant F1", "Tenant F2"})
+
+    def test_generate_diff_and_apply_vrf_no_rd_no_tenant_does_not_match_tenant_vrf(self):
+        """A no-tenant RD-less ingest must not collapse into a same-name VRF that has a tenant."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-G", "tenant": {"name": "Tenant G"}}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-G"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-G").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual(vrfs[0].tenant.name, "Tenant G")
+        self.assertIsNone(vrfs[1].tenant)
+
+    def test_generate_diff_and_apply_ip_address_with_assigned_object_interface(self):
+        """Test ip."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                    "assigned_object_interface": {
+                        "device": {
+                            "name": "Device ABC",
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Manufacturer ABC"
+                                },
+                                "model": "Device Type ABC"
+                            },
+                            "role": {
+                                "name": "Role ABC"
+                            },
+                            "platform": {
+                            "name": "Platform ABC",
+                            "manufacturer": {
+                                "name": "Manufacturer ABC"
+                            }
+                            },
+                            "site": {
+                                "name": "Site ABC"
+                            }
+                        },
+                        "name": "Interface ABC",
+                        "type": "1000base-t",
+                        "mode": "access"
+                    },
+                    "description": "IP Address description",
+                    "comments": "Lorem ipsum dolor sit amet",
+                    "tags": [
+                        {
+                            "name": "tag 1"
+                        },
+                        {
+                            "name": "tag 2"
+                        }
+                    ]
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_generate_diff_update_ip_address(self):
+        """Test generate diff update ip address."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/32",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "active",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116")
+        self.assertEqual(ip.status, "active")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/24",
+                    "status": "deprecated",
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116/24")
+        self.assertEqual(ip.role, "secondary")
+        self.assertEqual(ip.status, "deprecated")
+        self.assertEqual(ip.address, netaddr.IPNetwork("254.198.174.0/24"))
+
+        vrf_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/24",
+                    "status": "active",
+                    "vrf": {
+                        "name": f"VRF {vrf_uuid}"
+                    }
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116/24", vrf__name=f"VRF {vrf_uuid}")
+        self.assertEqual(ip.vrf.name, f"VRF {vrf_uuid}")
+        self.assertEqual(ip.status, "active")
+
+        ip2 = IPAddress.objects.get(address="254.198.174.116/24", vrf__isnull=True)
+        self.assertEqual(ip2.vrf, None)
+        self.assertEqual(ip2.status, "deprecated")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "dhcp",
+                    "vrf": {
+                        "name": f"VRF {vrf_uuid}"
+                    }
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116", vrf__name=f"VRF {vrf_uuid}")
+        self.assertEqual(ip.status, "dhcp")
+
+        ip2 = IPAddress.objects.get(address="254.198.174.116/24", vrf__isnull=True)
+        self.assertEqual(ip2.vrf, None)
+        self.assertEqual(ip2.status, "deprecated")
+
+    def test_generate_diff_and_apply_complex_vminterface(self):
+        """Test generate diff and apply and update a complex vm interface."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "virtualization.vminterface",
+            "entity": {
+                "vm_interface": {
+                    "virtual_machine": {
+                        "name": "Virtual Machine 15e00bdf-4294-41df-a450-ffcfec6c7f2b",
+                        "status": "active",
+                        "site": {
+                            "name": "Site 10"
+                        },
+                        "cluster": {
+                            "name": "Cluster 10",
+                            "type": {
+                                "name": "Cluster type 10"
+                            },
+                            "group": {
+                                "name": "Cluster group 10"
+                            },
+                            "status": "active",
+                            "scope_site": {
+                                "name": "Site 10"
+                            }
+                        },
+                        "role": {
+                            "name": "Role 10"
+                        },
+                        "platform": {
+                            "name": "Platform 10",
+                            "manufacturer": {
+                            "name": "Manufacturer 10"
+                            }
+                        },
+                        "vcpus": 1.0,
+                        "memory": "4096",
+                        "disk": "100",
+                        "description": "Virtual Machine A description",
+                        "comments": "Lorem ipsum dolor sit amet",
+                        "tags": [
+                            {
+                            "name": "tag 1"
+                            }
+                        ]
+                    },
+                    "name": "Interface 47e8a593-8b74-4e94-9a8e-c02113f0bf88",
+                    "enabled": False,
+                    "mtu": "1500",
+                    "primary_mac_address": {
+                        "mac_address": "00:00:00:00:00:00"
+                    },
+                    "description": "Interface A description",
+                    "tags": [
+                        {
+                            "name": "tag 1"
+                        }
+                    ]
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+
+        payload2 = copy.deepcopy(payload)
+        payload2['entity']['vm_interface']["mtu"] = "2000"
+        payload2['entity']['vm_interface']["primary_mac_address"] = {
+            "mac_address": "00:00:00:00:00:01"
+        }
+        _ = self.diff_and_apply(payload2)
+        vm_interface = VMInterface.objects.get(name="Interface 47e8a593-8b74-4e94-9a8e-c02113f0bf88")
+        self.assertEqual(vm_interface.mtu, 2000)
+        self.assertEqual(vm_interface.primary_mac_address.mac_address, "00:00:00:00:00:01")
+
+    def test_generate_diff_and_apply_dedupe_devicetype(self):
+        """Test generate diff and apply dedupe devicetype in wireless link."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "wireless.wirelesslink",
+            "entity": {
+                "wireless_link": {
+                    "interface_a": {
+                        "device": {
+                            "name": "Device 1",
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "role": {"name": "Device Role 1"},
+                            "site": {"name": "Site 1"}
+                        },
+                        "name": "Radio0/1",
+                        "type": "ieee802.11ac",
+                        "enabled": True
+                    },
+                    "interface_b": {
+                        "device": {
+                            "name": "Device 2",
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "role": {"name": "Device Role 1"},
+                            "site": {"name": "Site 1"}
+                        },
+                        "name": "Radio0/1",
+                        "type": "ieee802.11ac",
+                        "enabled": True
+                    },
+                    "ssid": "P2P-Link-1",
+                    "status": "connected",
+                    "tenant": {"name": "Tenant 1"},
+                    "auth_type": "wpa-personal",
+                    "auth_cipher": "aes",
+                    "auth_psk": "P2PLinkKey123!",
+                    "distance": 1.5,
+                    "distance_unit": "km",
+                    "description": "Point-to-point wireless backhaul link",
+                    "comments": "Building A to Building B wireless bridge",
+                    "tags": [
+                        {
+                            "name": "Tag 1"
+                        },
+                        {
+                            "name": "Tag 2"
+                        }
+                    ]
+                }
+            }
+        }
+
+        _ = self.diff_and_apply(payload)
+
+    def test_generate_diff_and_apply_provider_with_accounts(self):
+        """Test generate diff and apply provider with accounts."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "circuits.provider",
+            "entity": {
+                "provider": {
+                    "name": "Level 3 Communications",
+                    "slug": "level3",
+                    "description": "Global Tier 1 Internet Service Provider",
+                    "comments": "Primary transit provider for data center connectivity",
+                    "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                    "accounts": [
+                        {
+                            "provider": {"name": "Level 3 Communications"},
+                            "name": "East Coast Account",
+                            "account": "L3-12345",
+                            "description": "East Coast regional services account",
+                            "comments": "Managed through regional NOC"
+                        },
+                        {
+                            "provider": {"name": "Level 3 Communications"},
+                            "name": "West Coast Account",
+                            "account": "L3-67890",
+                            "description": "West Coast regional services account",
+                            "comments": "Managed through regional NOC"
+                        }
+                    ],
+                    "asns": [
+                        {
+                            "asn": "3356",
+                            "rir": {"name": "ARIN"},
+                            "tenant": {"name": "Tenant 1"},
+                            "description": "Level 3 Global ASN",
+                            "comments": "Primary transit ASN"
+                        }
+                    ]
+                }
+            }
+        }
+
+        _ = self.diff_and_apply(payload)
+        provider = Provider.objects.get(name="Level 3 Communications")
+        self.assertEqual(provider.accounts.count(), 2)
+        self.assertEqual(provider.asns.count(), 1)
+
+    def test_generate_diff_and_apply_module_bay_with_module(self):
+        """Test generate diff and apply module bay with a module installed (non-circular)."""
+        # First create the module bay
+        bay_payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "dcim.modulebay",
+            "entity": {
+                "module_bay": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Module Bay 1",
+                    "label": "STACK-1",
+                    "position": "Rear",
+                    "description": "Primary stacking module bay",
+                    "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+                }
+            }
+        }
+        _ = self.diff_and_apply(bay_payload)
+        module_bay = ModuleBay.objects.get(name="Module Bay 1")
+        self.assertEqual(module_bay.device.name, "Device 1")
+
+        # Then install a module into that bay (non-circular — module references
+        # the same bay it's installed in, no sub-bays that reference back)
+        module_payload = {
+            "timestamp": "2025-04-16T02:58:21.564615Z",
+            "object_type": "dcim.module",
+            "entity": {
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-STACK"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    }
+                }
+            }
+        }
+        _ = self.diff_and_apply(module_payload)
+        from dcim.models import Module
+        module = Module.objects.get(module_bay__name="Module Bay 1")
+        self.assertEqual(module.device.name, "Device 1")
+        self.assertEqual(module.module_type.manufacturer.name, "Cisco")
+        self.assertEqual(module.module_type.model, "C2960S-STACK")
+        self.assertEqual(module.module_bay.name, "Module Bay 1")
+
+    def test_generate_diff_and_apply_module_bay_circular_ref_fails(self):
+        """Test generate diff and apply module bay."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "dcim.modulebay",
+            "entity":     {
+                "module_bay": {
+                    "name": "Module Bay 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module": {
+                        "asset_tag": "1234567890",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "module_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S-STACK"
+                        },
+                        "module_bay": {
+                            "name": "Module Bay 1",
+                            "device": {
+                                "name": "Device 1",
+                                "role": {"name": "Device Role 1"},
+                                "device_type": {
+                                    "manufacturer": {"name": "Cisco"},
+                                    "model": "C2960S"
+                                },
+                                "site": {"name": "Site 1"}
+                            },
+                            "module": {
+                                "asset_tag": "1234567890",
+                            }
+                        }
+                    },
+                    "label": "STACK-2",
+                    "position": "Rear",
+                    "description": "Secondary stacking module bay",
+                    "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+                }
+            }
+        }
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+
+        response2 = self.client.post(
+            self.apply_url, data=diff, format="json", **self.authorization_header
+        )
+        self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn(
+            "A module bay cannot belong to a module installed within it.",
+            _get_error(response2, "dcim.modulebay", "__all__")
+        )
+
+    def test_generate_diff_and_apply_virtual_machine_with_primary_ip_4_ok(self):
+        """Test generate diff and apply virtual machine with primary ip 4 assigned."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "virtualization.virtualmachine",
+            "entity": {
+                "timestamp": "2025-04-16T13:45:02.045208Z",
+                "virtual_machine": {
+                    "name": "app-server-01",
+                    "status": "active",
+                    "site": {"name": "Site 1"},
+                    "cluster": {
+                        "name": "Cluster 1",
+                        "type": {"name": "Cluster Type 1"}
+                    },
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"},
+                        "cluster": {
+                            "name": "Cluster 1",
+                            "type": {"name": "Cluster Type 1"}
+                        }
+                    },
+                    "serial": "VM-2023-001",
+                    "role": {"name": "Application Server"},
+                    "tenant": {"name": "Tenant 1"},
+                    "platform": {"name": "Ubuntu 22.04"},
+                    "primary_ip4": {
+                        "address": "192.168.2.10",
+                        "assigned_object_vm_interface": {
+                            "virtual_machine": {
+                                "name": "app-server-01",
+                                "cluster": {
+                                    "name": "Cluster 1",
+                                    "type": {"name": "Cluster Type 1"}
+                                },
+                                "tenant": {"name": "Tenant 1"},
+                            },
+                            "name": "eth0",
+                            "enabled": True,
+                            "mtu": "1500",
+                        }
+                    },
+                    "vcpus": 4.0,
+                    "memory": "214748364",
+                    "disk": "147483647",
+                    "description": "Primary application server instance",
+                    "comments": "Hosts critical business applications",
+                    "tags": [
+                        {
+                            "name": "Tag 1"
+                        },
+                        {
+                            "name": "Tag 2"
+                        }
+                    ]
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+
+    def test_generate_diff_and_apply_update_cluster_location(self):
+        """Test generate diff and apply update cluster location, same site."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "virtualization.cluster",
+            "entity":     {
+                "cluster": {
+                    "name": "Cluster A",
+                    "type": {"name": "Cluster Type 1"},
+                    "group": {"name": "Cluster Group 1"},
+                    "status": "active",
+                    "tenant": {"name": "Tenant 1"},
+                    "scope_site": {"name": "Site 1"},
+                    "description": "Cluster 1 Description",
+                    "comments": "Cluster 1 Comments",
+                    "tags": [{"name": "Tag 1"}]
+                }
+            },
+        }
+        _ = self.diff_and_apply(payload)
+
+        cluster = Cluster.objects.get(name="Cluster A")
+        self.assertEqual(cluster.scope.name, "Site 1")
+
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "virtualization.cluster",
+            "entity":     {
+                "cluster": {
+                    "name": "Cluster A",
+                    "type": {"name": "Cluster Type 1"},
+                    "group": {"name": "Cluster Group 1"},
+                    "status": "active",
+                    "tenant": {"name": "Tenant 1"},
+                    "scope_location": {"name": "Location 1", "site": {"name": "Site 1"}},
+                    "description": "Cluster 1 Description",
+                    "comments": "Cluster 1 Comments",
+                    "tags": [{"name": "Tag 1"}]
+                }
+            },
+        }
+        _ = self.diff_and_apply(payload)
+        cluster = Cluster.objects.get(name="Cluster A")
+        self.assertEqual(cluster.scope.name, "Location 1")
+
+    def test_generate_diff_and_apply_create_and_update_owner(self):
+        """Test generate diff and apply create and update owner (NetBox 4.5.0)."""
+        owner_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "users.owner",
+            "entity": {
+                "owner": {
+                    "name": f"Owner {owner_uuid}",
+                    "group": {
+                        "name": f"Owner Group {group_uuid}",
+                    },
+                    "description": "Primary network owner",
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_owner = Owner.objects.get(name=f"Owner {owner_uuid}")
+        self.assertEqual(new_owner.description, "Primary network owner")
+        self.assertEqual(new_owner.group.name, f"Owner Group {group_uuid}")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "users.owner",
+            "entity": {
+                "owner": {
+                    "name": f"Owner {owner_uuid}",
+                    "group": {
+                        "name": f"Owner Group {group_uuid}",
+                    },
+                    "description": "Updated network owner",
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        updated_owner = Owner.objects.get(name=f"Owner {owner_uuid}")
+        self.assertEqual(updated_owner.description, "Updated network owner")
+
+    def test_generate_diff_and_apply_create_and_update_ownergroup(self):
+        """Test generate diff and apply create and update ownergroup (NetBox 4.5.0)."""
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "users.ownergroup",
+            "entity": {
+                "owner_group": {
+                    "name": f"Owner Group {group_uuid}",
+                    "description": "Network operations team",
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_group = OwnerGroup.objects.get(name=f"Owner Group {group_uuid}")
+        self.assertEqual(new_group.description, "Network operations team")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "users.ownergroup",
+            "entity": {
+                "owner_group": {
+                    "name": f"Owner Group {group_uuid}",
+                    "description": "Updated network operations team",
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        updated_group = OwnerGroup.objects.get(name=f"Owner Group {group_uuid}")
+        self.assertEqual(updated_group.description, "Updated network operations team")
+
+    def test_generate_diff_and_apply_create_device_with_owner(self):
+        """Test generate diff and apply create device with owner field (NetBox 4.5.0)."""
+        device_uuid = str(uuid4())
+        owner_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "device_type": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {uuid4()}"
+                    },
+                    "site": {
+                        "name": f"Site {uuid4()}"
+                    },
+                    "owner": {
+                        "name": f"Owner {owner_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(new_device.owner.name, f"Owner {owner_uuid}")
+
+    def test_generate_diff_and_apply_create_circuit_with_owner(self):
+        """Test generate diff and apply create circuit with owner field (NetBox 4.5.0)."""
+        circuit_uuid = str(uuid4())
+        owner_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "circuits.circuit",
+            "entity": {
+                "circuit": {
+                    "cid": f"Circuit {circuit_uuid}",
+                    "provider": {
+                        "name": f"Provider {uuid4()}",
+                    },
+                    "type": {
+                        "name": f"Circuit Type {uuid4()}",
+                    },
+                    "owner": {
+                        "name": f"Owner {owner_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_circuit = Circuit.objects.get(cid=f"Circuit {circuit_uuid}")
+        self.assertEqual(new_circuit.owner.name, f"Owner {owner_uuid}")
+
+    def test_generate_diff_and_apply_update_device_owner(self):
+        """Test generate diff and apply update device owner (NetBox 4.5.0)."""
+        device_uuid = str(uuid4())
+        site_uuid = str(uuid4())
+        owner1_uuid = str(uuid4())
+        owner2_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+
+        # Create device with initial owner
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "device_type": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {uuid4()}"
+                    },
+                    "site": {
+                        "name": f"Site {site_uuid}"
+                    },
+                    "owner": {
+                        "name": f"Owner {owner1_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.owner.name, f"Owner {owner1_uuid}")
+
+        # Update device to different owner
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "device_type": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {uuid4()}"
+                    },
+                    "site": {
+                        "name": f"Site {site_uuid}"
+                    },
+                    "owner": {
+                        "name": f"Owner {owner2_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.owner.name, f"Owner {owner2_uuid}")
+
+    def test_generate_diff_and_apply_create_frontport_with_positions(self):
+        """Test generate diff and apply create frontport with positions field (NetBox 4.5.0)."""
+        device_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.frontport",
+            "entity": {
+                "front_port": {
+                    "device": {
+                        "name": f"Device {device_uuid}",
+                        "device_type": {
+                            "manufacturer": {"name": f"Manufacturer {uuid4()}"},
+                            "model": f"Device Type {uuid4()}"
+                        },
+                        "role": {"name": f"Role {uuid4()}"},
+                        "site": {"name": f"Site {uuid4()}"}
+                    },
+                    "name": f"Front Port {uuid4()}",
+                    "type": "8p8c",
+                    "rear_port": {
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "device_type": {
+                                "manufacturer": {"name": f"Manufacturer {uuid4()}"},
+                                "model": f"Device Type {uuid4()}"
+                            },
+                            "role": {"name": f"Role {uuid4()}"},
+                            "site": {"name": f"Site {uuid4()}"}
+                        },
+                        "name": f"Rear Port {uuid4()}",
+                        "type": "8p8c",
+                        "positions": "2"
+                    },
+                    "rear_port_position": "1",
+                    "description": "Front port with positions"
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_generate_diff_and_apply_create_rearport(self):
+        """Test generate diff and apply create rearport (NetBox 4.5.0)."""
+        device_uuid = str(uuid4())
+        rearport_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.rearport",
+            "entity": {
+                "rear_port": {
+                    "device": {
+                        "name": f"Device {device_uuid}",
+                        "device_type": {
+                            "manufacturer": {"name": f"Manufacturer {uuid4()}"},
+                            "model": f"Device Type {uuid4()}"
+                        },
+                        "role": {"name": f"Role {uuid4()}"},
+                        "site": {"name": f"Site {uuid4()}"}
+                    },
+                    "name": f"Rear Port {rearport_uuid}",
+                    "type": "8p8c",
+                    "positions": "4",
+                    "description": "Rear port with multiple positions"
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_rearport = RearPort.objects.get(name=f"Rear Port {rearport_uuid}")
+        self.assertEqual(new_rearport.positions, 4)
+        self.assertEqual(new_rearport.type, "8p8c")
+
+    def test_generate_diff_and_apply_create_asn_with_sites(self):
+        """Test generate diff and apply create ASN with sites field (NetBox 4.5.0)."""
+        site1_uuid = str(uuid4())
+        site2_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.asn",
+            "entity": {
+                "asn": {
+                    "asn": "65001",
+                    "rir": {"name": f"RIR {uuid4()}"},
+                    "description": "ASN with multiple sites",
+                    "sites": [
+                        {"name": f"Site {site1_uuid}"},
+                        {"name": f"Site {site2_uuid}"}
+                    ]
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_asn = ASN.objects.get(asn=65001)
+        self.assertEqual(new_asn.sites.count(), 2)
+        site_names = [site.name for site in new_asn.sites.all()]
+        self.assertIn(f"Site {site1_uuid}", site_names)
+        self.assertIn(f"Site {site2_uuid}", site_names)
+
+    def test_generate_diff_and_apply_create_vlan_translation_policy(self):
+        """Test generate diff and apply create VLAN translation policy (NetBox 4.5.0)."""
+        policy_uuid = str(uuid4())
+        owner_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vlantranslationpolicy",
+            "entity": {
+                "vlan_translation_policy": {
+                    "name": f"VLAN Translation Policy {policy_uuid}",
+                    "description": "Policy for VLAN translation",
+                    "owner": {
+                        "name": f"Owner {owner_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_policy = VLANTranslationPolicy.objects.get(name=f"VLAN Translation Policy {policy_uuid}")
+        self.assertEqual(new_policy.description, "Policy for VLAN translation")
+        self.assertEqual(new_policy.owner.name, f"Owner {owner_uuid}")
+
+    def test_multiobject_cf_rediff_noop(self):
+        """
+        Test that re-diffing a device with multiobject custom field produces no changes.
+
+        INT-219: multiobject custom field values are order-insensitive (sets),
+        but the differ was comparing them as ordered lists. This caused phantom
+        changesets on every re-diff because the "before" IDs (from queryset,
+        ordered by name) didn't match the "desired" IDs (sorted numerically).
+        """
+        device_cf = CustomField.objects.create(
+            name='int219_multi_sites',
+            type=CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            required=False,
+            related_object_type=ObjectType.objects.get_for_model(Site),
+        )
+        device_object_type = ObjectType.objects.get_for_model(Device)
+        device_cf.object_types.set([device_object_type])
+        device_cf.save()
+
+        # Pre-create "Gamma" so it gets a LOWER ID than Alpha and Beta.
+        # When diff+apply later creates Alpha and Beta, they get higher IDs.
+        # This ensures name-alphabetical order (Alpha, Beta, Gamma) differs
+        # from numeric ID order (Gamma, Alpha, Beta) — which triggers the bug.
+        Site.objects.create(name="INT219-Site-Gamma", slug="int219-site-gamma")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "INT219-Test-Device",
+                    "role": {"name": "INT219-Role"},
+                    "site": {"name": "INT219-Site-Primary"},
+                    "device_type": {
+                        "model": "INT219-Model",
+                        "manufacturer": {"name": "INT219-Manufacturer"},
+                    },
+                    "serial": "INT219-SERIAL-001",
+                    "custom_fields": {
+                        "int219_multi_sites": {
+                            "multiple_objects": [
+                                {"site": {"name": "INT219-Site-Alpha"}},
+                                {"site": {"name": "INT219-Site-Beta"}},
+                                {"site": {"name": "INT219-Site-Gamma"}},
+                            ],
+                        },
+                    },
+                },
+            },
+        }
+
+        # First diff+apply: creates the device, Alpha, Beta (Gamma already exists)
+        self.diff_and_apply(payload)
+        device = Device.objects.get(name="INT219-Test-Device")
+        self.assertIsNotNone(device)
+        self.assertEqual(len(device.custom_field_data['int219_multi_sites']), 3)
+
+        # Verify IDs are NOT in alphabetical-name order (precondition for the bug)
+        alpha = Site.objects.get(name="INT219-Site-Alpha")
+        beta = Site.objects.get(name="INT219-Site-Beta")
+        gamma = Site.objects.get(name="INT219-Site-Gamma")
+        name_order_ids = [alpha.pk, beta.pk, gamma.pk]
+        numeric_order_ids = sorted(name_order_ids)
+        self.assertNotEqual(
+            name_order_ids, numeric_order_ids,
+            "Test precondition failed: IDs happen to match name order. "
+            "Pre-creating Gamma should have given it a lower ID than Alpha/Beta."
+        )
+
+        # Step 2: Re-diff with the exact same payload.
+        # Before the fix, this produces a false "update" changeset because
+        # cf.serialize() returns IDs in queryset name-order [alpha, beta, gamma]
+        # but the transformer sorts resolved IDs numerically [gamma, alpha, beta].
+        response = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+
+        # The re-diff should produce NO changes — the data hasn't changed.
+        self.assertEqual(
+            changes, [],
+            f"Expected no changes on re-diff, but got: {changes}"
+        )
+
+    def diff_and_apply(self, payload):
+        """Diff and apply the payload."""
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        response2 = self.client.post(
+            self.apply_url, data=diff, format="json", **self.authorization_header
+        )
+        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+        return (response1, response2)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_generate_diff.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_generate_diff.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+import logging
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest import mock
+from uuid import uuid4
+
+from core.models import ObjectType
+from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, RackType, Site
+from extras.models import CustomField
+from extras.models.customfields import CustomFieldTypeChoices
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+def _get_error(response, object_name, field):
+    return response.json().get("errors", {}).get(object_name, {}).get(field, [])
+
+
+class GenerateDiffTestCase(APITestCase):
+    """GenerateDiff test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/generate-diff/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+        self.object_type = ObjectType.objects.get_for_model(Site)
+
+        self.uuid_field = CustomField.objects.create(
+            name='myuuid',
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            required=False,
+            unique=True,
+        )
+        self.uuid_field.object_types.set([self.object_type])
+        self.uuid_field.save()
+
+        self.json_field = CustomField.objects.create(
+            name='some_json',
+            type=CustomFieldTypeChoices.TYPE_JSON,
+            required=False,
+            unique=False,
+        )
+        self.json_field.object_types.set([self.object_type])
+        self.json_field.save()
+
+        self.site_uuid = str(uuid4())
+        self.site = Site.objects.create(
+            name="Site Generate Diff 1",
+            slug="site-generate-diff-1",
+            facility="Alpha",
+            description="First test site",
+            physical_address="123 Fake St Lincoln NE 68588",
+            shipping_address="123 Fake St Lincoln NE 68588",
+            comments="Lorem ipsum etcetera",
+        )
+        self.site.custom_field_data[self.uuid_field.name] = self.site_uuid
+        self.site.custom_field_data[self.json_field.name] = {
+            "some_key": "some_value",
+        }
+        self.site.save()
+
+        self.manufacturer = Manufacturer.objects.create(
+            name="Manufacturer 1",
+        )
+        self.manufacturer.save()
+        self.rack_type = RackType.objects.create(
+            model="Rack Type 1",
+            slug="rack-type-1",
+            manufacturer=self.manufacturer,
+        )
+        self.rack_type.save()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def test_generate_diff_create_site(self):
+        """Test generate diff create site."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "A New Site",
+                    "slug": "a-new-site",
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.site")
+        self.assertEqual(change.get("change_type"), "create")
+        self.assertEqual(change.get("object_id"), None)
+        self.assertIsNotNone(change.get("ref_id"))
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("name"), "A New Site")
+        self.assertEqual(data.get("slug"), "a-new-site")
+
+    def test_generate_diff_create_site_with_custom_field(self):
+        """Test generate diff create site with custom field."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "A New Site",
+                    "slug": "a-new-site",
+                    "custom_fields": {
+                        "some_json": {
+                            "json": '{"some_key": 1234567890}',
+                        },
+                    },
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.site")
+        self.assertEqual(change.get("change_type"), "create")
+        self.assertEqual(change.get("object_id"), None)
+        self.assertIsNotNone(change.get("ref_id"))
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("name"), "A New Site")
+        self.assertEqual(data.get("slug"), "a-new-site")
+        self.assertEqual(data.get("custom_fields", {}).get("some_json", {}).get("some_key"), 1234567890)
+
+    def test_generate_diff_update_site(self):
+        """Test generate diff update site."""
+        """Test generate diff create site."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Site Generate Diff 1",
+                    "slug": "site-generate-diff-1",
+                    "comments": "An updated comment",
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.site")
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+        self.assertEqual(change.get("ref_id"), None)
+        self.assertEqual(change.get("data").get("name"), "Site Generate Diff 1")
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("name"), "Site Generate Diff 1")
+        self.assertEqual(data.get("slug"), "site-generate-diff-1")
+        self.assertEqual(data.get("comments"), "An updated comment")
+
+    def test_match_site_by_custom_field(self):
+        """Test match site by custom field."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    # here name and slug are not present in the payload
+                    # but we expect to match the existing site by the
+                    # unique custom field myuuid
+                    "comments": "A custom comment",
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": self.site_uuid,
+                        },
+                    },
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.site")
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+        self.assertEqual(change.get("ref_id"), None)
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("comments"), "A custom comment")
+        self.assertEqual(data.get("custom_fields", {}).get("myuuid"), self.site_uuid)
+
+        before = change.get("before", {})
+        self.assertEqual(before.get("name"), "Site Generate Diff 1")
+        self.assertEqual(before.get("slug"), "site-generate-diff-1")
+
+    def test_generate_diff_update_rack_type_autoslug(self):
+        """Test generate diff update rack type autoslug."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.racktype",
+            "entity": {
+                "rack_type": {
+                    "model": "Rack Type 1",
+                    "form_factor": "wall-frame",
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.racktype")
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.rack_type.id)
+        self.assertEqual(change.get("ref_id"), None)
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("model"), "Rack Type 1")
+        self.assertEqual(data.get("slug"), None) # slug is not set, use prior slug
+        self.assertEqual(data.get("form_factor"), "wall-frame")
+
+        before = change.get("before", {})
+        self.assertEqual(before.get("model"), "Rack Type 1")
+        # correct slug is present in before data
+        self.assertEqual(before.get("slug"), "rack-type-1")
+
+    def test_generate_diff_update_rack_type_camel_case(self):
+        """Test generate diff update rack type with came cased protoJSON."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.racktype",
+            "entity": {
+                "rackType": {
+                    "slug": "rack-type-1",
+                    "model": "Rack Type 1",
+                    "formFactor": "wall-frame",
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.racktype")
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.rack_type.id)
+        self.assertEqual(change.get("ref_id"), None)
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("model"), "Rack Type 1")
+        self.assertEqual(data.get("form_factor"), "wall-frame")
+
+        before = change.get("before", {})
+        self.assertEqual(before.get("model"), "Rack Type 1")
+
+    def test_merge_states_failed(self):
+        """Test merge states failed."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {
+                "vrf": {
+                    "name": "Customer-A-VRF",
+                    "rd": "65000:100",
+                    "tenant": {"name": "Tenant 1"},
+                    "enforce_unique": True,
+                    "description": "Isolated routing domain for Customer A",
+                    "comments": "Used for customer's private network services",
+                    "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                    ],
+                    "import_targets": [
+                        {
+                            "name": "65000:100",
+                            "description": "Primary import route target"
+                        },
+                        {
+                            "name": "65000:101",
+                            "description": "Backup import route target"
+                        }
+                    ],
+                    "export_targets": [
+                        {
+                            "name": "65000:100",
+                            "description": "Primary export route target"
+                        }
+                    ]
+                }
+            }
+        }
+
+        response = self.send_request(payload, status.HTTP_400_BAD_REQUEST)
+        logger.error(response.json())
+        errs = _get_error(response, "ipam.vrf", "__all__")
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertTrue(err.startswith("Conflicting values for 'description' merging duplicate ipam.routetarget"))
+
+    def test_vlangroup_error(self):
+        """Test vlangroup error."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vlangroup",
+            "entity": {
+                "vlan_group": {
+                    "name": "Data Center Core",
+                    "slug": "dc-core",
+                    "scope_site": {
+                        "name": "Data Center West",
+                        "slug": "dc-west",
+                        "status": "active"
+                    },
+                    "description": "Core network VLANs for data center infrastructure",
+                    "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                    ]
+                }
+            }
+        }
+        _ = self.send_request(payload)
+
+    def test_generate_diff_dedupe_different_object_types(self):
+        """Test generate diff dedupe different object types with same values."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "Cat8000V",
+                    "role": {"name": "undefined"},
+                    "site": {"name": "undefined"},
+                    "serial": "9OBXJHNNU5V",
+                    "status": "active",
+                    "platform": {"name": "ios", "manufacturer": {"name": "undefined"}},
+                    "device_type": {"model": "C8000V", "manufacturer": {"name": "undefined"}}
+                },
+            },
+        }
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 6)
+        by_object_type = defaultdict(int)
+        for change in changes:
+            by_object_type[change.get("object_type")] += 1
+
+        self.assertEqual(by_object_type["dcim.device"], 1)
+        self.assertEqual(by_object_type["dcim.manufacturer"], 1)
+        self.assertEqual(by_object_type["dcim.platform"], 1)
+        self.assertEqual(by_object_type["dcim.devicetype"], 1)
+        self.assertEqual(by_object_type["dcim.site"], 1)
+        self.assertEqual(by_object_type["dcim.devicerole"], 1)
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+
+class PKBasedMatchingTestCase(APITestCase):
+    """Test PK-based matching via metadata.source_match.netbox_id."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.url = "/netbox/api/plugins/diode/generate-diff/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(name="PK Test Site", slug="pk-test-site")
+        manufacturer = Manufacturer.objects.create(name="PK Test Manufacturer", slug="pk-test-manufacturer")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="PK Test Type", slug="pk-test-type"
+        )
+        self.role = DeviceRole.objects.create(name="PK Test Role", slug="pk-test-role", color="ff0000")
+        self.device = Device.objects.create(
+            name="PK Test Device",
+            device_type=device_type,
+            role=self.role,
+            site=self.site,
+            serial="ORIG-SERIAL",
+        )
+        self.interface = Interface.objects.create(
+            device=self.device,
+            name="eth0",
+            type="virtual",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_pk_match_noop(self):
+        """PK match with identical data produces no changes."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "PK Test Device",
+                    "serial": "ORIG-SERIAL",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": self.device.pk},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        # all changes should be noop since data matches
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertTrue(len(device_changes) <= 1)
+        if device_changes:
+            self.assertEqual(device_changes[0]["change_type"], "noop")
+
+    def test_pk_match_update(self):
+        """PK match with changed attribute produces update changeset."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "PK Test Device",
+                    "serial": "NEW-SERIAL",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": self.device.pk},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertEqual(len(device_changes), 1)
+        change = device_changes[0]
+        self.assertEqual(change["change_type"], "update")
+        self.assertEqual(change["object_id"], self.device.pk)
+        self.assertEqual(change["data"]["serial"], "NEW-SERIAL")
+
+    def test_pk_match_ignores_name(self):
+        """PK match finds the device even when the name is different — produces update, not create."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "Completely Different Name",
+                    "serial": "ORIG-SERIAL",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": self.device.pk},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertEqual(len(device_changes), 1)
+        change = device_changes[0]
+        self.assertEqual(change["change_type"], "update")
+        self.assertEqual(change["object_id"], self.device.pk)
+        # name change should be in the diff
+        self.assertEqual(change["data"]["name"], "Completely Different Name")
+
+    def test_pk_not_found_raises_error(self):
+        """PK that doesn't exist returns an error, not a create."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "Ghost Device",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": 999999},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+        errors = response.json().get("errors", {})
+        self.assertTrue(len(errors) > 0)
+
+    def test_no_metadata_uses_normal_matching(self):
+        """Without metadata, normal constraint-based matching applies."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "PK Test Device",
+                    "serial": "CHANGED-SERIAL",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertEqual(len(device_changes), 1)
+        change = device_changes[0]
+        # should still match by name+site and produce an update
+        self.assertEqual(change["change_type"], "update")
+        self.assertEqual(change["object_id"], self.device.pk)
+
+    def test_pk_match_device_via_nested_interface(self):
+        """Interface ingested with parent device carrying netbox_id — device matched by PK, interface by name."""
+        payload = {
+            "object_type": "dcim.interface",
+            "entity": {
+                "interface": {
+                    "name": "eth0",
+                    "type": "virtual",
+                    "mtu": 9000,
+                    "device": {
+                        "name": "Irrelevant Name",
+                        "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                        "role": {"name": "PK Test Role"},
+                        "site": {"name": "PK Test Site"},
+                        "metadata": {
+                            "source_match": {"netbox_id": self.device.pk},
+                        },
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        interface_changes = [c for c in changes if c["object_type"] == "dcim.interface"]
+        # device should be matched by PK (name differs so it's an update)
+        self.assertEqual(len(device_changes), 1)
+        self.assertEqual(device_changes[0]["change_type"], "update")
+        self.assertEqual(device_changes[0]["object_id"], self.device.pk)
+        # interface should be matched by name within the PK-resolved device
+        self.assertEqual(len(interface_changes), 1)
+        self.assertEqual(interface_changes[0]["change_type"], "update")
+        self.assertEqual(interface_changes[0]["object_id"], self.interface.pk)
+
+    def test_invalid_netbox_id_falls_through(self):
+        """Invalid (non-numeric) netbox_id is ignored with a warning, falls through to normal matching."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "PK Test Device",
+                    "serial": "CHANGED-FOR-INVALID-PK-TEST",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": "not-a-number"},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertEqual(len(device_changes), 1)
+        # should fall through to normal matching and find the device by name
+        self.assertEqual(device_changes[0]["change_type"], "update")
+        self.assertEqual(device_changes[0]["object_id"], self.device.pk)
+        # warning should be present
+        warnings = cs.get("warnings", {})
+        self.assertIn("metadata", warnings.get("dcim.device", {}))

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_get_default_branch.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_get_default_branch.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - GetDefaultBranch API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.models import Setting
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class GetDefaultBranchViewTestCase(APITestCase):
+    """Test cases for GetDefaultBranchView."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/default-branch/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def test_get_default_branch_unauthenticated(self):
+        """Test that unauthenticated requests are rejected."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_default_branch_without_read_scope(self):
+        """Test that requests without netbox:read scope are rejected."""
+        # Mock user with only write scope
+        user_without_read = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:write"],
+            token_data={"scope": "netbox:write"}
+        )
+
+        with mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=user_without_read
+        ):
+            response = self.client.get(self.url, **self.authorization_header)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_default_branch_no_branching_plugin(self):
+        """Test response when branching plugin is not installed."""
+        # Create a setting without branch
+        Setting.objects.create(diode_target="grpc://localhost:8080/diode")
+
+        # Mock Branch as None (simulating plugin not installed)
+        with mock.patch('netbox_diode_plugin.api.views.Branch', None):
+            response = self.client.get(self.url, **self.authorization_header)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("branch", response.json())
+            self.assertIsNone(response.json()["branch"])
+
+    def test_get_default_branch_no_settings(self):
+        """Test response when no settings exist."""
+        # Ensure no settings exist
+        Setting.objects.all().delete()
+
+        response = self.client.get(self.url, **self.authorization_header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("branch", response.json())
+        self.assertIsNone(response.json()["branch"])
+
+    def test_get_default_branch_settings_without_branch(self):
+        """Test response when settings exist but branch is not set."""
+        # Create a setting without branch
+        Setting.objects.create(diode_target="grpc://localhost:8080/diode", branch_id=None)
+
+        response = self.client.get(self.url, **self.authorization_header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("branch", response.json())
+        self.assertIsNone(response.json()["branch"])
+
+    def test_get_default_branch_with_branching_plugin_and_branch_set(self):
+        """Test response when branching plugin is installed and branch is set."""
+        # Create a mock Branch object
+        mock_branch = mock.Mock()
+        mock_branch.schema_id = "branch-123"
+        mock_branch.name = "main"
+        mock_branch.id = 1
+
+        # Create a setting with branch_id
+        Setting.objects.create(
+            diode_target="grpc://localhost:8080/diode",
+            branch_id=1
+        )
+
+        # Mock the Branch model and query
+        mock_branch_model = mock.Mock()
+        mock_branch_model.objects.get.return_value = mock_branch
+
+        with mock.patch('netbox_diode_plugin.api.views.Branch', mock_branch_model):
+            with mock.patch.object(Setting, 'branch', new_callable=mock.PropertyMock) as mock_branch_property:
+                mock_branch_property.return_value = mock_branch
+
+                response = self.client.get(self.url, **self.authorization_header)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertIn("branch", response.json())
+                self.assertIsNotNone(response.json()["branch"])
+                self.assertEqual(response.json()["branch"]["id"], "branch-123")
+                self.assertEqual(response.json()["branch"]["name"], "main")
+
+    def test_get_default_branch_exception_handling(self):
+        """Test that exceptions during branch retrieval are handled gracefully."""
+        # Create a setting with branch_id
+        Setting.objects.create(
+            diode_target="grpc://localhost:8080/diode",
+            branch_id=1
+        )
+
+        # Mock Branch model to exist but raise exception on query
+        mock_branch_model = mock.Mock()
+
+        with mock.patch('netbox_diode_plugin.api.views.Branch', mock_branch_model):
+            with mock.patch.object(Setting, 'branch', new_callable=mock.PropertyMock) as mock_branch_property:
+                # Simulate an exception when accessing the branch property
+                mock_branch_property.side_effect = Exception("Database error")
+
+                response = self.client.get(self.url, **self.authorization_header)
+
+                # Should return 200 with null branch due to exception handling
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertIn("branch", response.json())
+                self.assertIsNone(response.json()["branch"])
+
+    def test_get_default_branch_with_valid_authentication(self):
+        """Test that authenticated requests with proper scope are successful."""
+        response = self.client.get(self.url, **self.authorization_header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("branch", response.json())
+        # Response structure is correct even if branch is None
+        self.assertIsInstance(response.json(), dict)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_authentication.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_authentication.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Authentication Tests."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.test import APIRequestFactory
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class DiodeOAuth2AuthenticationTestCase(TestCase):
+    """Test cases for DiodeOAuth2Authentication."""
+
+    def setUp(self):
+        """Set up test case."""
+        self.auth = DiodeOAuth2Authentication()
+        self.factory = APIRequestFactory()
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+        self.valid_token = "valid_oauth_token"
+        self.invalid_token = "invalid_oauth_token"
+        self.token_without_scope = "token_without_scope"
+        self.token_with_scope = "token_with_scope"
+
+        # Mock the cache
+        self.cache_patcher = mock.patch.object(cache, 'get')
+        self.cache_get_mock = self.cache_patcher.start()
+        self.cache_set_patcher = mock.patch.object(cache, 'set')
+        self.cache_set_mock = self.cache_set_patcher.start()
+
+        # Mock requests.post for token introspection
+        self.requests_patcher = mock.patch('requests.post')
+        self.requests_mock = self.requests_patcher.start()
+        self.requests_mock.return_value.raise_for_status = mock.Mock()
+
+        # Mock get_diode_auth_introspect_url
+        self.introspect_url_patcher = mock.patch(
+            'netbox_diode_plugin.plugin_config.get_diode_auth_introspect_url',
+            return_value='http://test-introspect-url'
+        )
+        self.introspect_url_patcher.start()
+
+        self.required_audience_patcher = mock.patch(
+            'netbox_diode_plugin.api.authentication.get_required_token_audience',
+            return_value=[]
+        )
+        self.required_audience_mock = self.required_audience_patcher.start()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.cache_patcher.stop()
+        self.cache_set_patcher.stop()
+        self.requests_patcher.stop()
+        self.introspect_url_patcher.stop()
+        self.required_audience_patcher.stop()
+
+    def test_authenticate_no_auth_header(self):
+        """Test authentication with no Authorization header."""
+        request = self.factory.get('/')
+        result = self.auth.authenticate(request)
+        self.assertIsNone(result)
+
+    def test_authenticate_invalid_auth_header_format(self):
+        """Test authentication with invalid Authorization header format."""
+        request = self.factory.get('/', HTTP_AUTHORIZATION='InvalidFormat')
+        result = self.auth.authenticate(request)
+        self.assertIsNone(result)
+
+    def test_authenticate_cached_token(self):
+        """Test authentication with cached token."""
+        self.cache_get_mock.return_value = self.diode_user
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.valid_token}')
+
+        user, _ = self.auth.authenticate(request)
+        self.assertEqual(user, self.diode_user.user)
+        self.cache_get_mock.assert_called_once()
+
+    def test_authenticate_invalid_token(self):
+        """Test authentication with invalid token."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {'active': False}
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.invalid_token}')
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_authenticate_token_with_required_scope(self):
+        """Test authentication with token having required scope."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write',
+            'exp': 1000,
+            'iat': 500
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.token_with_scope}')
+
+        user, _ = self.auth.authenticate(request)
+        self.assertEqual(user, self.diode_user.user)
+        self.cache_set_mock.assert_called_once()
+
+    def test_authenticate_token_with_required_audience(self):
+        """Test authentication with token having required audience."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write',
+            'exp': 1000,
+            'iat': 500
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.token_with_scope}')
+
+        self.cache_get_mock.return_value = None
+        self.required_audience_mock.return_value = ['netbox']
+        try:
+            # should fail if the token does not have the required audience
+            with self.assertRaises(AuthenticationFailed):
+                self.auth.authenticate(request)
+            self.required_audience_mock.assert_called_once()
+            self.cache_set_mock.assert_not_called()
+
+            # should succeed if the token has the required audience
+            self.requests_mock.return_value.json.return_value = {
+                'active': True,
+                'aud': ['netbox', 'api', 'other'],
+                'scope': 'netbox:read netbox:write',
+                'exp': 1000,
+                'iat': 500
+            }
+
+            user, _ = self.auth.authenticate(request)
+            self.assertEqual(user, self.diode_user.user)
+            self.cache_set_mock.assert_called_once()
+        finally:
+            self.required_audience_patcher.return_value = []
+
+    def test_authenticate_token_introspection_failure(self):
+        """Test authentication when token introspection fails."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.side_effect = Exception("Introspection failed")
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.valid_token}')
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_authenticate_token_with_default_expiry(self):
+        """Test authentication with token having no expiry information."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write'
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.token_with_scope}')
+
+        user, _ = self.auth.authenticate(request)
+        self.assertEqual(user, self.diode_user.user)
+
+        self.cache_set_mock.assert_called_once()
+
+        # Get the actual call arguments
+        call_args = self.cache_set_mock.call_args
+        if not call_args:
+            self.fail("Cache set was not called with any arguments")
+
+        # The cache key should start with 'diode:oauth2:introspect:'
+        cache_key = call_args.args[0]
+        self.assertTrue(cache_key.startswith('diode:oauth2:introspect:'))
+
+        # The cached value should be the diode user
+        self.assertEqual(call_args.args[1].user, self.diode_user.user)
+        self.assertEqual(call_args.args[1].token_scopes, self.diode_user.token_scopes)
+
+        # The timeout should be 300 (default)
+        self.assertEqual(call_args.kwargs['timeout'], 300)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_diode_clients.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_diode_clients.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Diode Clients API Tests."""
+
+from unittest import mock
+
+from django.test import TestCase
+
+from netbox_diode_plugin.diode.clients import ClientAPI, ClientAPIError
+
+
+class DiodeClientsTestCase(TestCase):
+    """Test cases for Diode Clients API."""
+
+    def test_create_client(self):
+        """Test creating a client."""
+        with mock.patch('requests.post') as mock_post:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = {
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "client_name": "test-client",
+                "scope": "test-scope"
+            }
+
+            created = client.create_client(
+                name="test-client",
+                scope="test-scope"
+            )
+
+            self.assertEqual(created, {
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "client_name": "test-client",
+                "scope": "test-scope"
+            })
+
+            mock_post.assert_called_once_with(
+                "http://test-diode-url/clients",
+                headers={
+                    "Authorization": "Bearer test-client-auth-token"
+            },
+            json={
+                "client_name": "test-client",
+                "scope": "test-scope"
+            }
+        )
+
+    def test_list_clients(self):
+        """Test listing clients."""
+        with mock.patch('requests.get') as mock_get:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = {
+                "data": [
+                    {
+                        "client_id": "test-client-id",
+                        "client_name": "test-client",
+                        "scope": "test-scope"
+                    }
+                ],
+                "next_page_token": "test-next-page-token",
+                "prev_page_token": "test-prev-page-token"
+            }
+
+            result = client.list_clients(page_size=100)
+
+            self.assertEqual(result["data"], [
+                {
+                    "client_id": "test-client-id",
+                    "client_name": "test-client",
+                    "scope": "test-scope"
+                }
+            ])
+
+            self.assertEqual(result["next_page_token"], "test-next-page-token")
+            self.assertEqual(result["prev_page_token"], "test-prev-page-token")
+
+            mock_get.assert_called_once_with(
+                "http://test-diode-url/clients",
+                headers={
+                    "Authorization": "Bearer test-client-auth-token"
+                },
+                params={
+                    "page_size": 100,
+                }
+            )
+
+    def test_get_client(self):
+        """Test getting a client."""
+        with mock.patch('requests.get') as mock_get:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = {
+                "client_id": "test-client-id",
+                "client_name": "test-client",
+                "scope": "test-scope"
+            }
+
+            result = client.get_client("test-client-id")
+
+            self.assertEqual(result, {
+                "client_id": "test-client-id",
+                "client_name": "test-client",
+                "scope": "test-scope"
+            })
+
+            mock_get.assert_called_once_with(
+                "http://test-diode-url/clients/test-client-id",
+                headers={
+                    "Authorization": "Bearer test-client-auth-token"
+                }
+            )
+
+    def test_get_client_raises_error_on_bad_id(self):
+        """Test getting a client raises an error on bad ID."""
+        client = ClientAPI(
+            base_url="http://test-diode-url",
+            client_id="test-client-id",
+            client_secret="test-client-secret"
+        )
+        with self.assertRaises(ValueError):
+            client.get_client("../bad/../client/id")
+
+    def test_delete_client(self):
+        """Test deleting a client."""
+        with mock.patch('requests.delete') as mock_delete:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_delete.return_value.status_code = 204
+            mock_delete.return_value.raise_for_status = mock.Mock()
+
+            client.delete_client("test-client-id")
+
+            mock_delete.assert_called_once_with(
+                "http://test-diode-url/clients/test-client-id",
+                headers={
+                    "Authorization": "Bearer test-client-auth-token"
+                }
+            )
+
+    def test_delete_client_raises_error_on_bad_id(self):
+        """Test deleting a client raises an error on bad ID."""
+        client = ClientAPI(
+            base_url="http://test-diode-url",
+            client_id="test-client-id",
+            client_secret="test-client-secret"
+        )
+        with self.assertRaises(ValueError):
+            client.delete_client("../bad/../client/id")
+
+    def test_authentication_retries(self):
+        """Test authentication retries."""
+        with mock.patch('requests.post') as mock_post:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_post.side_effect = [
+                ClientAPIError("Failed to create client", 401),
+                mock.Mock(status_code=200, json=lambda: {"access_token": "new-access-token"}),
+                mock.Mock(status_code=201, json=lambda: {
+                    "client_id": "test-client-id",
+                    "client_secret": "test-client-secret",
+                    "client_name": "test-client",
+                    "scope": "diode:read diode:write"
+                }),
+            ]
+
+            result = client.create_client("test-client", "diode:read diode:write")
+            self.assertEqual(result, {
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "client_name": "test-client",
+                "scope": "diode:read diode:write"
+            })
+
+            self.assertEqual(mock_post.call_count, 3)
+
+            mock_post.assert_has_calls([
+                mock.call("http://test-diode-url/clients",
+                    headers={
+                        "Authorization": "Bearer test-client-auth-token"
+                    },
+                    json={
+                        "client_name": "test-client",
+                        "scope": "diode:read diode:write",
+                    }
+                ),
+                mock.call("http://test-diode-url/token",
+                    data='grant_type=client_credentials&client_id=test-client-id&client_secret=test-client-secret&scope=diode%3Aread+diode%3Awrite',
+                    headers={'Content-Type': 'application/x-www-form-urlencoded'}
+                ),
+                mock.call("http://test-diode-url/clients",
+                    headers={
+                        "Authorization": "Bearer new-access-token"
+                    },
+                    json={
+                        "client_name": "test-client",
+                        "scope": "diode:read diode:write",
+                    }
+                ),
+            ])
+
+

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_forms.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_forms.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+from unittest import mock
+
+from django.test import TestCase
+
+from netbox_diode_plugin.forms import SettingsForm
+from netbox_diode_plugin.models import Setting
+
+
+class SettingsFormTestCase(TestCase):
+    """Test case for the SettingsForm."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.setting = Setting.objects.create(
+            diode_target="grpc://localhost:8080/diode"
+        )
+
+    def test_form_initialization_with_override_allowed(self):
+        """Test form initialization when override is allowed."""
+        with mock.patch(
+            "netbox_diode_plugin.forms.get_plugin_config"
+        ) as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = None
+            form = SettingsForm(instance=self.setting)
+            mock_get_plugin_config.assert_called_with(
+                "netbox_diode_plugin", "diode_target_override"
+            )
+            self.assertFalse(form.fields["diode_target"].disabled)
+            self.assertNotIn(
+                "This field is not allowed to be modified.",
+                form.fields["diode_target"].help_text,
+            )
+
+    def test_form_initialization_with_diode_target_override(self):
+        """Test form initialization when override is disallowed."""
+        with mock.patch(
+            "netbox_diode_plugin.forms.get_plugin_config"
+        ) as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
+            form = SettingsForm(instance=self.setting)
+            mock_get_plugin_config.assert_called_with(
+                "netbox_diode_plugin", "diode_target_override"
+            )
+            self.assertTrue(form.fields["diode_target"].disabled)
+            self.assertEqual(
+                "This field is not allowed to be modified.",
+                form.fields["diode_target"].help_text,
+            )

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_generate_matching_docs.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests for generate_matching_docs command."""
+
+import io
+import sys
+from unittest import mock
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db.models import Q
+from django.test import TestCase
+
+from netbox_diode_plugin.api.matcher import AutoSlugMatcher, ObjectMatchCriteria
+from netbox_diode_plugin.management.commands.generate_matching_docs import (
+    Command,
+    MatcherInfo,
+)
+
+
+class MatcherInfoTestCase(TestCase):
+    """Test case for MatcherInfo dataclass."""
+
+    def test_matcher_info_creation(self):
+        """Test creating MatcherInfo with all fields."""
+        info = MatcherInfo(
+            name="test_matcher",
+            fields=["field1", "field2"],
+            condition="field1 is NOT NULL",
+            description="Test matcher description",
+            matcher_type="ObjectMatchCriteria",
+            version_constraints="≥4.3.0"
+        )
+
+        self.assertEqual(info.name, "test_matcher")
+        self.assertEqual(info.fields, ["field1", "field2"])
+        self.assertEqual(info.condition, "field1 is NOT NULL")
+        self.assertEqual(info.description, "Test matcher description")
+        self.assertEqual(info.matcher_type, "ObjectMatchCriteria")
+        self.assertEqual(info.version_constraints, "≥4.3.0")
+
+    def test_matcher_info_defaults(self):
+        """Test creating MatcherInfo with default values."""
+        info = MatcherInfo(name="test_matcher")
+
+        self.assertEqual(info.name, "test_matcher")
+        self.assertIsNone(info.fields)
+        self.assertIsNone(info.condition)
+        self.assertIsNone(info.description)
+        self.assertEqual(info.matcher_type, "ObjectMatchCriteria")
+        self.assertIsNone(info.version_constraints)
+
+
+class GenerateMatchingDocsCommandTestCase(TestCase):
+    """Test case for the generate_matching_docs command."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.command = Command()
+        self.command.stdout = io.StringIO()
+        self.command.stderr = io.StringIO()
+
+    def test_add_arguments(self):
+        """Test that the command accepts the --output argument."""
+        from django.core.management import get_commands
+        from django.core.management.base import BaseCommand
+
+        # Verify the command is registered
+        commands = get_commands()
+        self.assertIn('generate_matching_docs', commands)
+
+    def test_extract_condition_description_none(self):
+        """Test extracting condition description from None."""
+        result = self.command.extract_condition_description(None)
+        self.assertEqual(result, "None")
+
+    def test_extract_condition_description_simple(self):
+        """Test extracting condition description from a simple condition."""
+        condition = Q(field1__isnull=True)
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NULL")
+
+    def test_extract_condition_description_complex(self):
+        """Test extracting condition description from a complex condition."""
+        condition = Q(field1__isnull=True) & Q(field2="value")
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NULL AND field2 = value")
+
+    def test_extract_condition_description_or(self):
+        """Test extracting condition description with OR connector."""
+        condition = Q(field1="value1") | Q(field2="value2")
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 = value1 OR field2 = value2")
+
+    def test_extract_condition_description_not_null(self):
+        """Test extracting condition description for NOT NULL."""
+        condition = Q(field1__isnull=False)
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NOT NULL")
+
+    def test_get_matcher_description_ip_address_global(self):
+        """Test getting matcher description for IP address global matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_address_global_no_vrf"
+        mock_matcher.ip_fields = ["address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP address address in global namespace (no VRF)")
+
+    def test_get_matcher_description_ip_address_vrf(self):
+        """Test getting matcher description for IP address VRF matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_address_within_vrf"
+        mock_matcher.ip_fields = ["address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP address address within VRF")
+
+    def test_get_matcher_description_ip_range(self):
+        """Test getting matcher description for IP range matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_range_start_end_within_vrf"
+        mock_matcher.ip_fields = ["start_address", "end_address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP range start_address, end_address within VRF context")
+
+    def test_get_matcher_description_standard_fields(self):
+        """Test getting matcher description for standard field-based matcher."""
+        matcher = ObjectMatchCriteria(
+            fields=["name", "site"],
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
+
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: name, site")
+
+    def test_get_matcher_description_with_condition(self):
+        """Test getting matcher description for matcher with condition."""
+        matcher = ObjectMatchCriteria(
+            fields=["name", "site"],
+            name="test_matcher",
+            model_class=None,
+            condition=Q(site__isnull=False)
+        )
+
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: name, site where site is NOT NULL")
+
+    def test_get_matcher_description_custom(self):
+        """Test getting matcher description for custom matcher."""
+        matcher = ObjectMatchCriteria(
+            fields=None,
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
+
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Custom matcher")
+
+    def test_get_version_constraints_none(self):
+        """Test getting version constraints when none are set."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = None
+        mock_matcher.max_version = None
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertIsNone(result)
+
+    def test_get_version_constraints_min_only(self):
+        """Test getting version constraints with only min_version."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "4.3.0"
+        mock_matcher.max_version = None
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥4.3.0")
+
+    def test_get_version_constraints_max_only(self):
+        """Test getting version constraints with only max_version."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = None
+        mock_matcher.max_version = "4.2.99"
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≤4.2.99")
+
+    def test_get_version_constraints_both(self):
+        """Test getting version constraints with both min and max."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "4.3.0"
+        mock_matcher.max_version = "4.3.99"
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥4.3.0 ≤4.3.99")
+
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs._LOGICAL_MATCHERS')
+    def test_analyze_logical_matchers(self, mock_logical_matchers):
+        """Test analyzing logical matchers."""
+        # Create mock matchers
+        mock_matcher1 = mock.MagicMock()
+        mock_matcher1.name = "test_matcher_1"
+        mock_matcher1.fields = ["name"]
+        mock_matcher1.condition = None
+        mock_matcher1.min_version = "4.3.0"
+        mock_matcher1.max_version = None
+
+        mock_matcher2 = mock.MagicMock()
+        mock_matcher2.name = "test_matcher_2"
+        mock_matcher2.fields = ["name", "site"]
+        mock_matcher2.condition = Q(site__isnull=False)
+        mock_matcher2.min_version = None
+        mock_matcher2.max_version = "4.2.99"
+
+        # Mock the matcher factory
+        mock_logical_matchers.items.return_value = [
+            ("dcim.site", lambda: [mock_matcher1, mock_matcher2])
+        ]
+
+        result = self.command.analyze_logical_matchers()
+
+        self.assertIn("dcim.site", result)
+        self.assertEqual(len(result["dcim.site"]), 2)
+
+        # Check first matcher
+        matcher1_info = result["dcim.site"][0]
+        self.assertEqual(matcher1_info.name, "test_matcher_1")
+        self.assertEqual(matcher1_info.fields, ["name"])
+        self.assertEqual(matcher1_info.condition, "None")
+        self.assertEqual(matcher1_info.version_constraints, "≥4.3.0")
+        self.assertEqual(matcher1_info.matcher_source, "logical")
+
+        # Check second matcher
+        matcher2_info = result["dcim.site"][1]
+        self.assertEqual(matcher2_info.name, "test_matcher_2")
+        self.assertEqual(matcher2_info.fields, ["name", "site"])
+        self.assertEqual(matcher2_info.condition, "site is NOT NULL")
+        self.assertEqual(matcher2_info.version_constraints, "≤4.2.99")
+        self.assertEqual(matcher2_info.matcher_source, "logical")
+
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs.extract_supported_models')
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs.get_model_matchers')
+    def test_analyze_builtin_matchers(self, mock_get_model_matchers, mock_supported_models):
+        """Test analyzing builtin matchers."""
+        # Create mock model class
+        mock_model_class = mock.MagicMock()
+        mock_model_class.__name__ = "TestModel"
+
+        # Create mock builtin matchers
+        mock_unique_matcher = mock.MagicMock()
+        mock_unique_matcher.name = "unique_name"
+        mock_unique_matcher.fields = ["name"]
+        mock_unique_matcher.condition = None
+        mock_unique_matcher.min_version = None
+        mock_unique_matcher.max_version = None
+
+        mock_constraint_matcher = mock.MagicMock()
+        mock_constraint_matcher.name = "test_constraint"
+        mock_constraint_matcher.fields = ["field1", "field2"]
+        mock_constraint_matcher.condition = Q(field1__isnull=True)
+        mock_constraint_matcher.min_version = None
+        mock_constraint_matcher.max_version = None
+
+        # Mock logical matcher (should be skipped)
+        mock_logical_matcher = mock.MagicMock()
+        mock_logical_matcher.name = "logical_test"
+        mock_logical_matcher.fields = ["name"]
+        mock_logical_matcher.condition = None
+        mock_logical_matcher.min_version = None
+        mock_logical_matcher.max_version = None
+
+        # Mock the supported models and get_model_matchers
+        mock_supported_models.return_value = {
+            "dcim.site": {"model": mock_model_class}
+        }
+        mock_get_model_matchers.return_value = [
+            mock_unique_matcher,
+            mock_constraint_matcher,
+            mock_logical_matcher  # This should be skipped
+        ]
+
+        result = self.command.analyze_builtin_matchers()
+
+        self.assertIn("dcim.site", result)
+        self.assertEqual(len(result["dcim.site"]), 2)  # Should only include builtin matchers
+
+        # Check unique field matcher
+        unique_matcher_info = result["dcim.site"][0]
+        self.assertEqual(unique_matcher_info.name, "unique_name")
+        self.assertEqual(unique_matcher_info.fields, ["name"])
+        self.assertEqual(unique_matcher_info.matcher_source, "builtin")
+
+        # Check constraint matcher
+        constraint_matcher_info = result["dcim.site"][1]
+        self.assertEqual(constraint_matcher_info.name, "test_constraint")
+        self.assertEqual(constraint_matcher_info.fields, ["field1", "field2"])
+        self.assertEqual(constraint_matcher_info.matcher_source, "builtin")
+
+    def test_combine_matchers(self):
+        """Test combining logical and builtin matchers."""
+        # Create logical matchers
+        logical_matcher = MatcherInfo(
+            name="logical_test",
+            fields=["name"],
+            condition="N/A",
+            description="Logical matcher",
+            version_constraints="All versions",
+            matcher_source="logical"
+        )
+
+        # Create builtin matchers
+        builtin_matcher = MatcherInfo(
+            name="builtin_test",
+            fields=["name"],
+            condition="N/A",
+            description="Builtin matcher",
+            version_constraints="All versions",
+            matcher_source="builtin"
+        )
+
+        logical_docs = {
+            "dcim.site": [logical_matcher],
+            "dcim.device": [logical_matcher]
+        }
+
+        builtin_docs = {
+            "dcim.site": [builtin_matcher],
+            "ipam.prefix": [builtin_matcher]
+        }
+
+        result = self.command.combine_matchers(logical_docs, builtin_docs)
+
+        # Check that all object types are included
+        self.assertIn("dcim.site", result)
+        self.assertIn("dcim.device", result)
+        self.assertIn("ipam.prefix", result)
+
+        # Check that dcim.site has both logical and builtin matchers
+        site_matchers = result["dcim.site"]
+        self.assertEqual(len(site_matchers), 2)
+
+        # Check that logical matcher comes first (as it was added first)
+        self.assertEqual(site_matchers[0].name, "logical_test")
+        self.assertEqual(site_matchers[0].matcher_source, "logical")
+        self.assertEqual(site_matchers[1].name, "builtin_test")
+        self.assertEqual(site_matchers[1].matcher_source, "builtin")
+
+        # Check that other object types have correct matchers
+        self.assertEqual(len(result["dcim.device"]), 1)
+        self.assertEqual(result["dcim.device"][0].matcher_source, "logical")
+
+        self.assertEqual(len(result["ipam.prefix"]), 1)
+        self.assertEqual(result["ipam.prefix"][0].matcher_source, "builtin")
+
+    def test_get_matcher_description_builtin_types(self):
+        """Test getting matcher description for different builtin matcher types."""
+        # Test CustomFieldMatcher
+        mock_custom_field_matcher = mock.MagicMock()
+        mock_custom_field_matcher.custom_field = "test_field"
+        mock_custom_field_matcher.fields = None
+        mock_custom_field_matcher.ip_fields = None
+        mock_custom_field_matcher.vrf_field = None
+
+        result = self.command.get_matcher_description(mock_custom_field_matcher)
+        self.assertEqual(result, "Matches on unique custom field: test_field")
+
+    def test_get_matcher_description_autoslug(self):
+        """Test getting matcher description for AutoSlugMatcher."""
+        # Test AutoSlugMatcher
+        autoslug_matcher = AutoSlugMatcher(
+            name="test_autoslug",
+            model_class=None,
+            slug_field="slug"
+        )
+
+        result = self.command.get_matcher_description(autoslug_matcher)
+        self.assertEqual(result, "Matches on auto-generated slug field: slug")
+
+    def test_get_matcher_description_unique_field(self):
+        """Test getting matcher description for unique field matcher."""
+        # Test unique field matcher
+        mock_unique_matcher = mock.MagicMock()
+        mock_unique_matcher.name = "unique_name"
+        mock_unique_matcher.fields = ["name"]
+        mock_unique_matcher.ip_fields = None
+        mock_unique_matcher.vrf_field = None
+        mock_unique_matcher.custom_field = None
+        mock_unique_matcher.slug_field = None
+
+        result = self.command.get_matcher_description(mock_unique_matcher)
+        self.assertEqual(result, "Matches on unique field(s): name")
+
+    def test_get_matcher_description_unique_constraint(self):
+        """Test getting matcher description for unique constraint matcher."""
+        # Test unique constraint matcher
+        mock_constraint_matcher = mock.MagicMock()
+        mock_constraint_matcher.name = "test_constraint"
+        mock_constraint_matcher.fields = ["field1", "field2"]
+        mock_constraint_matcher.condition = None
+        mock_constraint_matcher.custom_field = None
+        mock_constraint_matcher.slug_field = None
+
+        result = self.command.get_matcher_description(mock_constraint_matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: field1, field2")
+
+    def test_generate_markdown_table_empty(self):
+        """Test generating markdown table with empty documentation."""
+        docs = {}
+        result = self.command.generate_markdown_table(docs)
+
+        expected_lines = [
+            "# NetBox Diode Plugin - Object Matching Criteria",
+            "",
+            "This document describes how the Diode NetBox Plugin matches existing objects when applying changes.",
+            ""
+        ]
+
+        for line in expected_lines:
+            self.assertIn(line, result)
+
+    def test_generate_markdown_table_with_matchers(self):
+        """Test generating markdown table with matchers."""
+        matcher_info1 = MatcherInfo(
+            name="test_matcher_1",
+            fields=["name"],
+            condition="N/A",
+            description="Test description 1",
+            version_constraints="All versions",
+            matcher_source="logical"
+        )
+
+        matcher_info2 = MatcherInfo(
+            name="test_matcher_2",
+            fields=["name", "site"],
+            condition="site is NOT NULL",
+            description="Test description 2",
+            version_constraints="≥4.3.0",
+            matcher_source="logical"
+        )
+
+        docs = {
+            "dcim.site": [matcher_info1, matcher_info2]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check header
+        self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", result)
+        self.assertIn("## dcim.site", result)
+
+        # Check table header
+        self.assertIn("| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |", result)
+        self.assertIn("|--------------|---------------------|------|--------|-----------|-------------|---------------------|", result)
+
+        # Check table rows
+        self.assertIn("| test_matcher_1 | 1 | logical | name | N/A | Test description 1 | All versions |", result)
+        self.assertIn("| test_matcher_2 | 2 | logical | name, site | site is NOT NULL | Test description 2 | ≥4.3.0 |", result)
+
+    def test_generate_markdown_table_with_pipe_escaping(self):
+        """Test generating markdown table with pipe character escaping."""
+        matcher_info = MatcherInfo(
+            name="test|matcher",
+            fields=["field|1", "field|2"],
+            condition="field|1 is NOT NULL",
+            description="Test|description",
+            version_constraints="≥4.3.0|test",
+            matcher_source="logical"
+        )
+
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check that pipe characters are escaped
+        self.assertIn(
+            "| test\\|matcher | 1 | logical | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |",
+            result,
+        )
+
+    def test_generate_markdown_table_no_matchers(self):
+        """Test generating markdown table for object type with no matchers."""
+        docs = {
+            "dcim.site": []
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        self.assertIn("## dcim.site", result)
+        self.assertIn("No specific matching criteria defined.", result)
+
+    def test_generate_markdown_table_sorted_object_types(self):
+        """Test that object types are sorted in the output."""
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=["name"],
+            condition="N/A",
+            description="Test description",
+            version_constraints="All versions"
+        )
+
+        docs = {
+            "dcim.device": [matcher_info],
+            "dcim.site": [matcher_info],
+            "ipam.prefix": [matcher_info]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check that sections appear in alphabetical order
+        site_index = result.find("## dcim.site")
+        device_index = result.find("## dcim.device")
+        prefix_index = result.find("## ipam.prefix")
+
+        self.assertLess(device_index, site_index)
+        self.assertLess(site_index, prefix_index)
+
+    def test_condition_extraction_with_none_Q_condition(self):
+        """Test edge cases in condition extraction."""
+        # Test with non-Q condition
+        condition = "simple_string_condition"
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "simple_string_condition")
+
+    def test_condition_extraction_with_Q_condition_with_no_children(self):
+        """Test with Q condition that has no children."""
+        condition = Q()
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "")
+
+    def test_condition_extraction_with_Q_condition_with_children(self):
+        """Test with complex nested condition."""
+        condition = Q(field1__isnull=True) & (Q(field2="value1") | Q(field2="value2"))
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NULL AND (OR: ('field2', 'value1'), ('field2', 'value2'))")
+
+    def test_matcher_description_edge_cases(self):
+        """Test edge cases in matcher description generation."""
+        # Test with matcher that has fields but no condition
+        matcher = ObjectMatchCriteria(
+            fields=["name"],
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
+
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: name")
+
+        # Test with matcher that has condition but no fields
+        matcher = ObjectMatchCriteria(
+            fields=None,
+            name="test_matcher",
+            model_class=None,
+            condition=Q(field1__isnull=True)
+        )
+
+        with mock.patch.object(self.command, 'extract_condition_description') as mock_extract:
+            mock_extract.return_value = "field1 is NULL"
+            result = self.command.get_matcher_description(matcher)
+
+        self.assertEqual(result, "Custom matcher")
+
+    def test_version_constraints_edge_cases(self):
+        """Test edge cases in version constraints."""
+        # Test with empty string versions
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = ""
+        mock_matcher.max_version = ""
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, None)
+
+        # Test with whitespace versions
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "  4.3.0  "
+        mock_matcher.max_version = "  4.3.99  "
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥  4.3.0   ≤  4.3.99  ")
+
+    def test_markdown_table_with_empty_values(self):
+        """Test edge cases in markdown table generation."""
+        # Test with None values
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=None,
+            condition=None,
+            description=None,
+            version_constraints=None,
+            matcher_source="logical"
+        )
+
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check that None values are handled gracefully
+        self.assertIn("| test_matcher | 1 | logical |  | N/A | N/A | All versions |", result)
+
+    def test_markdown_table_with_empty_fields(self):
+        """Test with empty fields list."""
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=[],
+            condition="N/A",
+            description="Test description",
+            version_constraints="All versions",
+            matcher_source="logical"
+        )
+
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check that empty fields list is handled
+        self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_matcher_cache.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_matcher_cache.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Matcher Cache Tests."""
+
+from unittest import mock
+
+from dcim.models import Manufacturer
+from django.core.cache import cache as django_cache
+from django.test import TestCase
+
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.matcher import (
+    _find_obj_cache_key,
+    _find_obj_rev_key,
+    find_existing_object,
+    invalidate_find_obj_entry,
+)
+
+
+class FindObjCacheKeyTestCase(TestCase):
+    """Tests for _find_obj_cache_key."""
+
+    def setUp(self):
+        """Clear cache before each test."""
+        django_cache.clear()
+
+    def tearDown(self):
+        """Clear cache after each test."""
+        django_cache.clear()
+
+    def test_simple_scalar_fields(self):
+        """Cache key is generated for data with simple scalar fields."""
+        data = {"name": "Cisco", "_object_type": "dcim.manufacturer", "_uuid": "abc"}
+        key = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertIsNotNone(key)
+        self.assertTrue(key.startswith("diode:fobj:"))
+
+    def test_deterministic(self):
+        """Same data produces same cache key."""
+        data = {"name": "Cisco", "_object_type": "dcim.manufacturer"}
+        key1 = _find_obj_cache_key(data, "dcim.manufacturer")
+        key2 = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertEqual(key1, key2)
+
+    def test_different_data_different_keys(self):
+        """Different data produces different cache keys."""
+        key1 = _find_obj_cache_key({"name": "Cisco"}, "dcim.manufacturer")
+        key2 = _find_obj_cache_key({"name": "Juniper"}, "dcim.manufacturer")
+        self.assertNotEqual(key1, key2)
+
+    def test_different_object_type_different_keys(self):
+        """Same data with different object types produces different cache keys."""
+        data = {"name": "test"}
+        key1 = _find_obj_cache_key(data, "dcim.manufacturer")
+        key2 = _find_obj_cache_key(data, "dcim.site")
+        self.assertNotEqual(key1, key2)
+
+    def test_skips_underscore_prefixed_fields(self):
+        """Fields starting with _ are excluded from cache key."""
+        data1 = {"name": "Cisco", "_object_type": "dcim.manufacturer", "_uuid": "abc"}
+        data2 = {"name": "Cisco", "_object_type": "dcim.manufacturer", "_uuid": "xyz"}
+        key1 = _find_obj_cache_key(data1, "dcim.manufacturer")
+        key2 = _find_obj_cache_key(data2, "dcim.manufacturer")
+        self.assertEqual(key1, key2)
+
+    def test_skips_dicts_and_lists(self):
+        """Dicts and lists are skipped, not rejected."""
+        data_with_list = {"name": "DC-1", "tags": [1, 2, 3]}
+        data_without_list = {"name": "DC-1"}
+        key1 = _find_obj_cache_key(data_with_list, "dcim.site")
+        key2 = _find_obj_cache_key(data_without_list, "dcim.site")
+        self.assertIsNotNone(key1)
+        self.assertEqual(key1, key2)
+
+    def test_unresolved_reference_encoded(self):
+        """UnresolvedReferences are encoded deterministically."""
+        ref = UnresolvedReference("dcim.site", "uuid-123")
+        data = {"name": "device-1", "site_id": ref}
+        key = _find_obj_cache_key(data, "dcim.device")
+        self.assertIsNotNone(key)
+
+    def test_unresolved_reference_same_type_same_key(self):
+        """Different UUIDs for same object type produce the same key."""
+        data1 = {"name": "device-1", "site_id": UnresolvedReference("dcim.site", "uuid-1")}
+        data2 = {"name": "device-1", "site_id": UnresolvedReference("dcim.site", "uuid-2")}
+        key1 = _find_obj_cache_key(data1, "dcim.device")
+        key2 = _find_obj_cache_key(data2, "dcim.device")
+        self.assertEqual(key1, key2)
+
+    def test_unresolved_reference_different_type_different_key(self):
+        """Different unresolved object types produce different keys."""
+        data1 = {"name": "x", "ref_id": UnresolvedReference("dcim.site", "uuid-1")}
+        data2 = {"name": "x", "ref_id": UnresolvedReference("dcim.region", "uuid-1")}
+        key1 = _find_obj_cache_key(data1, "dcim.device")
+        key2 = _find_obj_cache_key(data2, "dcim.device")
+        self.assertNotEqual(key1, key2)
+
+    def test_empty_items_returns_none(self):
+        """Returns None when no cacheable fields exist."""
+        data = {"_uuid": "abc", "_object_type": "dcim.site"}
+        key = _find_obj_cache_key(data, "dcim.site")
+        self.assertIsNone(key)
+
+    def test_only_complex_fields_returns_none(self):
+        """Returns None when only dicts/lists remain after filtering."""
+        data = {"tags": [1, 2], "metadata": {"a": 1}, "_uuid": "abc"}
+        key = _find_obj_cache_key(data, "dcim.site")
+        self.assertIsNone(key)
+
+
+class FindExistingObjectCacheTestCase(TestCase):
+    """Tests for find_existing_object caching behavior."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.manufacturer = Manufacturer.objects.create(
+            name="CacheTestManufacturer",
+            slug="cache-test-manufacturer",
+        )
+        django_cache.clear()
+
+    def tearDown(self):
+        """Clean up cache after each test."""
+        django_cache.clear()
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_cache_miss_populates_cache_on_found(self, _mock_ttl):
+        """First lookup misses cache, finds object, and populates cache."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+
+        self.assertIsNone(django_cache.get(cache_key))
+
+        result = find_existing_object(data, "dcim.manufacturer")
+        self.assertEqual(result.id, self.manufacturer.id)
+
+        # Lookup cache should contain the PK
+        self.assertEqual(django_cache.get(cache_key), self.manufacturer.id)
+
+        # Reverse index should point back to the lookup key
+        rev_key = f"diode:fobj:rev:dcim.manufacturer:{self.manufacturer.id}"
+        self.assertEqual(django_cache.get(rev_key), cache_key)
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_not_found_is_not_cached(self, _mock_ttl):
+        """Not-found results are not cached."""
+        data = {"name": "NonExistent", "_object_type": "dcim.manufacturer"}
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+
+        result = find_existing_object(data, "dcim.manufacturer")
+        self.assertIsNone(result)
+        self.assertIsNone(django_cache.get(cache_key))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_cache_hit_returns_found_object(self, _mock_ttl):
+        """Second lookup hits cache and returns object via PK."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # First call populates cache
+        result1 = find_existing_object(data, "dcim.manufacturer")
+        self.assertEqual(result1.id, self.manufacturer.id)
+
+        # Second call should hit cache
+        with mock.patch(
+            "netbox_diode_plugin.api.matcher.get_model_matchers"
+        ) as mock_matchers:
+            result2 = find_existing_object(data, "dcim.manufacturer")
+            self.assertEqual(result2.id, self.manufacturer.id)
+            mock_matchers.assert_not_called()
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_stale_cache_object_deleted(self, _mock_ttl):
+        """Cached PK for a deleted object falls through to full matcher lookup."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # Populate cache
+        find_existing_object(data, "dcim.manufacturer")
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertEqual(django_cache.get(cache_key), self.manufacturer.id)
+
+        # Delete the object
+        self.manufacturer.delete()
+
+        # Should fall through to matchers, find nothing
+        result = find_existing_object(data, "dcim.manufacturer")
+        self.assertIsNone(result)
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=0,
+    )
+    def test_cache_disabled_when_ttl_zero(self, _mock_ttl):
+        """Cache is bypassed when TTL is 0."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+
+        result = find_existing_object(data, "dcim.manufacturer")
+        self.assertEqual(result.id, self.manufacturer.id)
+        self.assertIsNone(django_cache.get(cache_key))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_deletes_cached_entry(self, _mock_ttl):
+        """Invalidating by PK deletes both lookup and reverse cache entries."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # Populate cache
+        find_existing_object(data, "dcim.manufacturer")
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+        rev_key = f"diode:fobj:rev:dcim.manufacturer:{self.manufacturer.id}"
+        self.assertIsNotNone(django_cache.get(cache_key))
+        self.assertIsNotNone(django_cache.get(rev_key))
+
+        # Invalidate
+        invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+
+        # Both entries should be gone
+        self.assertIsNone(django_cache.get(cache_key))
+        self.assertIsNone(django_cache.get(rev_key))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_causes_cache_miss_on_next_lookup(self, _mock_ttl):
+        """After invalidation, next lookup goes through matchers."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # Populate cache
+        find_existing_object(data, "dcim.manufacturer")
+
+        # Invalidate
+        invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+
+        # Next lookup should miss cache and go through matchers
+        with mock.patch(
+            "netbox_diode_plugin.api.matcher.get_model_matchers",
+            wraps=__import__(
+                "netbox_diode_plugin.api.matcher", fromlist=["get_model_matchers"]
+            ).get_model_matchers,
+        ) as mock_matchers:
+            result = find_existing_object(data, "dcim.manufacturer")
+            self.assertEqual(result.id, self.manufacturer.id)
+            mock_matchers.assert_called_once()
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_noop_for_uncached_pk(self, _mock_ttl):
+        """Invalidating a PK that was never cached is a no-op."""
+        # Should not raise
+        invalidate_find_obj_entry("dcim.manufacturer", 999999)
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_does_not_affect_other_entries(self, _mock_ttl):
+        """Invalidating one object does not affect other cached objects."""
+        other_mfr = Manufacturer.objects.create(
+            name="OtherManufacturer",
+            slug="other-manufacturer",
+        )
+        data_main = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+        data_other = {"name": "OtherManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # Populate cache for both
+        find_existing_object(data_main, "dcim.manufacturer")
+        find_existing_object(data_other, "dcim.manufacturer")
+
+        # Invalidate only the main one
+        invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+
+        # Other should still be cached
+        cache_key_other = _find_obj_cache_key(data_other, "dcim.manufacturer")
+        self.assertEqual(django_cache.get(cache_key_other), other_mfr.id)
+
+        # Main should be gone
+        cache_key_main = _find_obj_cache_key(data_main, "dcim.manufacturer")
+        self.assertIsNone(django_cache.get(cache_key_main))
+
+
+BRANCH_SCHEMA_MOCK = "netbox_diode_plugin.api.matcher._get_active_branch_schema"
+
+
+class BranchAwareCacheKeyTestCase(TestCase):
+    """Tests that cache keys are isolated per branch."""
+
+    def setUp(self):
+        """Clear cache before each test."""
+        django_cache.clear()
+
+    def tearDown(self):
+        """Clear cache after each test."""
+        django_cache.clear()
+
+    def test_different_branch_different_cache_key(self):
+        """Same data under different branches produces different cache keys."""
+        data = {"name": "Cisco"}
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            key_a = _find_obj_cache_key(data, "dcim.manufacturer")
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_b"):
+            key_b = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertNotEqual(key_a, key_b)
+
+    def test_same_branch_same_cache_key(self):
+        """Same data under the same branch produces identical cache keys."""
+        data = {"name": "Cisco"}
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            key1 = _find_obj_cache_key(data, "dcim.manufacturer")
+            key2 = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertEqual(key1, key2)
+
+    def test_no_branch_unchanged_from_legacy_format(self):
+        """Without active branch, cache key matches the original format."""
+        data = {"name": "Cisco"}
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            key = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertTrue(key.startswith("diode:fobj:"))
+
+    def test_branch_vs_no_branch_different_keys(self):
+        """A branched key differs from a non-branched key for the same data."""
+        data = {"name": "Cisco"}
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            key_main = _find_obj_cache_key(data, "dcim.manufacturer")
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            key_branch = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertNotEqual(key_main, key_branch)
+
+    def test_different_branch_different_rev_key(self):
+        """Reverse-index keys are isolated per branch."""
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            rev_a = _find_obj_rev_key("dcim.manufacturer", 100)
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_b"):
+            rev_b = _find_obj_rev_key("dcim.manufacturer", 100)
+        self.assertNotEqual(rev_a, rev_b)
+        self.assertIn("branch_a", rev_a)
+        self.assertIn("branch_b", rev_b)
+
+    def test_no_branch_rev_key_unchanged(self):
+        """Without active branch, rev key matches the original format."""
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            rev = _find_obj_rev_key("dcim.manufacturer", 100)
+        self.assertEqual(rev, "diode:fobj:rev:dcim.manufacturer:100")
+
+
+class BranchAwareFindExistingObjectTestCase(TestCase):
+    """Tests that find_existing_object cache does not cross branches."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.manufacturer = Manufacturer.objects.create(
+            name="BranchTestMfr",
+            slug="branch-test-mfr",
+        )
+        django_cache.clear()
+
+    def tearDown(self):
+        """Clean up cache after each test."""
+        django_cache.clear()
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_cache_does_not_cross_branches(self, _mock_ttl):
+        """Cache populated under branch A is a miss under branch B."""
+        data = {"name": "BranchTestMfr", "_object_type": "dcim.manufacturer"}
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            result_a = find_existing_object(data, "dcim.manufacturer")
+            self.assertEqual(result_a.id, self.manufacturer.id)
+            cache_key_a = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNotNone(django_cache.get(cache_key_a))
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_b"):
+            cache_key_b = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNone(django_cache.get(cache_key_b))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_does_not_cross_branches(self, _mock_ttl):
+        """Invalidation under branch B does not evict branch A's cache."""
+        data = {"name": "BranchTestMfr", "_object_type": "dcim.manufacturer"}
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            find_existing_object(data, "dcim.manufacturer")
+            cache_key_a = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNotNone(django_cache.get(cache_key_a))
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_b"):
+            invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            self.assertIsNotNone(django_cache.get(cache_key_a))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_within_same_branch(self, _mock_ttl):
+        """Invalidation under the same branch correctly evicts cache."""
+        data = {"name": "BranchTestMfr", "_object_type": "dcim.manufacturer"}
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            find_existing_object(data, "dcim.manufacturer")
+            cache_key_a = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNotNone(django_cache.get(cache_key_a))
+            invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+            self.assertIsNone(django_cache.get(cache_key_a))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_branch_and_main_caches_independent(self, _mock_ttl):
+        """Cache entries for main (no branch) and a branch are independent."""
+        data = {"name": "BranchTestMfr", "_object_type": "dcim.manufacturer"}
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            find_existing_object(data, "dcim.manufacturer")
+            cache_key_main = _find_obj_cache_key(data, "dcim.manufacturer")
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            cache_key_branch = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNone(django_cache.get(cache_key_branch))
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            self.assertIsNotNone(django_cache.get(cache_key_main))

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_models.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_models.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+from unittest import mock
+
+from django.apps import apps
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from netbox_diode_plugin.models import Setting
+
+
+class SettingModelTestCase(TestCase):
+    """Test case for the models."""
+
+    def test_validators(self):
+        """Check Setting model field validators are functional."""
+        setting = Setting(diode_target="http://localhost:8080")
+
+        with self.assertRaises(ValidationError):
+            setting.clean_fields()
+
+    def test_str(self):
+        """Check Setting model string representation."""
+        setting = Setting(diode_target="http://localhost:8080")
+        self.assertEqual(str(setting), "")
+
+    def test_absolute_url(self):
+        """Check Setting model absolute URL."""
+        setting = Setting()
+        self.assertEqual(setting.get_absolute_url(), "/netbox/plugins/diode/settings/")
+
+    def test_branch_id_field_exists(self):
+        """Check Setting model has branch_id field."""
+        setting = Setting(diode_target="grpc://localhost:8080/diode")
+        self.assertIsNone(setting.branch_id)
+
+        # Set branch_id
+        setting.branch_id = 123
+        self.assertEqual(setting.branch_id, 123)
+
+    def test_branch_property_returns_none_when_no_branch_id(self):
+        """Check branch property returns None when branch_id is not set."""
+        setting = Setting(diode_target="grpc://localhost:8080/diode")
+        self.assertIsNone(setting.branch)
+
+    def test_branch_property_returns_none_when_plugin_not_installed(self):
+        """Check branch property returns None when branching plugin is not installed."""
+        setting = Setting(diode_target="grpc://localhost:8080/diode", branch_id=123)
+
+        # Mock the import to simulate plugin not being available
+        with mock.patch.dict('sys.modules', {'netbox_branching.models': None}):
+            self.assertIsNone(setting.branch)
+
+    def test_branch_property_returns_branch_when_available(self):
+        """Check branch property returns Branch object when available."""
+        if not apps.is_installed("netbox_branching"):
+            self.skipTest("netbox_branching plugin not installed")
+
+        from netbox_branching.models import Branch
+
+        # Create a test branch
+        branch = Branch.objects.create(name="test-branch")
+
+        setting = Setting(diode_target="grpc://localhost:8080/diode", branch_id=branch.id)
+
+        # Check branch property returns the correct branch
+        self.assertEqual(setting.branch.id, branch.id)
+        self.assertEqual(setting.branch.name, "test-branch")
+
+        # Clean up
+        branch.delete()
+
+    def test_branch_setter(self):
+        """Check branch setter updates branch_id."""
+        if not apps.is_installed("netbox_branching"):
+            self.skipTest("netbox_branching plugin not installed")
+
+        from netbox_branching.models import Branch
+
+        # Create a test branch
+        branch = Branch.objects.create(name="test-branch-setter")
+
+        setting = Setting(diode_target="grpc://localhost:8080/diode")
+
+        # Use setter to assign branch
+        setting.branch = branch
+        self.assertEqual(setting.branch_id, branch.id)
+
+        # Set to None
+        setting.branch = None
+        self.assertIsNone(setting.branch_id)
+
+        # Clean up
+        branch.delete()
+
+    def test_branch_schema_id_property(self):
+        """Check branch_schema_id property returns schema_id when branch is set."""
+        if not apps.is_installed("netbox_branching"):
+            self.skipTest("netbox_branching plugin not installed")
+
+        from netbox_branching.models import Branch
+
+        # Create a test branch
+        branch = Branch.objects.create(name="test-branch-schema")
+
+        setting = Setting(diode_target="grpc://localhost:8080/diode", branch_id=branch.id)
+
+        # Check branch_schema_id returns the schema_id
+        self.assertEqual(setting.branch_schema_id, branch.schema_id)
+
+        # Check it returns None when no branch
+        setting.branch_id = None
+        self.assertIsNone(setting.branch_schema_id)
+
+        # Clean up
+        branch.delete()

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_plugin_config.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_plugin_config.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from netbox_diode_plugin.plugin_config import _parse_diode_target, get_diode_auth_introspect_url, get_diode_user
+
+User = get_user_model()
+
+
+class PluginConfigTestCase(TestCase):
+    """Test case for plugin config helpers."""
+
+    def test_get_diode_auth_introspect_url(self):
+        """Test get_diode_auth_introspect_url function."""
+        expected = "http://localhost:8080/diode/auth/introspect"
+        self.assertEqual(get_diode_auth_introspect_url(), expected)
+
+    def test_get_diode_user(self):
+        """Test get_diode_user function."""
+        diode_user = get_diode_user()
+        expected_diode_user = User.objects.get(username="diode")
+        self.assertEqual(diode_user, expected_diode_user)
+
+    def test__parse_diode_target_handles_ftp_prefix(self):
+        """Check that _parse_diode_target raises an error when the target contains ftp://."""
+        with pytest.raises(ValueError):
+            _parse_diode_target("ftp://localhost:8081")
+
+    def test__parse_diode_target_parses_authority_correctly(self):
+        """Check that _parse_diode_target parses the authority correctly."""
+        authority, path, tls_verify = _parse_diode_target("grpc://localhost:8081")
+        assert authority == "localhost:8081"
+        assert path == ""
+        assert tls_verify is False
+
+    def test__parse_diode_target_adds_default_port_if_missing(self):
+        """Check that _parse_diode_target adds the default port if missing."""
+        authority, _, _ = _parse_diode_target("grpc://localhost")
+        assert authority == "localhost:80"
+        authority, _, _ = _parse_diode_target("http://localhost")
+        assert authority == "localhost:80"
+        authority, _, _ = _parse_diode_target("grpcs://localhost")
+        assert authority == "localhost:443"
+        authority, _, _ = _parse_diode_target("https://localhost")
+        assert authority == "localhost:443"
+
+    def test__parse_diode_target_parses_path_correctly(self):
+        """Check that _parse_diode_target parses the path correctly."""
+        _, path, _ = _parse_diode_target("grpc://localhost:8081/my/path")
+        assert path == "/my/path"
+
+    def test__parse_diode_target_handles_no_path(self):
+        """Check that _parse_diode_target handles no path."""
+        _, path, _ = _parse_diode_target("grpc://localhost:8081")
+        assert path == ""
+
+    def test__parse_diode_target_parses_tls_verify_correctly(self):
+        """Check that _parse_diode_target parses tls_verify correctly."""
+        _, _, tls_verify = _parse_diode_target("grpc://localhost:8081")
+        assert tls_verify is False
+        _, _, tls_verify = _parse_diode_target("http://localhost:8081")
+        assert tls_verify is False
+        _, _, tls_verify = _parse_diode_target("grpcs://localhost:8081")
+        assert tls_verify is True
+        _, _, tls_verify = _parse_diode_target("https://localhost:8081")
+        assert tls_verify is True

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_updates.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_updates.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Diode NetBox Plugin - Tests."""
+
+import inspect
+import json
+import logging
+import os
+from types import SimpleNamespace
+from unittest import mock
+
+from django.db.models import QuerySet
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.common import harmonize_formats
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+def _harmonize_formats(data):
+    data = harmonize_formats(data)
+    return _tuples_to_lists(data)
+
+def _tuples_to_lists(data):
+    if isinstance(data, tuple | list):
+        return [_tuples_to_lists(d) for d in data]
+    if isinstance(data, dict):
+        return {k: _tuples_to_lists(v) for k, v in data.items()}
+    return data
+
+def load_test_cases(cls):
+    """Class decorator to load test cases and create test methods."""
+    logger.debug("Loading apply updates test cases")
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    test_data_path = os.path.join(current_dir, "test_updates_cases.json")
+
+    if not os.path.exists(test_data_path):
+        raise FileNotFoundError(f"Test data file not found at {test_data_path}")
+
+    def _create_and_update_test_case(case):
+        object_type = case["object_type"]
+
+        def test_func(self):
+            model = get_object_type_model(object_type)
+
+            payload = {
+                "timestamp": 1,
+                "object_type": object_type,
+                "entity": case["create"],
+            }
+            res = self.send_request(self.diff_url, payload)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+            diff = res.json().get("change_set", {})
+            res = self.client.post(
+                self.apply_url, data=diff, format="json", **self.authorization_header
+            )
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+            # lookup the object and check fields
+            obj = model.objects.get(**case["lookup"])
+            self._check_expect(obj, case["create_expect"])
+
+            # resending the same payload should not change anything
+            payload = {
+                "timestamp": 2,
+                "object_type": object_type,
+                "entity": case["create"],
+            }
+            res = self.send_request(self.diff_url, payload)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+            change_set = res.json().get("change_set", {})
+            if change_set.get("changes", []) != []:
+                logger.error(f"Unexpected change set {json.dumps(change_set, indent=4)}")
+
+            self.assertEqual(res.json().get("change_set", {}).get("changes", []), [])
+
+            # updating the object
+            payload = {
+                "timestamp": 3,
+                "object_type": object_type,
+                "entity": case["update"],
+            }
+            res = self.send_request(self.diff_url, payload)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+            diff = res.json().get("change_set", {})
+            res = self.client.post(
+                self.apply_url, data=diff, format="json", **self.authorization_header
+            )
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+            obj = model.objects.get(**case["lookup"])
+            self._check_expect(obj, case["update_expect"])
+
+        test_func.__name__ = f"test_updates_{case['name']}"
+        return test_func
+
+    with open(test_data_path) as f:
+        test_cases = json.load(f)
+        for case in test_cases:
+            t = _create_and_update_test_case(case)
+            logger.debug(f"Creating test case {t.__name__}")
+            setattr(cls, t.__name__, t)
+
+    return cls
+
+@load_test_cases
+class ApplyUpdatesTestCase(APITestCase):
+    """diff/create/update test cases."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test cases."""
+        super().setUpClass()
+
+    def setUp(self):
+        """Set up the test case."""
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def _follow_path(self, obj, path):
+        cur = obj
+        for i, p in enumerate(path):
+            if p.isdigit():
+                p = int(p)
+                cur = cur[p]
+            else:
+                cur = getattr(cur, p)
+            if i != len(path) - 1:
+                self.assertIsNotNone(cur)
+            if callable(cur):
+                try:
+                    signature = inspect.signature(cur)
+                    if len(signature.parameters) == 0:
+                        cur = cur()
+                except ValueError:
+                    pass
+            if isinstance(cur, QuerySet):
+                cur = list(cur)
+        return cur
+
+    def _check_set_by(self, obj, path, value):
+        key = path[-1][len("__by_"):]
+        path = path[:-1]
+        cur = self._follow_path(obj, path)
+
+        if isinstance(value, list | tuple):
+            vals = set(value)
+        else:
+            vals = {value}
+
+        cvals = {_harmonize_formats(getattr(c, key)) for c in cur}
+        self.assertEqual(cvals, vals)
+
+    def _check_equals(self, obj, path, value):
+        cur = self._follow_path(obj, path)
+        cur = _harmonize_formats(cur)
+        self.assertEqual(cur, value)
+
+    def _check_expect(self, obj, expect):
+        for field, value in expect.items():
+            path = field.strip().split(".")
+            if path[-1].startswith("__by_"):
+                self._check_set_by(obj, path, value)
+            else:
+                self._check_equals(obj, path, value)
+
+    def send_request(self, url, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
@@ -6224,5 +6224,257 @@
         "update_expect": {
             "description": "Device with owner updated"
         }
+    },
+    {
+        "name": "dcim_cablebundle_1",
+        "object_type": "dcim.cablebundle",
+        "lookup": {"name": "Bundle 1"},
+        "create_expect": {
+            "name": "Bundle 1",
+            "description": "Primary fiber bundle",
+            "comments": "Routed through riser A"
+        },
+        "create": {
+            "cable_bundle": {
+                "name": "Bundle 1",
+                "description": "Primary fiber bundle",
+                "comments": "Routed through riser A",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "cable_bundle": {
+                "name": "Bundle 1",
+                "description": "Primary fiber bundle Updated",
+                "comments": "Routed through riser A and B",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary fiber bundle Updated",
+            "comments": "Routed through riser A and B"
+        }
+    },
+    {
+        "name": "dcim_rackgroup_1",
+        "object_type": "dcim.rackgroup",
+        "lookup": {"slug": "rack-group-1"},
+        "create_expect": {
+            "name": "Rack Group 1",
+            "slug": "rack-group-1",
+            "description": "Primary rack group"
+        },
+        "create": {
+            "rack_group": {
+                "name": "Rack Group 1",
+                "slug": "rack-group-1",
+                "description": "Primary rack group",
+                "comments": "Top of data center",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "rack_group": {
+                "name": "Rack Group 1",
+                "slug": "rack-group-1",
+                "description": "Primary rack group Updated",
+                "comments": "Top of data center",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary rack group Updated"
+        }
+    },
+    {
+        "name": "virtualization_virtualmachinetype_1",
+        "object_type": "virtualization.virtualmachinetype",
+        "lookup": {"slug": "vm-type-1"},
+        "create_expect": {
+            "name": "VM Type 1",
+            "slug": "vm-type-1",
+            "description": "Standard 4GB VM profile",
+            "default_memory": 4096
+        },
+        "create": {
+            "virtual_machine_type": {
+                "name": "VM Type 1",
+                "slug": "vm-type-1",
+                "description": "Standard 4GB VM profile",
+                "default_memory": "4096",
+                "default_vcpus": 2.0,
+                "default_platform": {
+                    "name": "Ubuntu 22.04",
+                    "slug": "ubuntu-22-04"
+                },
+                "comments": "General purpose template",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "virtual_machine_type": {
+                "name": "VM Type 1",
+                "slug": "vm-type-1",
+                "description": "Standard 4GB VM profile",
+                "default_memory": "8192",
+                "default_vcpus": 2.0,
+                "default_platform": {
+                    "name": "Ubuntu 22.04",
+                    "slug": "ubuntu-22-04"
+                },
+                "comments": "General purpose template",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "default_memory": 8192
+        }
+    },
+    {
+        "name": "dcim_rack_with_group_1",
+        "object_type": "dcim.rack",
+        "lookup": {"asset_tag": "RACK-010"},
+        "create_expect": {
+            "name": "Rack With Group",
+            "site.name": "Site 1",
+            "group.name": "Rack Group A",
+            "description": "Rack assigned to Group A"
+        },
+        "create": {
+            "rack": {
+                "name": "Rack With Group",
+                "facility_id": "FAC-010",
+                "site": {"name": "Site 1"},
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": {
+                    "name": "Server Rack",
+                    "slug": "server-rack",
+                    "color": "0000ff"
+                },
+                "group": {
+                    "name": "Rack Group A",
+                    "slug": "rack-group-a"
+                },
+                "serial": "RACK010XYZ",
+                "asset_tag": "RACK-010",
+                "rack_type": {
+                    "manufacturer": {"name": "Manufacturer 1"},
+                    "model": "R2000",
+                    "slug": "r2000",
+                    "form_factor": "4-post-cabinet"
+                },
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "airflow": "front-to-rear",
+                "description": "Rack assigned to Group A",
+                "comments": "First rack in group A",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "rack": {
+                "name": "Rack With Group",
+                "facility_id": "FAC-010",
+                "site": {"name": "Site 1"},
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": {
+                    "name": "Server Rack",
+                    "slug": "server-rack",
+                    "color": "0000ff"
+                },
+                "group": {
+                    "name": "Rack Group B",
+                    "slug": "rack-group-b"
+                },
+                "serial": "RACK010XYZ",
+                "asset_tag": "RACK-010",
+                "rack_type": {
+                    "manufacturer": {"name": "Manufacturer 1"},
+                    "model": "R2000",
+                    "slug": "r2000",
+                    "form_factor": "4-post-cabinet"
+                },
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "airflow": "front-to-rear",
+                "description": "Rack assigned to Group A",
+                "comments": "First rack in group A",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "group.name": "Rack Group B"
+        }
+    },
+    {
+        "name": "virtualization_virtualmachine_with_type_1",
+        "object_type": "virtualization.virtualmachine",
+        "lookup": {"name": "vm-with-type-01"},
+        "create_expect": {
+            "name": "vm-with-type-01",
+            "virtual_machine_type.name": "VM Type A",
+            "description": "VM with a virtual_machine_type"
+        },
+        "create": {
+            "virtual_machine": {
+                "name": "vm-with-type-01",
+                "status": "active",
+                "site": {"name": "Site 1"},
+                "cluster": {
+                    "name": "Cluster 1",
+                    "type": {"name": "Cluster Type 1"},
+                    "scope_site": {"name": "Site 1"}
+                },
+                "role": {"name": "Application Server"},
+                "tenant": {"name": "Tenant 1"},
+                "virtual_machine_type": {
+                    "name": "VM Type A",
+                    "slug": "vm-type-a",
+                    "description": "Type A profile"
+                },
+                "vcpus": 4.0,
+                "memory": "8192",
+                "disk": "100",
+                "description": "VM with a virtual_machine_type",
+                "comments": "Linked to VM Type A",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "virtual_machine": {
+                "name": "vm-with-type-01",
+                "status": "active",
+                "site": {"name": "Site 1"},
+                "cluster": {
+                    "name": "Cluster 1",
+                    "type": {"name": "Cluster Type 1"},
+                    "scope_site": {"name": "Site 1"}
+                },
+                "role": {"name": "Application Server"},
+                "tenant": {"name": "Tenant 1"},
+                "virtual_machine_type": {
+                    "name": "VM Type B",
+                    "slug": "vm-type-b",
+                    "description": "Type B profile"
+                },
+                "vcpus": 4.0,
+                "memory": "8192",
+                "disk": "100",
+                "description": "VM with a virtual_machine_type",
+                "comments": "Linked to VM Type A",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "virtual_machine_type.name": "VM Type B"
+        }
     }
 ]

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
@@ -1,0 +1,6228 @@
+[
+    {
+        "name": "ipam_asn_1",
+        "object_type": "ipam.asn",
+        "lookup": {"asn": 555},
+        "create_expect": {
+            "asn": 555,
+            "description": "ASN 555 Description",
+            "rir.name": "RIR 1"
+        },
+        "create": {
+            "asn": {
+                "asn": "555",
+                "rir": {"name": "RIR 1"},
+                "tenant": {"name": "Tenant 1"},
+                "description": "ASN 555 Description",
+                "comments": "ASN 555 Comments",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "asn": {
+                "asn": "555",
+                "rir": {"name": "RIR 1"},
+                "tenant": {"name": "Tenant 1"},
+                "description": "ASN 555 Description Updated",
+                "comments": "ASN 555 Comments",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "ASN 555 Description Updated"
+        }
+    },
+    {
+        "name": "ipam_asnrange_1",
+        "object_type": "ipam.asnrange",
+        "lookup": {"name": "ASN Range 1"},
+        "create_expect": {
+            "name": "ASN Range 1",
+            "start": 1,
+            "end": 2,
+            "rir.name": "RIR 1"
+        },
+        "create": {
+            "asn_range": {
+                "name": "ASN Range 1",
+                "slug": "asn-range-1",
+                "rir": {"name": "RIR 1"},
+                "start": "1",
+                "end": "2",
+                "tenant": {"name": "Tenant 1"},
+                "description": "ASN Range 1 Description",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "asn_range": {
+                "name": "ASN Range 1",
+                "slug": "asn-range-1",
+                "rir": {"name": "RIR 1"},
+                "start": "1",
+                "end": "2",
+                "tenant": {"name": "Tenant 1"},
+                "description": "ASN Range 1 Description Updated",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "ASN Range 1 Description Updated"
+        }
+    },
+    {
+        "name": "ipam_aggregate_1",
+        "object_type": "ipam.aggregate",
+        "lookup": {"prefix": "182.82.82.0/24"},
+        "create_expect": {
+            "prefix": "182.82.82.0/24",
+            "rir.name": "RIR 1",
+            "description": "Aggregate Description"
+        },
+        "create": {
+            "aggregate": {
+                "prefix": "182.82.82.0/24",
+                "rir": {"name": "RIR 1"},
+                "tenant": {"name": "Tenant 1"},
+                "date_added": "2025-04-14T08:08:55Z",
+                "description": "Aggregate Description",
+                "comments": "Aggregate Comments",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]          
+            }
+        },
+        "update": {
+            "aggregate": {
+                "prefix": "182.82.82.0/24",
+                "rir": {"name": "RIR 1"},
+                "tenant": {"name": "Tenant 1"},
+                "date_added": "2025-04-14T08:08:55Z",
+                "description": "Aggregate Description Updated",
+                "comments": "Aggregate Comments",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]          
+            }
+        },
+        "update_expect": {
+            "description": "Aggregate Description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuit_1",
+        "object_type": "circuits.circuit",
+        "lookup": {"cid": "Circuit 1"},
+        "create_expect": {
+            "cid": "Circuit 1",
+            "provider.name": "Provider 1",
+            "type.name": "Circuit Type 1",
+            "description": "Circuit 1 Description"
+        },
+        "create": {
+            "circuit": {
+                "cid": "Circuit 1",
+                "provider": {"name": "Provider 1"},
+                "provider_account": {
+                    "provider": {"name": "Provider 1"},
+                    "account": "account1"
+                },
+                "type": {"name": "Circuit Type 1"},
+                "status": "offline",
+                "tenant": {"name": "Tenant 1"},
+                "install_date": "2025-04-14T00:00:00Z",
+                "termination_date": "2025-04-14T00:00:00Z",
+                "commit_rate": "10",
+                "description": "Circuit 1 Description",
+                "distance": 12.4,
+                "distance_unit": "ft",
+                "comments": "Circuit 1 Comments",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "circuit": {
+                "cid": "Circuit 1",
+                "provider": {"name": "Provider 1"},
+                "provider_account": {
+                    "provider": {"name": "Provider 1"},
+                    "account": "account1"
+                },
+                "type": {"name": "Circuit Type 1"},
+                "status": "offline",
+                "tenant": {"name": "Tenant 1"},
+                "install_date": "2025-04-14T00:00:00Z",
+                "termination_date": "2025-04-14T00:00:00Z",
+                "commit_rate": "10",
+                "description": "Circuit 1 Description Updated",
+                "distance": 12.4,
+                "distance_unit": "ft",
+                "comments": "Circuit 1 Comments",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Circuit 1 Description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuitgroup_1",
+        "object_type": "circuits.circuitgroup",
+        "lookup": {"name": "Circuit Group 1"},
+        "create_expect": {
+            "name": "Circuit Group 1",
+            "description": "Circuit Group 1 Description"
+        },
+        "create": {
+            "circuit_group": {
+                "name": "Circuit Group 1",
+                "description": "Circuit Group 1 Description",
+                "tenant": {"name": "Tenant 1"},
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "circuit_group": {
+                "name": "Circuit Group 1",
+                "description": "Circuit Group 1 Description Updated",
+                "tenant": {"name": "Tenant 1"},
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Circuit Group 1 Description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuitgroupassignment_1",
+        "object_type": "circuits.circuitgroupassignment",
+        "lookup": {
+            "group__name": "Circuit Group 1"
+        },
+        "create_expect": {
+            "group.name": "Circuit Group 1",
+            "member.cid": "Circuit 1",
+            "priority": "tertiary"
+        },
+        "create": {
+            "circuit_group_assignment": {
+                "group": {"name": "Circuit Group 1"},
+                "member_circuit": {
+                    "cid": "Circuit 1",
+                    "type": {"name": "Circuit Type 1"},
+                    "provider": {"name": "Provider 1"}
+                },
+                "priority": "tertiary"
+            }
+        },
+        "update": {
+            "circuit_group_assignment": {
+                "group": {"name": "Circuit Group 1"},
+                "member_circuit": {
+                    "cid": "Circuit 1",
+                    "type": {"name": "Circuit Type 1"},
+                    "provider": {"name": "Provider 1"}
+                },
+                "priority": "secondary"
+            }
+        },
+        "update_expect": {
+            "priority": "secondary"
+        }
+    },
+    {
+        "name": "circuits_circuitgroupassignment_2",
+        "object_type": "circuits.circuitgroupassignment",
+        "lookup": {
+            "group__name": "Circuit Group 1"
+        },
+        "create_expect": {
+            "group.name": "Circuit Group 1",
+            "member.cid": "Virtual Circuit 1",
+            "priority": "tertiary"
+        },
+        "create": {
+            "circuit_group_assignment": {
+                "group": {"name": "Circuit Group 1"},
+                "member_virtual_circuit": {
+                    "cid": "Virtual Circuit 1",
+                    "type": {"name": "Virtual Circuit Type 1"},
+                    "provider_network": {
+                        "name": "Provider Network 1",
+                        "provider": {"name": "Provider 1"}
+                    }
+                },
+                "priority": "tertiary"
+            }
+        },
+        "update": {
+            "circuit_group_assignment": {
+                "group": {"name": "Circuit Group 1"},
+                "member_virtual_circuit": {
+                    "cid": "Virtual Circuit 1",
+                    "type": {"name": "Virtual Circuit Type 1"},
+                    "provider_network": {
+                        "name": "Provider Network 1",
+                        "provider": {"name": "Provider 1"}
+                    }
+                },
+                "priority": "secondary"
+            }
+        },
+        "update_expect": {
+            "priority": "secondary"
+        }
+    },
+    {
+        "name": "circuits_circuittermination_1",
+        "object_type": "circuits.circuittermination",
+        "lookup": {
+            "circuit__cid": "Circuit 1",
+            "term_side": "A"
+        },
+        "create_expect": {
+            "circuit.cid": "Circuit 1",
+            "term_side": "A",
+            "port_speed": 9600,
+            "description": "description"
+        },
+        "create": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {"name": "Circuit Type 1"},
+                    "provider": {"name": "Provider 1"}
+                },
+                "term_side": "A",
+                "termination_location": {
+                    "name": "attic",
+                    "site": {"name": "Site 1"}
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {"name": "Circuit Type 1"},
+                    "provider": {"name": "Provider 1"}
+                },
+                "term_side": "A",
+                "termination_location": {
+                    "name": "attic",
+                    "site": {"name": "Site 1"}
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuittermination_2",
+        "object_type": "circuits.circuittermination",
+        "lookup": {
+            "circuit__cid": "Circuit 1",
+            "term_side": "A"
+        },
+        "create_expect": {
+            "circuit.cid": "Circuit 1",
+            "term_side": "A",
+            "port_speed": 9600,
+            "description": "description"
+        },
+        "create": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {"name": "Circuit Type 1"},
+                    "provider": {"name": "Provider 1"}
+                },
+                "term_side": "A",
+                "termination_provider_network": {
+                    "provider": {"name": "Provider 1"},
+                    "name": "Provider Network 1",
+                    "service_id": "service.1"
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]          
+            }
+        },
+        "update": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {"name": "Circuit Type 1"},
+                    "provider": {"name": "Provider 1"}
+                },
+                "term_side": "A",
+                "termination_provider_network": {
+                    "provider": {"name": "Provider 1"},
+                    "name": "Provider Network 1",
+                    "service_id": "service.1"
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]          
+            }
+        },
+        "update_expect": {
+            "description": "description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuittermination_3",
+        "object_type": "circuits.circuittermination",
+        "lookup": {
+            "circuit__cid": "Circuit 1",
+            "term_side": "A"
+        },
+        "create_expect": {
+            "circuit.cid": "Circuit 1",
+            "term_side": "A",
+            "port_speed": 9600,
+            "description": "description"
+        },
+        "create": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {"name": "Circuit Type 1"},
+                    "provider": {"name": "Provider 1"}
+                },
+                "term_side": "A",
+                "termination_site": {"name": "Site 1"},
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]          
+            }
+        },
+        "update": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {"name": "Circuit Type 1"},
+                    "provider": {"name": "Provider 1"}
+                },
+                "term_side": "A",
+                "termination_site": {"name": "Site 1"},
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]          
+            }            
+        },
+        "update_expect": {
+            "description": "description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuittype_1",
+        "object_type": "circuits.circuittype",
+        "lookup": {"name": "Circuit Type 1"},
+        "create_expect": {
+            "name": "Circuit Type 1",
+            "description": "Circuit Type 1 Description"
+        },
+        "create": {
+            "circuit_type": {
+                "name": "Circuit Type 1",
+                "slug": "circuit-type-1",
+                "color": "0000ff",
+                "description": "Circuit Type 1 Description",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "circuit_type": {
+                "name": "Circuit Type 1",
+                "slug": "circuit-type-1",
+                "color": "0000ff",
+                "description": "Circuit Type 1 Description Updated",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Circuit Type 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_cluster_1",
+        "object_type": "virtualization.cluster",
+        "lookup": {"name": "Cluster A"},
+        "create_expect": {
+            "name": "Cluster A",
+            "type.name": "Cluster Type 1",
+            "description": "Cluster 1 Description"
+        },
+        "create": {
+            "cluster": {
+                "name": "Cluster A",
+                "type": {"name": "Cluster Type 1"},
+                "group": {"name": "Cluster Group 1"},
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "scope_location": {
+                    "name": "Location 1",
+                    "site": {"name": "Site 1"}
+                },
+                "description": "Cluster 1 Description",
+                "comments": "Cluster 1 Comments",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "cluster": {
+                "name": "Cluster A",
+                "type": {"name": "Cluster Type 1"},
+                "group": {"name": "Cluster Group 1"},
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "scope_location": {
+                    "name": "Location 1",
+                    "site": {"name": "Site 1"}
+                },
+                "description": "Cluster 1 Description Updated",
+                "comments": "Cluster 1 Comments",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_cluster_2",
+        "object_type": "virtualization.cluster",
+        "lookup": {"name": "Cluster 2"},
+        "create_expect": {
+            "name": "Cluster 2",
+            "type.name": "Cluster Type 1",
+            "description": "Cluster 1 Description"
+        },
+        "create": {
+            "cluster": {
+                "name": "Cluster 2",
+                "type": {"name": "Cluster Type 1"},
+                "group": {"name": "Cluster Group 1"},
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "scope_region": {"name": "Region 1"},
+                "description": "Cluster 1 Description",
+                "comments": "Cluster 1 Comments",
+                "tags": [{"name": "Tag 1"}]    
+            }
+        },
+        "update": {
+            "cluster": {
+                "name": "Cluster 2",
+                "type": {"name": "Cluster Type 1"},
+                "group": {"name": "Cluster Group 1"},
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "scope_region": {"name": "Region 1"},
+                "description": "Cluster 1 Description Updated",
+                "comments": "Cluster 1 Comments",
+                "tags": [{"name": "Tag 1"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Cluster 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_cluster_3",
+        "object_type": "virtualization.cluster",
+        "lookup": {"name": "Cluster 3"},
+        "create_expect": {
+            "name": "Cluster 3",
+            "type.name": "Cluster Type 1",
+            "description": "Cluster 1 Description"
+        },
+        "create": {
+            "cluster": {
+                "name": "Cluster 3",
+                "type": {"name": "Cluster Type 1"},
+                "group": {"name": "Cluster Group 1"},
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "scope_site": {"name": "Site 1"},
+                "description": "Cluster 1 Description",
+                "comments": "Cluster 1 Comments",
+                "tags": [{"name": "Tag 1"}]    
+            }
+        },
+        "update": {
+            "cluster": {
+                "name": "Cluster 3",
+                "type": {"name": "Cluster Type 1"},
+                "group": {"name": "Cluster Group 1"},
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "scope_site": {"name": "Site 1"},
+                "description": "Cluster 1 Description Updated",
+                "comments": "Cluster 1 Comments",
+                "tags": [{"name": "Tag 1"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Cluster 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_cluster_4",
+        "object_type": "virtualization.cluster",
+        "lookup": {"name": "Cluster 4"},
+        "create_expect": {
+            "name": "Cluster 4",
+            "type.name": "Cluster Type 1",
+            "description": "Cluster 1 Description"
+        },
+        "create": {
+            "cluster": {
+                "name": "Cluster 4",
+                "type": {"name": "Cluster Type 1"},
+                "group": {"name": "Cluster Group 1"},
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "scope_site_group": {"name": "Site Group 1"},
+                "description": "Cluster 1 Description",
+                "comments": "Cluster 1 Comments",
+                "tags": [{"name": "Tag 1"}]    
+            }
+        },
+        "update": {
+            "cluster": {
+                "name": "Cluster 4",
+                "type": {"name": "Cluster Type 1"},
+                "group": {"name": "Cluster Group 1"},
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "scope_site_group": {"name": "Site Group 1"},
+                "description": "Cluster 1 Description Updated",
+                "comments": "Cluster 1 Comments",
+                "tags": [{"name": "Tag 1"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Cluster 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_clustergroup_1",
+        "object_type": "virtualization.clustergroup",
+        "lookup": {"name": "Cluster Group 1"},
+        "create_expect": {
+            "name": "Cluster Group 1",
+            "description": "Cluster Group 1 Description"
+        },
+        "create": {
+            "cluster_group": {
+                "name": "Cluster Group 1",
+                "description": "Cluster Group 1 Description",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "cluster_group": {
+                "name": "Cluster Group 1",
+                "description": "Cluster Group 1 Description Updated",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster Group 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_clustertype_1",
+        "object_type": "virtualization.clustertype",
+        "lookup": {"name": "Cluster Type 1"},
+        "create_expect": {
+            "name": "Cluster Type 1",
+            "description": "Cluster Type 1 Description"
+        },
+        "create": {
+            "cluster_type": {
+                "name": "Cluster Type 1",
+                "description": "Cluster Type 1 Description",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "cluster_type": {
+                "name": "Cluster Type 1",
+                "description": "Cluster Type 1 Description Updated",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster Type 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_consoleport_1",
+        "object_type": "dcim.consoleport",
+        "lookup": {"name": "Console Port 1"},
+        "create_expect": {
+            "name": "Console Port 1",
+            "description": "Console Port 1 Description"
+        },
+        "create": {
+            "console_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Manufacturer 1"
+                        },
+                        "model": "Module Type 1"
+                    }
+                },
+                "name": "Console Port 1",
+                "label": "Console Port 1 Label",
+                "type": "db-25",
+                "speed": "1200",
+                "description": "Console Port 1 Description",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "console_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Manufacturer 1"
+                        },
+                        "model": "Module Type 1"
+                    }
+                },
+                "name": "Console Port 1",
+                "label": "Console Port 1 Label",
+                "type": "db-25",
+                "speed": "1200",
+                "description": "Console Port 1 Description Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Console Port 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_consoleserverport_1",
+        "object_type": "dcim.consoleserverport",
+        "lookup": {"name": "Console Server Port 1"},
+        "create_expect": {
+            "name": "Console Server Port 1",
+            "description": "Console Server Port 1 Description"
+        },
+        "create": {
+            "console_server_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Manufacturer 1"
+                        },
+                        "model": "Module Type 1"
+                    }
+                },
+                "name": "Console Server Port 1",
+                "label": "Console Server Port 1 Label",
+                "type": "db-25",
+                "speed": "1200",
+                "description": "Console Server Port 1 Description",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "console_server_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Manufacturer 1"
+                        },
+                        "model": "Module Type 1"
+                    }
+                },
+                "name": "Console Server Port 1",
+                "label": "Console Server Port 1 Label",
+                "type": "db-25",
+                "speed": "1200",
+                "description": "Console Server Port 1 Description Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Console Server Port 1 Description Updated"
+        }
+    },
+    {
+        "name": "tenancy_contact_1",
+        "object_type": "tenancy.contact",
+        "lookup": {"name": "Contact 1"},
+        "create_expect": {
+            "name": "Contact 1",
+            "groups.all.__by_name": ["Contact Group 1"],
+            "description": "Contact 1 Description"
+        },
+        "create": {
+            "contact": {
+                "group": {"name": "Contact Group 1"},
+                "name": "Contact 1",
+                "title": "Contact 1 Title",
+                "phone": "1234567890",
+                "email": "contact1@example.com",
+                "address": "1234 Main St, Anytown, USA",
+                "link": "https://example.com",
+                "description": "Contact 1 Description",
+                "comments": "Contact 1 Comments",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "contact": {
+                "group": {"name": "Contact Group 1"},
+                "name": "Contact 1",
+                "title": "Contact 1 Title",
+                "phone": "1234567890",
+                "email": "contact1@example.com",
+                "address": "1234 Main St, Anytown, USA",
+                "link": "https://example.com",
+                "description": "Contact 1 Description Updated",
+                "comments": "Contact 1 Comments",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Contact 1 Description Updated"
+        }
+    },
+    {
+        "name": "tenancy_contactassignment_1",
+        "object_type": "tenancy.contactassignment",
+        "lookup": {
+            "contact__name": "Contact 1",
+            "role__name": "Contact Role 1"
+        },
+        "create_expect": {
+            "contact.name": "Contact 1",
+            "role.name": "Contact Role 1",
+            "priority": "primary"
+        },
+        "create": {
+            "contact_assignment": {
+                "contact": {
+                    "name": "Contact 1",
+                    "group": {"name": "Contact Group 1"},
+                    "title": "Contact 1 Title"    
+                },
+                "role": {"name": "Contact Role 1"},
+                "priority": "primary",
+                "tags": [{"name": "Tag 1"}],
+                "object_site": {"name": "Site 1"}
+            }
+        },
+        "update": {
+            "contact_assignment": {
+                "contact": {
+                    "name": "Contact 1",
+                    "group": {"name": "Contact Group 1"},
+                    "title": "Contact 1 Title"       
+                },
+                "role": {"name": "Contact Role 1"},
+                "priority": "secondary",
+                "tags": [{"name": "Tag 1"}],
+                "object_site": {"name": "Site 1"}
+            }
+        },
+        "update_expect": {
+            "priority": "secondary"
+        }
+    },
+    {
+        "name": "tenancy_contactgroup_1",
+        "object_type": "tenancy.contactgroup",
+        "lookup": {"name": "Contact Group 1"},
+        "create_expect": {
+            "name": "Contact Group 1",
+            "description": "Contact Group 1 Description"
+        },
+        "create": {
+            "contact_group": {
+                "name": "Contact Group 1",
+                "parent": {"name": "Contact Group 2"},
+                "description": "Contact Group 1 Description",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "contact_group": {
+                "name": "Contact Group 1",
+                "parent": {"name": "Contact Group 2"},
+                "description": "Contact Group 1 Description Updated",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Contact Group 1 Description Updated"
+        }
+    },
+    {
+        "name": "tenancy_contactrole_1",
+        "object_type": "tenancy.contactrole",
+        "lookup": {"name": "Contact Role 1"},
+        "create_expect": {
+            "name": "Contact Role 1",
+            "description": "Contact Role 1 Description"
+        },
+        "create": {
+            "contact_role": {
+                "name": "Contact Role 1",
+                "description": "Contact Role 1 Description",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "contact_role": {
+                "name": "Contact Role 1",
+                "description": "Contact Role 1 Description Updated",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Contact Role 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_device_1",
+        "object_type": "dcim.device",
+        "lookup": {"name": "Device ABC"},
+        "create_expect": {
+            "name": "Device ABC",
+            "device_type.manufacturer.name": "Cisco",
+            "device_type.model": "C2960S",
+            "role.name": "Device Role 1",
+            "description": "Device 1 Description"
+        },
+        "create": {
+            "device": {
+                "name": "Device ABC",
+                "device_type": {
+                    "manufacturer": {"name": "Cisco"},
+                    "model": "C2960S"
+                },
+                "role": {"name": "Device Role 1"},
+                "tenant": {"name": "Tenant 1"},
+                "platform": {"name": "Platform 1"},
+                "serial": "1234567890",
+                "asset_tag": "asset.1",
+                "site": {"name": "Site 1"},
+                "location": {
+                    "name": "Location 1",
+                    "site": {"name": "Site 1"}
+                },
+                "rack": {
+                    "name": "Rack 1",
+                    "site": {"name": "Site 1"},
+                    "location": {
+                        "name": "Location 1",
+                        "site": {"name": "Site 1"}
+                    }
+                },
+                "position": 1.0,
+                "face": "front",
+                "status": "active",
+                "airflow": "bottom-to-top",
+                "description": "Device 1 Description",
+                "comments": "Device 1 Comments",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "device": {
+                "name": "Device ABC",
+                "device_type": {
+                    "manufacturer": {"name": "Cisco"},
+                    "model": "C2960S"
+                },
+                "role": {"name": "Device Role 1"},
+                "tenant": {"name": "Tenant 1"},
+                "platform": {"name": "Platform 1"},
+                "serial": "1234567890",
+                "asset_tag": "asset.1",
+                "site": {"name": "Site 1"},
+                "location": {
+                    "name": "Location 1",
+                    "site": {"name": "Site 1"}
+                },
+                "rack": {
+                    "name": "Rack 1",
+                    "site": {"name": "Site 1"},
+                    "location": {
+                        "name": "Location 1",
+                        "site": {"name": "Site 1"}
+                    }
+                },
+                "position": 1.0,
+                "face": "front",
+                "status": "active",
+                "airflow": "bottom-to-top",
+                "description": "Device 1 Description Updated",
+                "comments": "Device 1 Comments",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Device 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_devicebay_1",
+        "object_type": "dcim.devicebay",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "Device Bay 1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "Device Bay 1",
+            "description": "Device Bay 1 Description"
+        },
+        "create": {
+            "device_bay": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C3P0",
+                        "subdevice_role": "parent"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "name": "Device Bay 1",
+                "label": "Device Bay 1 Label",
+                "description": "Device Bay 1 Description",
+                "installed_device": {
+                    "name": "Device 2",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "device_bay": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C3P0",
+                        "subdevice_role": "parent"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "name": "Device Bay 1",
+                "label": "Device Bay 1 Label",
+                "description": "Device Bay 1 Description Updated",
+                "installed_device": {
+                    "name": "Device 2",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Device Bay 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_devicerole_1",
+        "object_type": "dcim.devicerole",
+        "lookup": {"name": "Core Router"},
+        "create_expect": {
+            "name": "Core Router",
+            "description": "Primary network routing device"
+        },
+        "create": {
+            "device_role": {
+                "name": "Core Router",
+                "slug": "core-router",
+                "color": "ff0000",
+                "vm_role": true,
+                "description": "Primary network routing device",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "device_role": {
+                "name": "Core Router",
+                "slug": "core-router",
+                "color": "ff0000",
+                "vm_role": true,
+                "description": "Primary network routing device Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary network routing device Updated"
+        }
+    },
+    {
+        "name": "dcim_devicetype_1",
+        "object_type": "dcim.devicetype",
+        "lookup": {
+            "manufacturer__name": "Cisco",
+            "model": "Catalyst 9300"
+        },
+        "create_expect": {
+            "manufacturer.name": "Cisco",
+            "model": "Catalyst 9300",
+            "description": "Enterprise Series Switch"
+        },
+        "create": {
+            "device_type": {
+                "manufacturer": {"name": "Cisco"},
+                "default_platform": {"name": "IOS-XE"},
+                "model": "Catalyst 9300",
+                "slug": "catalyst-9300",
+                "part_number": "C9300-48P-E",
+                "u_height": 1.0,
+                "exclude_from_utilization": false,
+                "is_full_depth": true,
+                "subdevice_role": "parent",
+                "airflow": "front-to-rear",
+                "weight": 14.5,
+                "weight_unit": "lb",
+                "description": "Enterprise Series Switch",
+                "comments": "High-performance access switch",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "device_type": {
+                "manufacturer": {"name": "Cisco"},
+                "default_platform": {"name": "IOS-XE"},
+                "model": "Catalyst 9300",
+                "slug": "catalyst-9300",
+                "part_number": "C9300-48P-E",
+                "u_height": 1.0,
+                "exclude_from_utilization": false,
+                "is_full_depth": true,
+                "subdevice_role": "parent",
+                "airflow": "front-to-rear",
+                "weight": 14.5,
+                "weight_unit": "lb",
+                "description": "Enterprise Series Switch Updated",
+                "comments": "High-performance access switch",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Enterprise Series Switch Updated"
+        }
+    },
+    {
+        "name": "ipam_fhrpgroup_1",
+        "object_type": "ipam.fhrpgroup",
+        "lookup": {"name": "HSRP Group 10"},
+        "create_expect": {
+            "name": "HSRP Group 10",
+            "protocol": "hsrp",
+            "group_id": 10,
+            "description": "Core Router HSRP Group"
+        },
+        "create": {
+            "fhrp_group": {
+                "name": "HSRP Group 10",
+                "protocol": "hsrp",
+                "group_id": "10",
+                "auth_type": "md5",
+                "auth_key": "secretkey123",
+                "description": "Core Router HSRP Group",
+                "comments": "Primary gateway redundancy group",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "fhrp_group": {
+                "name": "HSRP Group 10",
+                "protocol": "hsrp",
+                "group_id": "10",
+                "auth_type": "md5",
+                "auth_key": "secretkey123",
+                "description": "Core Router HSRP Group Updated",
+                "comments": "Primary gateway redundancy group",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Core Router HSRP Group Updated"
+        }
+    },
+    {
+        "name": "ipam_fhrpgroupassignment_1",
+        "object_type": "ipam.fhrpgroupassignment",
+        "lookup": {
+            "group__name": "HSRP Group 10"
+        },
+        "create_expect": {
+            "group.name": "HSRP Group 10",
+            "priority": 100
+        },
+        "create": {
+            "fhrp_group_assignment": {
+                "group": {
+                    "name": "HSRP Group 10",
+                    "protocol": "hsrp",
+                    "group_id": "10"
+                },
+                "interface_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "priority": 100
+            }
+        },
+        "update": {
+            "fhrp_group_assignment": {
+                "group": {
+                    "name": "HSRP Group 10",
+                    "protocol": "hsrp",
+                    "group_id": "10"
+                },
+                "interface_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "priority": 200
+            }
+        },
+        "update_expect": {
+            "priority": 200
+        }
+    },
+    {
+        "name": "dcim_frontport_1",
+        "object_type": "dcim.frontport",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "Front Port 1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "Front Port 1",
+            "description": "Front fiber port"
+        },
+        "create": {
+            "front_port": {
+                "device": {
+                    "name": "Device 1",
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "role": {"name": "Device Role 1"},
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "name": "Front Port 1",
+                "label": "FP1",
+                "type": "lc-apc",
+                "color": "0000ff",
+                "rear_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Rear Port 1",
+                    "type": "lc-apc"
+                },
+                "rear_port_position": "1",
+                "description": "Front fiber port",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "front_port": {
+                "device": {
+                    "name": "Device 1",
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "role": {"name": "Device Role 1"},
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "name": "Front Port 1",
+                "label": "FP1",
+                "type": "lc-apc",
+                "color": "0000ff",
+                "rear_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Rear Port 1",
+                    "type": "lc-apc"
+                },
+                "rear_port_position": "1",
+                "description": "Front fiber port Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Front fiber port Updated"
+        }
+    },
+    {
+        "name": "vpn_ikepolicy_1",
+        "object_type": "vpn.ikepolicy",
+        "lookup": {"name": "IKE-POLICY-1"},
+        "create_expect": {
+            "name": "IKE-POLICY-1",
+            "version": 2,
+            "description": "Main IPSec IKE Policy"
+        },
+        "create": {
+            "ike_policy": {
+                "name": "IKE-POLICY-1",
+                "description": "Main IPSec IKE Policy",
+                "version": "2",
+                "preshared_key": "secretPSK123!",
+                "comments": "Primary IKE policy for VPN tunnels",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "proposals": [
+                    {
+                        "name": "IKE-PROPOSAL-1",
+                        "description": "AES-256 with SHA-256",
+                        "authentication_method": "preshared-keys",
+                        "encryption_algorithm": "aes-256-cbc",
+                        "authentication_algorithm": "hmac-sha256",
+                        "group": "14",
+                        "sa_lifetime": "28800"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "ike_policy": {
+                "name": "IKE-POLICY-1",
+                "description": "Main IPSec IKE Policy Updated",
+                "version": "2",
+                "preshared_key": "secretPSK123!",
+                "comments": "Primary IKE policy for VPN tunnels",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "proposals": [
+                    {
+                        "name": "IKE-PROPOSAL-1",
+                        "description": "AES-256 with SHA-256",
+                        "authentication_method": "preshared-keys",
+                        "encryption_algorithm": "aes-256-cbc",
+                        "authentication_algorithm": "hmac-sha256",
+                        "group": "14",
+                        "sa_lifetime": "28800"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Main IPSec IKE Policy Updated"
+        }
+    },
+    {
+        "name": "vpn_ikeproposal_1",
+        "object_type": "vpn.ikeproposal",
+        "lookup": {"name": "IKE-PROPOSAL-2"},
+        "create_expect": {
+            "name": "IKE-PROPOSAL-2",
+            "description": "High Security IKE Proposal"
+        },
+        "create": {
+            "ike_proposal": {
+                "name": "IKE-PROPOSAL-2",
+                "description": "High Security IKE Proposal",
+                "authentication_method": "certificates",
+                "encryption_algorithm": "aes-256-gcm",
+                "authentication_algorithm": "hmac-sha512",
+                "group": "21",
+                "sa_lifetime": "86400",
+                "comments": "Enhanced security proposal for critical VPNs",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "ike_proposal": {
+                "name": "IKE-PROPOSAL-2",
+                "description": "High Security IKE Proposal Updated",
+                "authentication_method": "certificates",
+                "encryption_algorithm": "aes-256-gcm",
+                "authentication_algorithm": "hmac-sha512",
+                "group": "21",
+                "sa_lifetime": "86400",
+                "comments": "Enhanced security proposal for critical VPNs",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "High Security IKE Proposal Updated"
+        }
+    },
+    {
+        "name": "ipam_ipaddress_1",
+        "object_type": "ipam.ipaddress",
+        "lookup": {"address": "192.168.100.1/24"},
+        "create_expect": {
+            "address": "192.168.100.1/24",
+            "vrf.name": "PROD-VRF",
+            "description": "Production VIP Address"
+        },
+        "create": {
+            "ip_address": {
+                "address": "192.168.100.1/24",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": "vip",
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t"
+                },
+                "nat_inside": {
+                    "address": "10.0.0.1/24"
+                },
+                "dns_name": "prod-vip.example.com",
+                "description": "Production VIP Address",
+                "comments": "Primary virtual IP for load balancing",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "ip_address": {
+                "address": "192.168.100.1/24",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": "vip",
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t"
+                },
+                "nat_inside": {
+                    "address": "10.0.0.1/24"
+                },
+                "dns_name": "prod-vip.example.com",
+                "description": "Production VIP Address Updated",
+                "comments": "Primary virtual IP for load balancing",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Production VIP Address Updated"
+        }
+    },
+    {
+        "name": "ipam_iprange_1",
+        "object_type": "ipam.iprange",
+        "lookup": {
+            "start_address": "10.100.0.1",
+            "end_address": "10.100.0.254"
+        },
+        "create_expect": {
+            "start_address": "10.100.0.1/32",
+            "end_address": "10.100.0.254/32",
+            "description": "Production Server IP Range"
+        },
+        "create": {
+            "ip_range": {
+                "start_address": "10.100.0.1",
+                "end_address": "10.100.0.254",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": {
+                    "name": "Server Pool",
+                    "slug": "server-pool"
+                },
+                "description": "Production Server IP Range",
+                "comments": "Allocated for production server deployments",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "mark_utilized": true
+            }
+        },
+        "update": {
+            "ip_range": {
+                "start_address": "10.100.0.1",
+                "end_address": "10.100.0.254",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": {
+                    "name": "Server Pool",
+                    "slug": "server-pool"
+                },
+                "description": "Production Server IP Range Updated",
+                "comments": "Allocated for production server deployments",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "mark_utilized": true
+            }
+        },
+        "update_expect": {
+            "description": "Production Server IP Range Updated"
+        }
+    },
+    {
+        "name": "vpn_ipsecpolicy_1",
+        "object_type": "vpn.ipsecpolicy",
+        "lookup": {"name": "IPSEC-POLICY-1"},
+        "create_expect": {
+            "name": "IPSEC-POLICY-1",
+            "description": "Site-to-Site VPN Policy"
+        },
+        "create": {
+            "ip_sec_policy": {
+                "name": "IPSEC-POLICY-1",
+                "description": "Site-to-Site VPN Policy",
+                "pfs_group": "14",
+                "comments": "High-security IPSec policy for site-to-site VPN",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "proposals": [
+                    {
+                        "name": "IPSEC-PROPOSAL-1",
+                        "description": "AES-256-GCM with ESP",
+                        "encryption_algorithm": "aes-256-gcm",
+                        "sa_lifetime_seconds": "28800",
+                        "sa_lifetime_data": "28800",
+                        "comments": "Strong encryption proposal for VPN tunnels"
+                    }
+                ]    
+            }
+        },
+        "update": {
+            "ip_sec_policy": {
+                "name": "IPSEC-POLICY-1",
+                "description": "Site-to-Site VPN Policy Updated",
+                "pfs_group": "14",
+                "comments": "High-security IPSec policy for site-to-site VPN",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "proposals": [
+                    {
+                        "name": "IPSEC-PROPOSAL-1",
+                        "description": "AES-256-GCM with ESP",
+                        "encryption_algorithm": "aes-256-gcm",
+                        "sa_lifetime_seconds": "28800",
+                        "sa_lifetime_data": "28800",
+                        "comments": "Strong encryption proposal for VPN tunnels"
+                    }
+                ]    
+            }
+        },
+        "update_expect": {
+            "description": "Site-to-Site VPN Policy Updated"
+        }
+    },
+    {
+        "name": "vpn_ipsecprofile_1",
+        "object_type": "vpn.ipsecprofile",
+        "lookup": {"name": "IPSEC-PROFILE-1"},
+        "create_expect": {
+            "name": "IPSEC-PROFILE-1",
+            "description": "Remote Access VPN Profile"
+        },
+        "create": {
+            "ip_sec_profile": {
+                "name": "IPSEC-PROFILE-1",
+                "description": "Remote Access VPN Profile",
+                "mode": "esp",
+                "ike_policy": {
+                    "name": "IKE-POLICY-1",
+                    "version": "2",
+                    "preshared_key": "secretkey123"
+                },
+                "ipsec_policy": {
+                    "name": "IPSEC-POLICY-1",
+                    "description": "Strong encryption policy",
+                    "pfs_group": "14"
+                },
+                "comments": "Standard IPSec profile for remote access VPN tunnels",
+                "tags": [{"name": "VPN"}, {"name": "Remote-Access"}]    
+            }
+        },
+        "update": {
+            "ip_sec_profile": {
+                "name": "IPSEC-PROFILE-1",
+                "description": "Remote Access VPN Profile Updated",
+                "mode": "esp",
+                "ike_policy": {
+                    "name": "IKE-POLICY-1",
+                    "version": "2",
+                    "preshared_key": "secretkey123"
+                },
+                "ipsec_policy": {
+                    "name": "IPSEC-POLICY-1",
+                    "description": "Strong encryption policy",
+                    "pfs_group": "14"
+                },
+                "comments": "Standard IPSec profile for remote access VPN tunnels",
+                "tags": [{"name": "VPN"}, {"name": "Remote-Access"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Remote Access VPN Profile Updated"
+        }
+    },
+    {
+        "name": "vpn_ipsecproposal_1",
+        "object_type": "vpn.ipsecproposal",
+        "lookup": {"name": "IPSec-Proposal-AES256"},
+        "create_expect": {
+            "name": "IPSec-Proposal-AES256",
+            "description": "High security IPSec proposal using AES-256-GCM"
+        },
+        "create": {
+            "ip_sec_proposal": {
+                "name": "IPSec-Proposal-AES256",
+                "description": "High security IPSec proposal using AES-256-GCM",
+                "encryption_algorithm": "aes-256-gcm",
+                "authentication_algorithm": "hmac-sha512",
+                "sa_lifetime_seconds": "28800",
+                "sa_lifetime_data": "42949",
+                "comments": "Used for critical infrastructure VPNs",
+                "tags": [
+                    {
+                        "name": "high-security",
+                        "slug": "high-security",
+                        "color": "0000ff"
+                    },
+                    {
+                        "name": "production",
+                        "slug": "production",
+                        "color": "0000ff"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "ip_sec_proposal": {
+                "name": "IPSec-Proposal-AES256",
+                "description": "High security IPSec proposal using AES-256-GCM Updated",
+                "encryption_algorithm": "aes-256-gcm",
+                "authentication_algorithm": "hmac-sha512",
+                "sa_lifetime_seconds": "28800",
+                "sa_lifetime_data": "42949",
+                "comments": "Used for critical infrastructure VPNs",
+                "tags": [
+                    {
+                        "name": "high-security",
+                        "slug": "high-security",
+                        "color": "0000ff"
+                    },
+                    {
+                        "name": "production",
+                        "slug": "production",
+                        "color": "0000ff"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "High security IPSec proposal using AES-256-GCM Updated"
+        }
+    },
+    {
+        "name": "dcim_interface_1",
+        "object_type": "dcim.interface",
+        "lookup": {"name": "GigabitEthernet1/0/1"},
+        "create_expect": {
+            "name": "GigabitEthernet1/0/1",
+            "label": "Core Link 1",
+            "tagged_vlans.all.__by_vid": [101, 102]
+        },
+        "create": {
+            "interface": {
+                "name": "GigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "1000base-t",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "lag": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Port-Channel2",
+                    "type": "lag"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "tagged",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "mgmt_only": false,
+                "poe_mode": "pse",
+                "poe_type": "type3-ieee802.3bt",
+                "untagged_vlan": {
+                    "vid": 100,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ],
+                "tagged_vlans": [
+                    {
+                        "vid": 101,
+                        "name": "Voice VLAN",
+                        "status": "active"
+                    },
+                    {
+                        "vid": 102,
+                        "name": "Data VLAN",
+                        "status": "active"
+                    }
+                ]    
+            }
+        },
+        "update": {
+            "interface": {
+                "name": "GigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "1000base-t",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "lag": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Port-Channel2",
+                    "type": "lag"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "q-in-q",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}, {"name": "Tag 3"}],
+                "mgmt_only": false,
+                "poe_mode": "pse",
+                "poe_type": "type3-ieee802.3bt",
+                "untagged_vlan": {
+                    "vid": 100,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ],
+                "tagged_vlans": [
+                    {
+                        "vid": 101,
+                        "name": "Voice VLAN",
+                        "status": "active"
+                    },
+                    {
+                        "vid": 102,
+                        "name": "Data VLAN",
+                        "status": "active"
+                    }
+                ]    
+            }
+        },
+        "update_expect": {
+            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"]
+        }
+    },
+    {
+        "name": "dcim_interface_2",
+        "object_type": "dcim.interface",
+        "lookup": {"name": "WirelessGigabitEthernet1/0/1"},
+        "create_expect": {
+            "name": "WirelessGigabitEthernet1/0/1",
+            "label": "Core Link 1"
+        },
+        "create": {
+            "interface": {
+                "name": "WirelessGigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "other-wireless",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "lag": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Port-Channel2",
+                    "type": "lag"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "rf_role": "ap",
+                "rf_channel": "2.4g-1-2412-22",
+                "tx_power": "20",
+                "wireless_lans": [
+                    {
+                        "ssid": "Corp-Secure",
+                        "description": "Corporate secure wireless network",
+                        "group": {
+                            "name": "Corporate Networks",
+                            "slug": "corporate-networks"
+                        },
+                        "status": "active",
+                        "vlan": {
+                            "vid": 800,
+                            "name": "Production Servers"
+                        },
+                        "tenant": {"name": "Tenant 1"}
+                    }
+                ],
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "access",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "mgmt_only": false,
+                "untagged_vlan": {
+                    "vid": 900,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ]
+            }    
+        },
+        "update": {
+            "interface": {
+                "name": "WirelessGigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "other-wireless",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "lag": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Port-Channel2",
+                    "type": "lag"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "rf_role": "ap",
+                "rf_channel": "2.4g-1-2412-22",
+                "tx_power": "20",
+                "wireless_lans": [
+                    {
+                        "ssid": "Corp-Secure",
+                        "description": "Corporate secure wireless network",
+                        "group": {
+                            "name": "Corporate Networks",
+                            "slug": "corporate-networks"
+                        },
+                        "status": "active",
+                        "vlan": {
+                            "vid": 800,
+                            "name": "Production Servers"
+                        },
+                        "tenant": {"name": "Tenant 1"}
+                    }
+                ],
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "access",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}, {"name": "Tag 3"}],
+                "mgmt_only": false,
+                "untagged_vlan": {
+                    "vid": 900,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ]
+            }    
+        },
+        "update_expect": {
+            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"]
+        }
+    },
+    {
+        "name": "dcim_interface_3",
+        "object_type": "dcim.interface",
+        "lookup": {"name": "VirtualGigabitEthernet1/0/1"},
+        "create_expect": {
+            "name": "VirtualGigabitEthernet1/0/1",
+            "label": "Core Link 1"
+        },
+        "create": {
+            "interface": {
+                "name": "VirtualGigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "parent": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Port-Channel1",
+                    "type": "1000base-t"
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "virtual",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "q-in-q",
+                "mark_connected": false,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "mgmt_only": false,
+                "untagged_vlan": {
+                    "vid": 444,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "qinq_svlan": {
+                    "vid": 2000,
+                    "name": "Service VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ]
+            }    
+        },
+        "update": {
+            "interface": {
+                "name": "VirtualGigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "parent": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Port-Channel1",
+                    "type": "1000base-t"
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "virtual",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "q-in-q",
+                "mark_connected": false,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}, {"name": "Tag 3"}],
+                "mgmt_only": false,
+                "untagged_vlan": {
+                    "vid": 444,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "qinq_svlan": {
+                    "vid": 2000,
+                    "name": "Service VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ]
+            }    
+        },
+        "update_expect": {
+            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"]
+        }
+    },
+    {
+        "name": "vpn_l2vpn_1",
+        "object_type": "vpn.l2vpn",
+        "lookup": {"name": "Customer-VPLS-1"},
+        "create_expect": {
+            "name": "Customer-VPLS-1",
+            "type": "vpls",
+            "description": "Customer VPLS service for multi-site connectivity"
+        },
+        "create": {
+            "l2vpn": {
+                "name": "Customer-VPLS-1",
+                "slug": "customer-vpls-1",
+                "type": "vpls",
+                "identifier": "65000",
+                "import_targets": [
+                    {
+                        "name": "65000:1001",
+                        "description": "Primary import target"
+                    },
+                    {
+                        "name": "65000:1002",
+                        "description": "Secondary import target"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:1003",
+                        "description": "Primary export target"
+                    }
+                ],
+                "description": "Customer VPLS service for multi-site connectivity",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "l2vpn": {
+                "name": "Customer-VPLS-1",
+                "slug": "customer-vpls-1",
+                "type": "vpls",
+                "identifier": "65000",
+                "import_targets": [
+                    {
+                        "name": "65000:1001",
+                        "description": "Primary import target"
+                    },
+                    {
+                        "name": "65000:1002",
+                        "description": "Secondary import target"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:1003",
+                        "description": "Primary export target"
+                    }
+                ],
+                "description": "Customer VPLS service for multi-site connectivity Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Customer VPLS service for multi-site connectivity Updated"
+        }
+    },
+    {
+        "name": "dcim_inventoryitem_1",
+        "object_type": "dcim.inventoryitem",
+        "lookup": {"name": "Power Supply 1"},
+        "create_expect": {
+            "name": "Power Supply 1",
+            "description": "715W AC Power Supply"
+        },
+        "create": {
+            "inventory_item": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "parent": {
+                    "name": "Chassis 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    }
+                },
+                "name": "Power Supply 1",
+                "label": "PSU1",
+                "role": {
+                    "name": "Power Supply",
+                    "color": "00ff00"
+                },
+                "manufacturer": {"name": "Cisco"},
+                "part_id": "PWR-C1-715WAC",
+                "serial": "ABC123XYZ",
+                "asset_tag": "ASSET-001",
+                "discovered": true,
+                "description": "715W AC Power Supply",
+                "status": "active",
+                "component_power_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "PSU1 Power Port",
+                    "type": "iec-60320-c14",
+                    "maximum_draw": 715,
+                    "allocated_draw": 500,
+                    "description": "Power input port for PSU1"
+                },
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "inventory_item": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "parent": {
+                    "name": "Chassis 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    }
+                },
+                "name": "Power Supply 1",
+                "label": "PSU1",
+                "role": {
+                    "name": "Power Supply",
+                    "color": "00ff00"
+                },
+                "manufacturer": {"name": "Cisco"},
+                "part_id": "PWR-C1-715WAC",
+                "serial": "ABC123XYZ",
+                "asset_tag": "ASSET-001",
+                "discovered": true,
+                "description": "715W AC Power Supply Updated",
+                "status": "active",
+                "component_power_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "PSU1 Power Port",
+                    "type": "iec-60320-c14",
+                    "maximum_draw": 715,
+                    "allocated_draw": 500,
+                    "description": "Power input port for PSU1"
+                },
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "715W AC Power Supply Updated"
+        }
+    },
+    {
+        "name": "dcim_inventoryitemrole_1",
+        "object_type": "dcim.inventoryitemrole",
+        "lookup": {"name": "Line Card"},
+        "create_expect": {
+            "name": "Line Card",
+            "description": "Network switch line card module"
+        },
+        "create": {
+            "inventory_item_role": {
+                "name": "Line Card",
+                "slug": "line-card",
+                "color": "0000ff",
+                "description": "Network switch line card module",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "inventory_item_role": {
+                "name": "Line Card",
+                "slug": "line-card",
+                "color": "0000ff",
+                "description": "Network switch line card module Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Network switch line card module Updated"
+        }
+    },
+    {
+        "name": "vpn_l2vpn_1",
+        "object_type": "vpn.l2vpn",
+        "lookup": {"name": "Customer-VPLS-1"},
+        "create_expect": {
+            "name": "Customer-VPLS-1",
+            "type": "vpls",
+            "identifier": 65000,
+            "description": "Customer VPLS service for multi-site connectivity"
+        },
+        "create": {
+            "l2vpn": {
+                "name": "Customer-VPLS-1",
+                "slug": "customer-vpls-1",
+                "type": "vpls",
+                "identifier": "65000",
+                "import_targets": [
+                    {
+                        "name": "65000:1001",
+                        "description": "Primary import target"
+                    },
+                    {
+                        "name": "65000:1002",
+                        "description": "Secondary import target"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:1003",
+                        "description": "Primary export target"
+                    }
+                ],
+                "description": "Customer VPLS service for multi-site connectivity",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "l2vpn": {
+                "name": "Customer-VPLS-1",
+                "slug": "customer-vpls-1",
+                "type": "vpls",
+                "identifier": "65000",
+                "import_targets": [
+                    {
+                        "name": "65000:1001",
+                        "description": "Primary import target"
+                    },
+                    {
+                        "name": "65000:1002",
+                        "description": "Secondary import target"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:1003",
+                        "description": "Primary export target"
+                    }
+                ],
+                "description": "Customer VPLS service for multi-site connectivity Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Customer VPLS service for multi-site connectivity Updated"
+        }
+    },
+    {
+        "name": "vpn_l2vpntermination_1",
+        "object_type": "vpn.l2vpntermination",
+        "lookup": {
+            "l2vpn__name": "Customer-VPLS-1"
+        },
+        "create_expect": {
+            "l2vpn.name": "Customer-VPLS-1",
+            "l2vpn.type": "vpls"
+        },
+        "create": {
+            "l2vpn_termination": {
+                "l2vpn": {
+                    "name": "Customer-VPLS-1",
+                    "type": "vpls",
+                    "identifier": "65000"
+                },
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "l2vpn_termination": {
+                "l2vpn": {
+                    "name": "Customer-VPLS-1",
+                    "type": "vpls",
+                    "identifier": "65000"
+                },
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}, {"name": "Tag 3"}]
+            }
+        },
+        "update_expect": {
+            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"]
+        }
+    },
+    {
+        "name": "dcim_location_1",
+        "object_type": "dcim.location",
+        "lookup": {"name": "Data Center East Wing"},
+        "create_expect": {
+            "name": "Data Center East Wing",
+            "description": "East wing of the main data center facility"
+        },
+        "create": {
+            "location": {
+                "name": "Data Center East Wing",
+                "slug": "dc-east-wing",
+                "site": {"name": "Site 1"},
+                "parent": {
+                    "name": "Main Data Center",
+                    "slug": "main-dc",
+                    "site": {"name": "Site 1"}
+                },
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "facility": "Building A, Floor 3",
+                "description": "East wing of the main data center facility",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "location": {
+                "name": "Data Center East Wing",
+                "slug": "dc-east-wing",
+                "site": {"name": "Site 1"},
+                "parent": {
+                    "name": "Main Data Center",
+                    "slug": "main-dc",
+                    "site": {"name": "Site 1"}
+                },
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "facility": "Building A, Floor 3",
+                "description": "East wing of the main data center facility Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "East wing of the main data center facility Updated"
+        }
+    },
+    {
+        "name": "dcim_macaddress_1",
+        "object_type": "dcim.macaddress",
+        "lookup": {"mac_address": "00:1A:2B:3C:4D:5E"},
+        "create_expect": {
+            "mac_address": "00:1A:2B:3C:4D:5E",
+            "description": "Primary management interface MAC"
+        },
+        "create": {
+            "mac_address": {
+                "mac_address": "00:1A:2B:3C:4D:5E",
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "description": "Primary management interface MAC",
+                "comments": "Reserved for network management access",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update": {
+            "mac_address": {
+                "mac_address": "00:1A:2B:3C:4D:5E",
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "description": "Primary management interface MAC Updated",
+                "comments": "Reserved for network management access",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Primary management interface MAC Updated"
+        }
+    },
+    {
+        "name": "dcim_manufacturer_1",
+        "object_type": "dcim.manufacturer",
+        "lookup": {"name": "Arista Networks"},
+        "create_expect": {
+            "name": "Arista Networks",
+            "slug": "arista-networks",
+            "description": "Leading provider of cloud networking solutions"
+        },
+        "create": {
+            "manufacturer": {
+                "name": "Arista Networks",
+                "slug": "arista-networks",
+                "description": "Leading provider of cloud networking solutions",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+    
+            }
+        },
+        "update": {
+            "manufacturer": {
+                "name": "Arista Networks",
+                "slug": "arista-networks",
+                "description": "Leading provider of cloud networking solutions Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Leading provider of cloud networking solutions Updated"
+        }
+    },
+    {
+        "name": "dcim_module_1",
+        "object_type": "dcim.module",
+        "lookup": {"asset_tag": "MOD-001"},
+        "create_expect": {
+            "status": "active",
+            "serial": "MOD123XYZ",
+            "asset_tag": "MOD-001",
+            "description": "Stacking module for switch interconnect"
+        },
+        "create": {
+            "module": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module_bay": {
+                    "name": "Module Bay 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    }
+                },
+                "module_type": {
+                    "manufacturer": {"name": "Cisco"},
+                    "model": "C2960S-STACK"
+                },
+                "status": "active",
+                "serial": "MOD123XYZ",
+                "asset_tag": "MOD-001",
+                "description": "Stacking module for switch interconnect",
+                "comments": "Primary stack member module",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "module": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module_bay": {
+                    "name": "Module Bay 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    }
+                },
+                "module_type": {
+                    "manufacturer": {"name": "Cisco"},
+                    "model": "C2960S-STACK"
+                },
+                "status": "active",
+                "serial": "MOD123XYZ",
+                "asset_tag": "MOD-001",
+                "description": "Stacking module for switch interconnect Updated",
+                "comments": "Primary stack member module",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Stacking module for switch interconnect Updated"
+        }
+    },
+    {
+        "name": "dcim_modulebay_1",
+        "object_type": "dcim.modulebay",
+        "lookup": {"name": "Stack Module Bay 2"},
+        "create_expect": {
+            "name": "Stack Module Bay 2",
+            "description": "Secondary stacking module bay"
+        },
+        "create": {
+            "module_bay": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "name": "Stack Module Bay 2",
+                "label": "STACK-2",
+                "position": "Rear",
+                "description": "Secondary stacking module bay",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "module_bay": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "name": "Stack Module Bay 2",
+                "label": "STACK-2",
+                "position": "Rear",
+                "description": "Secondary stacking module bay Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Secondary stacking module bay Updated"
+        }
+    },
+    {
+        "name": "dcim_moduletype_1",
+        "object_type": "dcim.moduletype",
+        "lookup": {
+            "manufacturer__name": "Cisco",
+            "model": "C9300-NM-8X"
+        },
+        "create_expect": {
+            "manufacturer.name": "Cisco",
+            "model": "C9300-NM-8X",
+            "description": "Catalyst 9300 8 x 10GE Network Module"
+        },
+        "create": {
+            "module_type": {
+                "manufacturer": {"name": "Cisco"},
+                "model": "C9300-NM-8X",
+                "part_number": "C9300-NM-8X=",
+                "airflow": "front-to-rear",
+                "weight": 0.7,
+                "weight_unit": "kg",
+                "description": "Catalyst 9300 8 x 10GE Network Module",
+                "comments": "Hot-swappable uplink module for C9300 series switches",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "module_type": {
+                "manufacturer": {"name": "Cisco"},
+                "model": "C9300-NM-8X",
+                "part_number": "C9300-NM-8X=",
+                "airflow": "front-to-rear",
+                "weight": 0.7,
+                "weight_unit": "kg",
+                "description": "Catalyst 9300 8 x 10GE Network Module Updated",
+                "comments": "Hot-swappable uplink module for C9300 series switches",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Catalyst 9300 8 x 10GE Network Module Updated"
+        }
+    },
+    {
+        "name": "dcim_moduletypeprofile_1",
+        "object_type": "dcim.moduletypeprofile",
+        "lookup": {"name": "Module Type Profile 1"},
+        "create_expect": {
+            "name": "Module Type Profile 1",
+            "description": "This is a module type profile"
+        },
+        "create": {
+            "module_type_profile": {
+                "name": "Module Type Profile 1",
+                "description": "This is a module type profile",
+                "schema": "{\"$schema\": \"https://json-schema.org/draft/2020-12/schema\", \"$id\": \"https://example.com/product.schema.json\", \"title\": \"Product\", \"description\": \"A product from Acme's catalog\", \"type\": \"object\", \"properties\": {\"productId\": {\"description\": \"The unique identifier for a product\", \"type\": \"integer\"}}}", 
+                "comments": "This is a module type profile comment"
+            }
+        },
+        "update": {
+            "module_type_profile": {
+                "name": "Module Type Profile 1",
+                "description": "This is a module type profile updated",
+                "schema": "{\"$schema\": \"https://json-schema.org/draft/2020-12/schema\", \"$id\": \"https://example.com/product.schema.json\", \"title\": \"Product\", \"description\": \"A product from Acme's catalog\", \"type\": \"object\", \"properties\": {\"productId\": {\"description\": \"The unique identifier for a product\", \"type\": \"integer\"}}}",
+                "comments": "This is a module type profile comment"
+            }
+        },
+        "update_expect": {
+            "description": "This is a module type profile updated"
+        }
+    },
+    {
+        "name": "dcim_platform_1",
+        "object_type": "dcim.platform",
+        "lookup": {"name": "Cisco IOS-XE"},
+        "create_expect": {
+            "name": "Cisco IOS-XE",
+            "manufacturer.name": "Cisco",
+            "description": "Enterprise-class IOS operating system for Catalyst switches and ISR routers"
+        },
+        "create": {
+            "platform": {
+                "name": "Cisco IOS-XE",
+                "slug": "cisco-ios-xe",
+                "manufacturer": {"name": "Cisco"},
+                "description": "Enterprise-class IOS operating system for Catalyst switches and ISR routers",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "platform": {
+                "name": "Cisco IOS-XE",
+                "slug": "cisco-ios-xe",
+                "manufacturer": {"name": "Cisco"},
+                "description": "Enterprise-class IOS operating system for Catalyst switches and ISR routers Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Enterprise-class IOS operating system for Catalyst switches and ISR routers Updated"
+        }
+    },
+    {
+        "name": "dcim_powerfeed_1",
+        "object_type": "dcim.powerfeed",
+        "lookup": {"name": "Power Feed A1"},
+        "create_expect": {
+            "name": "Power Feed A1",
+            "power_panel.name": "Panel A",
+            "description": "Primary power feed for network equipment rack"
+        },
+        "create": {
+            "power_feed": {
+                "power_panel": {
+                    "site": {"name": "Site 1"},
+                    "name": "Panel A"
+                },
+                "rack": {
+                    "name": "Rack 1",
+                    "site": {"name": "Site 1"},
+                    "location": {
+                        "name": "Location 1",
+                        "site": {"name": "Site 1"}
+                    }
+                },
+                "name": "Power Feed A1",
+                "status": "active",
+                "type": "primary",
+                "supply": "ac",
+                "phase": "three-phase",
+                "voltage": "208",
+                "amperage": "30",
+                "max_utilization": "80",
+                "mark_connected": true,
+                "description": "Primary power feed for network equipment rack",
+                "tenant": {"name": "Tenant 1"},
+                "comments": "Connected to UPS system A with redundant backup",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "power_feed": {
+                "power_panel": {
+                    "site": {"name": "Site 1"},
+                    "name": "Panel A"
+                },
+                "rack": {
+                    "name": "Rack 1",
+                    "site": {"name": "Site 1"},
+                    "location": {
+                        "name": "Location 1",
+                        "site": {"name": "Site 1"}
+                    }
+                },
+                "name": "Power Feed A1",
+                "status": "active",
+                "type": "primary",
+                "supply": "ac",
+                "phase": "three-phase",
+                "voltage": "208",
+                "amperage": "30",
+                "max_utilization": "80",
+                "mark_connected": true,
+                "description": "Primary power feed for network equipment rack Updated",
+                "tenant": {"name": "Tenant 1"},
+                "comments": "Connected to UPS system A with redundant backup",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary power feed for network equipment rack Updated"
+        }
+    },
+    {
+        "name": "dcim_poweroutlet_1",
+        "object_type": "dcim.poweroutlet",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "PSU1-Outlet1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "PSU1-Outlet1",
+            "description": "Power outlet for network switch PSU"
+        },
+        "create": {
+            "power_outlet": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "PWR-C1-715WAC"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    }
+                },
+                "name": "PSU1-Outlet1",
+                "label": "OUT-1",
+                "type": "iec-60320-c13",
+                "color": "0000ff",
+                "power_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "PSU1"
+                },
+                "feed_leg": "A",
+                "description": "Power outlet for network switch PSU",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "power_outlet": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "PWR-C1-715WAC"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    }
+                },
+                "name": "PSU1-Outlet1",
+                "label": "OUT-1",
+                "type": "iec-60320-c13",
+                "color": "0000ff",
+                "power_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "PSU1"
+                },
+                "feed_leg": "A",
+                "description": "Power outlet for network switch PSU Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Power outlet for network switch PSU Updated"
+        }
+    },
+    {
+        "name": "dcim_powerpanel_1",
+        "object_type": "dcim.powerpanel",
+        "lookup": {
+            "site__name": "Site 1",
+            "name": "Panel A"
+        },
+        "create_expect": {
+            "site.name": "Site 1",
+            "name": "Panel A",
+            "description": "Main power distribution panel"
+        },
+        "create": {
+            "power_panel": {
+                "site": {"name": "Site 1"},
+                "location": {
+                    "name": "Location 1",
+                    "site": {"name": "Site 1"}
+                },
+                "name": "Panel A",
+                "description": "Main power distribution panel",
+                "comments": "Primary power distribution for data center",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "power_panel": {
+                "site": {"name": "Site 1"},
+                "location": {
+                    "name": "Location 1",
+                    "site": {"name": "Site 1"}
+                },
+                "name": "Panel A",
+                "description": "Main power distribution panel Updated",
+                "comments": "Primary power distribution for data center",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Main power distribution panel Updated"
+        }
+    },
+    {
+        "name": "dcim_powerport_1",
+        "object_type": "dcim.powerport",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "PSU1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "PSU1",
+            "description": "Primary power supply unit"
+        },
+        "create": {
+            "power_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "PWR-C1-715WAC"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    }
+                },
+                "name": "PSU1",
+                "label": "PSU-1",
+                "type": "iec-60320-c14",
+                "maximum_draw": 715,
+                "allocated_draw": 650,
+                "description": "Primary power supply unit",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "power_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "PWR-C1-715WAC"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    }
+                },
+                "name": "PSU1",
+                "label": "PSU-1",
+                "type": "iec-60320-c14",
+                "maximum_draw": 715,
+                "allocated_draw": 650,
+                "description": "Primary power supply unit Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary power supply unit Updated"
+        }
+    },
+    {
+        "name": "ipam_prefix_1",
+        "object_type": "ipam.prefix",
+        "lookup": {"prefix": "10.100.0.0/16"},
+        "create_expect": {
+            "prefix": "10.100.0.0/16",
+            "description": "Production network address space"
+        },
+        "create": {
+            "prefix": {
+                "prefix": "10.100.0.0/16",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "scope_site": {"name": "Site 1"},
+                "tenant": {"name": "Tenant 1"},
+                "vlan": {
+                    "name": "Production VLAN",
+                    "vid": "112"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "is_pool": true,
+                "mark_utilized": true,
+                "description": "Production network address space",
+                "comments": "Primary address allocation for production services",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update": {
+            "prefix": {
+                "prefix": "10.100.0.0/16",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "scope_site": {"name": "Site 1"},
+                "tenant": {"name": "Tenant 1"},
+                "vlan": {
+                    "name": "Production VLAN",
+                    "vid": "112"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "is_pool": true,
+                "mark_utilized": true,
+                "description": "Production network address space Updated",
+                "comments": "Primary address allocation for production services",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Production network address space Updated"
+        }
+    },
+    {
+        "name": "circuits_provider_1",
+        "object_type": "circuits.provider",
+        "lookup": {"name": "Level 3 Communications"},
+        "create_expect": {
+            "name": "Level 3 Communications",
+            "slug": "level3",
+            "description": "Global Tier 1 Internet Service Provider"
+        },
+        "create": {
+            "provider": {
+                "name": "Level 3 Communications",
+                "slug": "level3",
+                "description": "Global Tier 1 Internet Service Provider",
+                "comments": "Primary transit provider for data center connectivity",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "accounts": [
+                    {
+                        "provider": {"name": "Level 3 Communications"},
+                        "name": "East Coast Account", 
+                        "account": "L3-12345",
+                        "description": "East Coast regional services account",
+                        "comments": "Managed through regional NOC"
+                    },
+                    {
+                        "provider": {"name": "Level 3 Communications"},
+                        "name": "West Coast Account",
+                        "account": "L3-67890",
+                        "description": "West Coast regional services account",
+                        "comments": "Managed through regional NOC"
+                    }
+                ],
+                "asns": [
+                    {
+                        "asn": "3356",
+                        "rir": {"name": "ARIN"},
+                        "tenant": {"name": "Tenant 1"},
+                        "description": "Level 3 Global ASN",
+                        "comments": "Primary transit ASN"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "provider": {
+                "name": "Level 3 Communications",
+                "slug": "level3",
+                "description": "Global Tier 1 Internet Service Provider Updated",
+                "comments": "Primary transit provider for data center connectivity",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "accounts": [
+                    {
+                        "provider": {"name": "Level 3 Communications"},
+                        "name": "East Coast Account",
+                        "account": "L3-12345",
+                        "description": "East Coast regional services account",
+                        "comments": "Managed through regional NOC"
+                    },
+                    {
+                        "provider": {"name": "Level 3 Communications"},
+                        "name": "West Coast Account",
+                        "account": "L3-67890",
+                        "description": "West Coast regional services account",
+                        "comments": "Managed through regional NOC"
+                    }
+                ],
+                "asns": [
+                    {
+                        "asn": "3356",
+                        "rir": {"name": "ARIN"},
+                        "tenant": {"name": "Tenant 1"},
+                        "description": "Level 3 Global ASN",
+                        "comments": "Primary transit ASN"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Global Tier 1 Internet Service Provider Updated"
+        }
+    },
+    {
+        "name": "circuits_provideraccount_1",
+        "object_type": "circuits.provideraccount",
+        "lookup": {
+            "provider__name": "Level 3 Communications",
+            "account": "ACCT-12345"
+        },
+        "create_expect": {
+            "provider.name": "Level 3 Communications",
+            "account": "ACCT-12345",
+            "description": "Primary enterprise account"
+        },
+        "create": {
+            "provider_account": {
+                "provider": {"name": "Level 3 Communications"},
+                "account": "ACCT-12345",
+                "name": "L3 Enterprise",
+                "description": "Primary enterprise account",
+                "comments": "Global services contract",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "provider_account": {
+                "provider": {"name": "Level 3 Communications"},
+                "account": "ACCT-12345",
+                "name": "L3 Enterprise",
+                "description": "Primary enterprise account Updated",
+                "comments": "Global services contract",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary enterprise account Updated"
+        }
+    },
+    {
+        "name": "circuits_providernetwork_1",
+        "object_type": "circuits.providernetwork",
+        "lookup": {"name": "Global MPLS Network"},
+        "create_expect": {
+            "name": "Global MPLS Network",
+            "provider.name": "Level 3 Communications",
+            "description": "Global MPLS backbone network"
+        },
+        "create": {
+            "provider_network": {
+                "provider": {"name": "Level 3 Communications"},
+                "name": "Global MPLS Network",
+                "service_id": "L3-MPLS-001",
+                "description": "Global MPLS backbone network",
+                "comments": "Primary enterprise MPLS network infrastructure",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "provider_network": {
+                "provider": {"name": "Level 3 Communications"},
+                "name": "Global MPLS Network",
+                "service_id": "L3-MPLS-001",
+                "description": "Global MPLS backbone network Updated",
+                "comments": "Primary enterprise MPLS network infrastructure",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Global MPLS backbone network Updated"
+        }
+    },
+    {
+        "name": "extras_custom_field_1",
+        "object_type": "extras.customfield",
+        "lookup": {"name": "wlans"},
+        "create_expect": {
+            "name": "wlans",
+            "label": "WLANs",
+            "type": "multiobject"
+        },
+        "create": {
+            "custom_field": {
+                "name": "wlans",
+                "label": "WLANs",
+                "object_types": ["dcim.device"],
+                "type": "multiobject",
+                "related_object_type": "wireless.wirelesslan",
+                "search_weight": 1000,
+                "filter_logic": "loose"
+            }
+        },
+        "update": {
+            "custom_field": {
+                "name": "wlans",
+                "label": "WLANs Served",
+                "object_types": ["dcim.device"],
+                "type": "multiobject",
+                "related_object_type": "wireless.wirelesslan",
+                "search_weight": 1000,
+                "filter_logic": "loose"
+            }
+        },
+        "update_expect": {
+            "label": "WLANs Served"
+        }
+    },
+    {
+        "name": "extras_customfieldchoiceset_1",
+        "object_type": "extras.customfieldchoiceset",
+        "lookup": {"name": "scope_choices"},
+        "create": {
+            "custom_field_choice_set": {
+                "name": "scope_choices",
+                "extra_choices": ["site:Site", "virtual_machine:Virtual Machine", "toadstool"]
+            }
+        },
+        "create_expect": {
+            "name": "scope_choices",
+            "extra_choices": [["site", "Site"], ["virtual_machine", "Virtual Machine"], ["toadstool", "toadstool"]]
+        },
+        "update": {
+            "custom_field_choice_set": {
+                "name": "scope_choices",
+                "extra_choices": ["site:Site", "virtual_machine:Virtual Machine", "toadstool:Toad Stool"]
+            }
+        },
+        "update_expect": {
+            "extra_choices": [["site", "Site"], ["virtual_machine", "Virtual Machine"], ["toadstool", "Toad Stool"]]
+        }
+    },
+    {
+        "name": "extras_custom_link_1",
+        "object_type": "extras.customlink",
+        "lookup": {"name": "Custom Link 1"},
+        "create":{
+            "custom_link": {
+                "name": "Custom Link 1",
+                "enabled": true,
+                "link_text": "Custom Link 1",
+                "link_url": "https://www.google.com",
+                "object_types": ["dcim.device"]
+            }
+        },
+        "create_expect": {
+            "name": "Custom Link 1",
+            "link_text": "Custom Link 1",
+            "link_url": "https://www.google.com"
+        },
+        "update":{
+            "custom_link": {
+                "name": "Custom Link 1",
+                "enabled": true,
+                "link_text": "Custom Link 1 Updated",
+                "link_url": "https://www.google.com",
+                "object_types": ["dcim.device"]
+            }
+        },
+        "update_expect": {
+            "link_text": "Custom Link 1 Updated"
+        }
+    },
+    {
+        "name": "extras_journal_entry_1",
+        "object_type": "extras.journalentry",
+        "lookup": {"comments": "This is a journal entry"},
+        "create": {
+            "journal_entry": {
+                "assigned_object_site": {
+                    "name": "Journal Test Site"
+                },
+                "comments": "This is a journal entry",
+                "kind": "info"
+            }
+        },
+        "create_expect": {
+            "assigned_object.name": "Journal Test Site",
+            "comments": "This is a journal entry",
+            "kind": "info"
+        },
+        "update": {
+            "journal_entry": {
+                "assigned_object_site": {
+                    "name": "Journal Test Site"
+                },
+                "comments": "This is a journal entry",
+                "kind": "danger"
+            }
+        },
+        "update_expect": {
+            "assigned_object.name": "Journal Test Site",
+            "comments": "This is a journal entry",
+            "kind": "danger"
+        }
+    },
+    {
+        "name": "ipam_rir_1",
+        "object_type": "ipam.rir",
+        "lookup": {"name": "ARIN"},
+        "create_expect": {
+            "name": "ARIN",
+            "description": "American Registry for Internet Numbers"
+        },
+        "create": {
+            "rir": {
+                "name": "ARIN",
+                "slug": "arin",
+                "is_private": false,
+                "description": "American Registry for Internet Numbers",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "rir": {
+                "name": "ARIN",
+                "slug": "arin",
+                "is_private": false,
+                "description": "American Registry for Internet Numbers Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "American Registry for Internet Numbers Updated"
+        }
+    },
+    {
+        "name": "dcim_rack_1",
+        "object_type": "dcim.rack",
+        "lookup": {"asset_tag": "RACK-009"},
+        "create_expect": {
+            "name": "Rack ZZ",
+            "site.name": "Site 1",
+            "description": "Standard 42U server rack"
+        },
+        "create": {
+            "rack": {
+                "name": "Rack ZZ",
+                "facility_id": "FAC-001",
+                "site": {"name": "Site 1"},
+                "location": {"name": "Data Center East Wing", "site": {"name": "Site 1"}},
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": {
+                    "name": "Server Rack",
+                    "slug": "server-rack",
+                    "color": "0000ff",
+                    "description": "Primary server rack role"
+                },
+                "serial": "RACK123XYZ",
+                "asset_tag": "RACK-009",
+                "rack_type": {
+                    "manufacturer": {"name": "Manufacturer 1"},
+                    "model": "R2000",
+                    "slug": "r2000",
+                    "form_factor": "4-post-cabinet"
+                },
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "airflow": "front-to-rear",
+                "description": "Standard 42U server rack",
+                "comments": "Located in primary data center",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "rack": {
+                "name": "Rack ZZ",
+                "facility_id": "FAC-001",
+                "site": {"name": "Site 1"},
+                "location": {"name": "Data Center East Wing", "site": {"name": "Site 1"}},
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": {
+                    "name": "Server Rack",
+                    "slug": "server-rack",
+                    "color": "0000ff",
+                    "description": "Primary server rack role"
+                },
+                "serial": "RACK123XYZ",
+                "asset_tag": "RACK-009",
+                "rack_type": {
+                    "manufacturer": {"name": "Manufacturer 1"},
+                    "model": "R2000",
+                    "slug": "r2000",
+                    "form_factor": "4-post-cabinet"
+                },
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "mounting_depth": "30",
+                "airflow": "front-to-rear",
+                "description": "Standard 42U server rack Updated",
+                "comments": "Located in primary data center",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Standard 42U server rack Updated"
+        }
+    },
+    {
+        "name": "dcim_rackrole_1",
+        "object_type": "dcim.rackrole",
+        "lookup": {"name": "Network Equipment"},
+        "create_expect": {
+            "name": "Network Equipment",
+            "description": "Dedicated racks for network infrastructure"
+        },
+        "create": {
+            "rack_role": {
+                "name": "Network Equipment",
+                "slug": "network-equipment",
+                "color": "0000ff",
+                "description": "Dedicated racks for network infrastructure",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "rack_role": {
+                "name": "Network Equipment",
+                "slug": "network-equipment",
+                "color": "0000ff",
+                "description": "Dedicated racks for network infrastructure Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Dedicated racks for network infrastructure Updated"
+        }
+    },
+    {
+        "name": "dcim_racktype_1",
+        "object_type": "dcim.racktype",
+        "lookup": {
+            "manufacturer__name": "Manufacturer 1",
+            "model": "R2000"
+        },
+        "create_expect": {
+            "manufacturer.name": "Manufacturer 1",
+            "model": "R2000",
+            "description": "Standard 42U server rack"
+        },
+        "create": {
+            "rack_type": {
+                "manufacturer": {"name": "Manufacturer 1"},
+                "model": "R2000",
+                "slug": "r2000",
+                "description": "Standard 42U server rack",
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "outer_width": "24",
+                "outer_depth": "36",
+                "outer_unit": "in",
+                "weight": "350.5",
+                "max_weight": "1000",
+                "weight_unit": "lb",
+                "mounting_depth": "30",
+                "comments": "Standard enterprise rack configuration",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "rack_type": {
+                "manufacturer": {"name": "Manufacturer 1"},
+                "model": "R2000",
+                "slug": "r2000",
+                "description": "Standard 42U server rack Updated",
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "outer_width": "24",
+                "outer_depth": "36",
+                "outer_unit": "in",
+                "weight": "350.5",
+                "max_weight": "1000",
+                "weight_unit": "lb",
+                "mounting_depth": "30",
+                "comments": "Standard enterprise rack configuration",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Standard 42U server rack Updated"
+        }
+    },
+    {
+        "name": "dcim_rearport_1",
+        "object_type": "dcim.rearport",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "Rear Port 1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "Rear Port 1",
+            "description": "Rear fiber port"
+        },
+        "create": {
+            "rear_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "name": "Rear Port 1",
+                "label": "RP1",
+                "type": "lc-apc",
+                "color": "0000ff",
+                "positions": "1",
+                "description": "Rear fiber port",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "rear_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "name": "Rear Port 1",
+                "label": "RP1",
+                "type": "lc-apc",
+                "color": "0000ff",
+                "positions": "1",
+                "description": "Rear fiber port Updated",
+                "mark_connected": true,
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Rear fiber port Updated"
+        }
+    },
+    {
+        "name": "dcim_region_1",
+        "object_type": "dcim.region",
+        "lookup": {"name": "North America"},
+        "create_expect": {
+            "name": "North America",
+            "parent.name": "Global",
+            "description": "North American Region"
+        },
+        "create": {
+            "region": {
+                "name": "North America",
+                "slug": "north-america",
+                "parent": {
+                    "name": "Global",
+                    "slug": "global",
+                    "description": "Global Region",
+                    "tags": [{"name": "Tag 1"}]
+                },
+                "description": "North American Region",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "region": {
+                "name": "North America",
+                "slug": "north-america",
+                "parent": {
+                    "name": "Global",
+                    "slug": "global",
+                    "description": "Global Region",
+                    "tags": [{"name": "Tag 1"}]
+                },
+                "description": "North American Region Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "North American Region Updated"
+        }
+    },
+    {
+        "name": "ipam_role_1",
+        "object_type": "ipam.role",
+        "lookup": {"name": "Network Administrator"},
+        "create_expect": {
+            "name": "Network Administrator",
+            "weight": 1000,
+            "description": "Primary network administration role"
+        },
+        "create": {
+            "role": {
+                "name": "Network Administrator",
+                "slug": "network-admin",
+                "weight": "1000",
+                "description": "Primary network administration role",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "role": {
+                "name": "Network Administrator",
+                "slug": "network-admin",
+                "weight": "1000",
+                "description": "Primary network administration role Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary network administration role Updated"
+        }
+    },
+    {
+        "name": "ipam_routetarget_1",
+        "object_type": "ipam.routetarget",
+        "lookup": {"name": "65000:1001"},
+        "create_expect": {
+            "name": "65000:1001",
+            "tenant.name": "Tenant 1",
+            "description": "Primary route target for MPLS VPN"
+        },
+        "create": {
+            "route_target": {
+                "name": "65000:1001",
+                "tenant": {"name": "Tenant 1"},
+                "description": "Primary route target for MPLS VPN",
+                "comments": "Used for customer VPN service",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "route_target": {
+                "name": "65000:1001",
+                "tenant": {"name": "Tenant 1"},
+                "description": "Primary route target for MPLS VPN Updated",
+                "comments": "Used for customer VPN service",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary route target for MPLS VPN Updated"
+        }
+    },
+    {
+        "name": "ipam_service_1",
+        "object_type": "ipam.service",
+        "lookup": {"name": "Web Server"},
+        "create_expect": {
+            "name": "Web Server",
+            "protocol": "tcp",
+            "ports": [80, 443],
+            "description": "Primary web server service"
+        },
+        "create": {
+            "service": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "name": "Web Server",
+                "protocol": "tcp",
+                "ports": ["80", "443"],
+                "description": "Primary web server service",
+                "comments": "Handles HTTPS traffic for main website",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "ipaddresses": [
+                    {
+                        "address": "192.168.1.100/24",
+                        "status": "active",
+                        "dns_name": "web.example.com"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "service": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "name": "Web Server",
+                "protocol": "tcp",
+                "ports": ["80", "443"],
+                "description": "Primary web server service Updated",
+                "comments": "Handles HTTPS traffic for main website",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "ipaddresses": [
+                    {
+                        "address": "192.168.1.100/24",
+                        "status": "active",
+                        "dns_name": "web.example.com"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary web server service Updated"
+        }
+    },
+    {
+        "name": "dcim_site_1",
+        "object_type": "dcim.site",
+        "lookup": {"name": "Data Center West"},
+        "create_expect": {
+            "name": "Data Center West",
+            "region.name": "North America",
+            "group.name": "Primary Data Centers",
+            "description": "Primary West Coast Data Center"
+        },
+        "create": {
+            "site": {
+                "name": "Data Center West",
+                "slug": "dc-west",
+                "status": "active",
+                "region": {
+                    "name": "North America",
+                    "slug": "north-america"
+                },
+                "group": {
+                    "name": "Primary Data Centers",
+                    "slug": "primary-dcs"
+                },
+                "tenant": {"name": "Tenant 1"},
+                "facility": "Building 7",
+                "time_zone": "America/Los_Angeles",
+                "description": "Primary West Coast Data Center",
+                "physical_address": "123 Tech Drive, San Jose, CA 95134",
+                "shipping_address": "Receiving Dock 3, 123 Tech Drive, San Jose, CA 95134",
+                "latitude": 37.3382,
+                "longitude": -121.8863,
+                "comments": "24x7 access requires security clearance",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "asns": [
+                    {
+                        "asn": "555",
+                        "rir": {"name": "RIR 1"},
+                        "tenant": {"name": "Tenant 1"},
+                        "description": "ASN 555 Description",
+                        "comments": "ASN 555 Comments",
+                        "tags": [{"name": "Tag 1"}]
+                    }
+                ]
+            }
+        },
+        "update": {
+            "site": {
+                "name": "Data Center West",
+                "slug": "dc-west",
+                "status": "active",
+                "region": {
+                    "name": "North America",
+                    "slug": "north-america"
+                },
+                "group": {
+                    "name": "Primary Data Centers",
+                    "slug": "primary-dcs"
+                },
+                "tenant": {"name": "Tenant 1"},
+                "facility": "Building 7",
+                "time_zone": "America/Los_Angeles",
+                "description": "Primary West Coast Data Center Updated",
+                "physical_address": "123 Tech Drive, San Jose, CA 95134",
+                "shipping_address": "Receiving Dock 3, 123 Tech Drive, San Jose, CA 95134",
+                "latitude": 37.3382,
+                "longitude": -121.8863,
+                "comments": "24x7 access requires security clearance",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "asns": [
+                    {
+                        "asn": "555",
+                        "rir": {"name": "RIR 1"},
+                        "tenant": {"name": "Tenant 1"},
+                        "description": "ASN 555 Description",
+                        "comments": "ASN 555 Comments",
+                        "tags": [{"name": "Tag 1"}]
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary West Coast Data Center Updated"
+        }
+    },
+    {
+        "name": "dcim_sitegroup_1",
+        "object_type": "dcim.sitegroup",
+        "lookup": {"name": "Global Data Centers"},
+        "create_expect": {
+            "name": "Global Data Centers",
+            "parent.name": "Infrastructure",
+            "description": "Worldwide data center facilities"
+        },
+        "create": {
+            "site_group": {
+                "name": "Global Data Centers",
+                "slug": "global-dcs",
+                "parent": {
+                    "name": "Infrastructure",
+                    "slug": "infrastructure"
+                },
+                "description": "Worldwide data center facilities",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "site_group": {
+                "name": "Global Data Centers",
+                "slug": "global-dcs",
+                "parent": {
+                    "name": "Infrastructure",
+                    "slug": "infrastructure"
+                },
+                "description": "Worldwide data center facilities Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Worldwide data center facilities Updated"
+        }
+    },
+    {
+        "name": "extras_tag_1",
+        "object_type": "extras.tag",
+        "lookup": {"name": "Production"},
+        "create_expect": {
+            "name": "Production",
+            "slug": "production",
+            "color": "ff0000"
+        },
+        "create": {
+            "tag": {
+                "name": "Production",
+                "slug": "production",
+                "color": "ff0000"
+            }
+        },
+        "update": {
+            "tag": {
+                "name": "Production",
+                "slug": "production",
+                "color": "00ff00"
+            }
+        },
+        "update_expect": {
+            "color": "00ff00"
+        }
+    },
+    {
+        "name": "tenancy_tenant_1",
+        "object_type": "tenancy.tenant",
+        "lookup": {"name": "Acme Corporation"},
+        "create_expect": {
+            "name": "Acme Corporation",
+            "slug": "acme-corp",
+            "description": "Global technology solutions provider"
+        },
+        "create": {
+            "tenant": {
+                "name": "Acme Corporation",
+                "slug": "acme-corp",
+                "group": {
+                    "name": "Enterprise Customers",
+                    "slug": "enterprise-customers"
+                },
+                "description": "Global technology solutions provider",
+                "comments": "Fortune 500 company with worldwide operations",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+    
+            }
+        },
+        "update": {
+            "tenant": {
+                "name": "Acme Corporation",
+                "slug": "acme-corp",
+                "group": {
+                    "name": "Enterprise Customers",
+                    "slug": "enterprise-customers"
+                },
+                "description": "Global technology solutions provider Updated",
+                "comments": "Fortune 500 company with worldwide operations",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Global technology solutions provider Updated"
+        }
+    },
+    {
+        "name": "tenancy_tenantgroup_1",
+        "object_type": "tenancy.tenantgroup",
+        "lookup": {"name": "Financial Services"},
+        "create_expect": {
+            "name": "Financial Services",
+            "description": "Banking and financial industry customers"
+        },
+        "create": {
+            "tenant_group": {
+                "name": "Financial Services",
+                "slug": "financial-services",
+                "parent": {
+                    "name": "Enterprise Sectors",
+                    "slug": "enterprise-sectors"
+                },
+                "description": "Banking and financial industry customers",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "tenant_group": {
+                "name": "Financial Services",
+                "slug": "financial-services",
+                "parent": {
+                    "name": "Enterprise Sectors",
+                    "slug": "enterprise-sectors"
+                },
+                "description": "Banking and financial industry customers Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Banking and financial industry customers Updated"
+        }
+    },
+    {
+        "name": "vpn_tunnel_1",
+        "object_type": "vpn.tunnel",
+        "lookup": {"name": "DC-West-to-East-Primary"},
+        "create_expect": {
+            "name": "DC-West-to-East-Primary",
+            "status": "active"
+        },
+        "create": {
+            "tunnel": {
+                "name": "DC-West-to-East-Primary",
+                "status": "active",
+                "group": {
+                    "name": "Inter-DC Tunnels",
+                    "slug": "inter-dc-tunnels"
+                },
+                "encapsulation": "ipsec-tunnel",
+                "ipsec_profile": {
+                    "name": "IPSEC-PROFILE-1",
+                    "mode": "esp",
+                    "ike_policy": {
+                        "name": "IKE-POLICY-TUN-1",
+                        "version": "2",
+                        "preshared_key": "1234567890",
+                        "comments": "Using AES-256-GCM encryption with PFS"
+                    },
+                    "ipsec_policy": {
+                        "name": "IPSEC-POLICY-1",
+                        "pfs_group": "2"
+                    }
+                },
+                "tenant": {"name": "Tenant 1"},
+                "tunnel_id": "1001",
+                "description": "Primary IPSec tunnel between West and East data centers",
+                "comments": "Using AES-256-GCM encryption with PFS",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "tunnel": {
+                "name": "DC-West-to-East-Primary",
+                "status": "active",
+                "group": {
+                    "name": "Inter-DC Tunnels",
+                    "slug": "inter-dc-tunnels"
+                },
+                "encapsulation": "ipsec-tunnel",
+                "ipsec_profile": {
+                    "name": "IPSEC-PROFILE-1",
+                    "mode": "esp",
+                    "ike_policy": {
+                        "name": "IKE-POLICY-TUN-1",
+                        "version": "2",
+                        "preshared_key": "1234567890",
+                        "comments": "Using AES-256-GCM encryption with PFS"
+                    },
+                    "ipsec_policy": {
+                        "name": "IPSEC-POLICY-1",
+                        "pfs_group": "2"
+                    }
+                },
+                "tenant": {"name": "Tenant 1"},
+                "tunnel_id": "1001",
+                "description": "Primary IPSec tunnel between West and East data centers Updated",
+                "comments": "Using AES-256-GCM encryption with PFS",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary IPSec tunnel between West and East data centers Updated"
+        }
+    },
+    {
+        "name": "vpn_tunnel_group_1",
+        "object_type": "vpn.tunnelgroup",
+        "lookup": {"name": "Regional Backbones"},
+        "create_expect": {
+            "name": "Regional Backbones",
+            "description": "High-capacity encrypted tunnels between regional data centers"
+        },
+        "create": {
+            "tunnel_group": {
+                "name": "Regional Backbones",
+                "slug": "regional-backbones",
+                "description": "High-capacity encrypted tunnels between regional data centers",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "tunnel_group": {
+                "name": "Regional Backbones",
+                "slug": "regional-backbones",
+                "description": "High-capacity encrypted tunnels between regional data centers Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "High-capacity encrypted tunnels between regional data centers Updated"
+        }
+    },
+    {
+        "name": "vpn_tunneltermination_1",
+        "object_type": "vpn.tunneltermination",
+        "lookup": {"tunnel__name": "DC-West-to-East-Primary"},
+        "create_expect": {
+            "tunnel.name": "DC-West-to-East-Primary",
+            "role": "hub"
+        },
+        "create": {
+            "tunnel_termination": {
+                "tunnel": {
+                    "name": "DC-West-to-East-Primary",
+                    "status": "active",
+                    "encapsulation": "ipsec-tunnel"
+                },
+                "role": "hub",
+                "termination_device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "outside_ip": {
+                    "address": "203.0.113.1/24",
+                    "status": "active",
+                    "dns_name": "vpn1.example.com"
+                },
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "tunnel_termination": {
+                "tunnel": {
+                    "name": "DC-West-to-East-Primary",
+                    "status": "active",
+                    "encapsulation": "ipsec-tunnel"
+                },
+                "role": "hub",
+                "termination_device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "outside_ip": {
+                    "address": "203.0.113.1/24",
+                    "status": "active",
+                    "dns_name": "vpn1.example.com"
+                },
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}, {"name": "Tag 3"}]
+            }    
+        },
+        "update_expect": {
+            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"]
+        }
+    },
+    {
+        "name": "ipam_vlan_1",
+        "object_type": "ipam.vlan",
+        "lookup": {"vid": 807},
+        "create_expect": {
+            "vid": 807,
+            "name": "Production Servers"
+        },
+        "create": {
+            "vlan": {
+                "group": {
+                    "name": "Production VLANs",
+                    "slug": "production-vlans"
+                },
+                "vid": "807",
+                "name": "Production Servers",
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "description": "Primary production server network",
+                "qinq_role": "cvlan",
+                "qinq_svlan": {
+                    "vid": "1909",
+                    "name": "Service Provider VLAN"
+                },
+                "comments": "Used for customer-facing production workloads",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "vlan": {
+                "group": {
+                    "name": "Production VLANs",
+                    "slug": "production-vlans"
+                },
+                "vid": "807",
+                "name": "Production Servers",
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "description": "Primary production server network Updated",
+                "qinq_role": "cvlan",
+                "qinq_svlan": {
+                    "vid": "1909",
+                    "name": "Service Provider VLAN"
+                },
+                "comments": "Used for customer-facing production workloads",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Primary production server network Updated"
+        }
+    },
+    {
+        "name": "ipam_vlan_2",
+        "object_type": "ipam.vlan",
+        "lookup": {"vid": 807},
+        "create_expect": {
+            "vid": 807,
+            "name": "Production Servers",
+            "site.name": "Site 1"
+        },
+        "create": {
+            "vlan": {
+                "vid": "807",
+                "name": "Production Servers",
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "site": {"name": "Site 1"},
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "description": "Primary production server network",
+                "comments": "Used for customer-facing production workloads",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "vlan": {
+                "vid": "807",
+                "name": "Production Servers",
+                "tenant": {"name": "Tenant 1"},
+                "status": "active",
+                "site": {"name": "Site 1"},
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "description": "Primary production server network Updated",
+                "comments": "Used for customer-facing production workloads",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Primary production server network Updated",
+            "site.name": "Site 1"
+        }
+    },
+    {
+        "name": "ipam_vlan_group_1",
+        "object_type": "ipam.vlangroup",
+        "lookup": {"name": "Data Center Core"},
+        "create_expect": {
+            "name": "Data Center Core",
+            "slug": "dc-core",
+            "description": "Core network VLANs for data center infrastructure"
+        },
+        "create": {
+            "vlan_group": {
+                "name": "Data Center Core",
+                "slug": "dc-core",
+                "scope_site": {
+                    "name": "Data Center West",
+                    "slug": "dc-west",
+                    "status": "active"
+                },
+                "vid_ranges": ["101", "102", "99", "100"],
+                "description": "Core network VLANs for data center infrastructure",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "vlan_group": {
+                "name": "Data Center Core",
+                "slug": "dc-core",
+                "scope_site": {
+                    "name": "Data Center West",
+                    "slug": "dc-west",
+                    "status": "active"
+                },
+                "vid_ranges": ["101", "102", "99", "100"],
+                "description": "Core network VLANs for data center infrastructure Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Core network VLANs for data center infrastructure Updated",
+            "vid_ranges": [[99, 100], [101, 102]]
+        }
+    },
+    {
+        "name": "ipam_vlan_translation_policy_1",
+        "object_type": "ipam.vlantranslationpolicy",
+        "lookup": {"name": "Customer Edge Translation"},
+        "create_expect": {
+            "name": "Customer Edge Translation",
+            "description": "VLAN translation policy for customer edge interfaces"
+        },
+        "create": {
+            "vlan_translation_policy": {
+                "name": "Customer Edge Translation",
+                "description": "VLAN translation policy for customer edge interfaces"
+            }
+        },
+        "update": {
+            "vlan_translation_policy": {
+                "name": "Customer Edge Translation",
+                "description": "VLAN translation policy for customer edge interfaces Updated"
+            }    
+        },
+        "update_expect": {
+            "description": "VLAN translation policy for customer edge interfaces Updated"
+        }
+    },
+    {
+        "name": "ipam_vlan_translation_rule_1",
+        "object_type": "ipam.vlantranslationrule",
+        "lookup": {"policy__name": "Customer Edge Translation", "local_vid": "100"},
+        "create_expect": {
+            "policy.name": "Customer Edge Translation",
+            "local_vid": 100,
+            "remote_vid": 1100,
+            "description": "Map customer VLAN 100 to provider VLAN 1100"
+        },
+        "create": {
+            "vlan_translation_rule": {
+                "policy": {
+                    "name": "Customer Edge Translation",
+                    "description": "VLAN translation policy for customer edge interfaces"
+                },
+                "local_vid": "100",
+                "remote_vid": "1100",
+                "description": "Map customer VLAN 100 to provider VLAN 1100"
+            }    
+        },
+        "update": {
+            "vlan_translation_rule": {
+                "policy": {
+                    "name": "Customer Edge Translation",
+                    "description": "VLAN translation policy for customer edge interfaces"
+                },
+                "local_vid": "100",
+                "remote_vid": "1100",
+                "description": "Map customer VLAN 100 to provider VLAN 1100 Updated"
+            }    
+        },
+        "update_expect": {
+            "description": "Map customer VLAN 100 to provider VLAN 1100 Updated"
+        }
+    },
+    {
+        "name": "virtualization_vminterface_1",
+        "object_type": "virtualization.vminterface",
+        "lookup": {"name": "eth0"},
+        "create_expect": {
+            "name": "eth0",
+            "description": "Primary network interface"
+        },
+        "create": {
+            "vm_interface": {
+                "virtual_machine": {
+                    "name": "web-server-01",
+                    "status": "active",
+                    "role": {"name": "Web Server"},
+                    "site": {"name": "Site 1"}
+                },
+                "name": "eth0",
+                "enabled": true,
+                "parent": {
+                    "virtual_machine": {
+                        "name": "web-server-01",
+                        "status": "active",
+                        "role": {"name": "Web Server"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "bond0"
+                },
+                "bridge": {
+                    "virtual_machine": {
+                        "name": "web-server-01",
+                        "status": "active",
+                        "role": {"name": "Web Server"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "br0"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:1A:2B:3C:4D:5E"
+                },
+                "description": "Primary network interface",
+                "mode": "q-in-q",
+                "untagged_vlan": {
+                    "vid": "1101",
+                    "name": "Production Servers"
+                },
+                "qinq_svlan": {
+                    "vid": "1000",
+                    "name": "Service Provider VLAN"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Edge Translation"
+                },
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "vm_interface": {
+                "virtual_machine": {
+                    "name": "web-server-01",
+                    "status": "active",
+                    "role": {"name": "Web Server"},
+                    "site": {"name": "Site 1"}
+                },
+                "name": "eth0",
+                "enabled": true,
+                "parent": {
+                    "virtual_machine": {
+                        "name": "web-server-01",
+                        "status": "active",
+                        "role": {"name": "Web Server"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "bond0"
+                },
+                "bridge": {
+                    "virtual_machine": {
+                        "name": "web-server-01",
+                        "status": "active",
+                        "role": {"name": "Web Server"},
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "br0"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:1A:2B:3C:4D:5E"
+                },
+                "description": "Primary network interface Updated",
+                "mode": "q-in-q",
+                "untagged_vlan": {
+                    "vid": "1101",
+                    "name": "Production Servers"
+                },
+                "qinq_svlan": {
+                    "vid": "1000",
+                    "name": "Service Provider VLAN"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Edge Translation"
+                },
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Primary network interface Updated"
+        }
+    },
+    {
+        "name": "ipam_vrf_1",
+        "object_type": "ipam.vrf",
+        "lookup": {"name": "Customer-A-VRF"},
+        "create_expect": {
+            "name": "Customer-A-VRF",
+            "rd": "65000:100",
+            "tenant.name": "Tenant 1",
+            "enforce_unique": true,
+            "description": "Isolated routing domain for Customer A",
+            "comments": "Used for customer's private network services"
+        },
+        "create": {
+            "vrf": {
+                "name": "Customer-A-VRF",
+                "rd": "65000:100",
+                "tenant": {"name": "Tenant 1"},
+                "enforce_unique": true,
+                "description": "Isolated routing domain for Customer A",
+                "comments": "Used for customer's private network services",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "import_targets": [
+                    {
+                        "name": "65000:100"
+                    },
+                    {
+                        "name": "65000:101"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:103"
+                    }
+                ]    
+            }
+        },
+        "update": {
+            "vrf": {
+                "name": "Customer-A-VRF",
+                "rd": "65000:100",
+                "tenant": {"name": "Tenant 1"},
+                "enforce_unique": true,
+                "description": "Isolated routing domain for Customer A Updated",
+                "comments": "Used for customer's private network services",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                "import_targets": [
+                    {
+                        "name": "65000:100"
+                    },
+                    {
+                        "name": "65000:101"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:103"
+                    }
+                ]    
+            }
+        },
+        "update_expect": {
+            "description": "Isolated routing domain for Customer A Updated"
+        }
+    },
+    {
+        "name": "dcim_virtualchassis_1",
+        "object_type": "dcim.virtualchassis",
+        "lookup": {"name": "Stack-DC1-Core"},
+        "create_expect": {
+            "name": "Stack-DC1-Core",
+            "domain": "dc1-core.example.com"
+        },
+        "create": {
+            "virtual_chassis": {
+                "name": "Stack-DC1-Core",
+                "domain": "dc1-core.example.com",
+                "master": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "description": "Core switch stack in DC1",
+                "comments": "Primary switching infrastructure for data center 1",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update": {
+            "virtual_chassis": {
+                "name": "Stack-DC1-Core",
+                "domain": "dc1-core.example.com",
+                "master": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "description": "Core switch stack in DC1 Updated",
+                "comments": "Primary switching infrastructure for data center 1",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Core switch stack in DC1 Updated"
+        }
+    },
+    {
+        "name": "circuits_virtualcircuit_1",
+        "object_type": "circuits.virtualcircuit",
+        "lookup": {"cid": "VC-001-LAX-NYC"},
+        "create_expect": {
+            "cid": "VC-001-LAX-NYC"
+        },
+        "create": {
+            "virtual_circuit": {
+                "cid": "VC-001-LAX-NYC",
+                "provider_network": {
+                    "provider": {"name": "Level 3 Communications"},
+                    "name": "Global MPLS Network",
+                    "service_id": "L3-MPLS-001"
+                },
+                "provider_account": {
+                    "provider": {"name": "Level 3 Communications"},
+                    "name": "East Coast Account",
+                    "account": "L3-12345"
+                },
+                "type": {
+                    "name": "MPLS L3VPN",
+                    "slug": "mpls-l3vpn"
+                },
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "description": "LAX to NYC MPLS circuit",
+                "comments": "Primary east-west connectivity",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "virtual_circuit": {
+                "cid": "VC-001-LAX-NYC",
+                "provider_network": {
+                    "provider": {"name": "Level 3 Communications"},
+                    "name": "Global MPLS Network",
+                    "service_id": "L3-MPLS-001"
+                },
+                "provider_account": {
+                    "provider": {"name": "Level 3 Communications"},
+                    "name": "East Coast Account",
+                    "account": "L3-12345"
+                },
+                "type": {
+                    "name": "MPLS L3VPN",
+                    "slug": "mpls-l3vpn"
+                },
+                "status": "active",
+                "tenant": {"name": "Tenant 1"},
+                "description": "LAX to NYC MPLS circuit Updated",
+                "comments": "Primary east-west connectivity",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "LAX to NYC MPLS circuit Updated"
+        }
+    },
+    {
+        "name": "circuits_virtualcircuittermination_1",
+        "object_type": "circuits.virtualcircuittermination",
+        "lookup": {"virtual_circuit__cid": "VC-001-LAX-NYC"},
+        "create_expect": {
+            "virtual_circuit.cid": "VC-001-LAX-NYC",
+            "role": "hub",
+            "interface.device.name": "Device 1"
+        },
+        "create": {
+            "virtual_circuit_termination": {
+                "virtual_circuit": {
+                    "cid": "VC-001-LAX-NYC",
+                    "provider_network": {
+                        "provider": {"name": "Level 3 Communications"},
+                        "name": "Global MPLS Network"
+                    },
+                    "type": {
+                        "name": "MPLS L3VPN",
+                        "slug": "mpls-l3vpn"
+                    }
+                },
+                "role": "hub",
+                "interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "MegabitEthernet1/0/1",
+                    "type": "virtual",
+                    "enabled": true
+                },
+                "description": "LAX hub termination for east-west MPLS circuit",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "virtual_circuit_termination": {
+                "virtual_circuit": {
+                    "cid": "VC-001-LAX-NYC",
+                    "provider_network": {
+                        "provider": {"name": "Level 3 Communications"},
+                        "name": "Global MPLS Network"
+                    },
+                    "type": {
+                        "name": "MPLS L3VPN",
+                        "slug": "mpls-l3vpn"
+                    }
+                },
+                "role": "hub",
+                "interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "MegabitEthernet1/0/1",
+                    "type": "virtual",
+                    "enabled": true
+                },
+                "description": "LAX hub termination for east-west MPLS circuit Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "LAX hub termination for east-west MPLS circuit Updated"
+        }
+    },
+    {
+        "name": "circuits_virtualcircuittype_1",
+        "object_type": "circuits.virtualcircuittype",
+        "lookup": {"name": "EVPN-VXLAN"},
+        "create_expect": {
+            "name": "EVPN-VXLAN",
+            "description": "Data center interconnect using EVPN-VXLAN overlay"
+        },
+        "create": {
+            "virtual_circuit_type": {
+                "name": "EVPN-VXLAN",
+                "slug": "evpn-vxlan",
+                "color": "0000ff",
+                "description": "Data center interconnect using EVPN-VXLAN overlay",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "virtual_circuit_type": {
+                "name": "EVPN-VXLAN",
+                "slug": "evpn-vxlan",
+                "color": "0000ff",
+                "description": "Data center interconnect using EVPN-VXLAN overlay Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Data center interconnect using EVPN-VXLAN overlay Updated"
+        }
+    },
+    {
+        "name": "dcim_virtualdevicecontext_1",
+        "object_type": "dcim.virtualdevicecontext",
+        "lookup": {"name": "VDC-Production"},
+        "create_expect": {
+            "name": "VDC-Production",
+            "description": "Production virtual device context",
+            "comments": "Isolated network context for production services",
+            "identifier": 1,
+            "device.name": "Device 1",
+            "primary_ip4.address": "192.168.1.1/32",
+            "primary_ip6.address": "2001:db8::1/128"
+        },
+        "create": {
+            "virtual_device_context": {
+                "name": "VDC-Production",
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "identifier": "1",
+                "tenant": {"name": "Tenant 1"},
+                "primary_ip4": {
+                    "address": "192.168.1.1", 
+                    "assigned_object_interface": {
+                        "type": "1000base-t",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "name": "eth0"
+                    }
+                },
+                "primary_ip6": {
+                    "address": "2001:db8::1",
+                    "assigned_object_interface": {
+                        "type": "1000base-t",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "name": "eth0"
+                    }
+                },
+                "status": "active",
+                "description": "Production virtual device context",
+                "comments": "Isolated network context for production services",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+    
+        },
+        "update": {
+            "virtual_device_context": {
+                "name": "VDC-Production",
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"}
+                },
+                "identifier": "1",
+                "tenant": {"name": "Tenant 1"},
+                "primary_ip4": {
+                    "address": "192.168.1.1", 
+                    "assigned_object_interface": {
+                        "type": "1000base-t",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "name": "eth0"
+                    }
+                },
+                "primary_ip6": {
+                    "address": "2001:db8::1",
+                    "assigned_object_interface": {
+                        "type": "1000base-t",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "name": "eth0"
+                    }
+                },
+                "status": "active",
+                "description": "Production virtual device context Updated",
+                "comments": "Isolated network context for production services",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Production virtual device context Updated"
+        }
+    },
+    {
+        "name": "virtualization_virtualdisk_1",
+        "object_type": "virtualization.virtualdisk",
+        "lookup": {"name": "root-volume"},
+        "create_expect": {
+            "name": "root-volume",
+            "description": "Primary system disk"
+        },
+        "create": {
+            "virtual_disk": {
+                "virtual_machine": {
+                    "name": "web-server-01",
+                    "status": "active",
+                    "role": {"name": "Web Server"},
+                    "site": {"name": "Site 1"}
+                },
+                "name": "root-volume",
+                "description": "Primary system disk",
+                "size": "182400",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "virtual_disk": {
+                "virtual_machine": {
+                    "name": "web-server-01",
+                    "status": "active",
+                    "role": {"name": "Web Server"},
+                    "site": {"name": "Site 1"}
+                },
+                "name": "root-volume",
+                "description": "Primary system disk Updated",
+                "size": "182400",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Primary system disk Updated"
+        }
+    },
+    {
+        "name": "virtualization_virtualmachine_1",
+        "object_type": "virtualization.virtualmachine",
+        "lookup": {"name": "app-server-01"},
+        "create_expect": {
+            "name": "app-server-01",
+            "description": "Primary application server instance",
+            "comments": "Hosts critical business applications"
+        },
+        "create": {
+            "virtual_machine": {
+                "name": "app-server-01",
+                "status": "active",
+                "site": {"name": "Site 1"},
+                "cluster": {
+                    "name": "Cluster 1",
+                    "type": {"name": "Cluster Type 1"},
+                    "scope_site": {"name": "Site 1"}
+                },
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"},
+                    "cluster": {
+                        "name": "Cluster 1",
+                        "type": {"name": "Cluster Type 1"},
+                        "scope_site": {"name": "Site 1"}
+                    }
+                },
+                "serial": "VM-2023-001",
+                "role": {"name": "Application Server"},
+                "tenant": {"name": "Tenant 1"},
+                "platform": {"name": "Ubuntu 22.04"},
+                "primary_ip4": {
+                    "address": "192.168.2.99",
+                    "assigned_object_vm_interface": {
+                        "virtual_machine": {
+                            "name": "app-server-01",
+                            "cluster": {
+                                "name": "Cluster 1",
+                                "type": {"name": "Cluster Type 1"},
+                                "scope_site": {"name": "Site 1"}
+                            },
+                            "tenant": {"name": "Tenant 1"}
+                        },
+                        "name": "eth0",
+                        "enabled": true,
+                        "mtu": "1500"
+                    }
+                },
+                "primary_ip6": {
+                    "address": "2001:db8::99",
+                    "assigned_object_vm_interface": {
+                        "virtual_machine": {
+                            "name": "app-server-01",
+                            "cluster": {
+                                "name": "Cluster 1",
+                                "type": {"name": "Cluster Type 1"},
+                                "scope_site": {"name": "Site 1"}
+                            },
+                            "tenant": {"name": "Tenant 1"}
+                        },
+                        "name": "eth0",
+                        "enabled": true,
+                        "mtu": "1500"
+                    }
+                },
+                "vcpus": 4.0,
+                "memory": "214748364",
+                "disk": "147483647",
+                "description": "Primary application server instance",
+                "comments": "Hosts critical business applications",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update": {
+            "virtual_machine": {
+                "name": "app-server-01",
+                "status": "active",
+                "site": {"name": "Site 1"},
+                "cluster": {
+                    "name": "Cluster 1",
+                    "type": {"name": "Cluster Type 1"},
+                    "scope_site": {"name": "Site 1"}
+                },
+                "device": {
+                    "name": "Device 1",
+                    "role": {"name": "Device Role 1"},
+                    "device_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S"
+                    },
+                    "site": {"name": "Site 1"},
+                    "cluster": {
+                        "name": "Cluster 1",
+                        "type": {"name": "Cluster Type 1"},
+                        "scope_site": {"name": "Site 1"}
+                    }
+                },
+                "serial": "VM-2023-001",
+                "role": {"name": "Application Server"},
+                "tenant": {"name": "Tenant 1"},
+                "platform": {"name": "Ubuntu 22.04"},
+                "primary_ip4": {
+                    "address": "192.168.2.99",
+                    "assigned_object_vm_interface": {
+                        "virtual_machine": {
+                            "name": "app-server-01",
+                            "cluster": {
+                                "name": "Cluster 1",
+                                "type": {"name": "Cluster Type 1"},
+                                "scope_site": {"name": "Site 1"}
+                            },
+                            "tenant": {"name": "Tenant 1"}
+                        },
+                        "name": "eth0",
+                        "enabled": true,
+                        "mtu": "1500"
+                    }
+                },
+                "primary_ip6": {
+                    "address": "2001:db8::99",
+                    "assigned_object_vm_interface": {
+                        "virtual_machine": {
+                            "name": "app-server-01",
+                            "cluster": {
+                                "name": "Cluster 1",
+                                "type": {"name": "Cluster Type 1"},
+                                "scope_site": {"name": "Site 1"}
+                            },
+                            "tenant": {"name": "Tenant 1"}
+                        },
+                        "name": "eth0",
+                        "enabled": true,
+                        "mtu": "1500"
+                    }
+                },
+                "vcpus": 4.0,
+                "memory": "214748364",
+                "disk": "147483647",
+                "description": "Primary application server instance Updated",
+                "comments": "Hosts critical business applications",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }    
+        },
+        "update_expect": {
+            "description": "Primary application server instance Updated"
+        }
+    },
+    {
+        "name": "wireless_wirelesslan_1",
+        "object_type": "wireless.wirelesslan",
+        "lookup": {"ssid": "Corp-Secure"},
+        "create_expect": {
+            "ssid": "Corp-Secure",
+            "group.name": "Corporate Networks",
+            "description": "Corporate secure wireless network"
+        },
+        "create": {
+            "wireless_lan": {
+                "ssid": "Corp-Secure",
+                "description": "Corporate secure wireless network",
+                "group": {
+                    "name": "Corporate Networks",
+                    "slug": "corporate-networks"
+                },
+                "status": "active",
+                "vlan": {
+                    "vid": 100,
+                    "name": "Production Servers"
+                },
+                "scope_site": {"name": "Site 1"},
+                "tenant": {"name": "Tenant 1"},
+                "auth_type": "wpa-enterprise",
+                "auth_cipher": "aes",
+                "auth_psk": "SecureWiFiKey123!",
+                "comments": "Primary corporate wireless network with 802.1X authentication",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "wireless_lan": {
+                "ssid": "Corp-Secure",
+                "description": "Corporate secure wireless network Updated",
+                "group": {
+                    "name": "Corporate Networks",
+                    "slug": "corporate-networks"
+                },
+                "status": "active",
+                "vlan": {
+                    "vid": 100,
+                    "name": "Production Servers"
+                },
+                "scope_site": {"name": "Site 1"},
+                "tenant": {"name": "Tenant 1"},
+                "auth_type": "wpa-enterprise",
+                "auth_cipher": "aes",
+                "auth_psk": "SecureWiFiKey123!",
+                "comments": "Primary corporate wireless network with 802.1X authentication",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Corporate secure wireless network Updated"
+        }
+    },
+    {
+        "name": "wireless_wirelesslangroup_1",
+        "object_type": "wireless.wirelesslangroup",
+        "lookup": {"name": "Corporate Networks"},
+        "create_expect": {
+            "name": "Corporate Networks",
+            "parent.name": "All Networks",
+            "description": "Enterprise corporate wireless networks"
+        },
+        "create": {
+            "wireless_lan_group": {
+                "name": "Corporate Networks",
+                "slug": "corporate-networks",
+                "parent": {
+                    "name": "All Networks",
+                    "slug": "all-networks"
+                },
+                "description": "Enterprise corporate wireless networks",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update": {
+            "wireless_lan_group": {
+                "name": "Corporate Networks",
+                "slug": "corporate-networks",
+                "parent": {
+                    "name": "All Networks",
+                    "slug": "all-networks"
+                },
+                "description": "Enterprise corporate wireless networks Updated",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+            }
+        },
+        "update_expect": {
+            "description": "Enterprise corporate wireless networks Updated"
+        }
+    }, 
+    {
+        "name": "wireless_wirelesslink_1",
+        "object_type": "wireless.wirelesslink",
+        "lookup": {"ssid": "P2P-Link-1"},
+        "create_expect": {
+            "interface_a.device.name": "Device 1",
+            "interface_b.device.name": "Device 2",
+            "description": "Point-to-point wireless backhaul link"
+        },
+        "create": {
+            "wireless_link": {
+                "interface_a": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Radio0/1",
+                    "type": "ieee802.11ac",
+                    "enabled": true
+                },
+                "interface_b": {
+                    "device": {
+                        "name": "Device 2",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Radio0/1",
+                    "type": "ieee802.11ac",
+                    "enabled": true
+                },
+                "ssid": "P2P-Link-1",
+                "status": "connected",
+                "tenant": {"name": "Tenant 1"},
+                "auth_type": "wpa-personal",
+                "auth_cipher": "aes",
+                "auth_psk": "P2PLinkKey123!",
+                "distance": 1.5,
+                "distance_unit": "km",
+                "description": "Point-to-point wireless backhaul link",
+                "comments": "Building A to Building B wireless bridge",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update": {
+            "wireless_link": {
+                "interface_a": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Radio0/1",
+                    "type": "ieee802.11ac",
+                    "enabled": true
+                },
+                "interface_b": {
+                    "device": {
+                        "name": "Device 2",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Radio0/1",
+                    "type": "ieee802.11ac",
+                    "enabled": true
+                },
+                "ssid": "P2P-Link-1",
+                "status": "connected",
+                "tenant": {"name": "Tenant 1"},
+                "auth_type": "wpa-personal",
+                "auth_cipher": "aes",
+                "auth_psk": "P2PLinkKey123!",
+                "distance": 1.5,
+                "distance_unit": "km",
+                "description": "Point-to-point wireless backhaul link Updated",
+                "comments": "Building A to Building B wireless bridge",
+                "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]    
+            }
+        },
+        "update_expect": {
+            "description": "Point-to-point wireless backhaul link Updated"
+        }
+    },
+    {
+        "name": "users_owner_1",
+        "object_type": "users.owner",
+        "lookup": {"name": "Owner 1"},
+        "create_expect": {
+            "name": "Owner 1",
+            "description": "Primary network owner",
+            "group.name": "Owner Group 1"
+        },
+        "create": {
+            "owner": {
+                "name": "Owner 1",
+                "group": {
+                    "name": "Owner Group 1"
+                },
+                "description": "Primary network owner"
+            }
+        },
+        "update": {
+            "owner": {
+                "name": "Owner 1",
+                "group": {
+                    "name": "Owner Group 1"
+                },
+                "description": "Primary network owner updated"
+            }
+        },
+        "update_expect": {
+            "description": "Primary network owner updated"
+        }
+    },
+    {
+        "name": "users_ownergroup_1",
+        "object_type": "users.ownergroup",
+        "lookup": {"name": "Owner Group 1"},
+        "create_expect": {
+            "name": "Owner Group 1",
+            "description": "Network operations team"
+        },
+        "create": {
+            "owner_group": {
+                "name": "Owner Group 1",
+                "description": "Network operations team"
+            }
+        },
+        "update": {
+            "owner_group": {
+                "name": "Owner Group 1",
+                "description": "Network operations team updated"
+            }
+        },
+        "update_expect": {
+            "description": "Network operations team updated"
+        }
+    },
+    {
+        "name": "circuits_circuit_with_owner_1",
+        "object_type": "circuits.circuit",
+        "lookup": {"cid": "CIRCUIT-OWNER-001"},
+        "create_expect": {
+            "cid": "CIRCUIT-OWNER-001",
+            "provider.name": "Provider 1",
+            "type.name": "Circuit Type 1",
+            "owner.name": "Owner 1"
+        },
+        "create": {
+            "circuit": {
+                "cid": "CIRCUIT-OWNER-001",
+                "provider": {"name": "Provider 1"},
+                "type": {"name": "Circuit Type 1"},
+                "owner": {
+                    "name": "Owner 1",
+                    "group": {"name": "Owner Group 1"}
+                },
+                "status": "active",
+                "description": "Circuit with owner",
+                "comments": "Test circuit ownership",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "circuit": {
+                "cid": "CIRCUIT-OWNER-001",
+                "provider": {"name": "Provider 1"},
+                "type": {"name": "Circuit Type 1"},
+                "owner": {
+                    "name": "Owner 1",
+                    "group": {"name": "Owner Group 1"}
+                },
+                "status": "active",
+                "description": "Circuit with owner updated",
+                "comments": "Test circuit ownership",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Circuit with owner updated"
+        }
+    },
+    {
+        "name": "dcim_device_with_owner_1",
+        "object_type": "dcim.device",
+        "lookup": {"name": "Device With Owner 1"},
+        "create_expect": {
+            "name": "Device With Owner 1",
+            "role.name": "Device Role 1",
+            "device_type.manufacturer.name": "Cisco",
+            "device_type.model": "C9300",
+            "site.name": "Site 1",
+            "owner.name": "Owner 1"
+        },
+        "create": {
+            "device": {
+                "name": "Device With Owner 1",
+                "role": {"name": "Device Role 1"},
+                "device_type": {
+                    "manufacturer": {"name": "Cisco"},
+                    "model": "C9300"
+                },
+                "site": {"name": "Site 1"},
+                "owner": {
+                    "name": "Owner 1",
+                    "group": {"name": "Owner Group 1"}
+                },
+                "status": "active",
+                "description": "Device with owner",
+                "comments": "Test device ownership",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update": {
+            "device": {
+                "name": "Device With Owner 1",
+                "role": {"name": "Device Role 1"},
+                "device_type": {
+                    "manufacturer": {"name": "Cisco"},
+                    "model": "C9300"
+                },
+                "site": {"name": "Site 1"},
+                "owner": {
+                    "name": "Owner 1",
+                    "group": {"name": "Owner Group 1"}
+                },
+                "status": "active",
+                "description": "Device with owner updated",
+                "comments": "Test device ownership",
+                "tags": [{"name": "Tag 1"}]
+            }
+        },
+        "update_expect": {
+            "description": "Device with owner updated"
+        }
+    }
+]

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_version.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_version.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+from django.test import TestCase
+
+from netbox_diode_plugin.version import version_display, version_semver
+
+
+class VersionTestCase(TestCase):
+    """Test case for the version module."""
+
+    def test_version(self):
+        """Check the injected semver."""
+        assert version_semver() == "0.0.0"
+
+    def test_version_display(self):
+        """Check the injected display."""
+        assert version_display() == "v0.0.0-dev-unknown"

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_views.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_views.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+from unittest import mock
+
+from django.contrib import messages
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+from django.test import TestCase as _TestCase
+from django.urls import reverse
+from rest_framework import status
+from users.models import ObjectPermission
+from utilities.permissions import resolve_permission_type
+
+from netbox_diode_plugin.models import Setting
+from netbox_diode_plugin.views import SettingsEditView, SettingsView
+
+User = get_user_model()
+
+
+class TestCase(_TestCase):
+    """Base test case class for NetBox Diode plugin tests."""
+
+    def add_permissions(self, user, *names):
+        """Assign a set of permissions to the test user. Accepts permission names in the form <app>.<action>_<model>."""
+        for name in names:
+            object_type, action = resolve_permission_type(name)
+            obj_perm = ObjectPermission(name=name, actions=[action])
+            obj_perm.save()
+            obj_perm.users.add(user)
+            obj_perm.object_types.add(object_type)
+
+
+class SettingsViewTestCase(TestCase):
+    """Test case for the SettingsView."""
+
+    def setUp(self):
+        """Setup the test case."""
+        self.path = reverse("plugins:netbox_diode_plugin:settings")
+        self.request = RequestFactory().get(self.path)
+        self.view = SettingsView()
+        self.view.setup(self.request)
+
+    def test_returns_200_for_authenticated(self):
+        """Test that the view returns 200 for an authenticated user."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        response = self.view.get(self.request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_redirects_to_login_page_for_unauthenticated_user(self):
+        """Test that the view returns 200 for an authenticated user."""
+        self.request.user = AnonymousUser()
+        self.view.setup(self.request)
+
+        response = SettingsView.as_view()(self.request)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, f"/netbox/login/?next={self.path}")
+
+    def test_settings_created_if_not_found(self):
+        """Test that the settings are created with placeholder data if not found."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        with mock.patch("netbox_diode_plugin.models.Setting.objects.get") as mock_get:
+            mock_get.side_effect = Setting.DoesNotExist
+
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpc://localhost:8080/diode", str(response.content))
+
+
+    def test_settings_display_with_diode_target_display(self):
+        """Test that diode_target_display overrides the displayed target."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        def mock_get_plugin_config(plugin, key):
+            if key == "diode_target_display":
+                return "grpcs://external.example.com/diode"
+            if key == "diode_target_override":
+                return None
+            if key == "diode_target":
+                return "grpc://localhost:8080/diode"
+            return None
+
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config",
+            side_effect=mock_get_plugin_config,
+        ):
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpcs://external.example.com/diode", str(response.content))
+            self.assertNotIn("grpc://localhost:8080/diode", str(response.content))
+
+    def test_diode_target_display_takes_precedence_over_override(self):
+        """Test that diode_target_display takes precedence over diode_target_override for display."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        def mock_get_plugin_config(plugin, key):
+            if key == "diode_target_display":
+                return "grpcs://external.example.com/diode"
+            if key == "diode_target_override":
+                return "grpc://internal-override:8080/diode"
+            if key == "diode_target":
+                return "grpc://localhost:8080/diode"
+            return None
+
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config",
+            side_effect=mock_get_plugin_config,
+        ):
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpcs://external.example.com/diode", str(response.content))
+            self.assertNotIn("grpc://internal-override:8080/diode", str(response.content))
+
+
+class SettingsEditViewTestCase(TestCase):
+    """Test case for the SettingsEditView."""
+
+    def setUp(self):
+        """Setup the test case."""
+        self.path = reverse("plugins:netbox_diode_plugin:settings_edit")
+        self.request_factory = RequestFactory()
+        self.view = SettingsEditView()
+
+    def test_returns_200_for_authenticated(self):
+        """Test that the view returns 200 for an authenticated user."""
+        request = self.request_factory.get(self.path)
+        request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(request.user, "netbox_diode_plugin.view_setting", "netbox_diode_plugin.change_setting")
+        request.htmx = None
+        self.view.setup(request)
+
+        response = self.view.get(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_redirects_to_login_page_for_unauthenticated_user(self):
+        """Test that the view redirects an authenticated user to login page."""
+        request = self.request_factory.get(self.path)
+        request.user = AnonymousUser()
+        self.view.setup(request)
+
+        response = self.view.get(request)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, f"/netbox/login/?next={self.path}")
+
+    def test_settings_updated(self):
+        """Test that the settings are updated."""
+        user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(user, "netbox_diode_plugin.view_setting", "netbox_diode_plugin.change_setting")
+
+        request = self.request_factory.get(self.path)
+        request.user = user
+        request.htmx = None
+        self.view.setup(request)
+
+        response = self.view.get(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("grpc://localhost:8080/diode", str(response.content))
+
+        request = self.request_factory.post(self.path)
+        request.user = user
+        request.htmx = None
+        request.POST = {"diode_target": "grpc://localhost:8090/diode"}
+
+        middleware = SessionMiddleware(get_response=lambda request: None)
+        middleware.process_request(request)
+        request.session.save()
+
+        middleware = MessageMiddleware(get_response=lambda request: None)
+        middleware.process_request(request)
+        request.session.save()
+
+        response = self.view.post(request)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, reverse("plugins:netbox_diode_plugin:settings"))
+
+        request = self.request_factory.get(self.path)
+        request.user = user
+        request.htmx = None
+        self.view.setup(request)
+
+        response = self.view.get(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("grpc://localhost:8090/diode", str(response.content))
+
+    def test_settings_update_post_redirects_to_login_page_for_unauthenticated_user(
+        self,
+    ):
+        """Test that the view redirects an authenticated user to login page."""
+        request = self.request_factory.post(self.path)
+        request.user = AnonymousUser()
+        request.htmx = None
+        request.POST = {"diode_target": "grpc://localhost:8090/diode"}
+
+        response = self.view.post(request)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, f"/netbox/login/?next={self.path}")
+
+    def test_settings_update_allowed_on_get_method_with_override(self):
+        """Test that accessing settings edit shows info message when diode target is overridden."""
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config"
+        ) as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
+
+            user = User.objects.create_user("foo", password="pass")
+            self.add_permissions(
+                user,
+                "netbox_diode_plugin.view_setting",
+                "netbox_diode_plugin.add_setting",
+                "netbox_diode_plugin.change_setting",
+            )
+
+            request = self.request_factory.get(self.path)
+            request.user = user
+            request.htmx = None
+
+            middleware = SessionMiddleware(get_response=lambda request: None)
+            middleware.process_request(request)
+            request.session.save()
+
+            middleware = MessageMiddleware(get_response=lambda request: None)
+            middleware.process_request(request)
+            request.session.save()
+
+            self.view.setup(request)
+            response = self.view.get(request)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            # Check that the message was added
+            storage = messages.get_messages(request)
+            message_list = list(storage)
+            self.assertEqual(len(message_list), 1)
+            self.assertEqual(
+                str(message_list[0]),
+                "The Diode target field is disabled because it is overridden in the plugin configuration.",
+            )
+
+    def test_settings_update_allowed_on_post_method_with_override(self):
+        """Test that updating settings succeeds when diode target is overridden (field is disabled in form)."""
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config"
+        ) as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
+
+            user = User.objects.create_user("foo", password="pass")
+            self.add_permissions(
+                user,
+                "netbox_diode_plugin.view_setting",
+                "netbox_diode_plugin.add_setting",
+                "netbox_diode_plugin.change_setting",
+            )
+
+            request = self.request_factory.post(self.path)
+            request.user = user
+            request.htmx = None
+            request.POST = {"diode_target": "grpc://localhost:8090/diode"}
+
+            middleware = SessionMiddleware(get_response=lambda request: None)
+            middleware.process_request(request)
+            request.session.save()
+
+            middleware = MessageMiddleware(get_response=lambda request: None)
+            middleware.process_request(request)
+            request.session.save()
+
+            setattr(request, "session", "session")
+            messages = FallbackStorage(request)
+            request._messages = messages
+
+            self.view.setup(request)
+            response = self.view.post(request)
+
+            # Should succeed and redirect to settings view
+            self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+            self.assertEqual(
+                response.url, reverse("plugins:netbox_diode_plugin:settings")
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "Brotli>=1.1.0",
     "certifi>=2024.7.4",
-    "grpcio>=1.68.1",
+    "grpcio>=1.76.0",
     "protobuf>=5.28.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "Brotli>=1.1.0",
+    "Brotli>=1.2.0",
     "certifi>=2024.7.4",
     "grpcio>=1.76.0",
     "protobuf>=5.28.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
 ]
 
 dependencies = [


### PR DESCRIPTION
## Summary

Adds plugin compatibility with NetBox 4.6 alongside existing 4.4 and 4.5 lines.

- New `docker/v4.6.x/` fixture mirroring `v4.5.x` with `netboxcommunity/netbox:v4.6.0-5.0.1`
- New `netbox_diode_plugin/tests/v4.6.x/` test tree (cloned byte-for-byte from `v4.5.x`)
- `max_version` widened from `"4.5.99"` → `"4.6.99"`
- CI matrix extended to `[v4.6.0, v4.5.5, v4.4.10]`; `DEFAULT_NETBOX_VERSION` → `v4.6.0`
- README compatibility table updated (plugin version cell `TBD` pending release)
- `pyproject.toml` adds Python 3.14 classifier and tightens dependency floors (see next section)
- `docs/matching-criteria-documentation.md` regenerated; surfaces two new `virtualization_virtualmachine` matchers for NetBox 4.6's device-attached-VM constraint
- **`netbox_diode_plugin/api/plugin_utils.py` regenerated** against a live NetBox 4.6.0 install — adds the three new built-in 4.6 model types and FK fields (see "What ingests now" below)

### Dependency floor bumps in `pyproject.toml`

NetBox 4.6 containers run Python 3.14. Two declared floors are below what 3.14 can install:

| Dep | Old floor | New floor | Why |
|---|---|---|---|
| `grpcio` | `>=1.68.1` | `>=1.76.0` | No cp314 wheel below 1.76; sdist fails because CPython 3.14 removed `pkg_resources` |
| `Brotli` | `>=1.1.0` | `>=1.2.0` | No cp314 wheel below 1.2.0 |
| `certifi` | `>=2024.7.4` | unchanged | Ships `py3-none-any` wheel — universal |
| `protobuf` | `>=5.28.1` | unchanged | Ships `py3-none-any` + abi3 wheels — universal |

Both bumps remain safe for Python 3.10–3.13 used by NetBox 4.4 and 4.5 installs.

### Test-fixture pin bumps in `docker/v4.6.x/requirements-diode-netbox-plugin.txt` only

- `grpcio==1.62.1` → `grpcio==1.76.0` (same reason as above)
- `netboxlabs-netbox-branching==0.8.3` → `1.0.3` — 0.8.3 declares NetBox `<4.6`. The branching plugin import surface (`Branch.objects`, `Branch.schema_id`) is unchanged across the 0.x → 1.x bump; all default-branch tests pass.

The v4.4.x and v4.5.x docker requirements are unchanged.

### What ingests now on NetBox 4.6

The regenerated `plugin_utils.py` adds these new 4.6 surfaces to the ingest allowlist:

| New 4.6 model | Related new FK on existing model |
|---|---|
| `virtualization.virtualmachinetype` | `virtualmachine.virtual_machine_type` |
| `dcim.cablebundle` | `cable.bundle` |
| `dcim.rackgroup` | `rack.group` |

The regenerator's first pass produced a `plugin_utils.py` that broke 17 existing tests because new single-type "flat" GFK accessor entries shadowed the legacy multi-target fanout entries (e.g., a new `scope` mapping to `dcim.site` next to the existing `scope_site`/`scope_region`/etc. fanout for `virtualization.cluster`). [drf-extract PR #49's `c345314`](https://github.com/netboxlabs/eng-observability-skunkworks/pull/49) fixes the emitter to suppress those shadowed flat entries; this PR's `78f435a` syncs the corrected file. Wire compat is preserved in `output/ingester.proto` independently.

## Test plan
- [x] `make NETBOX_VERSION=v4.4.10 docker-compose-netbox-plugin-test` — 304/304 PASS
- [x] `make NETBOX_VERSION=v4.5.5 docker-compose-netbox-plugin-test` — 325/325 PASS
- [x] `make NETBOX_VERSION=v4.6.0-5.0.1 docker-compose-netbox-plugin-test` — 325/325 PASS (re-run after syncing the new `plugin_utils.py`)
- [x] `ruff check netbox_diode_plugin/` — clean
- [x] CI re-run after pyproject floor bumps (verify no regression on v4.4 / v4.5 with the higher grpcio / Brotli floors)
- [x] Functional smoke of ingesting a `cablebundle` / `rackgroup` / `virtualmachinetype` payload end-to-end against NetBox 4.6 (manual; out of scope for the test suite which doesn't yet exercise these types)

## Out of scope (tracked separately)
- Custom Objects ingestion support (NetBox 4.6's user-defined polymorphic model feature) — 
- New plugin extension mechanisms (declarative layouts, reusable UI components, plugin-registered model actions) introduced in 4.6 — additive, no current driver
- Dropping NetBox 4.4 support — revisit when 4.7 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)