### PR TITLE
fix(transformer): defer post-create steps when referenced objects are updated later in the change set

### DIFF
--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -767,18 +767,28 @@ def _handle_post_creates(entities: list[dict]) -> list[str]:
         instance = entity.get('_instance')
         prior_index, prior_entity = by_uuid[instance]
 
-        # a post create can be merged whenever the entities it relies on
-        # already exist (were resolved) or there are no dependencies between
-        # the object being updated and the post-create.
+        # A post-create can only be merged into its object's main change when
+        # nothing it references is ordered after that object in the change
+        # set. That the referenced objects already exist is not enough: an
+        # existing object may itself be updated later in the same change set
+        # (e.g. an IP address that only gets assigned to an interface further
+        # down), and a merged reference would be applied before that update.
         can_merge = all(
-            by_uuid[r][1].get('_instance') is not None
+            by_uuid[r][0] <= prior_index
             for r in entity['_refs']
-        ) or sorted(by_uuid[r][0] for r in entity['_refs'])[-1] == prior_index
+        )
 
         if can_merge:
             prior_entity.update([x for x in entity.items() if not x[0].startswith('_')])
         else:
             entity['id'] = prior_entity['id']
+            # When the object already exists, diff the deferred step against
+            # its real state rather than the submitted node data (which never
+            # carries the deferred fields), so an already-converged reference
+            # NOOPs instead of re-diffing as an update on every ingest.
+            prior_instance = prior_entity.get('_instance')
+            if prior_instance is not None:
+                entity['_instance'] = prior_instance
             out.append(entity)
 
     return out

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_api_diff_and_apply.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import netaddr
 from circuits.models import Circuit, Provider
 from core.models import ObjectType
-from dcim.models import Device, FrontPort, Interface, ModuleBay, RearPort, Site
+from dcim.models import Device, DeviceRole, DeviceType, FrontPort, Interface, Manufacturer, ModuleBay, RearPort, Site
 from extras.models import CustomField
 from extras.models.customfields import CustomFieldChoiceSet, CustomFieldChoiceSetBaseChoices, CustomFieldTypeChoices
 from ipam.models import ASN, VRF, IPAddress, VLANGroup, VLANTranslationPolicy
@@ -486,6 +486,88 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
         device = Device.objects.get(name=f"Device {device_uuid}")
         self.assertEqual(device.primary_ip4.pk, new_ipaddress.pk)
+
+    def _create_device_with_interface(self, suffix, address=None):
+        """Create a site/role/type/device/interface graph, optionally with an IP."""
+        site = Site.objects.create(name=f"Site {suffix}", slug=f"site-{suffix}")
+        manufacturer = Manufacturer.objects.create(
+            name=f"Manufacturer {suffix}", slug=f"manufacturer-{suffix}"
+        )
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model=f"Device Type {suffix}",
+            slug=f"device-type-{suffix}",
+        )
+        role = DeviceRole.objects.create(
+            name=f"Role {suffix}", slug=f"role-{suffix}", color="ff0000"
+        )
+        device = Device.objects.create(
+            name=f"Device {suffix}", device_type=device_type, role=role, site=site
+        )
+        interface = Interface.objects.create(
+            device=device, name="GigabitEthernet1", type="1000base-t"
+        )
+        ip = IPAddress.objects.create(address=address) if address else None
+        return device, interface, ip
+
+    def _device_primary_ip4_payload(self, device, interface, address):
+        """Device-discovery style payload: IP assigned to an interface of a device whose primary_ip4 is that IP."""
+        return {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": address,
+                    "assigned_object_interface": {
+                        "name": interface.name,
+                        "type": interface.type,
+                        "device": {
+                            "name": device.name,
+                            "role": {"name": device.role.name},
+                            "site": {"name": device.site.name},
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": device.device_type.manufacturer.name
+                                },
+                                "model": device.device_type.model,
+                            },
+                            "primary_ip4": {"address": address},
+                        },
+                    },
+                },
+            },
+        }
+
+    def test_apply_device_primary_ip4_with_preexisting_unassigned_ip(self):
+        """Apply primary_ip4 when the IP exists unassigned and is only assigned to an interface later in the change set."""
+        addr = "10.0.1.123/24"
+        # poisoned state: a prior network-discovery ingest created the IP
+        # without an interface assignment; the device and interface exist too
+        device, interface, ip = self._create_device_with_interface(str(uuid4()), address=addr)
+
+        payload = self._device_primary_ip4_payload(device, interface, addr)
+        self.diff_and_apply(payload)
+
+        ip.refresh_from_db()
+        device.refresh_from_db()
+        self.assertEqual(ip.assigned_object, interface)
+        self.assertEqual(device.primary_ip4_id, ip.pk)
+
+    def test_rediff_converged_device_primary_ip4_is_noop(self):
+        """A converged device with primary_ip4 re-diffs to an empty change set."""
+        addr = "10.0.2.45/24"
+        device, interface, ip = self._create_device_with_interface(str(uuid4()), address=addr)
+        ip.assigned_object = interface
+        ip.save()
+        device.primary_ip4 = ip
+        device.save()
+
+        payload = self._device_primary_ip4_payload(device, interface, addr)
+        response = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
 
     def test_generate_diff_and_apply_create_device_with_primary_ip6(self):
         """Test generate diff and apply create device with primary ip6."""
@@ -2096,5 +2178,5 @@ class GenerateDiffAndApplyTestCase(APITestCase):
         response2 = self.client.post(
             self.apply_url, data=diff, format="json", **self.authorization_header
         )
-        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+        self.assertEqual(response2.status_code, status.HTTP_200_OK, response2.content)
         return (response1, response2)


### PR DESCRIPTION
## Problem

`_handle_post_creates` folded a deferred circular reference (e.g. `device.primary_ip4`) back into the object's main change whenever all referenced objects already existed in NetBox. Existence is not enough: an existing IP may only get its interface assignment later in the same change set (the device precedes the interface/IP in topo order), so the folded-in reference was applied first and NetBox rejected the device save with "The specified IP address (…) is not assigned to this device."

Trigger state: the same box ingested by network-discovery (IP created unassigned) and device-discovery (IP as `primary_ip4`, assigned to an interface). Deterministic — rediff/reapply does not recover.

## Fix

- `can_merge` is now ordering-only: a post-create folds back into the main change only when nothing it references is ordered after the object in the change set.
- When the step stays deferred and the object already exists, it carries the resolved model instance so the differ compares against real NetBox state — a converged reference NOOPs instead of re-diffing as an update on every ingest.

## Tests (4.6.x)

- `test_apply_device_primary_ip4_with_preexisting_unassigned_ip` — seeds device + interface + unassigned IP, then diff-and-applies the device-discovery payload; reproduced the exact error pre-fix.
- `test_rediff_converged_device_primary_ip4_is_noop` — converged device re-diffs to an empty change set; guards against the naive fix (never merging without instance-aware diffing would produce permanent deviations).

Full 4.6.x suite green (428 tests).