### PR TITLE
chore: remove leftover temp CI-trigger comment

### DIFF
--- a/netbox_diode_plugin/version.py
+++ b/netbox_diode_plugin/version.py
@@ -17,5 +17,3 @@ def version_display():
 def version_semver():
     """Semantic version."""
     return __version__
-
-# temp: trigger CI for workflow changes — revert before merge


### PR DESCRIPTION
Removes the temporary comment added in #191 to trigger the lint-tests workflow; it was meant to be reverted before merge.

Side benefit: this PR touches `netbox_diode_plugin/**`, so it exercises the upgraded lint-tests workflow (checkout v7, setup-python v6, coverage v3.3.1) that #191 couldn't trigger on itself.