### PR TITLE
feat(cabling): end-to-end Cable + GenericObject termination ingest (OBS-3370, OBS-1080)

### DIFF
--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -154,25 +154,24 @@ def _apply_change(data: dict, model_class: models.Model, change: Change, created
             invalidate_find_obj_entry(change.object_type, instance.id)
 
 def _set_path(data, path, value):
-    path = path.split(".")
-    key = path.pop(0)
-    if key.isdigit():
-        key = int(key)
-    while len(path) > 0:
-        data = data[key]
-        key = path.pop(0)
-        if key.isdigit():
-            key = int(key)
-    data[key] = value
+    keys = path.split(".")
+    for key in keys[:-1]:
+        data = data[_path_key(data, key)]
+    data[_path_key(data, keys[-1])] = value
 
 def _get_path(data, path):
-    path = path.split(".")
     v = data
-    for p in path:
-        if p.isdigit():
-            p = int(p)
-        v = v[p]
+    for p in path.split("."):
+        v = v[_path_key(v, p)]
     return v
+
+def _path_key(container, key):
+    # Coerce an all-digit segment to a list index ONLY when the container is a
+    # list (e.g. cable "a_terminations.0.object_id"). Dicts keep string keys so
+    # a custom field whose name is all digits still indexes correctly.
+    if isinstance(container, list | tuple) and key.isdigit():
+        return int(key)
+    return key
 
 def _pre_apply(model_class: models.Model, change: Change, created: dict):
     # deep copy: ref resolution mutates nested list/dict containers

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -53,6 +53,13 @@ def apply_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
         except IntegrityError as e:
             logger.error(f"Integrity error {object_type}: {e} {data}")
             raise _err(f"created a conflict with an existing {object_type}", object_type, "__all__")
+        except KeyError as e:
+            # A new_refs path referenced an object that was never created
+            # (e.g. a dangling or rewritten termination reference). Surface a
+            # clean per-entity deviation instead of an uncaught 500 -- the
+            # OBS-1080 failure class this feature set out to eliminate.
+            logger.error(f"unresolved reference applying {object_type}: {e}")
+            raise _err(f"unresolved reference applying {object_type}", object_type, "__all__")
 
     return ChangeSetResult(
         id=change_set.id,
@@ -187,6 +194,12 @@ def _pre_apply(model_class: models.Model, change: Change, created: dict):
                     ref_list.append(ref)
             _set_path(data, ref_field, ref_list)
         else:
+            if isinstance(v, int):
+                # `v` is already a resolved pk. This happens when a termination
+                # list is re-sorted (differ) after new_refs paths were computed,
+                # moving an already-resolved entry into an index that new_refs
+                # still lists. Nothing to resolve.
+                continue
             _set_path(data, ref_field, created[v].pk)
 
     # ignore? fields that are not in the data model (error?)

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -3,6 +3,7 @@
 """Diode NetBox Plugin - API - Applier."""
 
 
+import copy
 import logging
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -165,7 +166,14 @@ def _get_path(data, path):
     return v
 
 def _pre_apply(model_class: models.Model, change: Change, created: dict):
-    data = change.data.copy()
+    # `_set_path` mutates in place along the traversed path, and `new_refs`
+    # paths may descend into lists of dicts (e.g. "a_terminations.0.object_id").
+    # A shallow copy would leave those nested containers shared with
+    # `change.data`, so resolving refs here would permanently overwrite the
+    # original string refs with resolved pks -- breaking any retry of this
+    # same change (e.g. on deadlock) which needs the original refs again.
+    # Deep-copy just enough (dicts/lists) to isolate mutations.
+    data = copy.deepcopy(change.data)
 
     # resolve foreign key references to new objects
     for ref_field in change.new_refs:

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -90,7 +90,8 @@ def _try_find_and_update_existing_instance(data: dict, object_type: str, seriali
         instance = find_existing_object(data, object_type)
         if instance:
             snapshot_for_apply(instance)
-            serializer = serializer_class(instance, data=data, partial=True, context={"request": request})
+            update_data = _strip_matched_cable_terminations(data, object_type)
+            serializer = serializer_class(instance, data=update_data, partial=True, context={"request": request})
             serializer.is_valid(raise_exception=True)
             result = serializer.save()
             invalidate_find_obj_entry(object_type, instance.id)
@@ -98,6 +99,23 @@ def _try_find_and_update_existing_instance(data: dict, object_type: str, seriali
     except (ValueError, TypeError) as e:
         logger.debug(f"Could not find existing {object_type}: {e}")
     return None
+
+
+def _strip_matched_cable_terminations(data: dict, object_type: str) -> dict:
+    """
+    Drop termination fields from a pre-save-matched cable's update.
+
+    The cable matcher finds an existing cable by its A/B-insensitive
+    termination SET, so the set is identical by construction. Re-saving the
+    submitted terminations could only change the A/B/ordering assignment,
+    needlessly rewriting CableTermination.cable_end (and letting a stale,
+    end-swapped CREATE toggle it). Update attributes only; leave the existing
+    terminations intact. The differ's _align_cable_ends covers the plan-time
+    UPDATE path; this covers the applier pre-save-match path.
+    """
+    if object_type != "dcim.cable":
+        return data
+    return {k: v for k, v in data.items() if k not in ("a_terminations", "b_terminations")}
 
 
 def _create_or_find_instance(data: dict, object_type: str, serializer_class, request):

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -90,7 +90,7 @@ def _try_find_and_update_existing_instance(data: dict, object_type: str, seriali
         instance = find_existing_object(data, object_type)
         if instance:
             snapshot_for_apply(instance)
-            update_data = _strip_matched_cable_terminations(data, object_type)
+            update_data = _strip_matched_cable_terminations(data, object_type, instance)
             serializer = serializer_class(instance, data=update_data, partial=True, context={"request": request})
             serializer.is_valid(raise_exception=True)
             result = serializer.save()
@@ -101,21 +101,43 @@ def _try_find_and_update_existing_instance(data: dict, object_type: str, seriali
     return None
 
 
-def _strip_matched_cable_terminations(data: dict, object_type: str) -> dict:
+def _strip_matched_cable_terminations(data: dict, object_type: str, instance) -> dict:
     """
     Drop termination fields from a pre-save-matched cable's update.
 
     The cable matcher finds an existing cable by its A/B-insensitive
-    termination SET, so the set is identical by construction. Re-saving the
-    submitted terminations could only change the A/B/ordering assignment,
-    needlessly rewriting CableTermination.cable_end (and letting a stale,
-    end-swapped CREATE toggle it). Update attributes only; leave the existing
-    terminations intact. The differ's _align_cable_ends covers the plan-time
-    UPDATE path; this covers the applier pre-save-match path.
+    termination SET, so the set is identical by construction. Strip the
+    terminations ONLY when the submitted A/B grouping equals the existing one
+    up to a whole-end swap (identical, within-end reorder, or a pure swap) --
+    re-saving those would only churn CableTermination.cable_end (and let a
+    stale, end-swapped CREATE toggle it). A genuine repartition (same set,
+    different grouping) is passed through so the serializer applies it, keeping
+    this path consistent with the differ UPDATE path (which applies it too).
     """
     if object_type != "dcim.cable":
         return data
-    return {k: v for k, v in data.items() if k not in ("a_terminations", "b_terminations")}
+    if _cable_partition_matches(instance, data):
+        return {k: v for k, v in data.items() if k not in ("a_terminations", "b_terminations")}
+    return data
+
+
+def _cable_partition_matches(instance, data: dict) -> bool:
+    """True if data's A/B grouping equals the instance's, up to a whole-end swap."""
+    def _submitted(field):
+        return frozenset(
+            (t["object_type"], t["object_id"])
+            for t in data.get(field, [])
+            if isinstance(t, dict) and isinstance(t.get("object_id"), int)
+        )
+
+    def _existing(objs):
+        return frozenset(
+            (f"{o._meta.app_label}.{o._meta.model_name}", o.pk) for o in objs
+        )
+
+    sub_a, sub_b = _submitted("a_terminations"), _submitted("b_terminations")
+    exist_a, exist_b = _existing(instance.a_terminations), _existing(instance.b_terminations)
+    return (sub_a == exist_a and sub_b == exist_b) or (sub_a == exist_b and sub_b == exist_a)
 
 
 def _create_or_find_instance(data: dict, object_type: str, serializer_class, request):

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -61,7 +61,7 @@ def apply_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
             if not (isinstance(key, str) and key.startswith("new_object:")):
                 raise
             logger.error(f"unresolved reference applying {object_type}: {e}")
-            raise _err(f"unresolved reference applying {object_type}", object_type, "__all__")
+            raise _err(f"unresolved reference {key} applying {object_type}", object_type, "__all__")
 
     return ChangeSetResult(
         id=change_set.id,

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -146,15 +146,21 @@ def _apply_change(data: dict, model_class: models.Model, change: Change, created
 def _set_path(data, path, value):
     path = path.split(".")
     key = path.pop(0)
+    if key.isdigit():
+        key = int(key)
     while len(path) > 0:
         data = data[key]
         key = path.pop(0)
+        if key.isdigit():
+            key = int(key)
     data[key] = value
 
 def _get_path(data, path):
     path = path.split(".")
     v = data
     for p in path:
+        if p.isdigit():
+            p = int(p)
         v = v[p]
     return v
 

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -54,10 +54,12 @@ def apply_changeset(change_set: ChangeSet, request) -> ChangeSetResult:
             logger.error(f"Integrity error {object_type}: {e} {data}")
             raise _err(f"created a conflict with an existing {object_type}", object_type, "__all__")
         except KeyError as e:
-            # A new_refs path referenced an object that was never created
-            # (e.g. a dangling or rewritten termination reference). Surface a
-            # clean per-entity deviation instead of an uncaught 500 -- the
-            # OBS-1080 failure class this feature set out to eliminate.
+            # Only intercept a missing "new_object:..." reference lookup
+            # (a dangling ref that was never created); surface it as a clean
+            # per-entity error. Any other KeyError is a real bug — re-raise.
+            key = e.args[0] if e.args else None
+            if not (isinstance(key, str) and key.startswith("new_object:")):
+                raise
             logger.error(f"unresolved reference applying {object_type}: {e}")
             raise _err(f"unresolved reference applying {object_type}", object_type, "__all__")
 
@@ -173,13 +175,9 @@ def _get_path(data, path):
     return v
 
 def _pre_apply(model_class: models.Model, change: Change, created: dict):
-    # `_set_path` mutates in place along the traversed path, and `new_refs`
-    # paths may descend into lists of dicts (e.g. "a_terminations.0.object_id").
-    # A shallow copy would leave those nested containers shared with
-    # `change.data`, so resolving refs here would permanently overwrite the
-    # original string refs with resolved pks -- breaking any retry of this
-    # same change (e.g. on deadlock) which needs the original refs again.
-    # Deep-copy just enough (dicts/lists) to isolate mutations.
+    # deep copy: ref resolution mutates nested list/dict containers
+    # (e.g. "a_terminations.0.object_id"); a shallow copy would corrupt
+    # change.data for retries of this same change.
     data = copy.deepcopy(change.data)
 
     # resolve foreign key references to new objects
@@ -195,10 +193,7 @@ def _pre_apply(model_class: models.Model, change: Change, created: dict):
             _set_path(data, ref_field, ref_list)
         else:
             if isinstance(v, int):
-                # `v` is already a resolved pk. This happens when a termination
-                # list is re-sorted (differ) after new_refs paths were computed,
-                # moving an already-resolved entry into an index that new_refs
-                # still lists. Nothing to resolve.
+                # already a resolved pk; nothing to resolve
                 continue
             _set_path(data, ref_field, created[v].pk)
 

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -251,21 +251,7 @@ def _generate_changeset(entity: dict, object_type: str) -> ChangeSetResult:
     for entity in entities:
         prechange_data = {}
         changed_attrs = []
-        # Canonicalize termination-list order BEFORE cleanup_unresolved_references
-        # computes new_refs index paths (e.g. "a_terminations.0.object_id").
-        # _partially_merge later re-sorts these lists with the same key for
-        # stable prechange/postchange comparison; sorting here first makes that
-        # re-sort a no-op, so the index paths stay aligned with the data the
-        # applier resolves. Without this, an UPDATE (netbox_id-matched) whose
-        # end mixes an already-resolved pk (int) with a new unresolved ref
-        # re-sorts after the paths are computed, and the unresolved ref at its
-        # new index is never resolved. str(UnresolvedReference) equals the
-        # "new_object:..." string cleanup writes, so this sort and the
-        # post-cleanup sort order identically.
-        for term_field in ("a_terminations", "b_terminations"):
-            terms = entity.get(term_field)
-            if isinstance(terms, list) and terms:
-                entity[term_field] = _sorted_termination_refs(terms)
+        _canonicalize_termination_order(entity)
         new_refs = cleanup_unresolved_references(entity)
         object_type = entity.pop("_object_type")
         _ = entity.pop("_uuid")
@@ -345,8 +331,30 @@ def _partially_merge(prechange_data: dict, postchange_data: dict, instance) -> d
         set_custom_field_defaults(result, instance)
     return result
 
+def _canonicalize_termination_order(entity: dict) -> None:
+    """
+    Sort termination lists in place before new_refs index paths are computed.
+
+    cleanup_unresolved_references emits index paths (e.g.
+    "a_terminations.0.object_id") and _partially_merge later re-sorts these
+    lists with the same key for stable prechange/postchange comparison;
+    sorting here first makes that re-sort a no-op, so the index paths stay
+    aligned with the data the applier resolves. Without this, an UPDATE
+    (netbox_id-matched) whose end mixes an already-resolved pk (int) with a
+    new unresolved ref re-sorts after the paths are computed, and the
+    unresolved ref at its new index is never resolved.
+    str(UnresolvedReference) equals the "new_object:..." string cleanup
+    writes, so this sort and the post-cleanup sort order identically.
+    """
+    for term_field in ("a_terminations", "b_terminations"):
+        terms = entity.get(term_field)
+        if isinstance(terms, list) and terms:
+            entity[term_field] = _sorted_termination_refs(terms)
+
+
 def _sorted_termination_refs(refs: list) -> list:
-    """Sort a list of {object_type, object_id} termination refs for stable comparison.
+    """
+    Sort a list of {object_type, object_id} termination refs for stable comparison.
 
     object_id may be an int (resolved) or a string (still-unresolved
     `new_object:...` reference after cleanup_unresolved_references), so the

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -251,6 +251,21 @@ def _generate_changeset(entity: dict, object_type: str) -> ChangeSetResult:
     for entity in entities:
         prechange_data = {}
         changed_attrs = []
+        # Canonicalize termination-list order BEFORE cleanup_unresolved_references
+        # computes new_refs index paths (e.g. "a_terminations.0.object_id").
+        # _partially_merge later re-sorts these lists with the same key for
+        # stable prechange/postchange comparison; sorting here first makes that
+        # re-sort a no-op, so the index paths stay aligned with the data the
+        # applier resolves. Without this, an UPDATE (netbox_id-matched) whose
+        # end mixes an already-resolved pk (int) with a new unresolved ref
+        # re-sorts after the paths are computed, and the unresolved ref at its
+        # new index is never resolved. str(UnresolvedReference) equals the
+        # "new_object:..." string cleanup writes, so this sort and the
+        # post-cleanup sort order identically.
+        for term_field in ("a_terminations", "b_terminations"):
+            terms = entity.get(term_field)
+            if isinstance(terms, list) and terms:
+                entity[term_field] = _sorted_termination_refs(terms)
         new_refs = cleanup_unresolved_references(entity)
         object_type = entity.pop("_object_type")
         _ = entity.pop("_uuid")

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -98,20 +98,11 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
         else:
             prechange_data[field_name] = value
 
-    # Cable.a_terminations / b_terminations are model *properties* (backed by
-    # the reverse `terminations` relation), not real Django model fields, so
-    # they never appear in `fields.items()` above and are silently omitted
-    # from prechange_data. Without this, every re-diff of an already-applied
-    # cable spuriously reports an update (postchange always carries the
-    # resolved terminations; prechange never does), breaking idempotency.
-    # Mirror the {object_type, object_id} shape the transformer produces so
-    # shallow_compare_dict's `!=` sees them as equal when nothing changed.
-    # Sort by (object_type, object_id) rather than relying on the reverse
-    # relation's incidental ordering: for multi-termination cables NetBox
-    # gives no ordering guarantee on `terminations`, and postchange data
-    # (transformer/apply-resolved) is not guaranteed to line up positionally
-    # with whatever order the DB happens to return. A stable sort on both
-    # sides keeps list equality in shallow_compare_dict meaningful.
+    # Cable terminations are model properties (reverse `terminations`
+    # relation), not Django fields, so the loop above omits them and every
+    # re-diff of an applied cable would spuriously report an update. Capture
+    # them in the transformer's {object_type, object_id} shape, sorted for
+    # stable comparison (the relation has no ordering guarantee).
     for term_field in ("a_terminations", "b_terminations"):
         if term_field not in diode_fields or not hasattr(instance, term_field):
             continue
@@ -269,6 +260,7 @@ def _generate_changeset(entity: dict, object_type: str) -> ChangeSetResult:
                 # this is also important for custom fields because they do not appear to
                 # respsect paritial update serialization.
                 entity = _partially_merge(prechange_data, entity, instance)
+                _align_cable_ends(prechange_data, entity)
             changed_data = shallow_compare_dict(
                 prechange_data, entity,
             )
@@ -311,13 +303,8 @@ def _partially_merge(prechange_data: dict, postchange_data: dict, instance) -> d
         if key == "tags":
             result[key] = _merge_reference_list(prechange_data.get(key, []), value)
         elif key in ("a_terminations", "b_terminations") and isinstance(value, list):
-            # Cable termination lists carry no meaningful order (they are a set
-            # of endpoints, not a sequence), but shallow_compare_dict does a
-            # positional list comparison. prechange_data_from_instance() sorts
-            # its side by (object_type, object_id); sort postchange the same
-            # way here so idempotent re-diffs don't spuriously report a change
-            # when the DB's reverse `terminations` relation and the submitted
-            # payload happen to order multi-termination endpoints differently.
+            # termination lists are sets of endpoints; sort both sides the
+            # same way so positional list comparison stays meaningful
             result[key] = _sorted_termination_refs(value)
         else:
             result[key] = value
@@ -335,21 +322,37 @@ def _canonicalize_termination_order(entity: dict) -> None:
     """
     Sort termination lists in place before new_refs index paths are computed.
 
-    cleanup_unresolved_references emits index paths (e.g.
-    "a_terminations.0.object_id") and _partially_merge later re-sorts these
-    lists with the same key for stable prechange/postchange comparison;
-    sorting here first makes that re-sort a no-op, so the index paths stay
-    aligned with the data the applier resolves. Without this, an UPDATE
-    (netbox_id-matched) whose end mixes an already-resolved pk (int) with a
-    new unresolved ref re-sorts after the paths are computed, and the
-    unresolved ref at its new index is never resolved.
-    str(UnresolvedReference) equals the "new_object:..." string cleanup
-    writes, so this sort and the post-cleanup sort order identically.
+    _partially_merge later re-sorts these lists with the same key; sorting
+    first makes that a no-op, so index paths like "a_terminations.0.object_id"
+    stay aligned with the data the applier resolves (a later re-sort would
+    strand an unresolved ref at an index no path names).
     """
     for term_field in ("a_terminations", "b_terminations"):
         terms = entity.get(term_field)
         if isinstance(terms, list) and terms:
             entity[term_field] = _sorted_termination_refs(terms)
+
+
+def _align_cable_ends(prechange_data: dict, entity: dict) -> None:
+    """
+    Keep the existing A/B end assignment when the submitted ends are swapped.
+
+    Cable identity is A/B-insensitive, so a feed that reports the same two
+    termination sets with the ends flipped is the same cable; without this,
+    each such re-ingest diffs as an UPDATE that only flips cable_end, and
+    alternating feeds toggle forever instead of converging. Only a pure swap
+    is realigned (both submitted ends exactly equal the opposite existing
+    ends), which also guarantees all refs are resolved pks.
+    """
+    pre_a = prechange_data.get("a_terminations")
+    pre_b = prechange_data.get("b_terminations")
+    post_a = entity.get("a_terminations")
+    post_b = entity.get("b_terminations")
+    if not (pre_a and pre_b and post_a and post_b):
+        return
+    if post_a != pre_a and post_a == pre_b and post_b == pre_a:
+        entity["a_terminations"] = post_b
+        entity["b_terminations"] = post_a
 
 
 def _sorted_termination_refs(refs: list) -> list:

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -98,6 +98,26 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
         else:
             prechange_data[field_name] = value
 
+    # Cable.a_terminations / b_terminations are model *properties* (backed by
+    # the reverse `terminations` relation), not real Django model fields, so
+    # they never appear in `fields.items()` above and are silently omitted
+    # from prechange_data. Without this, every re-diff of an already-applied
+    # cable spuriously reports an update (postchange always carries the
+    # resolved terminations; prechange never does), breaking idempotency.
+    # Mirror the {object_type, object_id} shape the transformer produces so
+    # shallow_compare_dict's `!=` sees them as equal when nothing changed.
+    for term_field in ("a_terminations", "b_terminations"):
+        if term_field not in diode_fields or not hasattr(instance, term_field):
+            continue
+        terminations = getattr(instance, term_field)
+        prechange_data[term_field] = [
+            {
+                "object_type": f"{term.__class__._meta.app_label}.{term.__class__._meta.model_name}",
+                "object_id": term.pk,
+            }
+            for term in (terminations or [])
+        ]
+
     if hasattr(instance, "get_custom_fields"):
         # NetBox's instance.get_custom_fields() calls CustomField.objects.get_for_model
         # which uses a request-scoped query_cache - one DB hit per unique model per

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -106,17 +106,23 @@ def prechange_data_from_instance(instance) -> dict: # noqa: C901
     # resolved terminations; prechange never does), breaking idempotency.
     # Mirror the {object_type, object_id} shape the transformer produces so
     # shallow_compare_dict's `!=` sees them as equal when nothing changed.
+    # Sort by (object_type, object_id) rather than relying on the reverse
+    # relation's incidental ordering: for multi-termination cables NetBox
+    # gives no ordering guarantee on `terminations`, and postchange data
+    # (transformer/apply-resolved) is not guaranteed to line up positionally
+    # with whatever order the DB happens to return. A stable sort on both
+    # sides keeps list equality in shallow_compare_dict meaningful.
     for term_field in ("a_terminations", "b_terminations"):
         if term_field not in diode_fields or not hasattr(instance, term_field):
             continue
         terminations = getattr(instance, term_field)
-        prechange_data[term_field] = [
+        prechange_data[term_field] = _sorted_termination_refs([
             {
                 "object_type": f"{term.__class__._meta.app_label}.{term.__class__._meta.model_name}",
                 "object_id": term.pk,
             }
             for term in (terminations or [])
-        ]
+        ])
 
     if hasattr(instance, "get_custom_fields"):
         # NetBox's instance.get_custom_fields() calls CustomField.objects.get_for_model
@@ -303,6 +309,15 @@ def _partially_merge(prechange_data: dict, postchange_data: dict, instance) -> d
         # currently we only merge tags, but this could be extended to other reference lists?
         if key == "tags":
             result[key] = _merge_reference_list(prechange_data.get(key, []), value)
+        elif key in ("a_terminations", "b_terminations") and isinstance(value, list):
+            # Cable termination lists carry no meaningful order (they are a set
+            # of endpoints, not a sequence), but shallow_compare_dict does a
+            # positional list comparison. prechange_data_from_instance() sorts
+            # its side by (object_type, object_id); sort postchange the same
+            # way here so idempotent re-diffs don't spuriously report a change
+            # when the DB's reverse `terminations` relation and the submitted
+            # payload happen to order multi-termination endpoints differently.
+            result[key] = _sorted_termination_refs(value)
         else:
             result[key] = value
 
@@ -314,6 +329,21 @@ def _partially_merge(prechange_data: dict, postchange_data: dict, instance) -> d
                 result["custom_fields"][key] = value
         set_custom_field_defaults(result, instance)
     return result
+
+def _sorted_termination_refs(refs: list) -> list:
+    """Sort a list of {object_type, object_id} termination refs for stable comparison.
+
+    object_id may be an int (resolved) or a string (still-unresolved
+    `new_object:...` reference after cleanup_unresolved_references), so the
+    sort key coerces it to str to avoid cross-type comparison errors.
+    """
+    return sorted(
+        refs,
+        key=lambda t: (t.get("object_type", ""), str(t.get("object_id", "")))
+        if isinstance(t, dict)
+        else (str(t),),
+    )
+
 
 def _merge_reference_list(prechange_list: list, postchange_list: list) -> list:
     """Merge reference lists rather than replacing the full value."""

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -798,6 +798,15 @@ class CableTerminationSetMatcher:
         if not pairs:
             return None
 
+        # A cable cannot terminate the same object twice (CableTermination has
+        # a unique (termination_type, termination_id) constraint). A duplicate
+        # pair would both inflate len(pairs) and be satisfiable by one shared
+        # termination row (each filter is a separate join), letting an invalid
+        # payload like A:[if1] B:[if1] false-match a larger cable containing
+        # if1. Not authoritatively matchable -> let the serializer reject it.
+        if len(set(pairs)) != len(pairs):
+            return None
+
         qs = self.model_class.objects.annotate(
             _term_count=models.Count("terminations")
         ).filter(_term_count=len(pairs))

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -140,6 +140,12 @@ def requires_pre_save_match(object_type: str) -> bool:
 
 
 _LOGICAL_MATCHERS = {
+    "dcim.cable": lambda: [
+        CableTerminationSetMatcher(
+            model_class=get_object_type_model("dcim.cable"),
+            name="logical_cable_termination_set",
+        )
+    ],
     "dcim.macaddress": lambda: [
         ObjectMatchCriteria(
             fields=("mac_address", "assigned_object_type", "assigned_object_id"),

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -122,6 +122,7 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 # replicas - that would require a DB unique constraint or a
 # coordinating lock.
 _REQUIRES_PRE_SAVE_MATCH = frozenset({
+    "dcim.cable",
     "dcim.macaddress",
     "dcim.modulebay",
     "ipam.vlan",
@@ -688,6 +689,117 @@ class GlobalIPNetworkIPMatcher:
 
         return self.model_class.objects.filter(**filter)
 
+
+@dataclass
+class CableTerminationSetMatcher:
+    """Match a Cable by its canonical set of terminations (spec 5.3, contract F/G).
+
+    Cable has no DB unique constraint; identity is the sorted set of
+    (object_type, logical-id) termination tuples across BOTH ends, with
+    A/B and within-end order insignificant. ObjectMatchCriteria cannot
+    express a related-row set match (scalar-field-only, matcher.py:463-465),
+    so this dedicated matcher is required.
+    """
+
+    model_class: type[models.Model]
+    name: str
+    a_field: str = "a_terminations"
+    b_field: str = "b_terminations"
+
+    min_version: str | None = None
+    max_version: str | None = None
+
+    def has_required_fields(self, data: dict) -> bool:
+        """Both termination ends present and non-empty."""
+        a = data.get(self.a_field)
+        b = data.get(self.b_field)
+        return bool(a) and bool(b) and isinstance(a, list) and isinstance(b, list)
+
+    def _reduce(self, term: dict):
+        """Reduce one termination dict to a hashable (object_type, logical_id) tuple.
+
+        logical_id is the resolved pk (int) when available; at transform time
+        object_id is an UnresolvedReference -> reduce to ("__uuid__", uuid)
+        (best-effort in-batch dedup only, spec 5.3). Returns None if the item
+        is not a dict / lacks the expected keys.
+        """
+        if not isinstance(term, dict):
+            return None
+        object_type = term.get("object_type")
+        object_id = term.get("object_id")
+        if object_type is None or object_id is None:
+            return None
+        if isinstance(object_id, UnresolvedReference):
+            logical_id = ("__uuid__", object_id.uuid)
+        elif isinstance(object_id, int):
+            logical_id = object_id
+        else:
+            # stringified ref or unexpected type -- fold to a stable string
+            logical_id = ("__str__", str(object_id))
+        return (object_type, logical_id)
+
+    def _reduced_set(self, data: dict):
+        """Union of A+B reduced tuples, or None if any item is unreducible."""
+        reduced = []
+        for field in (self.a_field, self.b_field):
+            for term in data.get(field, []):
+                r = self._reduce(term)
+                if r is None:
+                    return None
+                reduced.append(r)
+        return reduced
+
+    def fingerprint(self, data: dict) -> str | None:
+        """Order-insensitive hash over the union of A+B reduced tuples.
+
+        Best-effort in-batch dedup: may be computed over uuids when terminations
+        are unresolved. Authoritative matching is build_queryset.
+        """
+        if not self.has_required_fields(data):
+            return None
+        reduced = self._reduced_set(data)
+        if reduced is None:
+            return None
+        return hash(
+            (self.model_class.__name__, self.name, tuple(sorted(reduced)))
+        )
+
+    def build_queryset(self, data: dict) -> models.QuerySet | None:
+        """Authoritative exact-set match over real CableTermination rows.
+
+        Annotate the termination count per Cable, require count == requested
+        count, then require every requested (termination_type ct_id,
+        termination_id pk) is present. Rejects subset/superset. Returns None if
+        any object_id is still unresolved (cannot authoritatively match).
+        """
+        if not self.has_required_fields(data):
+            return None
+
+        pairs = []  # (content_type_id, pk)
+        for field in (self.a_field, self.b_field):
+            for term in data.get(field, []):
+                if not isinstance(term, dict):
+                    return None
+                object_id = term.get("object_id")
+                object_type = term.get("object_type")
+                if not isinstance(object_id, int) or object_type is None:
+                    return None  # unresolved -> cannot authoritatively match
+                pairs.append((content_type_id(object_type), object_id))
+
+        if not pairs:
+            return None
+
+        qs = self.model_class.objects.annotate(
+            _term_count=models.Count("terminations")
+        ).filter(_term_count=len(pairs))
+        for ct_id, pk in pairs:
+            qs = qs.filter(
+                terminations__termination_type_id=ct_id,
+                terminations__termination_id=pk,
+            )
+        return qs.distinct()
+
+
 @dataclass
 class VRFIPNetworkIPMatcher:
     """Matches ip in a vrf, ignores mask."""
@@ -1008,6 +1120,9 @@ def _find_obj_cache_key(data: dict, object_type: str) -> str | None:
     solely on unresolved references (no scalar fields at all) are not
     cacheable.
     """
+    if object_type == "dcim.cable":
+        return None  # cable identity lives entirely in list fields skipped by the scalar-only cache key; always run the authoritative build_queryset matcher loop
+
     items = []
     for k, v in sorted(data.items()):
         if k.startswith("_"):

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -698,7 +698,8 @@ class GlobalIPNetworkIPMatcher:
 
 @dataclass
 class CableTerminationSetMatcher:
-    """Match a Cable by its canonical set of terminations (spec 5.3, contract F/G).
+    """
+    Match a Cable by its canonical set of terminations (spec 5.3, contract F/G).
 
     Cable has no DB unique constraint; identity is the sorted set of
     (object_type, logical-id) termination tuples across BOTH ends, with
@@ -722,7 +723,8 @@ class CableTerminationSetMatcher:
         return bool(a) and bool(b) and isinstance(a, list) and isinstance(b, list)
 
     def _reduce(self, term: dict):
-        """Reduce one termination dict to a hashable (object_type, logical_id) tuple.
+        """
+        Reduce one termination dict to a hashable (object_type, logical_id) tuple.
 
         logical_id is the resolved pk (int) when available; at transform time
         object_id is an UnresolvedReference -> reduce to ("__uuid__", uuid)
@@ -756,7 +758,8 @@ class CableTerminationSetMatcher:
         return reduced
 
     def fingerprint(self, data: dict) -> str | None:
-        """Order-insensitive hash over the union of A+B reduced tuples.
+        """
+        Order-insensitive hash over the union of A+B reduced tuples.
 
         Best-effort in-batch dedup: may be computed over uuids when terminations
         are unresolved. Authoritative matching is build_queryset.
@@ -771,7 +774,8 @@ class CableTerminationSetMatcher:
         )
 
     def build_queryset(self, data: dict) -> models.QuerySet | None:
-        """Authoritative exact-set match over real CableTermination rows.
+        """
+        Authoritative exact-set match over real CableTermination rows.
 
         Annotate the termination count per Cable, require count == requested
         count, then require every requested (termination_type ct_id,
@@ -1127,7 +1131,9 @@ def _find_obj_cache_key(data: dict, object_type: str) -> str | None:
     cacheable.
     """
     if object_type == "dcim.cable":
-        return None  # cable identity lives entirely in list fields skipped by the scalar-only cache key; always run the authoritative build_queryset matcher loop
+        # Cable identity lives entirely in list fields skipped by the scalar-only
+        # cache key; always run the authoritative build_queryset matcher loop.
+        return None
 
     items = []
     for k, v in sorted(data.items()):

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -699,13 +699,12 @@ class GlobalIPNetworkIPMatcher:
 @dataclass
 class CableTerminationSetMatcher:
     """
-    Match a Cable by its canonical set of terminations (spec 5.3, contract F/G).
+    Match a Cable by its canonical set of terminations.
 
     Cable has no DB unique constraint; identity is the sorted set of
     (object_type, logical-id) termination tuples across BOTH ends, with
-    A/B and within-end order insignificant. ObjectMatchCriteria cannot
-    express a related-row set match (scalar-field-only, matcher.py:463-465),
-    so this dedicated matcher is required.
+    A/B and within-end order insignificant. ObjectMatchCriteria is
+    scalar-field-only and cannot express a related-row set match.
     """
 
     model_class: type[models.Model]
@@ -728,8 +727,8 @@ class CableTerminationSetMatcher:
 
         logical_id is the resolved pk (int) when available; at transform time
         object_id is an UnresolvedReference -> reduce to ("__uuid__", uuid)
-        (best-effort in-batch dedup only, spec 5.3). Returns None if the item
-        is not a dict / lacks the expected keys.
+        (best-effort in-batch dedup only). Returns None if the item is not a
+        dict / lacks the expected keys.
         """
         if not isinstance(term, dict):
             return None
@@ -757,7 +756,7 @@ class CableTerminationSetMatcher:
                 reduced.append(r)
         return reduced
 
-    def fingerprint(self, data: dict) -> str | None:
+    def fingerprint(self, data: dict) -> int | None:
         """
         Order-insensitive hash over the union of A+B reduced tuples.
 

--- a/netbox_diode_plugin/api/plugin_utils.py
+++ b/netbox_diode_plugin/api/plugin_utils.py
@@ -2,7 +2,7 @@
 
 # Generated code. DO NOT EDIT.
 # Source: NetBox v4.6.0
-# Timestamp: 2026-05-14 20:30:15Z
+# Timestamp: 2026-07-01 02:51:21Z
 
 from dataclasses import dataclass
 import datetime
@@ -51,6 +51,7 @@ class RefInfo:
     field_name: str
     is_generic: bool = False
     is_many: bool = False
+    is_generic_object: bool = False
 
 
 CUSTOM_FIELD_OBJECT_REFERENCE_TYPE = "diode.custom_field_object_reference"
@@ -461,6 +462,18 @@ _JSON_REF_INFO = {
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "dcim.cable": {
+        "a_terminations": RefInfo(
+            object_type="",
+            field_name="a_terminations",
+            is_many=True,
+            is_generic_object=True,
+        ),
+        "b_terminations": RefInfo(
+            object_type="",
+            field_name="b_terminations",
+            is_many=True,
+            is_generic_object=True,
+        ),
         "bundle": RefInfo(object_type="dcim.cablebundle", field_name="bundle"),
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
@@ -2962,6 +2975,112 @@ def get_json_ref_info(
     if not isinstance(object_type, str):
         object_type = get_object_type(object_type)
     return _JSON_REF_INFO.get(object_type, {}).get(json_field_name)
+
+
+_GENERIC_OBJECT_VARIANTS: dict[str, str] = {
+    "object_aggregate": "ipam.aggregate",
+    "object_asn": "ipam.asn",
+    "object_asn_range": "ipam.asnrange",
+    "object_cable": "dcim.cable",
+    "object_cable_bundle": "dcim.cablebundle",
+    "object_cable_path": "dcim.cablepath",
+    "object_circuit": "circuits.circuit",
+    "object_circuit_group": "circuits.circuitgroup",
+    "object_circuit_group_assignment": "circuits.circuitgroupassignment",
+    "object_circuit_termination": "circuits.circuittermination",
+    "object_circuit_type": "circuits.circuittype",
+    "object_cluster": "virtualization.cluster",
+    "object_cluster_group": "virtualization.clustergroup",
+    "object_cluster_type": "virtualization.clustertype",
+    "object_console_port": "dcim.consoleport",
+    "object_console_server_port": "dcim.consoleserverport",
+    "object_contact": "tenancy.contact",
+    "object_contact_assignment": "tenancy.contactassignment",
+    "object_contact_group": "tenancy.contactgroup",
+    "object_contact_role": "tenancy.contactrole",
+    "object_custom_field": "extras.customfield",
+    "object_custom_field_choice_set": "extras.customfieldchoiceset",
+    "object_custom_link": "extras.customlink",
+    "object_device": "dcim.device",
+    "object_device_bay": "dcim.devicebay",
+    "object_device_role": "dcim.devicerole",
+    "object_device_type": "dcim.devicetype",
+    "object_fhrp_group": "ipam.fhrpgroup",
+    "object_fhrp_group_assignment": "ipam.fhrpgroupassignment",
+    "object_front_port": "dcim.frontport",
+    "object_ike_policy": "vpn.ikepolicy",
+    "object_ike_proposal": "vpn.ikeproposal",
+    "object_interface": "dcim.interface",
+    "object_inventory_item": "dcim.inventoryitem",
+    "object_inventory_item_role": "dcim.inventoryitemrole",
+    "object_ip_address": "ipam.ipaddress",
+    "object_ip_range": "ipam.iprange",
+    "object_ip_sec_policy": "vpn.ipsecpolicy",
+    "object_ip_sec_profile": "vpn.ipsecprofile",
+    "object_ip_sec_proposal": "vpn.ipsecproposal",
+    "object_journal_entry": "extras.journalentry",
+    "object_l2vpn": "vpn.l2vpn",
+    "object_l2vpn_termination": "vpn.l2vpntermination",
+    "object_location": "dcim.location",
+    "object_mac_address": "dcim.macaddress",
+    "object_manufacturer": "dcim.manufacturer",
+    "object_module": "dcim.module",
+    "object_module_bay": "dcim.modulebay",
+    "object_module_type": "dcim.moduletype",
+    "object_module_type_profile": "dcim.moduletypeprofile",
+    "object_owner": "users.owner",
+    "object_owner_group": "users.ownergroup",
+    "object_platform": "dcim.platform",
+    "object_power_feed": "dcim.powerfeed",
+    "object_power_outlet": "dcim.poweroutlet",
+    "object_power_panel": "dcim.powerpanel",
+    "object_power_port": "dcim.powerport",
+    "object_prefix": "ipam.prefix",
+    "object_provider": "circuits.provider",
+    "object_provider_account": "circuits.provideraccount",
+    "object_provider_network": "circuits.providernetwork",
+    "object_rack": "dcim.rack",
+    "object_rack_group": "dcim.rackgroup",
+    "object_rack_reservation": "dcim.rackreservation",
+    "object_rack_role": "dcim.rackrole",
+    "object_rack_type": "dcim.racktype",
+    "object_rear_port": "dcim.rearport",
+    "object_region": "dcim.region",
+    "object_rir": "ipam.rir",
+    "object_role": "ipam.role",
+    "object_route_target": "ipam.routetarget",
+    "object_script_module": "core.managedfile",
+    "object_service": "ipam.service",
+    "object_site": "dcim.site",
+    "object_site_group": "dcim.sitegroup",
+    "object_tag": "extras.tag",
+    "object_tenant": "tenancy.tenant",
+    "object_tenant_group": "tenancy.tenantgroup",
+    "object_tunnel": "vpn.tunnel",
+    "object_tunnel_group": "vpn.tunnelgroup",
+    "object_tunnel_termination": "vpn.tunneltermination",
+    "object_virtual_chassis": "dcim.virtualchassis",
+    "object_virtual_circuit": "circuits.virtualcircuit",
+    "object_virtual_circuit_termination": "circuits.virtualcircuittermination",
+    "object_virtual_circuit_type": "circuits.virtualcircuittype",
+    "object_virtual_device_context": "dcim.virtualdevicecontext",
+    "object_virtual_disk": "virtualization.virtualdisk",
+    "object_virtual_machine": "virtualization.virtualmachine",
+    "object_virtual_machine_type": "virtualization.virtualmachinetype",
+    "object_vlan": "ipam.vlan",
+    "object_vlan_group": "ipam.vlangroup",
+    "object_vlan_translation_policy": "ipam.vlantranslationpolicy",
+    "object_vlan_translation_rule": "ipam.vlantranslationrule",
+    "object_vm_interface": "virtualization.vminterface",
+    "object_vrf": "ipam.vrf",
+    "object_wireless_lan": "wireless.wirelesslan",
+    "object_wireless_lan_group": "wireless.wirelesslangroup",
+    "object_wireless_link": "wireless.wirelesslink",
+}
+
+
+def get_generic_object_variant(key: str) -> str | None:
+    return _GENERIC_OBJECT_VARIANTS.get(key)
 
 
 _LEGAL_FIELDS = {

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -202,14 +202,39 @@ def _transform_proto_json_1(proto_json: dict, object_type: str, supported_models
         if isinstance(value, list):
             ref_value = []
             for item in value:
-                nested = _transform_proto_json_1(item, ref_info.object_type, supported_models, nested_context)
-                nodes += nested
-                ref_uuid = nested[0]['_uuid']
-                ref_value.append(UnresolvedReference(
-                    object_type=ref_info.object_type,
-                    uuid=ref_uuid,
-                ))
-                refs.append(ref_uuid)
+                if ref_info.is_generic_object:
+                    # Each item is a GenericObject dict, e.g. {"object_interface": {...}}.
+                    # Resolve the concrete object_type from the single variant key.
+                    if not isinstance(item, dict) or len(item) != 1:
+                        node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
+                            f"Skipping malformed generic-object item (expected single-key dict): {item!r}"
+                        ]
+                        continue
+                    variant_key = next(iter(item))
+                    concrete_type = get_generic_object_variant(variant_key)
+                    if concrete_type is None:
+                        node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
+                            f"Skipping unknown generic-object variant key: {variant_key!r}"
+                        ]
+                        continue
+                    item_payload = item[variant_key]
+                    nested = _transform_proto_json_1(item_payload, concrete_type, supported_models, nested_context)
+                    nodes += nested
+                    ref_uuid = nested[0]['_uuid']
+                    ref_value.append({
+                        'object_type': concrete_type,
+                        'object_id': UnresolvedReference(object_type=concrete_type, uuid=ref_uuid),
+                    })
+                    refs.append(ref_uuid)
+                else:
+                    nested = _transform_proto_json_1(item, ref_info.object_type, supported_models, nested_context)
+                    nodes += nested
+                    ref_uuid = nested[0]['_uuid']
+                    ref_value.append(UnresolvedReference(
+                        object_type=ref_info.object_type,
+                        uuid=ref_uuid,
+                    ))
+                    refs.append(ref_uuid)
         else:
             nested = _transform_proto_json_1(value, ref_info.object_type, supported_models, nested_context)
             nodes += nested
@@ -630,6 +655,9 @@ def _update_resolved_refs(data, new_refs):
                 if isinstance(item, UnresolvedReference) and item.uuid in new_refs:
                     new_items.append(new_refs[item.uuid])
                     has_refs = True
+                elif isinstance(item, dict):
+                    _update_resolved_refs(item, new_refs)
+                    new_items.append(item)
                 else:
                     new_items.append(item)
             if has_refs:
@@ -651,6 +679,10 @@ def cleanup_unresolved_references(data: dict) -> list[str]:
                 if isinstance(item, UnresolvedReference):
                     unresolved.add(k)
                     items.append(str(item))
+                elif isinstance(item, dict):
+                    for uu in cleanup_unresolved_references(item):
+                        unresolved.add(f"{k}.{uu}")
+                    items.append(item)
                 else:
                     items.append(item)
             data[k] = items

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -675,13 +675,13 @@ def cleanup_unresolved_references(data: dict) -> list[str]:  # noqa: C901
             data[k] = str(v)
         elif isinstance(v, list | tuple):
             items = []
-            for item in v:
+            for i, item in enumerate(v):
                 if isinstance(item, UnresolvedReference):
                     unresolved.add(k)
                     items.append(str(item))
                 elif isinstance(item, dict):
                     for uu in cleanup_unresolved_references(item):
-                        unresolved.add(f"{k}.{uu}")
+                        unresolved.add(f"{k}.{i}.{uu}")
                     items.append(item)
                 else:
                     items.append(item)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -171,6 +171,8 @@ def _transform_proto_json_1(proto_json: dict, object_type: str, supported_models
     def is_supported(field_name, ref_info):
         if ref_info is None:
             return field_name in supported_fields
+        if ref_info.is_generic_object:
+            return ref_info.field_name in legal_fields(object_type)
         if ref_info.object_type not in supported_models:
             return False
         if ref_info.is_generic:

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -23,6 +23,7 @@ from .matcher import find_existing_object, fingerprints
 from .plugin_utils import (
     CUSTOM_FIELD_OBJECT_REFERENCE_TYPE,
     apply_format_transformations,
+    get_generic_object_variant,
     get_json_ref_info,
     get_object_type_model,
     get_primary_value,

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -212,13 +212,13 @@ def _transform_proto_json_1(proto_json: dict, object_type: str, supported_models
                         continue
                     variant_key = next(iter(item))
                     concrete_type = get_generic_object_variant(variant_key)
-                    if concrete_type is None:
+                    if concrete_type is None or concrete_type not in supported_models:
                         node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
                             f"Skipping unknown generic-object variant key: {variant_key!r}"
                         ]
                         continue
                     item_payload = item[variant_key]
-                    nested = _transform_proto_json_1(item_payload, concrete_type, supported_models, nested_context)
+                    nested = _transform_proto_json_1(item_payload, concrete_type, supported_models)
                     nodes += nested
                     ref_uuid = nested[0]['_uuid']
                     ref_value.append({

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -215,9 +215,15 @@ def _transform_proto_json_1(proto_json: dict, object_type: str, supported_models
                     # the nested variant key needs its own normalization.
                     variant_key = _camel_to_snake_case(raw_variant_key)
                     concrete_type = get_generic_object_variant(variant_key)
-                    if concrete_type is None or concrete_type not in supported_models:
+                    if concrete_type is None:
                         node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
                             f"Skipping unknown generic-object variant key: {variant_key!r}"
+                        ]
+                        continue
+                    if concrete_type not in supported_models:
+                        node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
+                            f"Skipping generic-object variant {variant_key!r}: "
+                            f"{concrete_type} is not supported in this version."
                         ]
                         continue
                     item_payload = item[raw_variant_key]

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -587,6 +587,13 @@ def _update_dict_refs(data, new_refs):
             for item in v:
                 if isinstance(item, UnresolvedReference) and item.uuid in new_refs:
                     item.uuid = new_refs[item.uuid]
+                elif isinstance(item, dict):
+                    # Refs nested in a list of dicts (e.g. cable
+                    # a_terminations/b_terminations = [{object_type,
+                    # object_id: UnresolvedReference}]) must be rewritten too
+                    # when the referenced entity dedupes to a surviving uuid;
+                    # otherwise a stale ref survives and later fails to resolve.
+                    _update_dict_refs(item, new_refs)
         elif isinstance(v, dict):
             _update_dict_refs(v, new_refs)
 

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -203,21 +203,24 @@ def _transform_proto_json_1(proto_json: dict, object_type: str, supported_models
             ref_value = []
             for item in value:
                 if ref_info.is_generic_object:
-                    # Each item is a GenericObject dict, e.g. {"object_interface": {...}}.
-                    # Resolve the concrete object_type from the single variant key.
+                    # Single-key GenericObject wrapper: the key names the
+                    # variant, e.g. {"object_interface": {...}}.
                     if not isinstance(item, dict) or len(item) != 1:
                         node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
                             f"Skipping malformed generic-object item (expected single-key dict): {item!r}"
                         ]
                         continue
-                    variant_key = next(iter(item))
+                    raw_variant_key = next(iter(item))
+                    # camelCase protoJSON is normalized at the top level only;
+                    # the nested variant key needs its own normalization.
+                    variant_key = _camel_to_snake_case(raw_variant_key)
                     concrete_type = get_generic_object_variant(variant_key)
                     if concrete_type is None or concrete_type not in supported_models:
                         node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
                             f"Skipping unknown generic-object variant key: {variant_key!r}"
                         ]
                         continue
-                    item_payload = item[variant_key]
+                    item_payload = item[raw_variant_key]
                     nested = _transform_proto_json_1(item_payload, concrete_type, supported_models)
                     nodes += nested
                     ref_uuid = nested[0]['_uuid']
@@ -588,11 +591,8 @@ def _update_dict_refs(data, new_refs):
                 if isinstance(item, UnresolvedReference) and item.uuid in new_refs:
                     item.uuid = new_refs[item.uuid]
                 elif isinstance(item, dict):
-                    # Refs nested in a list of dicts (e.g. cable
-                    # a_terminations/b_terminations = [{object_type,
-                    # object_id: UnresolvedReference}]) must be rewritten too
-                    # when the referenced entity dedupes to a surviving uuid;
-                    # otherwise a stale ref survives and later fails to resolve.
+                    # rewrite refs nested in list-of-dict items too
+                    # (e.g. cable termination {object_type, object_id})
                     _update_dict_refs(item, new_refs)
         elif isinstance(v, dict):
             _update_dict_refs(v, new_refs)
@@ -672,7 +672,23 @@ def _update_resolved_refs(data, new_refs):
         elif isinstance(v, dict):
             _update_resolved_refs(v, new_refs)
 
-def cleanup_unresolved_references(data: dict) -> list[str]:  # noqa: C901
+def _cleanup_list_refs(key: str, values, unresolved: set) -> list:
+    """Stringify unresolved refs in a list, indexing paths for dict items."""
+    items = []
+    for i, item in enumerate(values):
+        if isinstance(item, UnresolvedReference):
+            unresolved.add(key)
+            items.append(str(item))
+        elif isinstance(item, dict):
+            for uu in cleanup_unresolved_references(item):
+                unresolved.add(f"{key}.{i}.{uu}")
+            items.append(item)
+        else:
+            items.append(item)
+    return items
+
+
+def cleanup_unresolved_references(data: dict) -> list[str]:
     """Find and stringify unresolved references in fields."""
     unresolved = set()
     for k, v in data.items():
@@ -681,18 +697,7 @@ def cleanup_unresolved_references(data: dict) -> list[str]:  # noqa: C901
                 unresolved.add(k)
             data[k] = str(v)
         elif isinstance(v, list | tuple):
-            items = []
-            for i, item in enumerate(v):
-                if isinstance(item, UnresolvedReference):
-                    unresolved.add(k)
-                    items.append(str(item))
-                elif isinstance(item, dict):
-                    for uu in cleanup_unresolved_references(item):
-                        unresolved.add(f"{k}.{i}.{uu}")
-                    items.append(item)
-                else:
-                    items.append(item)
-            data[k] = items
+            data[k] = _cleanup_list_refs(k, v, unresolved)
         elif isinstance(v, dict):
             for uu in cleanup_unresolved_references(v):
                 unresolved.add(f"{k}.{uu}")

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -665,7 +665,7 @@ def _update_resolved_refs(data, new_refs):
         elif isinstance(v, dict):
             _update_resolved_refs(v, new_refs)
 
-def cleanup_unresolved_references(data: dict) -> list[str]:
+def cleanup_unresolved_references(data: dict) -> list[str]:  # noqa: C901
     """Find and stringify unresolved references in fields."""
     unresolved = set()
     for k, v in data.items():

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -39,6 +39,21 @@ def _camel_to_snake_case(name):
     name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", name).lower()
 
+@lru_cache(maxsize=1)
+def _cable_terminable_types() -> frozenset:
+    """
+    Object types valid as a cable termination, per NetBox's own constant.
+
+    Resolved from dcim.constants.CABLE_TERMINATION_MODELS so it tracks NetBox
+    rather than a hand-maintained list. Cached: ContentType rows are stable.
+    """
+    from dcim.constants import CABLE_TERMINATION_MODELS
+    from django.contrib.contenttypes.models import ContentType
+    return frozenset(
+        f"{ct.app_label}.{ct.model}"
+        for ct in ContentType.objects.filter(CABLE_TERMINATION_MODELS)
+    )
+
 # these are implied values pushed down to referenced objects.
 _NESTED_CONTEXT = {
     "dcim.interface": {
@@ -224,6 +239,16 @@ def _transform_proto_json_1(proto_json: dict, object_type: str, supported_models
                         node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
                             f"Skipping generic-object variant {variant_key!r}: "
                             f"{concrete_type} is not supported in this version."
+                        ]
+                        continue
+                    # The GenericObject variant map spans every content type, but
+                    # only NetBox's cable-terminable models are valid endpoints.
+                    # Reject others up front rather than recursing to create the
+                    # child object before the cable serializer rejects it.
+                    if object_type == "dcim.cable" and concrete_type not in _cable_terminable_types():
+                        node['_warnings'][field_name] = node['_warnings'].get(field_name, []) + [
+                            f"Skipping generic-object variant {variant_key!r}: "
+                            f"{concrete_type} is not a valid cable termination type."
                         ]
                         continue
                     item_payload = item[raw_variant_key]

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_diff_and_apply.py
@@ -2035,6 +2035,57 @@ class GenerateDiffAndApplyTestCase(APITestCase):
             f"Expected no changes on re-diff, but got: {changes}"
         )
 
+    def test_all_digit_name_object_cf_resolves_new_ref(self):
+        """
+        A CF whose name is all digits must resolve a new object ref, not 500.
+
+        NetBox permits all-digit custom field names (validator ^[a-z0-9_]+$).
+        The apply-time new_refs path for such a CF is "custom_fields.<digits>";
+        the ref-resolution path helpers must not coerce that dict key to a list
+        index (which would KeyError on the string-keyed custom_fields dict and,
+        because the KeyError arg is an int, bypass the unresolved-ref handler
+        and surface as a 500).
+        """
+        cf = CustomField.objects.create(
+            name='12345',
+            type=CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            required=False,
+            related_object_type=ObjectType.objects.get_for_model(Site),
+        )
+        cf.object_types.set([ObjectType.objects.get_for_model(Device)])
+        cf.save()
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "DigitCF-Device",
+                    "role": {"name": "DigitCF-Role"},
+                    "site": {"name": "DigitCF-Site-Primary"},
+                    "device_type": {
+                        "model": "DigitCF-Model",
+                        "manufacturer": {"name": "DigitCF-Manufacturer"},
+                    },
+                    # References a site that does not exist yet -> the CF ref is
+                    # unresolved and must be resolved at apply via new_refs.
+                    "custom_fields": {
+                        "12345": {
+                            "multiple_objects": [
+                                {"site": {"name": "DigitCF-Site-New"}},
+                            ],
+                        },
+                    },
+                },
+            },
+        }
+
+        # apply must succeed (diff_and_apply asserts 200 on both calls)
+        self.diff_and_apply(payload)
+        device = Device.objects.get(name="DigitCF-Device")
+        new_site = Site.objects.get(name="DigitCF-Site-New")
+        self.assertEqual(device.custom_field_data['12345'], [new_site.pk])
+
     def diff_and_apply(self, payload):
         """Diff and apply the payload."""
         response1 = self.client.post(

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
@@ -179,3 +179,100 @@ class CableMultiObjectUpdateTestCase(TestCase):
         self.assertIn(("A", self.iface_a0.pk), term_ids)
         self.assertIn(("A", new_iface.pk), term_ids)
         self.assertIn(("B", self.iface_b0.pk), term_ids)
+
+
+class CableEndSwapNoopTestCase(TestCase):
+    """
+    Re-ingesting the same cable with A/B ends swapped is a NOOP.
+
+    Cable identity is A/B-insensitive; without end alignment in the differ,
+    alternating feeds that flip endpoint order keep generating UPDATEs that
+    only toggle cable_end instead of converging.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed a cabled interface pair."""
+        mfr = Manufacturer.objects.create(name="MFR-Swap", slug="mfr-swap")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="DT-Swap", slug="dt-swap")
+        cls.role = DeviceRole.objects.create(name="Role-Swap", slug="role-swap")
+        cls.site = Site.objects.create(name="Site-Swap", slug="site-swap")
+        cls.dev_a = Device.objects.create(name="Swap Device A", device_type=cls.dt, role=cls.role, site=cls.site)
+        cls.dev_b = Device.objects.create(name="Swap Device B", device_type=cls.dt, role=cls.role, site=cls.site)
+        cls.iface_a = Interface.objects.create(device=cls.dev_a, name="sw-eth0", type="1000base-t")
+        cls.iface_b = Interface.objects.create(device=cls.dev_b, name="sw-eth1", type="1000base-t")
+
+    def _iface(self, device, name):
+        return {
+            "object_interface": {
+                "name": name,
+                "type": "1000base-t",
+                "device": {
+                    "name": device.name,
+                    "device_type": {"manufacturer": {"name": "MFR-Swap"}, "model": "DT-Swap"},
+                    "role": {"name": "Role-Swap"},
+                    "site": {"name": "Site-Swap"},
+                },
+            }
+        }
+
+    def test_swapped_ends_rediff_is_noop(self):
+        """Swapped-end re-ingest matches the cable and produces no changes."""
+        cs = ChangeSet(
+            id="cs-swap-seed",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id="new_object:dcim.cable:swap",
+                    data={
+                        "status": "connected",
+                        "a_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_a.pk}],
+                        "b_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_b.pk}],
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(cs, request=None)
+
+        # same cable, ends flipped
+        entity = {
+            "status": "connected",
+            "a_terminations": [self._iface(self.dev_b, "sw-eth1")],
+            "b_terminations": [self._iface(self.dev_a, "sw-eth0")],
+        }
+        result = generate_changeset(entity, "dcim.cable")
+        self.assertEqual(result.change_set.changes, [])
+
+
+class ApplierKeyErrorScopeTestCase(TestCase):
+    """Only missing new_object references become clean per-entity errors."""
+
+    def _change(self, data, new_refs):
+        return Change(
+            change_type=ChangeType.CREATE,
+            object_type="dcim.cable",
+            ref_id="new_object:dcim.cable:k1",
+            data=data,
+            new_refs=new_refs,
+        )
+
+    def test_dangling_new_object_ref_is_clean_error(self):
+        """A missing new_object ref surfaces as ChangeSetException, not a 500."""
+        from netbox_diode_plugin.api.common import ChangeSetException
+        cs = ChangeSet(
+            id="cs-keyerr-1",
+            changes=[self._change({"status": "connected", "label": "new_object:dcim.interface:missing"}, ["label"])],
+        )
+        with self.assertRaises(ChangeSetException):
+            apply_changeset(cs, request=None)
+
+    def test_unrelated_keyerror_propagates(self):
+        """A KeyError with a non-reference key is a real bug and propagates."""
+        cs = ChangeSet(
+            id="cs-keyerr-2",
+            changes=[self._change({"status": "connected", "label": "not-a-ref"}, ["label"])],
+        )
+        with self.assertRaises(KeyError):
+            apply_changeset(cs, request=None)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
@@ -3,7 +3,14 @@
 """Diode NetBox Plugin - Cable apply integration tests."""
 
 from dcim.models import (
-    Cable, CableTermination, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site,
+    Cable,
+    CableTermination,
+    Device,
+    DeviceRole,
+    DeviceType,
+    Interface,
+    Manufacturer,
+    Site,
 )
 from django.test import TestCase
 
@@ -16,6 +23,7 @@ class CableApplyTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Set up test fixtures."""
         mfr = Manufacturer.objects.create(name="MFR-Cable", slug="mfr-cable")
         dt = DeviceType.objects.create(manufacturer=mfr, model="DT-Cable", slug="dt-cable")
         role = DeviceRole.objects.create(name="Role-Cable", slug="role-cable")
@@ -42,6 +50,7 @@ class CableApplyTestCase(TestCase):
         )
 
     def test_cable_create_materializes_two_terminations(self):
+        """Cable create materializes two terminations."""
         cs = ChangeSet(id="cs-cable-1", changes=[self._cable_change(self.iface_a.pk, self.iface_b.pk)])
         apply_changeset(cs, request=None)
 
@@ -53,6 +62,7 @@ class CableApplyTestCase(TestCase):
         self.assertIn(("B", self.iface_b.pk), term_ids)
 
     def test_already_cabled_interface_fails_change_with_clean_error(self):
+        """Already cabled interface fails change with clean error."""
         # First cable connects A<->B. A second, distinct-termination-set cable
         # that reuses interface A (now already cabled) cannot be matched by
         # CableTerminationSetMatcher (different termination set: A<->C vs A<->B),

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Cable apply integration tests."""
+
+from dcim.models import (
+    Cable, CableTermination, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site,
+)
+from django.test import TestCase
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeType
+
+
+class CableApplyTestCase(TestCase):
+    """A cable CREATE materializes two CableTermination rows via CableSerializer."""
+
+    @classmethod
+    def setUpTestData(cls):
+        mfr = Manufacturer.objects.create(name="MFR-Cable", slug="mfr-cable")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="DT-Cable", slug="dt-cable")
+        role = DeviceRole.objects.create(name="Role-Cable", slug="role-cable")
+        site = Site.objects.create(name="Site-Cable", slug="site-cable")
+        dev_a = Device.objects.create(name="Cable Device A", device_type=dt, role=role, site=site)
+        dev_b = Device.objects.create(name="Cable Device B", device_type=dt, role=role, site=site)
+        dev_c = Device.objects.create(name="Cable Device C", device_type=dt, role=role, site=site)
+        cls.iface_a = Interface.objects.create(device=dev_a, name="Cable Iface A", type="1000base-t")
+        cls.iface_b = Interface.objects.create(device=dev_b, name="Cable Iface B", type="1000base-t")
+        cls.iface_c = Interface.objects.create(device=dev_c, name="Cable Iface C", type="1000base-t")
+
+    def _cable_change(self, a_pk, b_pk, label="Cable 1"):
+        return Change(
+            change_type=ChangeType.CREATE,
+            object_type="dcim.cable",
+            ref_id="new_object:dcim.cable:c1",
+            data={
+                "status": "connected",
+                "label": label,
+                "a_terminations": [{"object_type": "dcim.interface", "object_id": a_pk}],
+                "b_terminations": [{"object_type": "dcim.interface", "object_id": b_pk}],
+            },
+            new_refs=[],
+        )
+
+    def test_cable_create_materializes_two_terminations(self):
+        cs = ChangeSet(id="cs-cable-1", changes=[self._cable_change(self.iface_a.pk, self.iface_b.pk)])
+        apply_changeset(cs, request=None)
+
+        cable = Cable.objects.get(label="Cable 1")
+        terms = CableTermination.objects.filter(cable=cable)
+        self.assertEqual(terms.count(), 2)
+        term_ids = {(t.cable_end, t.termination_id) for t in terms}
+        self.assertIn(("A", self.iface_a.pk), term_ids)
+        self.assertIn(("B", self.iface_b.pk), term_ids)
+
+    def test_already_cabled_interface_fails_change_with_clean_error(self):
+        # First cable connects A<->B. A second, distinct-termination-set cable
+        # that reuses interface A (now already cabled) cannot be matched by
+        # CableTerminationSetMatcher (different termination set: A<->C vs A<->B),
+        # so it falls through to CableSerializer.is_valid()/Cable.clean(), which
+        # rejects it because interface A already has a cable connection.
+        cs1 = ChangeSet(id="cs-cable-a", changes=[self._cable_change(self.iface_a.pk, self.iface_b.pk)])
+        apply_changeset(cs1, request=None)
+
+        cs2 = ChangeSet(id="cs-cable-b", changes=[self._cable_change(self.iface_a.pk, self.iface_c.pk, label="Cable 2")])
+        with self.assertRaises(Exception) as ctx:
+            apply_changeset(cs2, request=None)
+        msg = str(ctx.exception).lower()
+        self.assertTrue(
+            any(s in msg for s in ("already", "cabled", "connect", "duplicate termination")),
+            f"expected a cable-conflict clean() message, got: {ctx.exception}",
+        )
+        self.assertFalse(Cable.objects.filter(label="Cable 2").exists())

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
@@ -84,7 +84,8 @@ class CableApplyTestCase(TestCase):
 
 
 class CableMultiObjectUpdateTestCase(TestCase):
-    """UPDATE of a multi-object end with mixed new/existing terminations resolves.
+    """
+    UPDATE of a multi-object end with mixed new/existing terminations resolves.
 
     Regression for the new_refs/resort desync: `_generate_changeset` computed
     index paths (``a_terminations.0.object_id``) via

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
@@ -245,6 +245,67 @@ class CableEndSwapNoopTestCase(TestCase):
         result = generate_changeset(entity, "dcim.cable")
         self.assertEqual(result.change_set.changes, [])
 
+    def test_stale_swapped_create_preserves_cable_ends(self):
+        """
+        A stale CREATE for an existing cable must not toggle cable_end.
+
+        Applying a CREATE change (as if planned before the cable existed) whose
+        ends are swapped relative to the existing cable hits the applier
+        pre-save-match path (dcim.cable in _REQUIRES_PRE_SAVE_MATCH). The match
+        is by A/B-insensitive set, so terminations must be left intact — only
+        attributes update — otherwise cable_end flips and alternating stale
+        creates toggle the physical assignment forever.
+        """
+        seed = ChangeSet(
+            id="cs-stale-seed",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id="new_object:dcim.cable:stale-seed",
+                    data={
+                        "status": "connected",
+                        "label": "Stale Cable",
+                        "a_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_a.pk}],
+                        "b_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_b.pk}],
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(seed, request=None)
+        cable = Cable.objects.get(label="Stale Cable")
+        ends_before = {(t.termination_id, t.cable_end) for t in CableTermination.objects.filter(cable=cable)}
+        self.assertEqual(ends_before, {(self.iface_a.pk, "A"), (self.iface_b.pk, "B")})
+
+        # stale CREATE for the SAME cable, ends swapped + a changed attribute
+        stale = ChangeSet(
+            id="cs-stale-swap",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id="new_object:dcim.cable:stale-swap",
+                    data={
+                        "status": "connected",
+                        "label": "Stale Cable Relabeled",
+                        "a_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_b.pk}],
+                        "b_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_a.pk}],
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(stale, request=None)
+
+        # still exactly one cable, ends UNCHANGED (no cable_end toggle)
+        self.assertEqual(Cable.objects.filter(label__startswith="Stale Cable").count(), 1)
+        cable.refresh_from_db()
+        ends_after = {(t.termination_id, t.cable_end) for t in CableTermination.objects.filter(cable=cable)}
+        self.assertEqual(ends_after, ends_before)
+        # non-termination attributes still update through the pre-save-match path
+        self.assertEqual(cable.label, "Stale Cable Relabeled")
+
 
 class ApplierKeyErrorScopeTestCase(TestCase):
     """Only missing new_object references become clean per-entity errors."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
@@ -15,7 +15,7 @@ from dcim.models import (
 from django.test import TestCase
 
 from netbox_diode_plugin.api.applier import apply_changeset
-from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeType
+from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeSetException, ChangeType
 from netbox_diode_plugin.api.differ import generate_changeset
 
 
@@ -73,7 +73,7 @@ class CableApplyTestCase(TestCase):
         apply_changeset(cs1, request=None)
 
         cs2 = ChangeSet(id="cs-cable-b", changes=[self._cable_change(self.iface_a.pk, self.iface_c.pk, label="Cable 2")])
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(ChangeSetException) as ctx:
             apply_changeset(cs2, request=None)
         msg = str(ctx.exception).lower()
         self.assertTrue(
@@ -260,7 +260,6 @@ class ApplierKeyErrorScopeTestCase(TestCase):
 
     def test_dangling_new_object_ref_is_clean_error(self):
         """A missing new_object ref surfaces as ChangeSetException, not a 500."""
-        from netbox_diode_plugin.api.common import ChangeSetException
         cs = ChangeSet(
             id="cs-keyerr-1",
             changes=[self._change({"status": "connected", "label": "new_object:dcim.interface:missing"}, ["label"])],

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
@@ -307,6 +307,97 @@ class CableEndSwapNoopTestCase(TestCase):
         self.assertEqual(cable.label, "Stale Cable Relabeled")
 
 
+class CablePartitionTestCase(TestCase):
+    """
+    Pre-save-match strip is A/B-grouping aware, not a blanket drop.
+
+    The set matcher finds a cable by its A/B-insensitive termination set, so a
+    stale CREATE for the same set matches it. Stripping terminations is correct
+    only when the submitted grouping equals the existing one up to a whole-end
+    swap; a genuine repartition (same set, different grouping) must be applied,
+    consistent with the differ UPDATE path — not silently dropped.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed a device with three interfaces for multi-termination cables."""
+        mfr = Manufacturer.objects.create(name="MFR-Part", slug="mfr-part")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="DT-Part", slug="dt-part")
+        role = DeviceRole.objects.create(name="Role-Part", slug="role-part")
+        site = Site.objects.create(name="Site-Part", slug="site-part")
+        cls.dev_a = Device.objects.create(name="Part Device A", device_type=dt, role=role, site=site)
+        cls.dev_b = Device.objects.create(name="Part Device B", device_type=dt, role=role, site=site)
+        cls.if1 = Interface.objects.create(device=cls.dev_a, name="p-eth0", type="1000base-t")
+        cls.if2 = Interface.objects.create(device=cls.dev_a, name="p-eth1", type="1000base-t")
+        cls.if3 = Interface.objects.create(device=cls.dev_b, name="p-eth2", type="1000base-t")
+
+    def _terms(self, *ifaces):
+        return [{"object_type": "dcim.interface", "object_id": i.pk} for i in ifaces]
+
+    def _seed(self, label, a_ifaces, b_ifaces):
+        cable = Cable(a_terminations=list(a_ifaces), b_terminations=list(b_ifaces))
+        cable.label = label
+        cable.status = "connected"
+        cable.save()
+        return cable
+
+    def _apply_create(self, cs_id, label, a_ifaces, b_ifaces):
+        cs = ChangeSet(
+            id=cs_id,
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id=f"new_object:dcim.cable:{cs_id}",
+                    data={
+                        "status": "connected",
+                        "label": label,
+                        "a_terminations": self._terms(*a_ifaces),
+                        "b_terminations": self._terms(*b_ifaces),
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(cs, request=None)
+
+    def _grouping(self, cable):
+        cable.refresh_from_db()
+        return {(t.termination_id, t.cable_end) for t in CableTermination.objects.filter(cable=cable)}
+
+    def test_genuine_repartition_is_applied(self):
+        """A:[if1,if2]/B:[if3] re-fed as A:[if1]/B:[if2,if3] moves if2 A->B."""
+        cable = self._seed("Repart", [self.if1, self.if2], [self.if3])
+        self.assertEqual(
+            self._grouping(cable),
+            {(self.if1.pk, "A"), (self.if2.pk, "A"), (self.if3.pk, "B")},
+        )
+        # stale CREATE with the same set but if2 moved to end B (+ relabel)
+        self._apply_create("cs-repart", "Repart-Relabeled", [self.if1], [self.if2, self.if3])
+        self.assertEqual(Cable.objects.filter(label__startswith="Repart").count(), 1)
+        self.assertEqual(
+            self._grouping(cable),
+            {(self.if1.pk, "A"), (self.if2.pk, "B"), (self.if3.pk, "B")},
+        )
+        cable.refresh_from_db()
+        self.assertEqual(cable.label, "Repart-Relabeled")
+
+    def test_whole_end_swap_stays_noop(self):
+        """A whole-end swap of a multi-termination cable does not toggle cable_end."""
+        cable = self._seed("Swap", [self.if1, self.if2], [self.if3])
+        before = self._grouping(cable)
+        # swap ends: A<->B (same grouping, opposite labels)
+        self._apply_create("cs-swap", "Swap", [self.if3], [self.if1, self.if2])
+        self.assertEqual(self._grouping(cable), before)
+
+    def test_within_end_reorder_stays_noop(self):
+        """Reordering terminations within an end changes nothing (same grouping)."""
+        cable = self._seed("Reorder", [self.if1, self.if2], [self.if3])
+        before = self._grouping(cable)
+        self._apply_create("cs-reorder", "Reorder", [self.if2, self.if1], [self.if3])
+        self.assertEqual(self._grouping(cable), before)
+
+
 class ApplierKeyErrorScopeTestCase(TestCase):
     """Only missing new_object references become clean per-entity errors."""
 

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_cable.py
@@ -16,6 +16,7 @@ from django.test import TestCase
 
 from netbox_diode_plugin.api.applier import apply_changeset
 from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
 
 
 class CableApplyTestCase(TestCase):
@@ -80,3 +81,100 @@ class CableApplyTestCase(TestCase):
             f"expected a cable-conflict clean() message, got: {ctx.exception}",
         )
         self.assertFalse(Cable.objects.filter(label="Cable 2").exists())
+
+
+class CableMultiObjectUpdateTestCase(TestCase):
+    """UPDATE of a multi-object end with mixed new/existing terminations resolves.
+
+    Regression for the new_refs/resort desync: `_generate_changeset` computed
+    index paths (``a_terminations.0.object_id``) via
+    ``cleanup_unresolved_references`` BEFORE ``_partially_merge`` re-sorted the
+    termination lists for stable comparison. On an end mixing an
+    already-resolved pk (int, sorts first — digits precede ``new_object:``)
+    with a still-unresolved new-object ref, the sort moved entries after the
+    paths were fixed: the path landed on the int (skipped) while the
+    unresolved ref at its new index was never resolved, reaching
+    CableSerializer as a string and failing the whole update. Goes through the
+    REAL ``generate_changeset`` -> ``apply_changeset`` path with the cable
+    matched via ``metadata.source_match.netbox_id``.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up an existing cabled pair; a third interface is created by ingest."""
+        mfr = Manufacturer.objects.create(name="MFR-MultiTerm", slug="mfr-multiterm")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="DT-MultiTerm", slug="dt-multiterm")
+        cls.role = DeviceRole.objects.create(name="Role-MultiTerm", slug="role-multiterm")
+        cls.site = Site.objects.create(name="Site-MultiTerm", slug="site-multiterm")
+        cls.dev_a = Device.objects.create(name="MultiTerm Device A", device_type=cls.dt, role=cls.role, site=cls.site)
+        cls.dev_b = Device.objects.create(name="MultiTerm Device B", device_type=cls.dt, role=cls.role, site=cls.site)
+        cls.iface_a0 = Interface.objects.create(device=cls.dev_a, name="mt-eth0", type="1000base-t")
+        cls.iface_b0 = Interface.objects.create(device=cls.dev_b, name="mt-eth1", type="1000base-t")
+
+    def _iface_payload(self, device, name):
+        return {
+            "object_interface": {
+                "name": name,
+                "type": "1000base-t",
+                "device": {
+                    "name": device.name,
+                    "device_type": {
+                        "manufacturer": {"name": "MFR-MultiTerm"},
+                        "model": "DT-MultiTerm",
+                    },
+                    "role": {"name": "Role-MultiTerm"},
+                    "site": {"name": "Site-MultiTerm"},
+                },
+            }
+        }
+
+    def test_add_new_termination_to_existing_cable_resolves(self):
+        """Adding a NEW interface to an existing cable's end resolves + applies."""
+        # existing cable A:[mt-eth0] <-> B:[mt-eth1]
+        cs = ChangeSet(
+            id="cs-mt-seed",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id="new_object:dcim.cable:seed",
+                    data={
+                        "status": "connected",
+                        "label": "MT Cable",
+                        "a_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_a0.pk}],
+                        "b_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_b0.pk}],
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(cs, request=None)
+        cable = Cable.objects.get(label="MT Cable")
+
+        # UPDATE via netbox_id: end A gains a NEW (not-yet-existing) interface.
+        # The new termination is listed FIRST so its pre-sort index (0) differs
+        # from its post-sort index (ints sort before "new_object:" strings) --
+        # the exact desync scenario.
+        entity = {
+            "status": "connected",
+            "label": "MT Cable",
+            "a_terminations": [
+                self._iface_payload(self.dev_a, "mt-eth2-new"),
+                self._iface_payload(self.dev_a, "mt-eth0"),
+            ],
+            "b_terminations": [self._iface_payload(self.dev_b, "mt-eth1")],
+            "metadata": {"source_match": {"netbox_id": cable.pk}},
+        }
+        result = generate_changeset(entity, "dcim.cable")
+        self.assertIsNotNone(result.change_set)
+        # must not raise (pre-fix: the unresolved new-object ref reached the
+        # serializer as a string and failed the update)
+        apply_changeset(result.change_set, request=None)
+
+        new_iface = Interface.objects.get(device=self.dev_a, name="mt-eth2-new")
+        terms = CableTermination.objects.filter(cable=cable)
+        self.assertEqual(terms.count(), 3)
+        term_ids = {(t.cable_end, t.termination_id) for t in terms}
+        self.assertIn(("A", self.iface_a0.pk), term_ids)
+        self.assertIn(("A", new_iface.pk), term_ids)
+        self.assertIn(("B", self.iface_b0.pk), term_ids)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_paths.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_paths.py
@@ -13,6 +13,7 @@ class PathHelperListIndexTestCase(SimpleTestCase):
     """_get_path / _set_path must treat all-digit segments as list indices."""
 
     def test_get_path_into_list_of_dicts(self):
+        """Get path into list of dicts."""
         data = {
             "a_terminations": [
                 {"object_type": "dcim.interface", "object_id": "new_object:dcim.interface:u0"},
@@ -23,6 +24,7 @@ class PathHelperListIndexTestCase(SimpleTestCase):
         self.assertEqual(_get_path(data, "a_terminations.1.object_id"), "new_object:dcim.interface:u1")
 
     def test_set_path_into_list_of_dicts(self):
+        """Set path into list of dicts."""
         data = {
             "b_terminations": [
                 {"object_type": "dcim.interface", "object_id": "new_object:dcim.interface:u9"},
@@ -33,6 +35,7 @@ class PathHelperListIndexTestCase(SimpleTestCase):
         self.assertEqual(data["b_terminations"][0]["object_type"], "dcim.interface")
 
     def test_string_keys_still_work(self):
+        """String keys still work."""
         data = {"name": {"nested": "x"}}
         self.assertEqual(_get_path(data, "name.nested"), "x")
         _set_path(data, "name.nested", "y")
@@ -48,6 +51,7 @@ class PreApplyTerminationResolutionTestCase(SimpleTestCase):
     """_pre_apply resolves termination object_id refs to {object_type, object_id: pk}."""
 
     def test_termination_refs_resolve_to_pk_dict_shape(self):
+        """Termination refs resolve to pk dict shape."""
         ref_a = "new_object:dcim.interface:ua"
         ref_b = "new_object:dcim.interface:ub"
         change = Change(

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_paths.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_paths.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Applier path-helper tests."""
+
+from django.test import SimpleTestCase
+
+from netbox_diode_plugin.api.applier import _get_path, _set_path
+
+
+class PathHelperListIndexTestCase(SimpleTestCase):
+    """_get_path / _set_path must treat all-digit segments as list indices."""
+
+    def test_get_path_into_list_of_dicts(self):
+        data = {
+            "a_terminations": [
+                {"object_type": "dcim.interface", "object_id": "new_object:dcim.interface:u0"},
+                {"object_type": "dcim.interface", "object_id": "new_object:dcim.interface:u1"},
+            ],
+        }
+        self.assertEqual(_get_path(data, "a_terminations.0.object_id"), "new_object:dcim.interface:u0")
+        self.assertEqual(_get_path(data, "a_terminations.1.object_id"), "new_object:dcim.interface:u1")
+
+    def test_set_path_into_list_of_dicts(self):
+        data = {
+            "b_terminations": [
+                {"object_type": "dcim.interface", "object_id": "new_object:dcim.interface:u9"},
+            ],
+        }
+        _set_path(data, "b_terminations.0.object_id", 123)
+        self.assertEqual(data["b_terminations"][0]["object_id"], 123)
+        self.assertEqual(data["b_terminations"][0]["object_type"], "dcim.interface")
+
+    def test_string_keys_still_work(self):
+        data = {"name": {"nested": "x"}}
+        self.assertEqual(_get_path(data, "name.nested"), "x")
+        _set_path(data, "name.nested", "y")
+        self.assertEqual(data["name"]["nested"], "y")

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_paths.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_paths.py
@@ -4,7 +4,9 @@
 
 from django.test import SimpleTestCase
 
-from netbox_diode_plugin.api.applier import _get_path, _set_path
+from netbox_diode_plugin.api.applier import _get_path, _pre_apply, _set_path
+from netbox_diode_plugin.api.common import Change, ChangeType
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
 
 
 class PathHelperListIndexTestCase(SimpleTestCase):
@@ -35,3 +37,56 @@ class PathHelperListIndexTestCase(SimpleTestCase):
         self.assertEqual(_get_path(data, "name.nested"), "x")
         _set_path(data, "name.nested", "y")
         self.assertEqual(data["name"]["nested"], "y")
+
+
+class _FakeInstance:
+    def __init__(self, pk):
+        self.pk = pk
+
+
+class PreApplyTerminationResolutionTestCase(SimpleTestCase):
+    """_pre_apply resolves termination object_id refs to {object_type, object_id: pk}."""
+
+    def test_termination_refs_resolve_to_pk_dict_shape(self):
+        ref_a = "new_object:dcim.interface:ua"
+        ref_b = "new_object:dcim.interface:ub"
+        change = Change(
+            change_type=ChangeType.CREATE,
+            object_type="dcim.cable",
+            ref_id="new_object:dcim.cable:uc",
+            data={
+                "status": "connected",
+                "a_terminations": [{"object_type": "dcim.interface", "object_id": ref_a}],
+                "b_terminations": [{"object_type": "dcim.interface", "object_id": ref_b}],
+            },
+            new_refs=["a_terminations.0.object_id", "b_terminations.0.object_id"],
+        )
+        created = {ref_a: _FakeInstance(101), ref_b: _FakeInstance(202)}
+
+        model_class = get_object_type_model("dcim.cable")
+        data = _pre_apply(model_class, change, created)
+
+        self.assertEqual(data["a_terminations"], [{"object_type": "dcim.interface", "object_id": 101}])
+        self.assertEqual(data["b_terminations"], [{"object_type": "dcim.interface", "object_id": 202}])
+        self.assertIn("a_terminations", data)
+        self.assertIn("b_terminations", data)
+
+    def test_original_change_data_not_mutated(self):
+        """A retried apply (e.g. after deadlock) must see the original string refs again."""
+        ref_a = "new_object:dcim.interface:ua"
+        change = Change(
+            change_type=ChangeType.CREATE,
+            object_type="dcim.cable",
+            ref_id="new_object:dcim.cable:uc",
+            data={
+                "status": "connected",
+                "a_terminations": [{"object_type": "dcim.interface", "object_id": ref_a}],
+            },
+            new_refs=["a_terminations.0.object_id"],
+        )
+        created = {ref_a: _FakeInstance(101)}
+        model_class = get_object_type_model("dcim.cable")
+
+        _pre_apply(model_class, change, created)
+
+        self.assertEqual(change.data["a_terminations"][0]["object_id"], ref_a)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_paths.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_applier_paths.py
@@ -2,7 +2,7 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Diode NetBox Plugin - Applier path-helper tests."""
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from netbox_diode_plugin.api.applier import _get_path, _pre_apply, _set_path
 from netbox_diode_plugin.api.common import Change, ChangeType
@@ -47,7 +47,7 @@ class _FakeInstance:
         self.pk = pk
 
 
-class PreApplyTerminationResolutionTestCase(SimpleTestCase):
+class PreApplyTerminationResolutionTestCase(TestCase):
     """_pre_apply resolves termination object_id refs to {object_type, object_id: pk}."""
 
     def test_termination_refs_resolve_to_pk_dict_shape(self):

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
@@ -279,6 +279,48 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         }
         self.assertIsNone(self.matcher.build_queryset(data))
 
+    def test_multi_termination_per_end_exact_match(self):
+        """
+        A cable with 2 terminations on one end matches its exact 3-set.
+
+        Proves successive build_queryset filters create separate joins (one
+        CableTermination row per requested pair), not a single-alias AND that
+        would make multi-termination matching impossible. Uses fresh
+        interfaces: a termination may only belong to one cable.
+        """
+        dev = self.if1.device
+        m1 = Interface.objects.create(device=dev, name="m0", type="1000base-t")
+        m2 = Interface.objects.create(device=dev, name="m1", type="1000base-t")
+        m3 = Interface.objects.create(device=dev, name="m2", type="1000base-t")
+        multi = Cable(a_terminations=[m1, m2], b_terminations=[m3])
+        multi.save()
+        data = {
+            "a_terminations": [
+                {"object_type": "dcim.interface", "object_id": m1.pk},
+                {"object_type": "dcim.interface", "object_id": m2.pk},
+            ],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": m3.pk}],
+        }
+        qs = self.matcher.build_queryset(data)
+        self.assertEqual(list(qs.values_list("pk", flat=True)), [multi.pk])
+
+    def test_multi_termination_superset_rejected(self):
+        """A 2-per-end request must NOT match a cable missing one of them."""
+        dev = self.if1.device
+        m1 = Interface.objects.create(device=dev, name="n0", type="1000base-t")
+        m2 = Interface.objects.create(device=dev, name="n1", type="1000base-t")
+        m3 = Interface.objects.create(device=dev, name="n2", type="1000base-t")
+        # cable only has {m1, m2}; request adds a third (m3)
+        Cable(a_terminations=[m1], b_terminations=[m2]).save()
+        data = {
+            "a_terminations": [
+                {"object_type": "dcim.interface", "object_id": m1.pk},
+                {"object_type": "dcim.interface", "object_id": m3.pk},
+            ],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": m2.pk}],
+        }
+        self.assertEqual(list(self.matcher.build_queryset(data)), [])
+
     def test_find_existing_object_matches_via_matcher(self):
         """Find existing object matches via matcher."""
         data = {

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
@@ -5,6 +5,7 @@
 from dcim.models import Cable, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 from django.test import TestCase
 
+from netbox_diode_plugin.api.common import UnresolvedReference
 from netbox_diode_plugin.api.matcher import (
     CableTerminationSetMatcher,
     _find_obj_cache_key,
@@ -172,3 +173,83 @@ class FindExistingObjectCableDbTestCase(TestCase):
     def test_no_match_for_nonexistent_termination_set(self):
         result = find_existing_object(self._data(self.if1, self.if3), "dcim.cable")
         self.assertIsNone(result)
+
+
+class CableTerminationSetMatcherQuerysetTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name="S1", slug="s1")
+        mfr = Manufacturer.objects.create(name="M1", slug="m1")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="DT1", slug="dt1")
+        role = DeviceRole.objects.create(name="R1", slug="r1")
+        dev = Device.objects.create(name="D1", site=site, device_type=dt, role=role)
+        cls.if1 = Interface.objects.create(device=dev, name="eth0", type="1000base-t")
+        cls.if2 = Interface.objects.create(device=dev, name="eth1", type="1000base-t")
+        cls.if3 = Interface.objects.create(device=dev, name="eth2", type="1000base-t")
+        cls.cable = Cable(a_terminations=[cls.if1], b_terminations=[cls.if2])
+        cls.cable.save()
+        cls.matcher = CableTerminationSetMatcher(
+            model_class=get_object_type_model("dcim.cable"),
+            name="logical_cable_termination_set",
+        )
+
+    def _data(self, *pairs):
+        terms = [{"object_type": t, "object_id": i} for t, i in pairs]
+        return {"a_terminations": terms[:1], "b_terminations": terms[1:]}
+
+    def test_exact_set_matches(self):
+        data = self._data(("dcim.interface", self.if1.pk), ("dcim.interface", self.if2.pk))
+        qs = self.matcher.build_queryset(data)
+        self.assertIsNotNone(qs)
+        self.assertEqual(list(qs.values_list("pk", flat=True)), [self.cable.pk])
+
+    def test_exact_set_matches_under_ab_swap(self):
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if2.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+        }
+        self.assertEqual(
+            list(self.matcher.build_queryset(data).values_list("pk", flat=True)),
+            [self.cable.pk],
+        )
+
+    def test_empty_end_returns_none(self):
+        qs = self.matcher.build_queryset(
+            {"a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+             "b_terminations": []}
+        )
+        self.assertIsNone(qs)  # has_required_fields False for empty b
+
+    def test_superset_rejected(self):
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+            "b_terminations": [
+                {"object_type": "dcim.interface", "object_id": self.if2.pk},
+                {"object_type": "dcim.interface", "object_id": self.if3.pk},
+            ],
+        }
+        self.assertEqual(list(self.matcher.build_queryset(data)), [])
+
+    def test_partial_overlap_rejected(self):
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if3.pk}],
+        }
+        self.assertEqual(list(self.matcher.build_queryset(data)), [])
+
+    def test_unresolved_returns_none(self):
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface",
+                                "object_id": UnresolvedReference("dcim.interface", "u-1")}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if2.pk}],
+        }
+        self.assertIsNone(self.matcher.build_queryset(data))
+
+    def test_find_existing_object_matches_via_matcher(self):
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if2.pk}],
+        }
+        found = find_existing_object(data, "dcim.cable")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.pk, self.cable.pk)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
@@ -253,3 +253,17 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         found = find_existing_object(data, "dcim.cable")
         self.assertIsNotNone(found)
         self.assertEqual(found.pk, self.cable.pk)
+
+
+class CableFingerprintsNoCrashTestCase(TestCase):
+    def test_fingerprints_no_crash_on_termination_dicts(self):
+        # Regression for OBS-1080: list-of-dict terminations must not raise
+        # "unhashable type: 'dict'" in _fingerprint_all.
+        from netbox_diode_plugin.api.matcher import fingerprints
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": 1}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}],
+        }
+        fps = fingerprints(data, "dcim.cable")  # must not raise
+        self.assertIsInstance(fps, list)
+        self.assertGreaterEqual(len(fps), 1)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
@@ -2,11 +2,14 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Unit tests for CableTerminationSetMatcher and dcim.cable pre-save routing."""
 
+from dcim.models import Cable, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 from django.test import TestCase
 
 from netbox_diode_plugin.api.matcher import (
     CableTerminationSetMatcher,
     _find_obj_cache_key,
+    find_existing_object,
+    get_model_matchers,
     requires_pre_save_match,
 )
 from netbox_diode_plugin.api.plugin_utils import get_object_type_model
@@ -79,3 +82,93 @@ class FindObjCacheKeyCableTestCase(TestCase):
             "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}],
         }
         self.assertIsNone(_find_obj_cache_key(data, "dcim.cable"))
+
+
+class CableTerminationSetMatcherRegistrationTestCase(TestCase):
+    """dcim.cable must resolve to a non-empty matcher list including the set matcher.
+
+    Regression for: CableTerminationSetMatcher was defined but never wired into
+    _LOGICAL_MATCHERS, so get_model_matchers("dcim.cable") returned [] and the
+    matcher's build_queryset/fingerprint logic never ran for real cable ingestion.
+    """
+
+    def test_get_model_matchers_returns_cable_termination_set_matcher(self):
+        model_class = get_object_type_model("dcim.cable")
+        matchers = get_model_matchers(model_class)
+        self.assertTrue(
+            any(isinstance(m, CableTerminationSetMatcher) for m in matchers),
+            "CableTerminationSetMatcher is not registered for dcim.cable "
+            "(get_model_matchers returned no such matcher)",
+        )
+
+
+class FindExistingObjectCableDbTestCase(TestCase):
+    """DB-backed regression: two distinct cables must not cross-resolve.
+
+    Exercises find_existing_object end-to-end (registration + build_queryset)
+    against real Cable/CableTermination rows, per brief Step 8.
+    """
+
+    def setUp(self):
+        manufacturer = Manufacturer.objects.create(name="CableTestMfr", slug="cable-test-mfr")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="CableTestModel", slug="cable-test-model")
+        device_role = DeviceRole.objects.create(name="CableTestRole", slug="cable-test-role", color="ff0000")
+        site = Site.objects.create(name="CableTestSite", slug="cable-test-site")
+
+        self.device1 = Device.objects.create(
+            name="CableTestDevice1", device_type=device_type, role=device_role, site=site,
+        )
+        self.device2 = Device.objects.create(
+            name="CableTestDevice2", device_type=device_type, role=device_role, site=site,
+        )
+        self.device3 = Device.objects.create(
+            name="CableTestDevice3", device_type=device_type, role=device_role, site=site,
+        )
+        self.device4 = Device.objects.create(
+            name="CableTestDevice4", device_type=device_type, role=device_role, site=site,
+        )
+
+        # A termination (interface) can belong to at most one cable, so each
+        # cable in this fixture uses its own dedicated pair of interfaces.
+        self.if1 = Interface.objects.create(device=self.device1, name="eth0", type="1000base-t")
+        self.if2 = Interface.objects.create(device=self.device2, name="eth0", type="1000base-t")
+        self.if3 = Interface.objects.create(device=self.device3, name="eth0", type="1000base-t")
+        self.if4 = Interface.objects.create(device=self.device4, name="eth0", type="1000base-t")
+
+        self.cable_12 = Cable.objects.create(status="connected")
+        self.cable_12.a_terminations = [self.if1]
+        self.cable_12.b_terminations = [self.if2]
+        self.cable_12.save()
+
+        self.cable_34 = Cable.objects.create(status="connected")
+        self.cable_34.a_terminations = [self.if3]
+        self.cable_34.b_terminations = [self.if4]
+        self.cable_34.save()
+
+    def _data(self, a_if, b_if):
+        return {
+            "status": "connected",
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": a_if.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": b_if.pk}],
+        }
+
+    def test_finds_correct_cable_for_its_own_termination_set(self):
+        result = find_existing_object(self._data(self.if1, self.if2), "dcim.cable")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, self.cable_12.pk)
+
+    def test_does_not_cross_resolve_distinct_cable(self):
+        result_34 = find_existing_object(self._data(self.if3, self.if4), "dcim.cable")
+        self.assertIsNotNone(result_34)
+        self.assertEqual(result_34.pk, self.cable_34.pk)
+        self.assertNotEqual(result_34.pk, self.cable_12.pk)
+
+    def test_ab_swap_still_resolves_same_cable(self):
+        # A/B order is insignificant for identity (spec 5.3 contract).
+        result = find_existing_object(self._data(self.if2, self.if1), "dcim.cable")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, self.cable_12.pk)
+
+    def test_no_match_for_nonexistent_termination_set(self):
+        result = find_existing_object(self._data(self.if1, self.if3), "dcim.cable")
+        self.assertIsNone(result)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
@@ -279,6 +279,21 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         }
         self.assertIsNone(self.matcher.build_queryset(data))
 
+    def test_duplicate_pair_returns_none(self):
+        """
+        A:[if1] B:[if1] must not false-match the if1<->if2 cable.
+
+        The same object on both ends is an invalid cable (unique termination
+        constraint). Without dedup, len(pairs)==2 and both existence filters
+        are satisfied by the single if1 row of cable if1<->if2, matching it.
+        build_queryset must return None so the serializer rejects the payload.
+        """
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+        }
+        self.assertIsNone(self.matcher.build_queryset(data))
+
     def test_multi_termination_per_end_exact_match(self):
         """
         A cable with 2 terminations on one end matches its exact 3-set.

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
@@ -295,7 +295,7 @@ class CableFingerprintsNoCrashTestCase(TestCase):
 
     def test_fingerprints_no_crash_on_termination_dicts(self):
         """Fingerprints no crash on termination dicts."""
-        # Regression for OBS-1080: list-of-dict terminations must not raise
+        # regression: list-of-dict terminations must not raise
         # "unhashable type: 'dict'" in _fingerprint_all.
         from netbox_diode_plugin.api.matcher import fingerprints
         data = {

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for CableTerminationSetMatcher and dcim.cable pre-save routing."""
+
+from django.test import TestCase
+
+from netbox_diode_plugin.api.matcher import (
+    CableTerminationSetMatcher,
+    _find_obj_cache_key,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+class RequiresPreSaveMatchTestCase(TestCase):
+    def test_dcim_cable_requires_pre_save_match(self):
+        # Cable has no DB unique constraint; uniqueness lives on CableTermination,
+        # so the applier must look up an existing cable before CREATE (spec 5.3, contract H).
+        self.assertTrue(requires_pre_save_match("dcim.cable"))
+
+
+class CableTerminationSetMatcherFingerprintTestCase(TestCase):
+    def setUp(self):
+        self.matcher = CableTerminationSetMatcher(
+            model_class=get_object_type_model("dcim.cable"),
+            name="logical_cable_termination_set",
+        )
+
+    def _data(self, a, b):
+        return {
+            "a_terminations": [{"object_type": t, "object_id": i} for t, i in a],
+            "b_terminations": [{"object_type": t, "object_id": i} for t, i in b],
+        }
+
+    def test_has_required_fields_both_ends_nonempty(self):
+        self.assertTrue(self.matcher.has_required_fields(
+            self._data([("dcim.interface", 1)], [("dcim.interface", 2)])))
+
+    def test_has_required_fields_missing_end(self):
+        self.assertFalse(self.matcher.has_required_fields(
+            {"a_terminations": [{"object_type": "dcim.interface", "object_id": 1}]}))
+
+    def test_has_required_fields_empty_list(self):
+        self.assertFalse(self.matcher.has_required_fields(
+            {"a_terminations": [], "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}]}))
+
+    def test_fingerprint_equal_under_ab_swap(self):
+        fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
+        fp2 = self.matcher.fingerprint(self._data([("dcim.interface", 2)], [("dcim.interface", 1)]))
+        self.assertIsNotNone(fp1)
+        self.assertEqual(fp1, fp2)
+
+    def test_fingerprint_equal_under_within_end_reorder(self):
+        fp1 = self.matcher.fingerprint(self._data(
+            [("dcim.interface", 1), ("dcim.interface", 3)], [("dcim.interface", 2)]))
+        fp2 = self.matcher.fingerprint(self._data(
+            [("dcim.interface", 3), ("dcim.interface", 1)], [("dcim.interface", 2)]))
+        self.assertEqual(fp1, fp2)
+
+    def test_fingerprint_differs_for_different_set(self):
+        fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
+        fp2 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 9)]))
+        self.assertNotEqual(fp1, fp2)
+
+    def test_fingerprint_distinguishes_object_type(self):
+        fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
+        fp2 = self.matcher.fingerprint(self._data([("dcim.frontport", 1)], [("dcim.interface", 2)]))
+        self.assertNotEqual(fp1, fp2)
+
+    def test_fingerprint_none_when_not_matchable(self):
+        self.assertIsNone(self.matcher.fingerprint({"a_terminations": []}))
+
+
+class FindObjCacheKeyCableTestCase(TestCase):
+    def test_find_obj_cache_key_none_for_cable(self):
+        data = {
+            "status": "connected",
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": 1}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}],
+        }
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.cable"))

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_cable_matcher.py
@@ -17,14 +17,20 @@ from netbox_diode_plugin.api.plugin_utils import get_object_type_model
 
 
 class RequiresPreSaveMatchTestCase(TestCase):
+    """Tests for requires_pre_save_match on dcim.cable."""
+
     def test_dcim_cable_requires_pre_save_match(self):
+        """Dcim cable requires pre save match."""
         # Cable has no DB unique constraint; uniqueness lives on CableTermination,
         # so the applier must look up an existing cable before CREATE (spec 5.3, contract H).
         self.assertTrue(requires_pre_save_match("dcim.cable"))
 
 
 class CableTerminationSetMatcherFingerprintTestCase(TestCase):
+    """Tests for CableTerminationSetMatcher.fingerprint."""
+
     def setUp(self):
+        """Set up test fixtures."""
         self.matcher = CableTerminationSetMatcher(
             model_class=get_object_type_model("dcim.cable"),
             name="logical_cable_termination_set",
@@ -37,24 +43,29 @@ class CableTerminationSetMatcherFingerprintTestCase(TestCase):
         }
 
     def test_has_required_fields_both_ends_nonempty(self):
+        """Has required fields both ends nonempty."""
         self.assertTrue(self.matcher.has_required_fields(
             self._data([("dcim.interface", 1)], [("dcim.interface", 2)])))
 
     def test_has_required_fields_missing_end(self):
+        """Has required fields missing end."""
         self.assertFalse(self.matcher.has_required_fields(
             {"a_terminations": [{"object_type": "dcim.interface", "object_id": 1}]}))
 
     def test_has_required_fields_empty_list(self):
+        """Has required fields empty list."""
         self.assertFalse(self.matcher.has_required_fields(
             {"a_terminations": [], "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}]}))
 
     def test_fingerprint_equal_under_ab_swap(self):
+        """Fingerprint equal under ab swap."""
         fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
         fp2 = self.matcher.fingerprint(self._data([("dcim.interface", 2)], [("dcim.interface", 1)]))
         self.assertIsNotNone(fp1)
         self.assertEqual(fp1, fp2)
 
     def test_fingerprint_equal_under_within_end_reorder(self):
+        """Fingerprint equal under within end reorder."""
         fp1 = self.matcher.fingerprint(self._data(
             [("dcim.interface", 1), ("dcim.interface", 3)], [("dcim.interface", 2)]))
         fp2 = self.matcher.fingerprint(self._data(
@@ -62,21 +73,27 @@ class CableTerminationSetMatcherFingerprintTestCase(TestCase):
         self.assertEqual(fp1, fp2)
 
     def test_fingerprint_differs_for_different_set(self):
+        """Fingerprint differs for different set."""
         fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
         fp2 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 9)]))
         self.assertNotEqual(fp1, fp2)
 
     def test_fingerprint_distinguishes_object_type(self):
+        """Fingerprint distinguishes object type."""
         fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
         fp2 = self.matcher.fingerprint(self._data([("dcim.frontport", 1)], [("dcim.interface", 2)]))
         self.assertNotEqual(fp1, fp2)
 
     def test_fingerprint_none_when_not_matchable(self):
+        """Fingerprint none when not matchable."""
         self.assertIsNone(self.matcher.fingerprint({"a_terminations": []}))
 
 
 class FindObjCacheKeyCableTestCase(TestCase):
+    """Tests for _find_obj_cache_key with dcim.cable."""
+
     def test_find_obj_cache_key_none_for_cable(self):
+        """Find obj cache key none for cable."""
         data = {
             "status": "connected",
             "a_terminations": [{"object_type": "dcim.interface", "object_id": 1}],
@@ -86,7 +103,8 @@ class FindObjCacheKeyCableTestCase(TestCase):
 
 
 class CableTerminationSetMatcherRegistrationTestCase(TestCase):
-    """dcim.cable must resolve to a non-empty matcher list including the set matcher.
+    """
+    dcim.cable must resolve to a non-empty matcher list including the set matcher.
 
     Regression for: CableTerminationSetMatcher was defined but never wired into
     _LOGICAL_MATCHERS, so get_model_matchers("dcim.cable") returned [] and the
@@ -94,6 +112,7 @@ class CableTerminationSetMatcherRegistrationTestCase(TestCase):
     """
 
     def test_get_model_matchers_returns_cable_termination_set_matcher(self):
+        """Get model matchers returns cable termination set matcher."""
         model_class = get_object_type_model("dcim.cable")
         matchers = get_model_matchers(model_class)
         self.assertTrue(
@@ -104,13 +123,15 @@ class CableTerminationSetMatcherRegistrationTestCase(TestCase):
 
 
 class FindExistingObjectCableDbTestCase(TestCase):
-    """DB-backed regression: two distinct cables must not cross-resolve.
+    """
+    DB-backed regression: two distinct cables must not cross-resolve.
 
     Exercises find_existing_object end-to-end (registration + build_queryset)
     against real Cable/CableTermination rows, per brief Step 8.
     """
 
     def setUp(self):
+        """Set up test fixtures."""
         manufacturer = Manufacturer.objects.create(name="CableTestMfr", slug="cable-test-mfr")
         device_type = DeviceType.objects.create(manufacturer=manufacturer, model="CableTestModel", slug="cable-test-model")
         device_role = DeviceRole.objects.create(name="CableTestRole", slug="cable-test-role", color="ff0000")
@@ -154,30 +175,37 @@ class FindExistingObjectCableDbTestCase(TestCase):
         }
 
     def test_finds_correct_cable_for_its_own_termination_set(self):
+        """Finds correct cable for its own termination set."""
         result = find_existing_object(self._data(self.if1, self.if2), "dcim.cable")
         self.assertIsNotNone(result)
         self.assertEqual(result.pk, self.cable_12.pk)
 
     def test_does_not_cross_resolve_distinct_cable(self):
+        """Does not cross resolve distinct cable."""
         result_34 = find_existing_object(self._data(self.if3, self.if4), "dcim.cable")
         self.assertIsNotNone(result_34)
         self.assertEqual(result_34.pk, self.cable_34.pk)
         self.assertNotEqual(result_34.pk, self.cable_12.pk)
 
     def test_ab_swap_still_resolves_same_cable(self):
+        """Ab swap still resolves same cable."""
         # A/B order is insignificant for identity (spec 5.3 contract).
         result = find_existing_object(self._data(self.if2, self.if1), "dcim.cable")
         self.assertIsNotNone(result)
         self.assertEqual(result.pk, self.cable_12.pk)
 
     def test_no_match_for_nonexistent_termination_set(self):
+        """No match for nonexistent termination set."""
         result = find_existing_object(self._data(self.if1, self.if3), "dcim.cable")
         self.assertIsNone(result)
 
 
 class CableTerminationSetMatcherQuerysetTestCase(TestCase):
+    """Tests for CableTerminationSetMatcher.build_queryset."""
+
     @classmethod
     def setUpTestData(cls):
+        """Set Up Test Data."""
         site = Site.objects.create(name="S1", slug="s1")
         mfr = Manufacturer.objects.create(name="M1", slug="m1")
         dt = DeviceType.objects.create(manufacturer=mfr, model="DT1", slug="dt1")
@@ -198,12 +226,14 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         return {"a_terminations": terms[:1], "b_terminations": terms[1:]}
 
     def test_exact_set_matches(self):
+        """Exact set matches."""
         data = self._data(("dcim.interface", self.if1.pk), ("dcim.interface", self.if2.pk))
         qs = self.matcher.build_queryset(data)
         self.assertIsNotNone(qs)
         self.assertEqual(list(qs.values_list("pk", flat=True)), [self.cable.pk])
 
     def test_exact_set_matches_under_ab_swap(self):
+        """Exact set matches under ab swap."""
         data = {
             "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if2.pk}],
             "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
@@ -214,6 +244,7 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         )
 
     def test_empty_end_returns_none(self):
+        """Empty end returns none."""
         qs = self.matcher.build_queryset(
             {"a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
              "b_terminations": []}
@@ -221,6 +252,7 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         self.assertIsNone(qs)  # has_required_fields False for empty b
 
     def test_superset_rejected(self):
+        """Superset rejected."""
         data = {
             "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
             "b_terminations": [
@@ -231,6 +263,7 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         self.assertEqual(list(self.matcher.build_queryset(data)), [])
 
     def test_partial_overlap_rejected(self):
+        """Partial overlap rejected."""
         data = {
             "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
             "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if3.pk}],
@@ -238,6 +271,7 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         self.assertEqual(list(self.matcher.build_queryset(data)), [])
 
     def test_unresolved_returns_none(self):
+        """Unresolved returns none."""
         data = {
             "a_terminations": [{"object_type": "dcim.interface",
                                 "object_id": UnresolvedReference("dcim.interface", "u-1")}],
@@ -246,6 +280,7 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
         self.assertIsNone(self.matcher.build_queryset(data))
 
     def test_find_existing_object_matches_via_matcher(self):
+        """Find existing object matches via matcher."""
         data = {
             "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
             "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if2.pk}],
@@ -256,7 +291,10 @@ class CableTerminationSetMatcherQuerysetTestCase(TestCase):
 
 
 class CableFingerprintsNoCrashTestCase(TestCase):
+    """Regression: cable fingerprinting must not crash on edge-case input."""
+
     def test_fingerprints_no_crash_on_termination_dicts(self):
+        """Fingerprints no crash on termination dicts."""
         # Regression for OBS-1080: list-of-dict terminations must not raise
         # "unhashable type: 'dict'" in _fingerprint_all.
         from netbox_diode_plugin.api.matcher import fingerprints

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -225,3 +225,40 @@ class Obs1080AndMultiTerminationTestCase(TestCase):
         for end in ("a_terminations", "b_terminations"):
             for t in cable[end]:
                 hash(t["object_id"])  # must not raise
+
+
+class SameTerminationObjectBothEndsTestCase(TestCase):
+    """Regression: the same logical object referenced by two termination slots
+    in one batch must dedupe to a single surviving ref, with NO dangling ref.
+
+    Before the fix, _update_dict_refs did not recurse into dict items of
+    termination lists, so when the two identical interfaces deduped to one
+    surviving uuid, the second termination kept a stale uuid that was never
+    created -- and _pre_apply's created[stale_uuid] raised an uncaught
+    KeyError (HTTP 500), the OBS-1080 failure class. Runs the FULL pipeline
+    (transform_proto_json) because the rewrite happens in the dedup stage.
+    """
+
+    def test_same_interface_both_ends_no_dangling_ref(self):
+        """Same interface on both ends -> both refs point to the survivor."""
+        supported = extract_supported_models()
+        iface = {"name": "eth0", "device": {"name": "router1"}}
+        entity = {
+            "a_terminations": [{"object_interface": dict(iface)}],
+            "b_terminations": [{"object_interface": dict(iface)}],
+        }
+        entities = transformer.transform_proto_json(entity, "dcim.cable", supported)
+        cable = next(e for e in entities if e["_object_type"] == "dcim.cable")
+        iface_uuids = {
+            e["_uuid"] for e in entities if e["_object_type"] == "dcim.interface"
+        }
+        # the two identical interfaces dedupe to exactly one surviving node
+        self.assertEqual(len(iface_uuids), 1)
+        a_ref = cable["a_terminations"][0]["object_id"]
+        b_ref = cable["b_terminations"][0]["object_id"]
+        self.assertIsInstance(a_ref, UnresolvedReference)
+        self.assertIsInstance(b_ref, UnresolvedReference)
+        # BOTH terminations reference the surviving interface (no dangling uuid)
+        self.assertIn(a_ref.uuid, iface_uuids)
+        self.assertIn(b_ref.uuid, iface_uuids)
+        self.assertEqual(a_ref.uuid, b_ref.uuid)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -228,8 +228,8 @@ class Obs1080AndMultiTerminationTestCase(TestCase):
 
 
 class SameTerminationObjectBothEndsTestCase(TestCase):
-    """Regression: the same logical object referenced by two termination slots
-    in one batch must dedupe to a single surviving ref, with NO dangling ref.
+    """
+    Same logical object in two termination slots dedupes with no dangling ref.
 
     Before the fix, _update_dict_refs did not recurse into dict items of
     termination lists, so when the two identical interfaces deduped to one

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -174,6 +174,10 @@ class Obs1080AndMultiTerminationTestCase(TestCase):
     """OBS-1080 payload transforms cleanly; multi-object-per-end is supported."""
 
     def test_obs_1080_payload_extracts_both_interfaces(self):
+        # NOTE: IsSupportedGenericObjectTestCase.test_a_terminations_list_processing_non_empty
+        # already covers the single-interface-per-end path.  This test is distinct in that it
+        # exercises both a_terminations AND b_terminations simultaneously and asserts the two
+        # child interface nodes are emitted (len == 2), which the earlier test does not check.
         supported = extract_supported_models()
         entity = {
             "a_terminations": [{"object_interface": {"name": "eth0", "device": {"name": "A"}}}],

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -92,3 +92,52 @@ class IsSupportedGenericObjectTestCase(TestCase):
         a_terms = cable_node.get("a_terminations")
         self.assertIsInstance(a_terms, list)
         self.assertEqual(len(a_terms), 0)
+
+
+def _wrap(variant_key, inner):
+    return {variant_key: inner}
+
+
+class GenericObjectListExtractionTestCase(TestCase):
+    """Each certified termination variant extracts to {object_type, object_id}."""
+
+    CERTIFIED = [
+        ("object_interface", "dcim.interface"),
+        ("object_front_port", "dcim.frontport"),
+        ("object_rear_port", "dcim.rearport"),
+        ("object_console_port", "dcim.consoleport"),
+        ("object_console_server_port", "dcim.consoleserverport"),
+        ("object_power_port", "dcim.powerport"),
+        ("object_power_outlet", "dcim.poweroutlet"),
+        ("object_power_feed", "dcim.powerfeed"),
+        ("object_circuit_termination", "circuits.circuittermination"),
+    ]
+
+    def _inner_for(self, object_type):
+        if object_type == "circuits.circuittermination":
+            return {"term_side": "A", "circuit": {"cid": "C1"}}
+        if object_type == "dcim.powerfeed":
+            return {"name": "feed1", "power_panel": {"name": "panel1"}}
+        return {"name": "p1", "device": {"name": "Device A"}}
+
+    def test_each_variant_extracts_termination_dict_and_refs(self):
+        supported = extract_supported_models()
+        for variant_key, expected_ot in self.CERTIFIED:
+            with self.subTest(variant=variant_key):
+                entity = {
+                    "a_terminations": [_wrap(variant_key, self._inner_for(expected_ot))],
+                    "b_terminations": [_wrap("object_interface", {"name": "eth1", "device": {"name": "Device B"}})],
+                }
+                nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+                cable = nodes[0]
+                self.assertNotIn("a_terminations", cable["_warnings"])
+                terms = cable["a_terminations"]
+                self.assertEqual(len(terms), 1)
+                t = terms[0]
+                self.assertEqual(set(t.keys()), {"object_type", "object_id"})
+                self.assertEqual(t["object_type"], expected_ot)
+                self.assertIsInstance(t["object_id"], UnresolvedReference)
+                self.assertEqual(t["object_id"].object_type, expected_ot)
+                self.assertIn(t["object_id"].uuid, cable["_refs"])
+                child_types = {n["_object_type"] for n in nodes[1:]}
+                self.assertIn(expected_ot, child_types)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -13,6 +13,7 @@ class TransformerImportTestCase(SimpleTestCase):
     """Imports needed by the generic-object-list arm are wired."""
 
     def test_get_generic_object_variant_imported(self):
+        """Get generic object variant imported."""
         self.assertTrue(
             hasattr(transformer, "get_generic_object_variant"),
             "transformer must import get_generic_object_variant from plugin_utils",
@@ -23,6 +24,7 @@ class IsSupportedGenericObjectTestCase(TestCase):
     """is_supported() accepts the generic-object-list field by its list name."""
 
     def test_a_terminations_is_supported(self):
+        """A terminations is supported."""
         supported = extract_supported_models()
         result = transformer._transform_proto_json_1(
             {"a_terminations": [], "b_terminations": []},
@@ -35,7 +37,8 @@ class IsSupportedGenericObjectTestCase(TestCase):
         self.assertNotIn("b_terminations", node["_warnings"])
 
     def test_a_terminations_list_processing_non_empty(self):
-        """Non-empty a_terminations with a valid generic-object item returns 200.
+        """
+        Non-empty a_terminations with a valid generic-object item returns 200.
 
         Each item is a GenericObject dict such as {"object_interface": {...}}.
         The list-processing branch calls get_generic_object_variant to resolve
@@ -121,6 +124,7 @@ class GenericObjectListExtractionTestCase(TestCase):
         return {"name": "p1", "device": {"name": "Device A"}}
 
     def test_each_variant_extracts_termination_dict_and_refs(self):
+        """Each variant extracts termination dict and refs."""
         supported = extract_supported_models()
         for variant_key, expected_ot in self.CERTIFIED:
             with self.subTest(variant=variant_key):
@@ -147,6 +151,7 @@ class UnsupportedVariantTestCase(TestCase):
     """Unknown/unsupported variant warns and skips that one termination."""
 
     def test_unknown_key_warns_and_skips_keeps_cable(self):
+        """Unknown key warns and skips keeps cable."""
         supported = extract_supported_models()
         entity = {
             "a_terminations": [
@@ -174,6 +179,7 @@ class Obs1080AndMultiTerminationTestCase(TestCase):
     """OBS-1080 payload transforms cleanly; multi-object-per-end is supported."""
 
     def test_obs_1080_payload_extracts_both_interfaces(self):
+        """Obs 1080 payload extracts both interfaces."""
         # NOTE: IsSupportedGenericObjectTestCase.test_a_terminations_list_processing_non_empty
         # already covers the single-interface-per-end path.  This test is distinct in that it
         # exercises both a_terminations AND b_terminations simultaneously and asserts the two
@@ -195,6 +201,7 @@ class Obs1080AndMultiTerminationTestCase(TestCase):
         self.assertIn(b_uuid, cable["_refs"])
 
     def test_multi_object_per_end(self):
+        """Multi object per end."""
         supported = extract_supported_models()
         entity = {
             "a_terminations": [

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -168,3 +168,49 @@ class UnsupportedVariantTestCase(TestCase):
         self.assertIn("b_terminations", cable["_warnings"])
         self.assertTrue(any("object_not_a_real_variant" in w for w in cable["_warnings"]["a_terminations"]))
         self.assertTrue(any("object_cable_termination" in w for w in cable["_warnings"]["b_terminations"]))
+
+
+class Obs1080AndMultiTerminationTestCase(TestCase):
+    """OBS-1080 payload transforms cleanly; multi-object-per-end is supported."""
+
+    def test_obs_1080_payload_extracts_both_interfaces(self):
+        supported = extract_supported_models()
+        entity = {
+            "a_terminations": [{"object_interface": {"name": "eth0", "device": {"name": "A"}}}],
+            "b_terminations": [{"object_interface": {"name": "eth1", "device": {"name": "B"}}}],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        self.assertEqual(cable["a_terminations"][0]["object_type"], "dcim.interface")
+        self.assertEqual(cable["b_terminations"][0]["object_type"], "dcim.interface")
+        ifaces = [n for n in nodes[1:] if n["_object_type"] == "dcim.interface"]
+        self.assertEqual(len(ifaces), 2)
+        a_uuid = cable["a_terminations"][0]["object_id"].uuid
+        b_uuid = cable["b_terminations"][0]["object_id"].uuid
+        self.assertIn(a_uuid, cable["_refs"])
+        self.assertIn(b_uuid, cable["_refs"])
+
+    def test_multi_object_per_end(self):
+        supported = extract_supported_models()
+        entity = {
+            "a_terminations": [
+                {"object_interface": {"name": "eth0", "device": {"name": "A"}}},
+                {"object_interface": {"name": "eth1", "device": {"name": "A"}}},
+            ],
+            "b_terminations": [
+                {"object_front_port": {"name": "fp0", "device": {"name": "B"}}},
+                {"object_front_port": {"name": "fp1", "device": {"name": "B"}}},
+            ],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        self.assertEqual(len(cable["a_terminations"]), 2)
+        self.assertEqual(len(cable["b_terminations"]), 2)
+        self.assertEqual({t["object_type"] for t in cable["a_terminations"]}, {"dcim.interface"})
+        self.assertEqual({t["object_type"] for t in cable["b_terminations"]}, {"dcim.frontport"})
+        for end in ("a_terminations", "b_terminations"):
+            for t in cable[end]:
+                self.assertIn(t["object_id"].uuid, cable["_refs"])
+        for end in ("a_terminations", "b_terminations"):
+            for t in cable[end]:
+                hash(t["object_id"])  # must not raise

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -45,10 +45,10 @@ class IsSupportedGenericObjectTestCase(TestCase):
         the concrete object_type ("dcim.interface") and recurses with that type.
         The termination list item is emitted as
         {'object_type': 'dcim.interface', 'object_id': UnresolvedReference(...)}.
-        OBS-1080 payload with non-empty terminations must not raise ValidationError.
+        A payload with non-empty terminations must not raise ValidationError.
         """
         supported = extract_supported_models()
-        # Minimal OBS-1080-style payload: one interface termination on side A.
+        # minimal payload: one interface termination on side A
         payload = {
             "a_terminations": [
                 {"object_interface": {"name": "eth0", "device": {"name": "router1"}}}
@@ -175,11 +175,11 @@ class UnsupportedVariantTestCase(TestCase):
         self.assertTrue(any("object_cable_termination" in w for w in cable["_warnings"]["b_terminations"]))
 
 
-class Obs1080AndMultiTerminationTestCase(TestCase):
-    """OBS-1080 payload transforms cleanly; multi-object-per-end is supported."""
+class MultiTerminationTransformTestCase(TestCase):
+    """Termination payloads transform cleanly; multi-object-per-end is supported."""
 
-    def test_obs_1080_payload_extracts_both_interfaces(self):
-        """Obs 1080 payload extracts both interfaces."""
+    def test_both_end_payload_extracts_both_interfaces(self):
+        """Both-end termination payload extracts both interfaces."""
         # NOTE: IsSupportedGenericObjectTestCase.test_a_terminations_list_processing_non_empty
         # already covers the single-interface-per-end path.  This test is distinct in that it
         # exercises both a_terminations AND b_terminations simultaneously and asserts the two
@@ -235,7 +235,7 @@ class SameTerminationObjectBothEndsTestCase(TestCase):
     termination lists, so when the two identical interfaces deduped to one
     surviving uuid, the second termination kept a stale uuid that was never
     created -- and _pre_apply's created[stale_uuid] raised an uncaught
-    KeyError (HTTP 500), the OBS-1080 failure class. Runs the FULL pipeline
+    KeyError (HTTP 500). Runs the FULL pipeline
     (transform_proto_json) because the rewrite happens in the dedup stage.
     """
 
@@ -262,3 +262,29 @@ class SameTerminationObjectBothEndsTestCase(TestCase):
         self.assertIn(a_ref.uuid, iface_uuids)
         self.assertIn(b_ref.uuid, iface_uuids)
         self.assertEqual(a_ref.uuid, b_ref.uuid)
+
+
+class CamelCaseTerminationTestCase(TestCase):
+    """
+    camelCase protoJSON terminations resolve like snake_case ones.
+
+    Top-level keys are normalized by _ensure_snake_case, but the nested
+    GenericObject variant key (e.g. "objectInterface") arrives untouched and
+    must be normalized before the variant-map lookup.
+    """
+
+    def test_camel_case_variant_keys_extract(self):
+        """aTerminations/objectInterface payload extracts both terminations."""
+        supported = extract_supported_models()
+        entity = {
+            "aTerminations": [{"objectInterface": {"name": "eth0", "device": {"name": "A"}}}],
+            "bTerminations": [{"objectInterface": {"name": "eth1", "device": {"name": "B"}}}],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        self.assertNotIn("a_terminations", cable["_warnings"])
+        self.assertNotIn("b_terminations", cable["_warnings"])
+        for end in ("a_terminations", "b_terminations"):
+            self.assertEqual(len(cable[end]), 1)
+            self.assertEqual(cable[end][0]["object_type"], "dcim.interface")
+            self.assertIsInstance(cable[end][0]["object_id"], UnresolvedReference)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -174,6 +174,39 @@ class UnsupportedVariantTestCase(TestCase):
         self.assertTrue(any("object_not_a_real_variant" in w for w in cable["_warnings"]["a_terminations"]))
         self.assertTrue(any("object_cable_termination" in w for w in cable["_warnings"]["b_terminations"]))
 
+    def test_non_terminable_variant_skipped_without_creating_child(self):
+        """
+        A supported-but-non-terminable variant (object_device) is rejected up front.
+
+        object_device maps to dcim.device (a supported model) but is not a valid
+        cable endpoint. It must warn + skip WITHOUT recursing to create the
+        device node, so no stray dependency object is planned for a cable that
+        would fail at apply.
+        """
+        supported = extract_supported_models()
+        entity = {
+            "a_terminations": [
+                {"object_device": {"name": "Bogus Device", "site": {"name": "S"}}},
+                {"object_interface": {"name": "eth0", "device": {"name": "Device A"}}},
+            ],
+            "b_terminations": [
+                {"object_interface": {"name": "eth1", "device": {"name": "Device B"}}},
+            ],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        # only the interface termination survived on end A
+        self.assertEqual(len(cable["a_terminations"]), 1)
+        self.assertEqual(cable["a_terminations"][0]["object_type"], "dcim.interface")
+        self.assertIn("a_terminations", cable["_warnings"])
+        self.assertTrue(
+            any("not a valid cable termination type" in w for w in cable["_warnings"]["a_terminations"])
+        )
+        # the rejected termination's device node was NOT created (the valid
+        # interface still brings its own parent device, "Device A")
+        device_names = {n.get("name") for n in nodes if n["_object_type"] == "dcim.device"}
+        self.assertNotIn("Bogus Device", device_names)
+
 
 class MultiTerminationTransformTestCase(TestCase):
     """Termination payloads transform cleanly; multi-object-per-end is supported."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests - cabling generic-object transform."""
+
+from django.test import SimpleTestCase
+
+from netbox_diode_plugin.api import transformer
+
+
+class TransformerImportTestCase(SimpleTestCase):
+    """Imports needed by the generic-object-list arm are wired."""
+
+    def test_get_generic_object_variant_imported(self):
+        self.assertTrue(
+            hasattr(transformer, "get_generic_object_variant"),
+            "transformer must import get_generic_object_variant from plugin_utils",
+        )

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -32,3 +32,36 @@ class IsSupportedGenericObjectTestCase(TestCase):
         # empty lists are legal fields and must NOT be warned as unsupported
         self.assertNotIn("a_terminations", node["_warnings"])
         self.assertNotIn("b_terminations", node["_warnings"])
+
+    def test_a_terminations_list_processing_branch_gap(self):
+        """Non-empty a_terminations exercises the list loop (lines 202-212).
+
+        Each item is a GenericObject dict such as {"object_interface": {...}}.
+        The list-processing branch recurses with ref_info.object_type="" because
+        is_generic_object=True carries an empty object_type on the RefInfo.
+        get_generic_object_variant is not yet called inside the loop to resolve
+        the concrete object_type before recursing.
+
+        Current behaviour (gap): _supported_diode_fields("") raises a
+        ValidationError because "" is not a registered supported type.
+        This test pins that behaviour and documents the coverage gap that must
+        be closed before OBS-1080 can be declared resolved.
+        """
+        from rest_framework.exceptions import ValidationError
+
+        supported = extract_supported_models()
+        # Minimal OBS-1080-style payload: one interface termination on side A.
+        payload = {
+            "a_terminations": [
+                {"object_interface": {"name": "eth0", "device": {"name": "router1"}}}
+            ],
+            "b_terminations": [],
+        }
+        # The list loop recurses with object_type="" which is not a supported
+        # model, so the transformer currently raises rather than handling it.
+        with self.assertRaises(ValidationError) as ctx:
+            transformer._transform_proto_json_1(payload, "dcim.cable", supported)
+        self.assertIn(
+            "is not supported in this version",
+            str(ctx.exception.detail),
+        )

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -2,9 +2,10 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Diode NetBox Plugin - Tests - cabling generic-object transform."""
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from netbox_diode_plugin.api import transformer
+from netbox_diode_plugin.api.supported_models import extract_supported_models
 
 
 class TransformerImportTestCase(SimpleTestCase):
@@ -15,3 +16,19 @@ class TransformerImportTestCase(SimpleTestCase):
             hasattr(transformer, "get_generic_object_variant"),
             "transformer must import get_generic_object_variant from plugin_utils",
         )
+
+
+class IsSupportedGenericObjectTestCase(TestCase):
+    """is_supported() accepts the generic-object-list field by its list name."""
+
+    def test_a_terminations_is_supported(self):
+        supported = extract_supported_models()
+        result = transformer._transform_proto_json_1(
+            {"a_terminations": [], "b_terminations": []},
+            "dcim.cable",
+            supported,
+        )
+        node = result[0]
+        # empty lists are legal fields and must NOT be warned as unsupported
+        self.assertNotIn("a_terminations", node["_warnings"])
+        self.assertNotIn("b_terminations", node["_warnings"])

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -141,3 +141,30 @@ class GenericObjectListExtractionTestCase(TestCase):
                 self.assertIn(t["object_id"].uuid, cable["_refs"])
                 child_types = {n["_object_type"] for n in nodes[1:]}
                 self.assertIn(expected_ot, child_types)
+
+
+class UnsupportedVariantTestCase(TestCase):
+    """Unknown/unsupported variant warns and skips that one termination."""
+
+    def test_unknown_key_warns_and_skips_keeps_cable(self):
+        supported = extract_supported_models()
+        entity = {
+            "a_terminations": [
+                {"object_interface": {"name": "eth0", "device": {"name": "Device A"}}},
+                {"object_not_a_real_variant": {"name": "x"}},
+            ],
+            "b_terminations": [
+                {"object_cable_termination": {"foo": "bar"}},  # deprecated -> variant map returns None
+                {"object_interface": {"name": "eth1", "device": {"name": "Device B"}}},
+            ],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        self.assertEqual(len(cable["a_terminations"]), 1)
+        self.assertEqual(cable["a_terminations"][0]["object_type"], "dcim.interface")
+        self.assertEqual(len(cable["b_terminations"]), 1)
+        self.assertEqual(cable["b_terminations"][0]["object_type"], "dcim.interface")
+        self.assertIn("a_terminations", cable["_warnings"])
+        self.assertIn("b_terminations", cable["_warnings"])
+        self.assertTrue(any("object_not_a_real_variant" in w for w in cable["_warnings"]["a_terminations"]))
+        self.assertTrue(any("object_cable_termination" in w for w in cable["_warnings"]["b_terminations"]))

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_transformer_cabling.py
@@ -5,6 +5,7 @@
 from django.test import SimpleTestCase, TestCase
 
 from netbox_diode_plugin.api import transformer
+from netbox_diode_plugin.api.common import UnresolvedReference
 from netbox_diode_plugin.api.supported_models import extract_supported_models
 
 
@@ -33,22 +34,16 @@ class IsSupportedGenericObjectTestCase(TestCase):
         self.assertNotIn("a_terminations", node["_warnings"])
         self.assertNotIn("b_terminations", node["_warnings"])
 
-    def test_a_terminations_list_processing_branch_gap(self):
-        """Non-empty a_terminations exercises the list loop (lines 202-212).
+    def test_a_terminations_list_processing_non_empty(self):
+        """Non-empty a_terminations with a valid generic-object item returns 200.
 
         Each item is a GenericObject dict such as {"object_interface": {...}}.
-        The list-processing branch recurses with ref_info.object_type="" because
-        is_generic_object=True carries an empty object_type on the RefInfo.
-        get_generic_object_variant is not yet called inside the loop to resolve
-        the concrete object_type before recursing.
-
-        Current behaviour (gap): _supported_diode_fields("") raises a
-        ValidationError because "" is not a registered supported type.
-        This test pins that behaviour and documents the coverage gap that must
-        be closed before OBS-1080 can be declared resolved.
+        The list-processing branch calls get_generic_object_variant to resolve
+        the concrete object_type ("dcim.interface") and recurses with that type.
+        The termination list item is emitted as
+        {'object_type': 'dcim.interface', 'object_id': UnresolvedReference(...)}.
+        OBS-1080 payload with non-empty terminations must not raise ValidationError.
         """
-        from rest_framework.exceptions import ValidationError
-
         supported = extract_supported_models()
         # Minimal OBS-1080-style payload: one interface termination on side A.
         payload = {
@@ -57,11 +52,43 @@ class IsSupportedGenericObjectTestCase(TestCase):
             ],
             "b_terminations": [],
         }
-        # The list loop recurses with object_type="" which is not a supported
-        # model, so the transformer currently raises rather than handling it.
-        with self.assertRaises(ValidationError) as ctx:
-            transformer._transform_proto_json_1(payload, "dcim.cable", supported)
-        self.assertIn(
-            "is not supported in this version",
-            str(ctx.exception.detail),
+        # Must not raise — the list loop resolves the concrete object_type.
+        result = transformer._transform_proto_json_1(payload, "dcim.cable", supported)
+        cable_node = result[0]
+
+        # a_terminations must be present and not warned as unsupported
+        self.assertNotIn("a_terminations", cable_node["_warnings"])
+
+        # The field is stored as a list of termination dicts
+        a_terms = cable_node.get("a_terminations")
+        self.assertIsInstance(a_terms, list)
+        self.assertEqual(len(a_terms), 1)
+
+        term = a_terms[0]
+        self.assertIsInstance(term, dict, "termination item must be a dict")
+        self.assertEqual(term.get("object_type"), "dcim.interface")
+        self.assertIsInstance(
+            term.get("object_id"),
+            UnresolvedReference,
+            "object_id must be an UnresolvedReference before resolution",
         )
+        self.assertEqual(term["object_id"].object_type, "dcim.interface")
+
+    def test_a_terminations_unknown_variant_warns_and_skips(self):
+        """An unrecognised variant key emits a warning and skips the item."""
+        supported = extract_supported_models()
+        payload = {
+            "a_terminations": [
+                {"object_totally_unknown_thing": {"name": "x"}}
+            ],
+            "b_terminations": [],
+        }
+        result = transformer._transform_proto_json_1(payload, "dcim.cable", supported)
+        cable_node = result[0]
+
+        # The item is skipped; a warning is recorded on a_terminations
+        self.assertIn("a_terminations", cable_node["_warnings"])
+        # The list is present but empty (item was skipped)
+        a_terms = cable_node.get("a_terminations")
+        self.assertIsInstance(a_terms, list)
+        self.assertEqual(len(a_terms), 0)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
@@ -6557,5 +6557,294 @@
         "length": 5.0,
         "length_unit": "m"
       }
+    },
+    {
+      "name": "dcim_cable_frontport_rearport",
+      "object_type": "dcim.cable",
+      "lookup": { "label": "Cable FP-RP" },
+      "create_expect": {
+        "label": "Cable FP-RP",
+        "status": "connected",
+        "a_terminations.0.name": "FrontPort1",
+        "b_terminations.0.name": "RearPort2"
+      },
+      "create": {
+        "cable": {
+          "label": "Cable FP-RP",
+          "status": "connected",
+          "a_terminations": [
+            { "object_front_port": {
+                "name": "FrontPort1",
+                "type": "8p8c",
+                "device": {
+                  "name": "Patch Panel A",
+                  "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" },
+                  "site": { "name": "Site 1" }
+                },
+                "rear_port": {
+                  "name": "RearPort1",
+                  "type": "8p8c",
+                  "device": {
+                    "name": "Patch Panel A",
+                    "role": { "name": "Device Role 1" },
+                    "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" },
+                    "site": { "name": "Site 1" }
+                  }
+                }
+            } }
+          ],
+          "b_terminations": [
+            { "object_rear_port": {
+                "name": "RearPort2",
+                "type": "8p8c",
+                "device": {
+                  "name": "Patch Panel B",
+                  "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" },
+                  "site": { "name": "Site 1" }
+                }
+            } }
+          ]
+        }
+      },
+      "update": {
+        "cable": {
+          "label": "Cable FP-RP",
+          "status": "planned",
+          "a_terminations": [
+            { "object_front_port": {
+                "name": "FrontPort1", "type": "8p8c",
+                "device": { "name": "Patch Panel A", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } },
+                "rear_port": { "name": "RearPort1", "type": "8p8c",
+                  "device": { "name": "Patch Panel A", "role": { "name": "Device Role 1" },
+                    "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } } }
+            } }
+          ],
+          "b_terminations": [
+            { "object_rear_port": {
+                "name": "RearPort2", "type": "8p8c",
+                "device": { "name": "Patch Panel B", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update_expect": { "status": "planned" }
+    },
+    {
+      "name": "dcim_cable_power",
+      "object_type": "dcim.cable",
+      "lookup": { "label": "Cable PWR" },
+      "create_expect": {
+        "label": "Cable PWR",
+        "a_terminations.0.name": "PowerPort1",
+        "b_terminations.0.name": "PowerOutlet1"
+      },
+      "create": {
+        "cable": {
+          "label": "Cable PWR",
+          "status": "connected",
+          "a_terminations": [
+            { "object_power_port": {
+                "name": "PowerPort1",
+                "device": { "name": "PDU Consumer", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ],
+          "b_terminations": [
+            { "object_power_outlet": {
+                "name": "PowerOutlet1",
+                "device": { "name": "PDU Source", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update": {
+        "cable": {
+          "label": "Cable PWR", "status": "connected", "color": "ff0000",
+          "a_terminations": [
+            { "object_power_port": {
+                "name": "PowerPort1",
+                "device": { "name": "PDU Consumer", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ],
+          "b_terminations": [
+            { "object_power_outlet": {
+                "name": "PowerOutlet1",
+                "device": { "name": "PDU Source", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update_expect": { "color": "ff0000" }
+    },
+    {
+      "name": "dcim_cable_console",
+      "object_type": "dcim.cable",
+      "lookup": { "label": "Cable CON" },
+      "create_expect": {
+        "label": "Cable CON",
+        "a_terminations.0.name": "ConsolePort1",
+        "b_terminations.0.name": "ConsoleServerPort1"
+      },
+      "create": {
+        "cable": {
+          "label": "Cable CON",
+          "status": "connected",
+          "a_terminations": [
+            { "object_console_port": {
+                "name": "ConsolePort1",
+                "device": { "name": "Console Device", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ],
+          "b_terminations": [
+            { "object_console_server_port": {
+                "name": "ConsoleServerPort1",
+                "device": { "name": "Console Server", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update": {
+        "cable": {
+          "label": "Cable CON", "status": "decommissioning",
+          "a_terminations": [
+            { "object_console_port": {
+                "name": "ConsolePort1",
+                "device": { "name": "Console Device", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ],
+          "b_terminations": [
+            { "object_console_server_port": {
+                "name": "ConsoleServerPort1",
+                "device": { "name": "Console Server", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update_expect": { "status": "decommissioning" }
+    },
+    {
+      "name": "dcim_cable_circuit",
+      "object_type": "dcim.cable",
+      "lookup": { "label": "Cable CKT" },
+      "create_expect": {
+        "label": "Cable CKT",
+        "a_terminations.0.term_side": "A",
+        "b_terminations.0.name": "eth-ckt"
+      },
+      "create": {
+        "cable": {
+          "label": "Cable CKT",
+          "status": "connected",
+          "a_terminations": [
+            { "object_circuit_termination": {
+                "term_side": "A",
+                "circuit": {
+                  "cid": "CKT-1",
+                  "provider": { "name": "Provider 1" },
+                  "type": { "name": "Circuit Type 1" }
+                },
+                "termination_site": { "name": "Site 1" }
+            } }
+          ],
+          "b_terminations": [
+            { "object_interface": {
+                "name": "eth-ckt",
+                "type": "1000base-t",
+                "device": { "name": "CKT Device", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update": {
+        "cable": {
+          "label": "Cable CKT", "status": "planned",
+          "a_terminations": [
+            { "object_circuit_termination": {
+                "term_side": "A",
+                "circuit": {
+                  "cid": "CKT-1",
+                  "provider": { "name": "Provider 1" },
+                  "type": { "name": "Circuit Type 1" }
+                },
+                "termination_site": { "name": "Site 1" }
+            } }
+          ],
+          "b_terminations": [
+            { "object_interface": {
+                "name": "eth-ckt",
+                "type": "1000base-t",
+                "device": { "name": "CKT Device", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update_expect": { "status": "planned" }
+    },
+    {
+      "name": "dcim_cable_powerfeed",
+      "object_type": "dcim.cable",
+      "lookup": { "label": "Cable PF" },
+      "create_expect": {
+        "label": "Cable PF",
+        "a_terminations.0.name": "Feed1",
+        "b_terminations.0.name": "PowerPortPF"
+      },
+      "create": {
+        "cable": {
+          "label": "Cable PF",
+          "status": "connected",
+          "a_terminations": [
+            { "object_power_feed": {
+                "name": "Feed1",
+                "power_panel": {
+                  "name": "Panel 1",
+                  "site": { "name": "Site 1" }
+                }
+            } }
+          ],
+          "b_terminations": [
+            { "object_power_port": {
+                "name": "PowerPortPF",
+                "device": { "name": "PF Consumer", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update": {
+        "cable": {
+          "label": "Cable PF", "status": "connected", "color": "00ff00",
+          "a_terminations": [
+            { "object_power_feed": {
+                "name": "Feed1",
+                "power_panel": {
+                  "name": "Panel 1",
+                  "site": { "name": "Site 1" }
+                }
+            } }
+          ],
+          "b_terminations": [
+            { "object_power_port": {
+                "name": "PowerPortPF",
+                "device": { "name": "PF Consumer", "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" }, "site": { "name": "Site 1" } }
+            } }
+          ]
+        }
+      },
+      "update_expect": { "color": "00ff00" }
     }
 ]

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
@@ -6476,5 +6476,86 @@
         "update_expect": {
             "virtual_machine_type.name": "VM Type B"
         }
+    },
+    {
+      "name": "dcim_cable_iface_iface",
+      "object_type": "dcim.cable",
+      "lookup": { "label": "Cable A-B" },
+      "create_expect": {
+        "label": "Cable A-B",
+        "status": "connected",
+        "type": "cat6",
+        "a_terminations.0.name": "GigabitEthernet0/1",
+        "b_terminations.0.name": "GigabitEthernet0/2"
+      },
+      "create": {
+        "cable": {
+          "label": "Cable A-B",
+          "status": "connected",
+          "type": "cat6",
+          "a_terminations": [
+            { "object_interface": {
+                "name": "GigabitEthernet0/1",
+                "type": "1000base-t",
+                "device": {
+                  "name": "Cable Device A",
+                  "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" },
+                  "site": { "name": "Site 1" }
+                }
+            } }
+          ],
+          "b_terminations": [
+            { "object_interface": {
+                "name": "GigabitEthernet0/2",
+                "type": "1000base-t",
+                "device": {
+                  "name": "Cable Device B",
+                  "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" },
+                  "site": { "name": "Site 1" }
+                }
+            } }
+          ]
+        }
+      },
+      "update": {
+        "cable": {
+          "label": "Cable A-B",
+          "status": "connected",
+          "type": "cat6a",
+          "a_terminations": [
+            { "object_interface": {
+                "name": "GigabitEthernet0/2",
+                "type": "1000base-t",
+                "device": {
+                  "name": "Cable Device B",
+                  "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" },
+                  "site": { "name": "Site 1" }
+                }
+            } }
+          ],
+          "b_terminations": [
+            { "object_interface": {
+                "name": "GigabitEthernet0/1",
+                "type": "1000base-t",
+                "device": {
+                  "name": "Cable Device A",
+                  "role": { "name": "Device Role 1" },
+                  "device_type": { "manufacturer": { "name": "Cisco" }, "model": "C2960S" },
+                  "site": { "name": "Site 1" }
+                }
+            } }
+          ],
+          "length": 5.0,
+          "length_unit": "m"
+        }
+      },
+      "update_expect": {
+        "type": "cat6a",
+        "length": 5.0,
+        "length_unit": "m"
+      }
     }
 ]


### PR DESCRIPTION
## Summary

End-to-end **cabling ingest** for Diode (OBS-3370), and the fix for the OBS-1080 crash (`TypeError: unhashable type: 'dict'` / HTTP 500 when ingesting a `Cable` with `a_terminations`/`b_terminations`). Cables now flow through the full plan → apply pipeline: a `Cable` with `GenericObject` terminations creates/updates the correct `dcim_cable` + `dcim_cabletermination` rows, idempotently and A/B-order-insensitive.


## What changes

- **Transformer** — extracts each `GenericObject` termination to `{object_type, object_id: UnresolvedReference}`, dispatching on the variant key via `get_generic_object_variant` (nested variant keys are snake-case-normalized, so camelCase protoJSON like `objectInterface` resolves too); records termination uuids in `_refs` (terminated objects are created before the cable); unknown variant keys and known-but-unsupported object types warn (with distinct messages) + skip that single termination (never crash, never drop the cable).
- **Matcher** — new `CableTerminationSetMatcher`: matches a cable by its **canonical, A/B-insensitive termination set** (`build_queryset` does an exact `CableTermination`-set match, rejecting subset/superset — including multi-termination-per-end). `dcim.cable` added to `_REQUIRES_PRE_SAVE_MATCH`; `_find_obj_cache_key` returns `None` for cable (its identity lives in list fields the scalar cache key skips).
- **Applier** — resolves termination refs to `{object_type, object_id: pk}` (numeric list-index path support in `_get_path`/`_set_path`; deep-copy of change data) and saves via the existing `CableSerializer`, whose `save() → update_terminations()` auto-creates the `CableTermination` rows (no separate apply). `Cable.clean()` conflicts (already-cabled / both-ends-required / incompatible types) surface as clean per-entity deviations. A dangling `new_object:` reference at apply time raises a clean, key-named per-entity error rather than a 500; unrelated `KeyError`s propagate as real bugs.
- **Differ** — captures the property-backed `a_terminations`/`b_terminations` with stable ordering so re-diff of an applied cable is a no-op (idempotency). Because cable identity is A/B-insensitive, a re-feed with the ends swapped is realigned to the existing assignment (`_align_cable_ends`) and converges as a NOOP instead of toggling `cable_end` forever.

## Certified scope

All 9 single-object termination types: interface, front port, rear port, console port, console-server port, power port, power outlet, power feed, circuit termination. Identity = A/B-insensitive termination set; `type`/`status`/`label`/`length`/`tenant` are mutable attributes (update, never fork). Conflicts fail the change as a per-entity deviation.

## Validation

- Full v4.6.x plugin suite: **419 tests OK** (transformer, matcher DB-backed set-match incl. multi-termination-per-end, applier end-to-end apply, integration fixtures across all termination types).
- **Live e2e (validated during development, harness not included in this PR)**: with a local real-OAuth + HTTP + NetBox harness, two A/B-swapped `bulk-plan`+`bulk-apply` requests converged to **one** cable, and an already-cabled interface returned a clean HTTP 207 deviation (no 500). The shipped regression coverage for these behaviors lives in the v4.6.x suite above (matcher set-match + applier end-to-end apply + integration idempotency).
- **Review hardening** — two adversarial review passes plus several Codex review rounds. Blocking edge-case bugs found and fixed (nested-termination-ref dedup, re-sorted-termination int at ref path, an order-fragile DB test), each with regression coverage; review follow-ups addressed: camelCase nested variant keys, A/B end-swap NOOP convergence, narrowed apply-time `KeyError` handling with actionable messages, `fingerprint` return-type annotation, distinct skip warnings, and removal of a `noqa: C901` by extracting a helper. Findings judged invalid were refuted with tests (e.g. multi-termination `build_queryset` matching; NetBox's `Cable(a_terminations=…, b_terminations=…)` constructor).

## Performance (hot-path audit)

**No material degradation for non-cable entities.** The plugin hot path (`transform → diff → apply`, run per-entity for many entities per bulk request) was audited change-by-change against `develop`.

- **All real cabling work is gated** behind `a_/b_terminations` key presence, `object_type == "dcim.cable"`, or membership in a cable-only dict — so common entities (devices, interfaces, IPs, prefixes) never enter the set-match query, termination sort, or generic-object variant paths. Their only added cost is a handful of O(1) probes per node/key (tuple-membership `==`, `dict.get`→`None`, a frozenset miss), each sub-microsecond and dwarfed by the surrounding `harmonize_formats` / `find_existing_object` / serializer work already in those loops.
- **The one unconditional per-entity change** is `_pre_apply` switching from a shallow `.copy()` to `copy.deepcopy(change.data)` on the apply path. Benchmarked at ~10.7 µs (typical payload) to ~41 µs (large) per call — i.e. **~1–4 ms per 100 entities, ~10–41 ms per 1000**. Each call is immediately followed by `serializer.is_valid()` + `save()` (a DB write, hundreds of µs to ms), so the deepcopy is **&lt;1–4 % of per-change cost** and, scaling per-change, never becomes the bottleneck. It is also **correctness-required**: ref resolution mutates nested containers (e.g. `a_terminations.0.object_id`) in place, and a shallow copy would corrupt `change.data` on retry (the data is plain JSON — no model instances — so deepcopy carries no hidden expense).

**Conclusion: no change warranted on performance grounds.** (Optional future polish: deepcopy only when a `new_refs` path is multi-segment/nested — cable terminations — and keep the shallow copy for single-segment FK refs; the measured impact doesn't justify it today.)

## Known limitations / backlog

- **Multi-object-per-end (LAG/breakout) UPDATE**: ~~out of certified scope; fails cleanly~~ **resolved** — termination lists are sorted before `new_refs` index paths are computed, so adding a new termination to an existing (netbox_id-matched) cable's end resolves and applies. Regression-tested through the real `generate_changeset → apply_changeset` path.
- **Breakout / profiled-cable connector semantics** (NetBox 4.6 cable profiles / per-termination `connector`) remain out of scope — that needs a proto change to carry per-termination lane info. The termination-set sort is A/B/order-insensitive by design, so it does not preserve the positional lane mapping a profiled cable would need. Tracked as **OBS-3411** (raised in review).

Refs: OBS-3370, OBS-1080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
