### PR TITLE
feat: ingest RackReservation with match-only user resolution

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       matrix:
         python: [ "3.10" ]

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -12,12 +12,20 @@ from django.db.utils import IntegrityError
 from rest_framework.exceptions import ValidationError as ValidationError
 
 from .change_log_buffer import snapshot_for_apply
-from .common import NON_FIELD_ERRORS, Change, ChangeSet, ChangeSetException, ChangeSetResult, ChangeType, error_from_validation_error
+from .common import (
+    MATCH_ONLY_TYPES,
+    NON_FIELD_ERRORS,
+    Change,
+    ChangeSet,
+    ChangeSetException,
+    ChangeSetResult,
+    ChangeType,
+    error_from_validation_error,
+)
 from .matcher import find_existing_object, invalidate_find_obj_entry, requires_pre_save_match
 from .plugin_utils import get_object_type_model, legal_fields
 from .profile import profiled
 from .supported_models import get_serializer_for_model
-from .transformer import _MATCH_ONLY_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +171,7 @@ def _apply_change(data: dict, model_class: models.Model, change: Change, created
     # never created OR updated via ingest. The transformer guards the plan path;
     # this guards the direct apply-change-set / bulk-apply path, which bypasses
     # the transformer, so a client changeset can't create or rename a user.
-    if change.object_type in _MATCH_ONLY_TYPES and change_type in (ChangeType.CREATE, ChangeType.UPDATE):
+    if change.object_type in MATCH_ONLY_TYPES and change_type in (ChangeType.CREATE, ChangeType.UPDATE):
         raise _err(
             f"{change.object_type} is match-only and cannot be created or updated via ingest",
             change.object_type, "__all__",

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -17,6 +17,7 @@ from .matcher import find_existing_object, invalidate_find_obj_entry, requires_p
 from .plugin_utils import get_object_type_model, legal_fields
 from .profile import profiled
 from .supported_models import get_serializer_for_model
+from .transformer import _MATCH_ONLY_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +158,16 @@ def _create_or_find_instance(data: dict, object_type: str, serializer_class, req
 def _apply_change(data: dict, model_class: models.Model, change: Change, created: dict, request):
     serializer_class = get_serializer_for_model(model_class)
     change_type = change.change_type
+
+    # Match-only types (e.g. users.user) are resolved against existing rows and
+    # never created OR updated via ingest. The transformer guards the plan path;
+    # this guards the direct apply-change-set / bulk-apply path, which bypasses
+    # the transformer, so a client changeset can't create or rename a user.
+    if change.object_type in _MATCH_ONLY_TYPES and change_type in (ChangeType.CREATE, ChangeType.UPDATE):
+        raise _err(
+            f"{change.object_type} is match-only and cannot be created or updated via ingest",
+            change.object_type, "__all__",
+        )
 
     if change_type == ChangeType.CREATE:
         # For component types that may be auto-created from e.g. DeviceType or ModuleType templates,

--- a/netbox_diode_plugin/api/common.py
+++ b/netbox_diode_plugin/api/common.py
@@ -28,6 +28,14 @@ logger = logging.getLogger("netbox.diode_data")
 
 NON_FIELD_ERRORS = "__all__"
 
+# Types resolved against existing rows only; never created (or updated) via
+# ingest. A reference to one that has no match becomes a per-entity deviation,
+# not a CREATE. (users.user is exposed only as a match-only reference target;
+# auto-minting Django auth users from ingest data is a privilege/security risk.)
+# Shared contract between the transformer (plan path) and applier (direct-apply
+# path); lives here so neither layer owns the other's constant.
+MATCH_ONLY_TYPES = frozenset({"users.user"})
+
 
 @lru_cache(maxsize=256)
 def _get_custom_fields_for_model(model) -> tuple:

--- a/netbox_diode_plugin/api/plugin_utils.py
+++ b/netbox_diode_plugin/api/plugin_utils.py
@@ -2,7 +2,7 @@
 
 # Generated code. DO NOT EDIT.
 # Source: NetBox v4.6.0
-# Timestamp: 2026-07-01 02:51:21Z
+# Timestamp: 2026-07-08 14:57:56Z
 
 from dataclasses import dataclass
 import datetime
@@ -364,6 +364,7 @@ _JSON_REF_INFO = {
             field_name="object",
             is_generic=True,
         ),
+        "user": RefInfo(object_type="users.user", field_name="object", is_generic=True),
     },
     "circuits.circuit": {
         "assignments": RefInfo(
@@ -712,6 +713,7 @@ _JSON_REF_INFO = {
         "rack": RefInfo(object_type="dcim.rack", field_name="rack"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
         "tenant": RefInfo(object_type="tenancy.tenant", field_name="tenant"),
+        "user": RefInfo(object_type="users.user", field_name="user"),
     },
     "dcim.rackrole": {
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
@@ -1168,6 +1170,10 @@ _JSON_REF_INFO = {
             field_name="assigned_object",
             is_generic=True,
         ),
+        "assigned_object_user": RefInfo(
+            object_type="users.user", field_name="assigned_object", is_generic=True
+        ),
+        "created_by": RefInfo(object_type="users.user", field_name="created_by"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "ipam.aggregate": {
@@ -1537,6 +1543,9 @@ _JSON_REF_INFO = {
             object_type="virtualization.virtualmachinetype",
             field_name="interface",
             is_generic=True,
+        ),
+        "interface_user": RefInfo(
+            object_type="users.user", field_name="interface", is_generic=True
         ),
     },
     "ipam.ipaddress": {
@@ -2012,6 +2021,9 @@ _JSON_REF_INFO = {
             field_name="object",
             is_generic=True,
         ),
+        "object_user": RefInfo(
+            object_type="users.user", field_name="object", is_generic=True
+        ),
         "role": RefInfo(object_type="tenancy.contactrole", field_name="role"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
@@ -2036,6 +2048,7 @@ _JSON_REF_INFO = {
     },
     "users.owner": {
         "group": RefInfo(object_type="users.ownergroup", field_name="group"),
+        "users": RefInfo(object_type="users.user", field_name="users", is_many=True),
     },
     "virtualization.cluster": {
         "group": RefInfo(object_type="virtualization.clustergroup", field_name="group"),
@@ -2556,6 +2569,9 @@ _JSON_REF_INFO = {
             field_name="assigned_object",
             is_generic=True,
         ),
+        "assigned_object_user": RefInfo(
+            object_type="users.user", field_name="assigned_object", is_generic=True
+        ),
         "l2vpn": RefInfo(object_type="vpn.l2vpn", field_name="l2vpn"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
@@ -2933,6 +2949,9 @@ _JSON_REF_INFO = {
             field_name="termination",
             is_generic=True,
         ),
+        "termination_user": RefInfo(
+            object_type="users.user", field_name="termination", is_generic=True
+        ),
         "tunnel": RefInfo(object_type="vpn.tunnel", field_name="tunnel"),
     },
     "wireless.wirelesslan": {
@@ -3059,6 +3078,7 @@ _GENERIC_OBJECT_VARIANTS: dict[str, str] = {
     "object_tunnel": "vpn.tunnel",
     "object_tunnel_group": "vpn.tunnelgroup",
     "object_tunnel_termination": "vpn.tunneltermination",
+    "object_user": "users.user",
     "object_virtual_chassis": "dcim.virtualchassis",
     "object_virtual_circuit": "circuits.virtualcircuit",
     "object_virtual_circuit_termination": "circuits.virtualcircuittermination",
@@ -3651,6 +3671,7 @@ _LEGAL_FIELDS = {
             "tags",
             "tenant",
             "units",
+            "user",
         ]
     ),
     "dcim.rackrole": frozenset(
@@ -3838,6 +3859,7 @@ _LEGAL_FIELDS = {
             "assigned_object_id",
             "assigned_object_type",
             "comments",
+            "created_by",
             "custom_fields",
             "kind",
             "tags",
@@ -4124,8 +4146,9 @@ _LEGAL_FIELDS = {
             "tags",
         ]
     ),
-    "users.owner": frozenset(["description", "group", "name"]),
+    "users.owner": frozenset(["description", "group", "name", "users"]),
     "users.ownergroup": frozenset(["description", "name"]),
+    "users.user": frozenset(["username"]),
     "virtualization.cluster": frozenset(
         [
             "comments",
@@ -4409,6 +4432,7 @@ _OBJECT_TYPE_PRIMARY_VALUE_FIELD_MAP = {
     "dcim.moduletype": "model",
     "ipam.prefix": "prefix",
     "dcim.racktype": "model",
+    "users.user": "username",
     "circuits.virtualcircuit": "cid",
     "wireless.wirelesslan": "ssid",
 }

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -107,6 +107,12 @@ _IS_CIRCULAR_REFERENCE = {
 def _is_circular_reference(object_type, field_name):
     return field_name in _IS_CIRCULAR_REFERENCE.get(object_type, frozenset())
 
+# Types resolved against existing rows only; never created (or updated) via
+# ingest. A reference to one that has no match becomes a per-entity deviation,
+# not a CREATE. (users.user is exposed only as a match-only reference target;
+# auto-minting Django auth users from ingest data is a privilege/security risk.)
+_MATCH_ONLY_TYPES = frozenset({"users.user"})
+
 @profiled("transform")
 def transform_proto_json(proto_json: dict, object_type: str, supported_models: dict) -> list[dict]: # noqa: C901
     """
@@ -667,6 +673,14 @@ def _resolve_existing_references(entities: list[dict]) -> list[dict]:
 
         existing = find_existing_object(data, object_type)
         if existing is not None:
+            if object_type in _MATCH_ONLY_TYPES:
+                # Pure reference target: resolve the parent's reference to the
+                # existing pk and emit NO change for this node. Match-only types
+                # (users.user) are never created or updated via ingest, and a
+                # change for them would fail validation anyway (e.g. NetBox's
+                # User requires a password we never carry).
+                new_refs[data['_uuid']] = existing.id
+                continue
             fp = (object_type, existing.id)
             if fp in seen:
                 logger.warning(f"objects resolved to the same existing id after deduplication: {seen[fp]} and {data}")
@@ -677,6 +691,15 @@ def _resolve_existing_references(entities: list[dict]) -> list[dict]:
             new_refs[data['_uuid']] = existing.id
             resolved.append(data)
         else:
+            if object_type in _MATCH_ONLY_TYPES:
+                primary = get_primary_value(data, object_type)
+                raise ChangeSetException(
+                    f"{object_type} not found for match-only reference",
+                    errors={object_type: {NON_FIELD_ERRORS: [
+                        f"No existing {object_type} matches {primary!r}; this type is "
+                        f"resolved against existing objects only and is not created via ingest."
+                    ]}},
+                )
             data['id'] = UnresolvedReference(object_type, data['_uuid'])
             _update_resolved_refs(data, new_refs)
             resolved.append(data)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -636,6 +636,44 @@ def _update_dict_refs(data, new_refs):
 
 
 @profiled("resolve_refs")
+def _mark_seen(data, object_type, existing, seen):
+    """Record a resolved (object_type, id) for in-batch dedup, warning on clash."""
+    fp = (object_type, existing.id)
+    if fp in seen:
+        logger.warning(f"objects resolved to the same existing id after deduplication: {seen[fp]} and {data}")
+    else:
+        seen[fp] = data
+
+
+def _resolve_by_netbox_id(data, object_type, seen, new_refs, resolved) -> bool:
+    """
+    Resolve a node via metadata netbox_id (PK lookup).
+
+    Returns True if the node had a netbox_id and was handled (caller should
+    skip further resolution); False if no netbox_id was present. Raises if the
+    netbox_id does not resolve to an existing object.
+    """
+    netbox_id = data.pop('_netbox_id', None)
+    if netbox_id is None:
+        return False
+    model_class = get_object_type_model(object_type)
+    existing = model_class.objects.filter(pk=netbox_id).first()
+    if existing is None:
+        raise ChangeSetException(
+            f"Object not found for {object_type} with netbox_id={netbox_id}",
+            errors={NON_FIELD_ERRORS: [f"No {object_type} found with id {netbox_id}"]}
+        )
+    new_refs[data['_uuid']] = existing.id
+    if object_type in _MATCH_ONLY_TYPES:
+        # pure reference target: resolved to the existing pk, no change emitted
+        return True
+    _mark_seen(data, object_type, existing, seen)
+    data['id'] = existing.id
+    data['_instance'] = existing
+    resolved.append(data)
+    return True
+
+
 def _resolve_existing_references(entities: list[dict]) -> list[dict]:
     seen = {}
     new_refs = {}
@@ -650,56 +688,33 @@ def _resolve_existing_references(entities: list[dict]) -> list[dict]:
             resolved.append(data)
             continue
 
-        # PK-based lookup: if metadata provided a netbox_id, use it directly
-        netbox_id = data.pop('_netbox_id', None)
-        if netbox_id is not None:
-            model_class = get_object_type_model(object_type)
-            existing = model_class.objects.filter(pk=netbox_id).first()
-            if existing is not None:
-                fp = (object_type, existing.id)
-                if fp in seen:
-                    logger.warning(f"objects resolved to the same existing id after deduplication: {seen[fp]} and {data}")
-                else:
-                    seen[fp] = data
-                data['id'] = existing.id
-                data['_instance'] = existing
-                new_refs[data['_uuid']] = existing.id
-                resolved.append(data)
-                continue
-            raise ChangeSetException(
-                f"Object not found for {object_type} with netbox_id={netbox_id}",
-                errors={NON_FIELD_ERRORS: [f"No {object_type} found with id {netbox_id}"]}
-            )
+        if _resolve_by_netbox_id(data, object_type, seen, new_refs, resolved):
+            continue
 
         existing = find_existing_object(data, object_type)
         if existing is not None:
+            new_refs[data['_uuid']] = existing.id
             if object_type in _MATCH_ONLY_TYPES:
                 # Pure reference target: resolve the parent's reference to the
                 # existing pk and emit NO change for this node. Match-only types
                 # (users.user) are never created or updated via ingest, and a
                 # change for them would fail validation anyway (e.g. NetBox's
                 # User requires a password we never carry).
-                new_refs[data['_uuid']] = existing.id
                 continue
-            fp = (object_type, existing.id)
-            if fp in seen:
-                logger.warning(f"objects resolved to the same existing id after deduplication: {seen[fp]} and {data}")
-            else:
-                seen[fp] = data
+            _mark_seen(data, object_type, existing, seen)
             data['id'] = existing.id
             data['_instance'] = existing
-            new_refs[data['_uuid']] = existing.id
             resolved.append(data)
+        elif object_type in _MATCH_ONLY_TYPES:
+            primary = get_primary_value(data, object_type)
+            raise ChangeSetException(
+                f"{object_type} not found for match-only reference",
+                errors={object_type: {NON_FIELD_ERRORS: [
+                    f"No existing {object_type} matches {primary!r}; this type is "
+                    f"resolved against existing objects only and is not created via ingest."
+                ]}},
+            )
         else:
-            if object_type in _MATCH_ONLY_TYPES:
-                primary = get_primary_value(data, object_type)
-                raise ChangeSetException(
-                    f"{object_type} not found for match-only reference",
-                    errors={object_type: {NON_FIELD_ERRORS: [
-                        f"No existing {object_type} matches {primary!r}; this type is "
-                        f"resolved against existing objects only and is not created via ingest."
-                    ]}},
-                )
             data['id'] = UnresolvedReference(object_type, data['_uuid'])
             _update_resolved_refs(data, new_refs)
             resolved.append(data)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -17,7 +17,15 @@ from django.utils.text import slugify
 from extras.models.customfields import CustomField
 from rest_framework import serializers
 
-from .common import NON_FIELD_ERRORS, AutoSlug, ChangeSetException, UnresolvedReference, harmonize_formats, sort_ints_first
+from .common import (
+    MATCH_ONLY_TYPES,
+    NON_FIELD_ERRORS,
+    AutoSlug,
+    ChangeSetException,
+    UnresolvedReference,
+    harmonize_formats,
+    sort_ints_first,
+)
 from .compat import apply_entity_migrations
 from .matcher import find_existing_object, fingerprints
 from .plugin_utils import (
@@ -106,12 +114,6 @@ _IS_CIRCULAR_REFERENCE = {
 
 def _is_circular_reference(object_type, field_name):
     return field_name in _IS_CIRCULAR_REFERENCE.get(object_type, frozenset())
-
-# Types resolved against existing rows only; never created (or updated) via
-# ingest. A reference to one that has no match becomes a per-entity deviation,
-# not a CREATE. (users.user is exposed only as a match-only reference target;
-# auto-minting Django auth users from ingest data is a privilege/security risk.)
-_MATCH_ONLY_TYPES = frozenset({"users.user"})
 
 @profiled("transform")
 def transform_proto_json(proto_json: dict, object_type: str, supported_models: dict) -> list[dict]: # noqa: C901
@@ -664,7 +666,7 @@ def _resolve_by_netbox_id(data, object_type, seen, new_refs, resolved) -> bool:
             errors={NON_FIELD_ERRORS: [f"No {object_type} found with id {netbox_id}"]}
         )
     new_refs[data['_uuid']] = existing.id
-    if object_type in _MATCH_ONLY_TYPES:
+    if object_type in MATCH_ONLY_TYPES:
         # pure reference target: resolved to the existing pk, no change emitted
         return True
     _mark_seen(data, object_type, existing, seen)
@@ -694,7 +696,7 @@ def _resolve_existing_references(entities: list[dict]) -> list[dict]:
         existing = find_existing_object(data, object_type)
         if existing is not None:
             new_refs[data['_uuid']] = existing.id
-            if object_type in _MATCH_ONLY_TYPES:
+            if object_type in MATCH_ONLY_TYPES:
                 # Pure reference target: resolve the parent's reference to the
                 # existing pk and emit NO change for this node. Match-only types
                 # (users.user) are never created or updated via ingest, and a
@@ -705,7 +707,7 @@ def _resolve_existing_references(entities: list[dict]) -> list[dict]:
             data['id'] = existing.id
             data['_instance'] = existing
             resolved.append(data)
-        elif object_type in _MATCH_ONLY_TYPES:
+        elif object_type in MATCH_ONLY_TYPES:
             primary = get_primary_value(data, object_type)
             raise ChangeSetException(
                 f"{object_type} not found for match-only reference",

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_user_rackreservation.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_user_rackreservation.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - User (match-only) + RackReservation ingest tests."""
+
+from dcim.models import RackReservation
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api import transformer
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeSetException, ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.supported_models import extract_supported_models
+
+
+class MatchOnlyUserTransformTestCase(TestCase):
+    """The plan path (transformer) never creates a user for an unresolved ref."""
+
+    def test_unknown_user_ref_deviates_not_create(self):
+        """An unresolved users.user ref raises a deviation, not a CREATE."""
+        supported = extract_supported_models()
+        with self.assertRaises(ChangeSetException):
+            transformer.transform_proto_json({"username": "ghost"}, "users.user", supported)
+        self.assertFalse(User.objects.filter(username="ghost").exists())
+
+
+class MatchOnlyUserApplyTestCase(TestCase):
+    """The direct-apply path (applier) rejects create/update of users.user."""
+
+    def test_direct_create_user_changeset_rejected(self):
+        """A CREATE changeset for users.user is rejected; no user row is created."""
+        cs = ChangeSet(id="cs-u-create", changes=[Change(
+            change_type=ChangeType.CREATE, object_type="users.user",
+            ref_id="new_object:users.user:x", data={"username": "should-not-create"}, new_refs=[])])
+        with self.assertRaises(ChangeSetException):
+            apply_changeset(cs, request=None)
+        self.assertFalse(User.objects.filter(username="should-not-create").exists())
+
+    def test_direct_update_user_changeset_rejected_username_unchanged(self):
+        """An UPDATE changeset for users.user is rejected; the username is unchanged."""
+        u = User.objects.create(username="keep-me")
+        cs = ChangeSet(id="cs-u-update", changes=[Change(
+            change_type=ChangeType.UPDATE, object_type="users.user",
+            object_id=u.pk, data={"username": "renamed"}, new_refs=[])])
+        with self.assertRaises(ChangeSetException):
+            apply_changeset(cs, request=None)
+        u.refresh_from_db()
+        self.assertEqual(u.username, "keep-me")
+
+
+class RackReservationApplyTestCase(TestCase):
+    """
+    RackReservation ingests end-to-end with a match-only user reference.
+
+    Only the user is pre-seeded; the site + rack are created by the ingest.
+    (dcim.rack has no reliable natural-key match when location is null, so
+    assertions key off the reservation's resolved user, not a pre-seeded rack.)
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed only the existing user the reservation will reference."""
+        cls.user = User.objects.create(username="rr-owner")
+
+    def _entity(self, username):
+        return {"rack": {"name": "RR-Rack", "site": {"name": "RR-Site"}},
+                "units": [1, 2, 3], "description": "reserved",
+                "user": {"username": username}}
+
+    def test_reservation_with_existing_user_applies(self):
+        """A reservation referencing an existing user resolves that user + applies."""
+        r = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+        apply_changeset(r.change_set, request=None)
+        self.assertEqual(RackReservation.objects.count(), 1)
+        rr = RackReservation.objects.first()
+        self.assertEqual(rr.user_id, self.user.pk)  # matched existing user, not created
+        self.assertEqual(rr.rack.name, "RR-Rack")
+        self.assertEqual(sorted(rr.units), [1, 2, 3])
+        # match-only: no new user was minted
+        self.assertEqual(User.objects.filter(username="rr-owner").count(), 1)
+
+    def test_reservation_with_unknown_user_deviates(self):
+        """An unknown user -> clean deviation, no user created, no reservation."""
+        with self.assertRaises(ChangeSetException):
+            generate_changeset(self._entity("ghost"), "dcim.rackreservation")
+        self.assertFalse(User.objects.filter(username="ghost").exists())
+        self.assertEqual(RackReservation.objects.count(), 0)
+
+    def test_reservation_case_mismatch_username_deviates(self):
+        """Username matching is exact/case-sensitive: a case variant deviates."""
+        with self.assertRaises(ChangeSetException):
+            generate_changeset(self._entity("RR-OWNER"), "dcim.rackreservation")
+
+    def test_reservation_missing_user_deviates(self):
+        """RackReservation.user is required; omitting it -> deviation, no row created."""
+        entity = {"rack": {"name": "RR-Rack", "site": {"name": "RR-Site"}},
+                  "units": [1, 2, 3], "description": "reserved"}
+        with self.assertRaises(ChangeSetException):
+            r = generate_changeset(entity, "dcim.rackreservation")
+            apply_changeset(r.change_set, request=None)
+        self.assertEqual(RackReservation.objects.count(), 0)
+
+    def test_existing_user_resolution_is_idempotent(self):
+        """Re-ingesting resolves the same existing user each time; never mints one."""
+        for _ in range(2):
+            r = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+            apply_changeset(r.change_set, request=None)
+        # the match-only user is resolved, never duplicated/created
+        self.assertEqual(User.objects.filter(username="rr-owner").count(), 1)
+        self.assertTrue(all(rr.user_id == self.user.pk for rr in RackReservation.objects.all()))

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_user_rackreservation.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_user_rackreservation.py
@@ -28,12 +28,16 @@ class MatchOnlyUserApplyTestCase(TestCase):
     """The direct-apply path (applier) rejects create/update of users.user."""
 
     def test_direct_create_user_changeset_rejected(self):
-        """A CREATE changeset for users.user is rejected; no user row is created."""
+        """A CREATE changeset for users.user is rejected by the match-only guard."""
+        # Serializer-valid payload (password present) so the assertion detects
+        # the guard specifically, not incidental UserSerializer validation.
         cs = ChangeSet(id="cs-u-create", changes=[Change(
             change_type=ChangeType.CREATE, object_type="users.user",
-            ref_id="new_object:users.user:x", data={"username": "should-not-create"}, new_refs=[])])
-        with self.assertRaises(ChangeSetException):
+            ref_id="new_object:users.user:x",
+            data={"username": "should-not-create", "password": "Str0ng-P@ssw0rd!"}, new_refs=[])])
+        with self.assertRaises(ChangeSetException) as cm:
             apply_changeset(cs, request=None)
+        self.assertIn("match-only", str(cm.exception))
         self.assertFalse(User.objects.filter(username="should-not-create").exists())
 
     def test_direct_update_user_changeset_rejected_username_unchanged(self):
@@ -70,6 +74,8 @@ class RackReservationApplyTestCase(TestCase):
     def test_reservation_with_existing_user_applies(self):
         """A reservation referencing an existing user resolves that user + applies."""
         r = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+        # match-only: the matched user is a pure reference — NO users.user change
+        self.assertFalse(any(c.object_type == "users.user" for c in r.change_set.changes))
         apply_changeset(r.change_set, request=None)
         self.assertEqual(RackReservation.objects.count(), 1)
         rr = RackReservation.objects.first()
@@ -90,6 +96,8 @@ class RackReservationApplyTestCase(TestCase):
         """Username matching is exact/case-sensitive: a case variant deviates."""
         with self.assertRaises(ChangeSetException):
             generate_changeset(self._entity("RR-OWNER"), "dcim.rackreservation")
+        self.assertFalse(User.objects.filter(username="RR-OWNER").exists())
+        self.assertEqual(RackReservation.objects.count(), 0)
 
     def test_reservation_missing_user_deviates(self):
         """RackReservation.user is required; omitting it -> deviation, no row created."""
@@ -101,10 +109,21 @@ class RackReservationApplyTestCase(TestCase):
         self.assertEqual(RackReservation.objects.count(), 0)
 
     def test_existing_user_resolution_is_idempotent(self):
-        """Re-ingesting resolves the same existing user each time; never mints one."""
+        """
+        Re-ingesting resolves the same existing user each time; never mints one.
+
+        Scoped to the USER guarantee: the match-only user is resolved (never
+        duplicated or created) and the reservation's user never changes across
+        re-ingests. NOTE: a full-changeset NOOP is NOT asserted here because
+        dcim.rackreservation is keyless AND its nested dcim.rack has no reliable
+        natural-key match when location is null (a re-diff re-creates the rack
+        and re-points the reservation) — both pre-existing behaviors unrelated
+        to this feature. The user, correctly, is the one node that stays matched.
+        """
         for _ in range(2):
             r = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+            # user is always a pure reference — never a change node
+            self.assertFalse(any(c.object_type == "users.user" for c in r.change_set.changes))
             apply_changeset(r.change_set, request=None)
-        # the match-only user is resolved, never duplicated/created
         self.assertEqual(User.objects.filter(username="rr-owner").count(), 1)
         self.assertTrue(all(rr.user_id == self.user.pk for rr in RackReservation.objects.all()))


### PR DESCRIPTION

## Summary

Makes `dcim.rackreservation` ingestable by resolving its required `user` FK, and
adds **match-only** resolution for `users.user`: users are resolved against
existing rows by `username` and are **never created or updated** via ingest.
Previously a rack reservation could not be applied at all (`Field user is
required`), because `user` was not a resolvable reference.

## What changes

- **Generated metadata (`plugin_utils.py`)** — updated to include `users.user`
  (username) in the legal fields and the `RackReservation.user` reference (plus
  the other restored user references).
- **Transformer** — a match-only reference that resolves to an existing user is
  emitted as a *pure reference* (the parent gets the user's pk; no change node is
  emitted for the user). An **unresolved** user reference produces a clean
  per-entity deviation instead of a create.
- **Applier** — rejects any create/update of a match-only type in `_apply_change`.
  This covers the direct `apply-change-set` / `bulk-apply` path (which bypasses
  the transformer), so a client-supplied changeset cannot create or rename a user.

## Why match-only

Auto-creating or renaming Django auth users from discovery/ingest data is a
privilege/security risk (which password? which permissions?). Users must
pre-exist; a reservation referencing an unknown user deviates cleanly rather than
minting one.

## Scope note

Enabling `users.user` as a resolvable reference restores it everywhere it is
referenced — `RackReservation.user`, `Owner.users`, `JournalEntry.created_by`,
and the generic-object `*_user` variants — all match-only (never created/updated).

## Tests (v4.6.x suite green, ruff clean)

- existing user resolves + reservation applies (user emitted as a pure reference,
  no `users.user` change; existing user not duplicated)
- unknown / case-mismatch / missing user → clean per-entity deviation, no row created
- direct `users.user` CREATE and UPDATE changesets → rejected by the applier guard
  (username unchanged in the DB)
- user resolution is idempotent across re-ingests

## Merge order

Depends on the ingester proto + SDK changes landing first (the regenerated
`plugin_utils.py` metadata reflects the new `user` reference).
