### PR TITLE
fix: migration of pre-existing branches fails when the plugin is enabled

### DIFF
--- a/netbox_diode_plugin/migrations/0001_squashed_0005.py
+++ b/netbox_diode_plugin/migrations/0001_squashed_0005.py
@@ -6,6 +6,12 @@ import utilities.json
 from django.db import migrations, models
 from netbox.plugins import get_plugin_config
 
+# Setting is not branch-aware: its queries always route to the main schema,
+# and per-branch settings live there via the branch_id column. Branch schemas
+# must not get a copy of this table; netbox-branching (>= 1.0.1) honors this
+# flag and skips the migration when migrating a branch.
+fake_on_branch = True
+
 
 def create_settings_entity(apps, schema_editor):
     """Create a Setting entity."""
@@ -16,7 +22,14 @@ def create_settings_entity(apps, schema_editor):
         "netbox_diode_plugin", "diode_target_override", default_diode_target
     )
 
-    Setting.objects.create(diode_target=diode_target)
+    # Pin the insert to the connection running this migration. The default
+    # connection points at the main schema, whose table may already be
+    # migrated past 0007 (no created/last_updated columns) when this
+    # migration is replayed on a branch by an older netbox-branching that
+    # ignores fake_on_branch.
+    Setting.objects.using(schema_editor.connection.alias).create(
+        diode_target=diode_target
+    )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## Problem

Enabling the plugin on a NetBox instance with branches created **before** the plugin was installed breaks branch migration:

```
column "created" of relation "netbox_diode_plugin_setting" does not exist
LINE 1: INSERT INTO "netbox_diode_plugin_setting" ("created", "last_...
```

The RunPython in `0001_squashed_0005` calls `Setting.objects.create(...)` without pinning the connection. `Setting` is a plain `models.Model` (not branch-aware), so during branch migration `BranchAwareRouter` falls through to the default connection — the main schema — whose table is already migrated past `0007_setting_model_cleanup` and no longer has the `created`/`last_updated`/`custom_field_data` columns the historical model still carries. The `activate_branch()` wrapper added in netbox-branching v1.0.2 doesn't help, since routing bails at the `supports_branching()` check, so this reproduces on every branching version.

## Fix

- `Setting.objects.using(schema_editor.connection.alias).create(...)` — the Django-documented pattern for RunPython. No-op on regular installs (`default` alias); during a branch migration the insert lands in the branch-schema table that was just created with matching columns.
- `fake_on_branch = True` module attribute — netbox-branching ≥ 1.0.1 honors it and skips the migration on branches entirely. Branch schemas never need this table: `Setting` queries always route to main, where per-branch settings live via `branch_id` (added in `0008`), and branches provisioned after plugin install never get the table anyway. `0006`–`0008` are already auto-faked by branching's heuristic; `0001` can't be auto-classified because `CreateModel`/`RunPython` carry no `model_name`, which is why it runs today.

Existing broken branches recover on the next migrate: the failed INSERT rolled back atomically, so `0001` was never recorded and re-runs cleanly.

## Testing

- Full plugin test suite (375 tests) passes on a fresh database, exercising the modified migration end-to-end on a clean install.