### PR TITLE
fix: honour NumericRange bounds in harmonize_formats

### DIFF
--- a/netbox_diode_plugin/api/common.py
+++ b/netbox_diode_plugin/api/common.py
@@ -317,6 +317,36 @@ def error_from_validation_error(e, object_name):
             }
     return ChangeSetException("validation error", errors=errors)
 
+def _numeric_range_to_inclusive_pair(data):
+    """
+    Convert a NumericRange to an inclusive ``[lower, upper]`` pair.
+
+    The bounds must be honoured rather than assumed. A range read back from
+    Postgres is canonicalized to half-open ``[lower, upper)``, but a range
+    constructed in Python keeps whatever bounds it was given, and NetBox's own
+    model defaults use inclusive ones -- ``ipam.models.vlans.default_vid_ranges``
+    returns ``NumericRange(1, 4094, bounds="[]")``. Treating that as half-open
+    silently drops the top of the range, so a VLAN group created through Diode
+    ended up permitting only 1-4093 and rejected VID 4094 for the lifetime of
+    the group.
+
+    Mirrors the same normalization in NetBox's ``VLANGroup.clean()``.
+
+    Only discrete integer bounds can be shifted by one. ``NumericRange`` is an
+    alias of psycopg's generic ``Range``, so date, datetime and decimal ranges
+    match this branch too; those have no meaningful integer step, so their
+    bounds are passed through untouched rather than raising on ``date - 1``.
+    ``vid_ranges`` is currently NetBox's only range field, so nothing else
+    reaches this. A date or datetime range field would need real date
+    arithmetic here, and its exclusive bounds would be reported one step wide.
+    """
+    lower, upper = data.lower, data.upper
+    if isinstance(lower, int) and not data.lower_inc:
+        lower += 1
+    if isinstance(upper, int) and not data.upper_inc:
+        upper -= 1
+    return [lower, upper]
+
 def harmonize_formats(data):
     """Puts all data in a format that can be serialized and compared."""
     match data:
@@ -333,7 +363,7 @@ def harmonize_formats(data):
         case datetime.date():
             return data.strftime("%Y-%m-%d")
         case NumericRange():
-            return [data.lower, data.upper-1]
+            return _numeric_range_to_inclusive_pair(data)
         case netaddr.IPNetwork() | EUI() | ZoneInfo():
             return str(data)
         case _:

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_harmonize_formats.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_harmonize_formats.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - harmonize_formats Tests."""
+
+import datetime
+import decimal
+
+from django.db.backends.postgresql.psycopg_any import DateRange, DateTimeTZRange, NumericRange
+from django.test import TestCase
+
+from netbox_diode_plugin.api.common import harmonize_formats
+
+
+class HarmonizeFormatsNumericRangeTestCase(TestCase):
+    """Test NumericRange normalization to inclusive [lower, upper] pairs."""
+
+    def test_half_open_range_from_postgres(self):
+        """A range read back from Postgres is canonicalized half-open."""
+        self.assertEqual(harmonize_formats(NumericRange(1, 4095, bounds="[)")), [1, 4094])
+
+    def test_inclusive_range_from_python(self):
+        """
+        An inclusive range keeps its upper bound.
+
+        This is the shape of NetBox's own model default for
+        ``ipam.VLANGroup.vid_ranges`` (``default_vid_ranges`` returns
+        ``NumericRange(1, 4094, bounds="[]")``). The transformer applies that
+        default whenever the caller omits the field, so treating it as half-open
+        made every VLAN group created through Diode permit only 1-4093 and
+        reject VID 4094 for the lifetime of the group.
+        """
+        self.assertEqual(harmonize_formats(NumericRange(1, 4094, bounds="[]")), [1, 4094])
+
+    def test_operator_narrowed_range_is_preserved_either_way(self):
+        """A deliberately narrowed range round-trips from both bound styles."""
+        self.assertEqual(harmonize_formats(NumericRange(1, 1001, bounds="[)")), [1, 1000])
+        self.assertEqual(harmonize_formats(NumericRange(1, 1000, bounds="[]")), [1, 1000])
+
+    def test_exclusive_lower_bound(self):
+        """An exclusive lower bound is advanced to the first included value."""
+        self.assertEqual(harmonize_formats(NumericRange(0, 4095, bounds="()")), [1, 4094])
+
+    def test_unbounded_ends_do_not_raise(self):
+        """An unbounded end stays None rather than raising on None arithmetic."""
+        self.assertEqual(harmonize_formats(NumericRange(None, 4095, bounds="[)")), [None, 4094])
+        self.assertEqual(harmonize_formats(NumericRange(1, None, bounds="[)")), [1, None])
+
+    def test_non_integer_ranges_do_not_raise(self):
+        """
+        Date, datetime and decimal ranges must not blow up on integer arithmetic.
+
+        ``NumericRange`` is an alias of psycopg's generic ``Range``, so every
+        range type matches the same branch. Shifting a bound by one is only
+        meaningful for discrete integers, so other bound types are passed
+        through. ``vid_ranges`` is NetBox's only range field today, so none of
+        these are reachable, but the branch should stay total.
+        """
+        self.assertEqual(
+            harmonize_formats(DateRange(datetime.date(2020, 1, 1), datetime.date(2020, 2, 1))),
+            [datetime.date(2020, 1, 1), datetime.date(2020, 2, 1)],
+        )
+        self.assertEqual(
+            harmonize_formats(
+                DateTimeTZRange(datetime.datetime(2020, 1, 1), datetime.datetime(2020, 2, 1)),
+            ),
+            [datetime.datetime(2020, 1, 1), datetime.datetime(2020, 2, 1)],
+        )
+        self.assertEqual(
+            harmonize_formats(NumericRange(decimal.Decimal("1.5"), decimal.Decimal("9.5"))),
+            [decimal.Decimal("1.5"), decimal.Decimal("9.5")],
+        )
+
+    def test_nested_in_list_and_dict(self):
+        """Ranges are normalized through the containers the transformer emits."""
+        self.assertEqual(
+            harmonize_formats({"vid_ranges": [NumericRange(1, 4094, bounds="[]")]}),
+            {"vid_ranges": [[1, 4094]]},
+        )

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_harmonize_formats.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_harmonize_formats.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - harmonize_formats Tests."""
+
+import datetime
+import decimal
+
+from django.db.backends.postgresql.psycopg_any import DateRange, DateTimeTZRange, NumericRange
+from django.test import TestCase
+
+from netbox_diode_plugin.api.common import harmonize_formats
+
+
+class HarmonizeFormatsNumericRangeTestCase(TestCase):
+    """Test NumericRange normalization to inclusive [lower, upper] pairs."""
+
+    def test_half_open_range_from_postgres(self):
+        """A range read back from Postgres is canonicalized half-open."""
+        self.assertEqual(harmonize_formats(NumericRange(1, 4095, bounds="[)")), [1, 4094])
+
+    def test_inclusive_range_from_python(self):
+        """
+        An inclusive range keeps its upper bound.
+
+        This is the shape of NetBox's own model default for
+        ``ipam.VLANGroup.vid_ranges`` (``default_vid_ranges`` returns
+        ``NumericRange(1, 4094, bounds="[]")``). The transformer applies that
+        default whenever the caller omits the field, so treating it as half-open
+        made every VLAN group created through Diode permit only 1-4093 and
+        reject VID 4094 for the lifetime of the group.
+        """
+        self.assertEqual(harmonize_formats(NumericRange(1, 4094, bounds="[]")), [1, 4094])
+
+    def test_operator_narrowed_range_is_preserved_either_way(self):
+        """A deliberately narrowed range round-trips from both bound styles."""
+        self.assertEqual(harmonize_formats(NumericRange(1, 1001, bounds="[)")), [1, 1000])
+        self.assertEqual(harmonize_formats(NumericRange(1, 1000, bounds="[]")), [1, 1000])
+
+    def test_exclusive_lower_bound(self):
+        """An exclusive lower bound is advanced to the first included value."""
+        self.assertEqual(harmonize_formats(NumericRange(0, 4095, bounds="()")), [1, 4094])
+
+    def test_unbounded_ends_do_not_raise(self):
+        """An unbounded end stays None rather than raising on None arithmetic."""
+        self.assertEqual(harmonize_formats(NumericRange(None, 4095, bounds="[)")), [None, 4094])
+        self.assertEqual(harmonize_formats(NumericRange(1, None, bounds="[)")), [1, None])
+
+    def test_non_integer_ranges_do_not_raise(self):
+        """
+        Date, datetime and decimal ranges must not blow up on integer arithmetic.
+
+        ``NumericRange`` is an alias of psycopg's generic ``Range``, so every
+        range type matches the same branch. Shifting a bound by one is only
+        meaningful for discrete integers, so other bound types are passed
+        through. ``vid_ranges`` is NetBox's only range field today, so none of
+        these are reachable, but the branch should stay total.
+        """
+        self.assertEqual(
+            harmonize_formats(DateRange(datetime.date(2020, 1, 1), datetime.date(2020, 2, 1))),
+            [datetime.date(2020, 1, 1), datetime.date(2020, 2, 1)],
+        )
+        self.assertEqual(
+            harmonize_formats(
+                DateTimeTZRange(datetime.datetime(2020, 1, 1), datetime.datetime(2020, 2, 1)),
+            ),
+            [datetime.datetime(2020, 1, 1), datetime.datetime(2020, 2, 1)],
+        )
+        self.assertEqual(
+            harmonize_formats(NumericRange(decimal.Decimal("1.5"), decimal.Decimal("9.5"))),
+            [decimal.Decimal("1.5"), decimal.Decimal("9.5")],
+        )
+
+    def test_nested_in_list_and_dict(self):
+        """Ranges are normalized through the containers the transformer emits."""
+        self.assertEqual(
+            harmonize_formats({"vid_ranges": [NumericRange(1, 4094, bounds="[]")]}),
+            {"vid_ranges": [[1, 4094]]},
+        )

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_harmonize_formats.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_harmonize_formats.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - harmonize_formats Tests."""
+
+import datetime
+import decimal
+
+from django.db.backends.postgresql.psycopg_any import DateRange, DateTimeTZRange, NumericRange
+from django.test import TestCase
+
+from netbox_diode_plugin.api.common import harmonize_formats
+
+
+class HarmonizeFormatsNumericRangeTestCase(TestCase):
+    """Test NumericRange normalization to inclusive [lower, upper] pairs."""
+
+    def test_half_open_range_from_postgres(self):
+        """A range read back from Postgres is canonicalized half-open."""
+        self.assertEqual(harmonize_formats(NumericRange(1, 4095, bounds="[)")), [1, 4094])
+
+    def test_inclusive_range_from_python(self):
+        """
+        An inclusive range keeps its upper bound.
+
+        This is the shape of NetBox's own model default for
+        ``ipam.VLANGroup.vid_ranges`` (``default_vid_ranges`` returns
+        ``NumericRange(1, 4094, bounds="[]")``). The transformer applies that
+        default whenever the caller omits the field, so treating it as half-open
+        made every VLAN group created through Diode permit only 1-4093 and
+        reject VID 4094 for the lifetime of the group.
+        """
+        self.assertEqual(harmonize_formats(NumericRange(1, 4094, bounds="[]")), [1, 4094])
+
+    def test_operator_narrowed_range_is_preserved_either_way(self):
+        """A deliberately narrowed range round-trips from both bound styles."""
+        self.assertEqual(harmonize_formats(NumericRange(1, 1001, bounds="[)")), [1, 1000])
+        self.assertEqual(harmonize_formats(NumericRange(1, 1000, bounds="[]")), [1, 1000])
+
+    def test_exclusive_lower_bound(self):
+        """An exclusive lower bound is advanced to the first included value."""
+        self.assertEqual(harmonize_formats(NumericRange(0, 4095, bounds="()")), [1, 4094])
+
+    def test_unbounded_ends_do_not_raise(self):
+        """An unbounded end stays None rather than raising on None arithmetic."""
+        self.assertEqual(harmonize_formats(NumericRange(None, 4095, bounds="[)")), [None, 4094])
+        self.assertEqual(harmonize_formats(NumericRange(1, None, bounds="[)")), [1, None])
+
+    def test_non_integer_ranges_do_not_raise(self):
+        """
+        Date, datetime and decimal ranges must not blow up on integer arithmetic.
+
+        ``NumericRange`` is an alias of psycopg's generic ``Range``, so every
+        range type matches the same branch. Shifting a bound by one is only
+        meaningful for discrete integers, so other bound types are passed
+        through. ``vid_ranges`` is NetBox's only range field today, so none of
+        these are reachable, but the branch should stay total.
+        """
+        self.assertEqual(
+            harmonize_formats(DateRange(datetime.date(2020, 1, 1), datetime.date(2020, 2, 1))),
+            [datetime.date(2020, 1, 1), datetime.date(2020, 2, 1)],
+        )
+        self.assertEqual(
+            harmonize_formats(
+                DateTimeTZRange(datetime.datetime(2020, 1, 1), datetime.datetime(2020, 2, 1)),
+            ),
+            [datetime.datetime(2020, 1, 1), datetime.datetime(2020, 2, 1)],
+        )
+        self.assertEqual(
+            harmonize_formats(NumericRange(decimal.Decimal("1.5"), decimal.Decimal("9.5"))),
+            [decimal.Decimal("1.5"), decimal.Decimal("9.5")],
+        )
+
+    def test_nested_in_list_and_dict(self):
+        """Ranges are normalized through the containers the transformer emits."""
+        self.assertEqual(
+            harmonize_formats({"vid_ranges": [NumericRange(1, 4094, bounds="[]")]}),
+            {"vid_ranges": [[1, 4094]]},
+        )


### PR DESCRIPTION
## The bug

`harmonize_formats` assumed every `NumericRange` was in Postgres canonical half-open form:

```python
case NumericRange():
    return [data.lower, data.upper-1]
```

That holds for a range **read back from the database**, but not for one constructed in Python, which keeps whatever bounds it was given. NetBox's own model default for `ipam.VLANGroup.vid_ranges` is inclusive:

```python
def default_vid_ranges():
    return [NumericRange(VLAN_VID_MIN, VLAN_VID_MAX, bounds='[]')]   # 1..4094
```

`transformer.py:419-431` applies that default whenever the caller omits the field, then hands the entity to `harmonize_formats`:

```python
if entity.get(field_name) is None and field_info.get("default") is not None:
    default = field_info["default"]
    if callable(default):
        default = default()
    entity[field_name] = default
...
out.append(harmonize_formats(entity))
```

So `upper-1` silently dropped the top of the range. **Every VLAN group created through Diode permitted only 1-4093** and rejected VID 4094 for the lifetime of the group:

```
{"ipam.vlan":{"vid":["VID must be in ranges 1-4093 for VLANs in group <name>"]}}
```

## Evidence

NetBox's changelog for a group created through Diode records exactly what was written:

```
postchange_data.vid_ranges = [{"bounds": "[)", "lower": "1", "upper": "4094"}]
```

`bounds "[)"` with `upper` 4094 is inclusive **1-4093**. The same group created directly through the NetBox REST API gets `[[1, 4094]]`.

And `harmonize_formats` reproduces it on the model default in isolation:

| input | before | after |
|---|---|---|
| `default_vid_ranges()[0]` (`bounds='[]'`) | `[1, 4093]` ❌ | `[1, 4094]` ✅ |
| same range read back from Postgres (`bounds='[)'`) | `[1, 4094]` ✅ | `[1, 4094]` ✅ |
| operator-narrowed 1-1000 from Postgres | `[1, 1000]` ✅ | `[1, 1000]` ✅ |
| operator-narrowed 1-1000 inclusive | `[1, 999]` ❌ | `[1, 1000]` ✅ |

## The fix

Honour the bounds on both ends, mirroring the same normalization NetBox itself does in `VLANGroup.clean()`. `None` ends are passed through rather than raising on `None` arithmetic — not reachable for `vid_ranges`, which NetBox validates to 1..4094, but `harmonize_formats` is generic.

## Why the `-1` was there, and why changing it is safe

Worth addressing head-on, since the line is old and looks deliberate.

It arrived in `0d3522a` ("fix: create and fix failing tests", #87), whose lead bullet is *"handle callable defaults, defaults with non serializable values"*. That one commit added all three pieces together:

1. `if callable(default): default = default()` in `transformer.py` — which yields `NumericRange(1, 4094, bounds='[]')`
2. `out.append(harmonize_formats(entity))` — routing it through this function
3. the `case NumericRange(): return (data.lower, data.upper-1)` arm itself

So the arm was introduced **specifically to serialize that callable VLAN-group default**, and `upper-1` was the wrong normalization for that exact input. It has been wrong since introduction; this is not a deliberate decision being undone.

The reason it survived review is that `-1` *is* correct for the other input to the same function — ranges read back from Postgres, which are canonicalized half-open. One arm serves both, right for the prechange side and wrong for the default side. This PR leaves `[)` → `upper-1` untouched, so the prechange side is unchanged.

(`3d4c27ea` later touched this line, but only to change the tuple to a list.)

## Scope: creates, not updates

Verified rather than assumed, by reverting a live container to `develop` and re-testing: an existing group already at `[[1, 4094]]` is **not** narrowed by a Diode ingest on `develop`. The defect only manifests where the default is materialized and written, i.e. on create. Diffs against existing groups were already correct and stay correct.

## Other range types — checked, and one latent crash removed

`NumericRange` is an **alias of psycopg's generic `Range`** (`psycopg.types.range.Range`), so this branch catches *every* range type, not just integer ones. Behaviour of each, before and after:

| range | on `develop` | with this PR |
|---|---|---|
| `NumericRange` int, `bounds='[)'` | `[1, 4094]` ✅ | `[1, 4094]` ✅ |
| `NumericRange` int, `bounds='[]'` | `[1, 4093]` ❌ | `[1, 4094]` ✅ |
| `DateRange` | **raises `TypeError`** | `[date, date]` |
| `DateTimeTZRange` | **raises `TypeError`** | `[datetime, datetime]` |
| `NumericRange` decimal | `[1.5, 8.5]` (meaningless) | `[1.5, 9.5]` |

So the shift is restricted to integer bounds — `date - 1` is a `TypeError`, and a decimal range has no integer step. That removes a latent crash rather than introducing one; the `TypeError` is pre-existing on `develop`.

None of those are reachable today: `ipam.VLANGroup.vid_ranges` is the **only** range field in this install, verified by walking every model for range fields and `ArrayField`s of range fields with plugins loaded. Django offers six range field classes; NetBox uses one. Documented in the docstring that a real date-range field would need genuine date arithmetic here, and that its exclusive bounds would otherwise be reported one step wide.

Note the neighbouring candidate fix would have been wrong to make here: the inbound `vid_ranges` transform at `plugin_utils.py:4668` is **generated code** (`# Generated code. DO NOT EDIT.`, byte-identical to `diode-drf-extract/output/plugin_utils.py`) and would be reverted on the next extract. It is also not the defect — supplying `vid_ranges` explicitly already produces a correct `[[1, 4094]]`. The bug is on the read/normalise side, in hand-written code.

## Testing

Added `test_harmonize_formats.py` to all three version dirs (`v4.4.x`, `v4.5.x`, `v4.6.x`), matching the existing convention of byte-identical duplication for version-independent tests. It covers both bound styles, the operator-narrowed case, an exclusive lower bound, unbounded ends, and nesting inside the dict/list shapes the transformer emits. It uses `NumericRange` directly rather than importing NetBox internals, so it is version-independent.

Verified against NetBox 4.5.5:

- 5 of the 7 new tests fail on `develop` and pass with the fix; a 6th errors on `develop` (the unbounded-ends case) and the 7th covers the non-integer ranges above.
- Full v4.5.x suite: 382 tests, same 4 pre-existing failures before and after (`test_settings_*`, `test_get_diode_auth_introspect_url` — environmental, my dev container uses `host.docker.internal` where they expect `localhost`). No regressions.
- `ruff check netbox_diode_plugin` clean.
- The existing `test_generate_diff_and_apply_vlan_group_with_vid_ranges` still passes; it exercises the supply path, which is unaffected.

## End-to-end verification

Against a live NetBox 4.5.5 + diode stack with this fix loaded:

- A VLAN group created **through Diode with no `vid_ranges` sent** now gets `[[1, 4094]]`, and VID 4094 is accepted (previously `[[1, 4093]]`, rejected).
- An operator-narrowed group (`[[1, 1000]]`) is **left alone** at `[[1, 1000]]` — the point of fixing it here rather than having the agent send the field.
- Replaying the reported 432-interface payload with only the companion agent-side fix (netboxlabs/orb-agent#509): **432/432 interfaces, twice**, up from 36-49 missing.

## Context

Found while investigating missing interfaces on a 432-interface chassis. Because `bulk-plan-apply` batches plans and a failed plan takes its whole batch down, this one guaranteed-rejected VLAN per run was also costing unrelated interfaces. Fixing it upstream here avoids the alternative, which was for the agent to send `vid_ranges` itself — that would silently widen an operator's deliberately narrowed range on every discovery run, so it was rejected in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
