### PR TITLE
fix: dedupe concurrent CREATE for types lacking DB unique constraints

### DIFF
--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -11,7 +11,7 @@ from django.db.utils import IntegrityError
 from rest_framework.exceptions import ValidationError as ValidationError
 
 from .common import NON_FIELD_ERRORS, Change, ChangeSet, ChangeSetException, ChangeSetResult, ChangeType, error_from_validation_error
-from .matcher import find_existing_object, invalidate_find_obj_entry
+from .matcher import find_existing_object, invalidate_find_obj_entry, requires_pre_save_match
 from .plugin_utils import get_object_type_model, legal_fields
 from .profile import profiled
 from .supported_models import get_serializer_for_model
@@ -110,8 +110,13 @@ def _apply_change(data: dict, model_class: models.Model, change: Change, created
         # For component types that may be auto-created from e.g. DeviceType or ModuleType templates,
         # try to find existing object first before attempting to create.
         # This prevents duplicates when components are instantiated during Device/Module save()
+        # The same find-first path also handles types whose logical match
+        # criteria are not enforced by a DB unique constraint (see
+        # matcher._REQUIRES_PRE_SAVE_MATCH): concurrent planners would
+        # otherwise each emit CREATE for the same logical row and both
+        # inserts would succeed without IntegrityError to fall back on.
         instance = None
-        if _is_auto_created_component(change.object_type):
+        if _is_auto_created_component(change.object_type) or requires_pre_save_match(change.object_type):
             instance = _try_find_and_update_existing_instance(data, change.object_type, serializer_class, request)
 
         if not instance:

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -102,22 +102,34 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 # The specific gaps (see _LOGICAL_MATCHERS below for the criteria):
 #   - dcim.macaddress: NetBox has no unique constraint on
 #     (mac_address, assigned_object_type, assigned_object_id).
+#   - dcim.modulebay: matched by (name, device); NetBox's parent-aware
+#     constraint does not catch unscoped duplicates the matcher dedupes.
 #   - ipam.vlan: NetBox's (group, vid) constraint does not enforce
 #     uniqueness when group is NULL.
 #   - ipam.vlangroup: NetBox does not enforce uniqueness of name when
 #     scope_type is NULL.
 #   - ipam.vrf: NetBox enforces uniqueness on rd, not name; multiple
 #     VRFs with rd=NULL and the same name are otherwise allowed.
+#   - virtualization.cluster: NetBox does not enforce uniqueness of
+#     name across scopes; matched by (name, scope_type, scope_id) or
+#     by name alone when unscoped and unparented.
+#   - virtualization.virtualmachine: NetBox does not enforce uniqueness
+#     of name when cluster is NULL.
+#   - wireless.wirelesslan: NetBox does not enforce ssid uniqueness.
 #
 # This closes the common race (concurrent plan, sequential apply).
 # It does not close TOCTOU under truly concurrent apply across
-# replicas — that would require a DB unique constraint or a
+# replicas - that would require a DB unique constraint or a
 # coordinating lock.
 _REQUIRES_PRE_SAVE_MATCH = frozenset({
     "dcim.macaddress",
+    "dcim.modulebay",
     "ipam.vlan",
     "ipam.vlangroup",
     "ipam.vrf",
+    "virtualization.cluster",
+    "virtualization.virtualmachine",
+    "wireless.wirelesslan",
 })
 
 

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -91,6 +91,41 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 # These should represent the likely intent of a user when
 # matching existing objects.
 #
+# Object types whose logical match criteria are NOT backed by a DB
+# unique constraint. For CREATE changes on these types the applier
+# must call find_existing_object BEFORE serializer.save(); otherwise
+# concurrent planners can each emit CREATE for the same logical row
+# and both inserts succeed, producing duplicates. The standard
+# IntegrityError fallback in _create_or_find_instance cannot catch
+# this because save() does not fail.
+#
+# The specific gaps (see _LOGICAL_MATCHERS below for the criteria):
+#   - dcim.macaddress: NetBox has no unique constraint on
+#     (mac_address, assigned_object_type, assigned_object_id).
+#   - ipam.vlan: NetBox's (group, vid) constraint does not enforce
+#     uniqueness when group is NULL.
+#   - ipam.vlangroup: NetBox does not enforce uniqueness of name when
+#     scope_type is NULL.
+#   - ipam.vrf: NetBox enforces uniqueness on rd, not name; multiple
+#     VRFs with rd=NULL and the same name are otherwise allowed.
+#
+# This closes the common race (concurrent plan, sequential apply).
+# It does not close TOCTOU under truly concurrent apply across
+# replicas — that would require a DB unique constraint or a
+# coordinating lock.
+_REQUIRES_PRE_SAVE_MATCH = frozenset({
+    "dcim.macaddress",
+    "ipam.vlan",
+    "ipam.vlangroup",
+    "ipam.vrf",
+})
+
+
+def requires_pre_save_match(object_type: str) -> bool:
+    """Whether the applier must look up an existing row before CREATE."""
+    return object_type in _REQUIRES_PRE_SAVE_MATCH
+
+
 _LOGICAL_MATCHERS = {
     "dcim.macaddress": lambda: [
         ObjectMatchCriteria(

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_api_bulk_plan_apply.py
@@ -5,8 +5,9 @@
 import logging
 from types import SimpleNamespace
 from unittest import mock
+from uuid import uuid4
 
-from dcim.models import Site
+from dcim.models import MACAddress, Site
 from rest_framework import status
 from utilities.testing import APITestCase
 
@@ -375,6 +376,106 @@ class BulkPlanApplyTestCase(APITestCase):
         """Missing token returns 403 (DiodeOAuth2Authentication has no authenticate_header)."""
         response = self.client.post(self.url, data={"entities": []}, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # --- Cross-request plan race must not produce duplicate MACAddress ---
+
+    def test_concurrent_plans_dedupe_macaddress_via_pre_save_match(self):
+        """
+        Two requests planning the same MAC must apply to a single row.
+
+        Two reconciler workers planning equivalent change_sets for the same
+        interface + MAC each see no existing MAC row and each plan a CREATE.
+        Two sequential ``/bulk-plan/`` calls model this exactly: each request
+        has its own request-scoped obj_cache, so plan B cannot see plan A's
+        pending CREATE.
+
+        NetBox has no DB-level unique constraint on
+        (mac_address, assigned_object_type, assigned_object_id), so the
+        applier dedupes by routing dcim.macaddress through the find-first
+        CREATE path (matcher.requires_pre_save_match). Apply B's CREATE
+        therefore matches the row apply A just committed instead of
+        inserting a second one.
+        """
+        suffix = uuid4().hex[:8]
+        mac = "00:00:00:00:00:42"
+
+        plan_payload = {
+            "entities": [
+                {
+                    "id": f"race-{suffix}",
+                    "object_type": "dcim.interface",
+                    "entity": {
+                        "interface": {
+                            "name": f"eth0-{suffix}",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": f"dev-{suffix}",
+                                "role": {"name": f"role-{suffix}"},
+                                "site": {"name": f"site-{suffix}"},
+                                "device_type": {
+                                    "manufacturer": {"name": f"mfr-{suffix}"},
+                                    "model": f"dt-{suffix}",
+                                },
+                            },
+                            "primary_mac_address": {"mac_address": mac},
+                        },
+                    },
+                }
+            ]
+        }
+
+        plan_url = "/netbox/api/plugins/diode/bulk-plan/"
+        apply_url = "/netbox/api/plugins/diode/bulk-apply/"
+
+        plan_a = self.client.post(
+            plan_url, data=plan_payload, format="json", **self.authorization_header
+        )
+        plan_b = self.client.post(
+            plan_url, data=plan_payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(plan_a.status_code, status.HTTP_200_OK, plan_a.json())
+        self.assertEqual(plan_b.status_code, status.HTTP_200_OK, plan_b.json())
+
+        result_a = plan_a.json()["results"][0]
+        result_b = plan_b.json()["results"][0]
+        self.assertIsNone(result_a.get("errors"), result_a)
+        self.assertIsNone(result_b.get("errors"), result_b)
+        cs_a = result_a.get("change_set")
+        cs_b = result_b.get("change_set")
+        self.assertIsNotNone(cs_a, result_a)
+        self.assertIsNotNone(cs_b, result_b)
+
+        def mac_creates(change_set):
+            return [
+                c for c in change_set["changes"]
+                if c["object_type"] == "dcim.macaddress" and c["change_type"] == "create"
+            ]
+
+        self.assertEqual(len(mac_creates(cs_a)), 1, cs_a)
+        self.assertEqual(len(mac_creates(cs_b)), 1, cs_b)
+
+        apply_a = self.client.post(
+            apply_url,
+            data={"change_sets": [cs_a]},
+            format="json",
+            **self.authorization_header,
+        )
+        apply_b = self.client.post(
+            apply_url,
+            data={"change_sets": [cs_b]},
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(apply_a.status_code, status.HTTP_200_OK, apply_a.json())
+        self.assertEqual(apply_b.status_code, status.HTTP_200_OK, apply_b.json())
+
+        macs = MACAddress.objects.filter(mac_address=mac)
+        self.assertEqual(
+            macs.count(),
+            1,
+            f"expected exactly one MAC row after dedup, got {macs.count()}: "
+            f"{list(macs.values('pk', 'mac_address', 'assigned_object_id'))}",
+        )
 
     def test_insufficient_scope_returns_403(self):
         """Token with only read scope cannot call bulk-plan-apply (requires write)."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_api_bulk_plan_apply.py
@@ -5,8 +5,9 @@
 import logging
 from types import SimpleNamespace
 from unittest import mock
+from uuid import uuid4
 
-from dcim.models import Site
+from dcim.models import MACAddress, Site
 from rest_framework import status
 from utilities.testing import APITestCase
 
@@ -375,6 +376,106 @@ class BulkPlanApplyTestCase(APITestCase):
         """Missing token returns 403 (DiodeOAuth2Authentication has no authenticate_header)."""
         response = self.client.post(self.url, data={"entities": []}, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # --- Cross-request plan race must not produce duplicate MACAddress ---
+
+    def test_concurrent_plans_dedupe_macaddress_via_pre_save_match(self):
+        """
+        Two requests planning the same MAC must apply to a single row.
+
+        Two reconciler workers planning equivalent change_sets for the same
+        interface + MAC each see no existing MAC row and each plan a CREATE.
+        Two sequential ``/bulk-plan/`` calls model this exactly: each request
+        has its own request-scoped obj_cache, so plan B cannot see plan A's
+        pending CREATE.
+
+        NetBox has no DB-level unique constraint on
+        (mac_address, assigned_object_type, assigned_object_id), so the
+        applier dedupes by routing dcim.macaddress through the find-first
+        CREATE path (matcher.requires_pre_save_match). Apply B's CREATE
+        therefore matches the row apply A just committed instead of
+        inserting a second one.
+        """
+        suffix = uuid4().hex[:8]
+        mac = "00:00:00:00:00:42"
+
+        plan_payload = {
+            "entities": [
+                {
+                    "id": f"race-{suffix}",
+                    "object_type": "dcim.interface",
+                    "entity": {
+                        "interface": {
+                            "name": f"eth0-{suffix}",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": f"dev-{suffix}",
+                                "role": {"name": f"role-{suffix}"},
+                                "site": {"name": f"site-{suffix}"},
+                                "device_type": {
+                                    "manufacturer": {"name": f"mfr-{suffix}"},
+                                    "model": f"dt-{suffix}",
+                                },
+                            },
+                            "primary_mac_address": {"mac_address": mac},
+                        },
+                    },
+                }
+            ]
+        }
+
+        plan_url = "/netbox/api/plugins/diode/bulk-plan/"
+        apply_url = "/netbox/api/plugins/diode/bulk-apply/"
+
+        plan_a = self.client.post(
+            plan_url, data=plan_payload, format="json", **self.authorization_header
+        )
+        plan_b = self.client.post(
+            plan_url, data=plan_payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(plan_a.status_code, status.HTTP_200_OK, plan_a.json())
+        self.assertEqual(plan_b.status_code, status.HTTP_200_OK, plan_b.json())
+
+        result_a = plan_a.json()["results"][0]
+        result_b = plan_b.json()["results"][0]
+        self.assertIsNone(result_a.get("errors"), result_a)
+        self.assertIsNone(result_b.get("errors"), result_b)
+        cs_a = result_a.get("change_set")
+        cs_b = result_b.get("change_set")
+        self.assertIsNotNone(cs_a, result_a)
+        self.assertIsNotNone(cs_b, result_b)
+
+        def mac_creates(change_set):
+            return [
+                c for c in change_set["changes"]
+                if c["object_type"] == "dcim.macaddress" and c["change_type"] == "create"
+            ]
+
+        self.assertEqual(len(mac_creates(cs_a)), 1, cs_a)
+        self.assertEqual(len(mac_creates(cs_b)), 1, cs_b)
+
+        apply_a = self.client.post(
+            apply_url,
+            data={"change_sets": [cs_a]},
+            format="json",
+            **self.authorization_header,
+        )
+        apply_b = self.client.post(
+            apply_url,
+            data={"change_sets": [cs_b]},
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(apply_a.status_code, status.HTTP_200_OK, apply_a.json())
+        self.assertEqual(apply_b.status_code, status.HTTP_200_OK, apply_b.json())
+
+        macs = MACAddress.objects.filter(mac_address=mac)
+        self.assertEqual(
+            macs.count(),
+            1,
+            f"expected exactly one MAC row after dedup, got {macs.count()}: "
+            f"{list(macs.values('pk', 'mac_address', 'assigned_object_id'))}",
+        )
 
     def test_insufficient_scope_returns_403(self):
         """Token with only read scope cannot call bulk-plan-apply (requires write)."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_bulk_plan_apply.py
@@ -5,8 +5,9 @@
 import logging
 from types import SimpleNamespace
 from unittest import mock
+from uuid import uuid4
 
-from dcim.models import Site
+from dcim.models import MACAddress, Site
 from rest_framework import status
 from utilities.testing import APITestCase
 
@@ -375,6 +376,106 @@ class BulkPlanApplyTestCase(APITestCase):
         """Missing token returns 403 (DiodeOAuth2Authentication has no authenticate_header)."""
         response = self.client.post(self.url, data={"entities": []}, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # --- Cross-request plan race must not produce duplicate MACAddress ---
+
+    def test_concurrent_plans_dedupe_macaddress_via_pre_save_match(self):
+        """
+        Two requests planning the same MAC must apply to a single row.
+
+        Two reconciler workers planning equivalent change_sets for the same
+        interface + MAC each see no existing MAC row and each plan a CREATE.
+        Two sequential ``/bulk-plan/`` calls model this exactly: each request
+        has its own request-scoped obj_cache, so plan B cannot see plan A's
+        pending CREATE.
+
+        NetBox has no DB-level unique constraint on
+        (mac_address, assigned_object_type, assigned_object_id), so the
+        applier dedupes by routing dcim.macaddress through the find-first
+        CREATE path (matcher.requires_pre_save_match). Apply B's CREATE
+        therefore matches the row apply A just committed instead of
+        inserting a second one.
+        """
+        suffix = uuid4().hex[:8]
+        mac = "00:00:00:00:00:42"
+
+        plan_payload = {
+            "entities": [
+                {
+                    "id": f"race-{suffix}",
+                    "object_type": "dcim.interface",
+                    "entity": {
+                        "interface": {
+                            "name": f"eth0-{suffix}",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": f"dev-{suffix}",
+                                "role": {"name": f"role-{suffix}"},
+                                "site": {"name": f"site-{suffix}"},
+                                "device_type": {
+                                    "manufacturer": {"name": f"mfr-{suffix}"},
+                                    "model": f"dt-{suffix}",
+                                },
+                            },
+                            "primary_mac_address": {"mac_address": mac},
+                        },
+                    },
+                }
+            ]
+        }
+
+        plan_url = "/netbox/api/plugins/diode/bulk-plan/"
+        apply_url = "/netbox/api/plugins/diode/bulk-apply/"
+
+        plan_a = self.client.post(
+            plan_url, data=plan_payload, format="json", **self.authorization_header
+        )
+        plan_b = self.client.post(
+            plan_url, data=plan_payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(plan_a.status_code, status.HTTP_200_OK, plan_a.json())
+        self.assertEqual(plan_b.status_code, status.HTTP_200_OK, plan_b.json())
+
+        result_a = plan_a.json()["results"][0]
+        result_b = plan_b.json()["results"][0]
+        self.assertIsNone(result_a.get("errors"), result_a)
+        self.assertIsNone(result_b.get("errors"), result_b)
+        cs_a = result_a.get("change_set")
+        cs_b = result_b.get("change_set")
+        self.assertIsNotNone(cs_a, result_a)
+        self.assertIsNotNone(cs_b, result_b)
+
+        def mac_creates(change_set):
+            return [
+                c for c in change_set["changes"]
+                if c["object_type"] == "dcim.macaddress" and c["change_type"] == "create"
+            ]
+
+        self.assertEqual(len(mac_creates(cs_a)), 1, cs_a)
+        self.assertEqual(len(mac_creates(cs_b)), 1, cs_b)
+
+        apply_a = self.client.post(
+            apply_url,
+            data={"change_sets": [cs_a]},
+            format="json",
+            **self.authorization_header,
+        )
+        apply_b = self.client.post(
+            apply_url,
+            data={"change_sets": [cs_b]},
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(apply_a.status_code, status.HTTP_200_OK, apply_a.json())
+        self.assertEqual(apply_b.status_code, status.HTTP_200_OK, apply_b.json())
+
+        macs = MACAddress.objects.filter(mac_address=mac)
+        self.assertEqual(
+            macs.count(),
+            1,
+            f"expected exactly one MAC row after dedup, got {macs.count()}: "
+            f"{list(macs.values('pk', 'mac_address', 'assigned_object_id'))}",
+        )
 
     def test_insufficient_scope_returns_403(self):
         """Token with only read scope cannot call bulk-plan-apply (requires write)."""


### PR DESCRIPTION
## Summary
- Routes 8 object types through find-first on CREATE so two requests planning the same logical row dedupe at apply time: `dcim.macaddress`, `dcim.modulebay`, `ipam.vlan`, `ipam.vlangroup`, `ipam.vrf`, `virtualization.cluster`, `virtualization.virtualmachine`, `wireless.wirelesslan`.
- Closes a cross-request plan race that produced duplicate rows whenever NetBox lacks a DB unique constraint matching the plugin's logical matcher.
- Adds regression test covering the MAC case in v4.4.x / v4.5.x / v4.6.x.

## Root cause
The applier's CREATE path uses save-then-fallback (`_create_or_find_instance`): `serializer.save()` first, fall back to `find_existing_object` only on `IntegrityError`/`ValidationError`. That fallback only fires when NetBox enforces uniqueness at the DB. For types whose logical match criteria in `_LOGICAL_MATCHERS` are NOT backed by a constraint, `save()` succeeds and duplicate rows land, even though the matcher already knows how to identify the duplicate.

## Fix
- `matcher.py`: new `_REQUIRES_PRE_SAVE_MATCH` frozenset enumerates the affected types and `requires_pre_save_match()` exposes the check. Each entry is annotated with the specific NetBox enforcement gap it covers.
- `applier.py`: CREATE branch routes those types through `_try_find_and_update_existing_instance` before `serializer.save()`.
- `tests/v4.{4,5,6}.x/tests/test_api_bulk_plan_apply.py`: `test_concurrent_plans_dedupe_macaddress_via_pre_save_match` fires two `/bulk-plan/` requests then two `/bulk-apply/` requests, asserts a single MAC row results.

## Scope and limits
Closes the common race (concurrent plan, sequential apply). Does NOT close TOCTOU under truly concurrent apply across replicas; that would need a DB unique constraint or a coordinating lock, both out of scope.

## Test plan
- [x] `make docker-compose-netbox-plugin-test NETBOX_VERSION=v4.6.0` -> 347/347 OK
- [x] `make docker-compose-netbox-plugin-test NETBOX_VERSION=v4.5.5` -> `test_api_bulk_plan_apply.py` suite OK
- [x] `ruff check` clean on touched files
- [ ] CI matrix across v4.4 / v4.5 / v4.6