### PR TITLE
chore(ci): upgrade actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/labeler@v5
+      - uses: actions/checkout@v7
+      - uses: actions/labeler@v6
         with:
           configuration-path: '.github/pull_request_labeler.yaml'

--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -33,9 +33,9 @@ jobs:
         netbox: [ "v4.6.0", "v4.5.5", "v4.4.10" ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
             exit 1
           fi
       - name: Coverage comment
-        uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
+        uses: orgoro/coverage@53d6a49e69e38cf1606ea91ee3f4e64e2754fabb # v3.3.1
         if: github.event.pull_request.head.repo.full_name == github.repository && matrix.netbox == env.DEFAULT_NETBOX_VERSION
         with:
           coverageFile: ./docker/coverage/report.xml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Python package name
         id: python-package-name
         run: echo "python-package-name=${{ env.PYTHON_PACKAGE_NAME }}" >> "$GITHUB_OUTPUT"
@@ -37,65 +37,61 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
       - name: Write package.json
-        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
-        with:
-          path: ./package.json
-          write-mode: overwrite
-          contents: |
-            {
-              "name": "${{ env.APP_NAME }}",
-              "version": "1.0.0",
-              "devDependencies": {
-                "semantic-release-export-data": "^1.0.1",
-                "@semantic-release/changelog": "^6.0.3"
-              }
+        run: |
+          cat > ./package.json <<'EOF'
+          {
+            "name": "${{ env.APP_NAME }}",
+            "version": "1.0.0",
+            "devDependencies": {
+              "semantic-release-export-data": "^1.0.1",
+              "@semantic-release/changelog": "^6.0.3"
             }
+          }
+          EOF
       - name: Write .releaserc.json
-        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
-        with:
-          path: ./.releaserc.json
-          write-mode: overwrite
-          contents: |
-            {
-              "branches": "release",
-              "repositoryUrl": "https://github.com/netboxlabs/diode-netbox-plugin",
-              "debug": "true",
-              "tagFormat": "v${version}",
-              "plugins": [
-                ["semantic-release-export-data"],
-                ["@semantic-release/commit-analyzer", {
-                  "releaseRules": [
-                    { "message": "*", "release": "patch"},
-                    { "message": "fix*", "release": "patch" },
-                    { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
-                  ]
-                }],
-                "@semantic-release/release-notes-generator",
-                [
-                  "@semantic-release/changelog",
-                  {
-                    "changelogFile": "CHANGELOG.md",
-                    "changelogTitle": "# Semantic Versioning Changelog"
-                  }
-                ],
-                [
-                  "@semantic-release/github",
-                  {
-                    "assets": [
-                      {
-                        "path": "release/**"
-                      }
-                    ]
-                  }
+        run: |
+          cat > ./.releaserc.json <<'EOF'
+          {
+            "branches": "release",
+            "repositoryUrl": "https://github.com/netboxlabs/diode-netbox-plugin",
+            "debug": "true",
+            "tagFormat": "v${version}",
+            "plugins": [
+              ["semantic-release-export-data"],
+              ["@semantic-release/commit-analyzer", {
+                "releaseRules": [
+                  { "message": "*", "release": "patch"},
+                  { "message": "fix*", "release": "patch" },
+                  { "message": "feat*", "release": "minor" },
+                  { "message": "perf*",  "release": "major" }
                 ]
+              }],
+              "@semantic-release/release-notes-generator",
+              [
+                "@semantic-release/changelog",
+                {
+                  "changelogFile": "CHANGELOG.md",
+                  "changelogTitle": "# Semantic Versioning Changelog"
+                }
+              ],
+              [
+                "@semantic-release/github",
+                {
+                  "assets": [
+                    {
+                      "path": "release/**"
+                    }
+                  ]
+                }
               ]
-            }
+            ]
+          }
+          EOF
       - name: setup semantic-release
         run: npm i
       - name: release dry-run
@@ -124,7 +120,7 @@ jobs:
     needs: get-next-version
     if: needs.get-next-version.outputs.new-release-published == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Confirm version
         env:
           NEXT_RELEASE_VERSION: ${{ needs.get-next-version.outputs.new-release-version }}
@@ -142,8 +138,8 @@ jobs:
       BUILD_COMMIT: ${{ needs.get-next-version.outputs.short-sha }}
       OUTPUT_FILENAME: ${{ needs.get-python-package-name.outputs.python-package-name }}-${{ needs.get-next-version.outputs.new-release-version }}.tar.gz
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_RUNTIME_VERSION }}
       - name: Insert version variables into Python
@@ -161,7 +157,7 @@ jobs:
           python3 -m pip install --upgrade build
           python3 -m build --sdist --outdir dist/
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.OUTPUT_FILENAME }}
           path: dist/${{ env.OUTPUT_FILENAME }}
@@ -178,65 +174,61 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
       - name: Write package.json
-        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
-        with:
-          path: ./package.json
-          write-mode: overwrite
-          contents: |
-            {
-              "name": "${{ env.APP_NAME }}",
-              "version": "1.0.0",
-              "devDependencies": {
-                "semantic-release-export-data": "^1.0.1",
-                "@semantic-release/changelog": "^6.0.3"
-              }
+        run: |
+          cat > ./package.json <<'EOF'
+          {
+            "name": "${{ env.APP_NAME }}",
+            "version": "1.0.0",
+            "devDependencies": {
+              "semantic-release-export-data": "^1.0.1",
+              "@semantic-release/changelog": "^6.0.3"
             }
+          }
+          EOF
       - name: Write .releaserc.json
-        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
-        with:
-          path: ./.releaserc.json
-          write-mode: overwrite
-          contents: |
-            {
-              "branches": "release",
-              "repositoryUrl": "https://github.com/netboxlabs/diode-netbox-plugin",
-              "debug": "true",
-              "tagFormat": "v${version}",
-              "plugins": [
-                ["semantic-release-export-data"],
-                ["@semantic-release/commit-analyzer", {
-                  "releaseRules": [
-                    { "message": "*", "release": "patch"},
-                    { "message": "fix*", "release": "patch" },
-                    { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
-                  ]
-                }],
-                "@semantic-release/release-notes-generator",
-                [
-                  "@semantic-release/changelog",
-                  {
-                    "changelogFile": "CHANGELOG.md",
-                    "changelogTitle": "# Semantic Versioning Changelog"
-                  }
-                ],
-                [
-                  "@semantic-release/github",
-                  {
-                    "assets": [
-                      {
-                        "path": "release/**"
-                      }
-                    ]
-                  }
+        run: |
+          cat > ./.releaserc.json <<'EOF'
+          {
+            "branches": "release",
+            "repositoryUrl": "https://github.com/netboxlabs/diode-netbox-plugin",
+            "debug": "true",
+            "tagFormat": "v${version}",
+            "plugins": [
+              ["semantic-release-export-data"],
+              ["@semantic-release/commit-analyzer", {
+                "releaseRules": [
+                  { "message": "*", "release": "patch"},
+                  { "message": "fix*", "release": "patch" },
+                  { "message": "feat*", "release": "minor" },
+                  { "message": "perf*",  "release": "major" }
                 ]
+              }],
+              "@semantic-release/release-notes-generator",
+              [
+                "@semantic-release/changelog",
+                {
+                  "changelogFile": "CHANGELOG.md",
+                  "changelogTitle": "# Semantic Versioning Changelog"
+                }
+              ],
+              [
+                "@semantic-release/github",
+                {
+                  "assets": [
+                    {
+                      "path": "release/**"
+                    }
+                  ]
+                }
               ]
-            }
+            ]
+          }
+          EOF
       - name: setup semantic-release
         run: npm i
       - name: Release

--- a/netbox_diode_plugin/version.py
+++ b/netbox_diode_plugin/version.py
@@ -17,3 +17,5 @@ def version_display():
 def version_semver():
     """Semantic version."""
     return __version__
+
+# temp: trigger CI for workflow changes — revert before merge


### PR DESCRIPTION
Recent runs emit `Node.js 20 is deprecated ... forced to run on Node.js 24` warnings (e.g. Lint and tests run 29405341822, PR labeler run 29405342087). All bumped versions verified to declare `runs.using: node24`.

## Changes

- `actions/checkout` v3/v4 → **v7** (all workflows)
- `actions/setup-python` v5 → **v6**
- `actions/setup-node` v4 → **v7**
- `actions/upload-artifact` v4 → **v7**
- `actions/labeler` v5 → **v6**
- `orgoro/coverage` v3.2 → **v3.3.1** (SHA re-pinned)
- `DamianReeves/write-file-action` (4 uses in release.yaml) replaced with plain `run:` heredoc steps — the action is unmaintained and its latest release still targets node20. Quoted heredoc delimiter keeps semantic-release's `${version}` template unexpanded; both generated JSON files validated.

Not changed: `pypa/gh-action-pypi-publish` (composite action, unaffected by the Node deprecation — can be bumped v1.12.3 → v1.14.0 separately if desired).

All intermediate majors (checkout v5–v7, labeler v6, setup-node v5–v7, upload-artifact v5–v7) are Node-runtime bumps with no config-format changes; all jobs run on `ubuntu-latest` so the node24 runner requirement is met.

## Testing

- YAML parse validated for all three workflows
- Both heredoc-generated JSON files parse as valid JSON with `tagFormat: v${version}` preserved
- Note: release.yaml changes only exercise on the next release run