### PR TITLE
feat: adopt duplicate module creates and guard all-None matcher lookups

### DIFF
--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -99,12 +99,6 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 # IntegrityError fallback in _create_or_find_instance cannot catch
 # this because save() does not fail.
 #
-# The list also covers DB-constraint-backed types where find-first replaces
-# a lossy, noisy IntegrityError recovery with a real adopt-update:
-#   - dcim.module: plan-ahead topologies (plan-all-then-apply-all) emit a
-#     second CREATE for an occupied module bay; find-first adopts it and
-#     applies the payload instead of discarding it after a failed INSERT.
-#
 # The specific gaps (see _LOGICAL_MATCHERS below for the criteria):
 #   - dcim.macaddress: NetBox has no unique constraint on
 #     (mac_address, assigned_object_type, assigned_object_id).
@@ -122,6 +116,12 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 #   - virtualization.virtualmachine: NetBox does not enforce uniqueness
 #     of name when cluster is NULL.
 #   - wireless.wirelesslan: NetBox does not enforce ssid uniqueness.
+#
+# The list also covers a DB-constraint-backed type where find-first replaces
+# a lossy, noisy IntegrityError recovery with a real adopt-update:
+#   - dcim.module: plan-ahead topologies (plan-all-then-apply-all) emit a
+#     second CREATE for an occupied module bay; find-first adopts it and
+#     applies the payload instead of discarding it after a failed INSERT.
 #
 # This closes the common race (concurrent plan, sequential apply).
 # It does not close TOCTOU under truly concurrent apply across

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -470,7 +470,7 @@ class ObjectMatchCriteria:
             if isinstance(value, dict):
                 logger.warning(f"unexpected value type for fingerprinting: {value}")
                 return None
-            if field in insensitive:
+            if field in insensitive and value is not None:
                 value = value.lower()
             values.append(value)
 
@@ -556,14 +556,13 @@ class ObjectMatchCriteria:
 
     def _build_expressions_queryset(self, data) -> models.QuerySet:
         """Builds a queryset for the constraint with the given data."""
-        data = self._prepare_data(data)
-
-        ref_names = set()
-        for expr in self.expressions:
-            e = expr.get_expression_for_validation() if hasattr(expr, "get_expression_for_validation") else expr
-            ref_names |= _get_refs(e)
-        if ref_names and all(data.get(r) is None for r in ref_names):
+        # Same all-None skip as the fields path, using the cached ref set;
+        # raw data is checked so both guards read identical inputs.
+        refs = self._get_refs()
+        if refs and all(data.get(r) is None for r in refs):
             return None
+
+        data = self._prepare_data(data)
 
         replacements = {
             F(field): Value(value) if isinstance(value, str | int | float | bool) else value

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -474,6 +474,9 @@ class ObjectMatchCriteria:
                 value = value.lower()
             values.append(value)
 
+        if values and all(v is None for v in values):
+            return None
+
         return hash((self.model_class.__name__, self.name, tuple(values)))
 
     def _check_condition(self, data) -> bool:
@@ -526,6 +529,13 @@ class ObjectMatchCriteria:
         if not self._check_condition(data):
             return None
 
+        # A lookup whose referenced values are ALL null can only "match" via
+        # IS NULL on every field, binding an arbitrary row (e.g. a null
+        # asset_tag adopting an unrelated module). Partial nulls keep the
+        # long-standing clear-FK dedupe: Django renders =None as IS NULL.
+        if all(data.get(field_name) is None for field_name in self.fields):
+            return None
+
         data = self._prepare_data(data)
         lookup_kwargs = {}
         for field_name in self.fields:
@@ -547,6 +557,14 @@ class ObjectMatchCriteria:
     def _build_expressions_queryset(self, data) -> models.QuerySet:
         """Builds a queryset for the constraint with the given data."""
         data = self._prepare_data(data)
+
+        ref_names = set()
+        for expr in self.expressions:
+            e = expr.get_expression_for_validation() if hasattr(expr, "get_expression_for_validation") else expr
+            ref_names |= _get_refs(e)
+        if ref_names and all(data.get(r) is None for r in ref_names):
+            return None
+
         replacements = {
             F(field): Value(value) if isinstance(value, str | int | float | bool) else value
             for field, value in data.items()
@@ -582,9 +600,11 @@ class ObjectMatchCriteria:
                 if field.is_relation and hasattr(field, "related_model") and field.related_model == ContentType:
                     # Handle ManyToMany fields (list of object types) and ForeignKey fields (single object type)
                     if isinstance(value, list):
-                        prepared[field_name] = [content_type_id(v) for v in value]
+                        prepared[field_name] = [
+                            content_type_id(v) if v is not None else None for v in value
+                        ]
                     else:
-                        prepared[field_name] = content_type_id(value)
+                        prepared[field_name] = content_type_id(value) if value is not None else None
                 else:
                     prepared[field_name] = value
 

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -99,6 +99,12 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 # IntegrityError fallback in _create_or_find_instance cannot catch
 # this because save() does not fail.
 #
+# The list also covers DB-constraint-backed types where find-first replaces
+# a lossy, noisy IntegrityError recovery with a real adopt-update:
+#   - dcim.module: plan-ahead topologies (plan-all-then-apply-all) emit a
+#     second CREATE for an occupied module bay; find-first adopts it and
+#     applies the payload instead of discarding it after a failed INSERT.
+#
 # The specific gaps (see _LOGICAL_MATCHERS below for the criteria):
 #   - dcim.macaddress: NetBox has no unique constraint on
 #     (mac_address, assigned_object_type, assigned_object_id).
@@ -124,6 +130,7 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 _REQUIRES_PRE_SAVE_MATCH = frozenset({
     "dcim.cable",
     "dcim.macaddress",
+    "dcim.module",
     "dcim.modulebay",
     "ipam.vlan",
     "ipam.vlangroup",

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_matcher_none_guard.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_matcher_none_guard.py
@@ -1,0 +1,138 @@
+"""Unit tests for the all-None matcher guard and None-safe data preparation."""
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    MACAddress,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+    Rack,
+    Site,
+    VirtualChassis,
+)
+from django.test import TestCase
+
+from netbox_diode_plugin.api.matcher import find_existing_object, fingerprints, get_model_matchers
+
+
+def _matcher(model_class, name, predicate=None):
+    """
+    Return the matcher registered under the given name.
+
+    Some object types register more than one matcher under the same
+    name (e.g. dcim.macaddress's parented vs. isnull variants both use
+    "logical_mac_address_within_parent"). Pass a predicate to select
+    among same-named matches; otherwise the first match wins.
+    """
+    matches = [m for m in get_model_matchers(model_class) if getattr(m, "name", None) == name]
+    if predicate is not None:
+        matches = [m for m in matches if predicate(m)]
+    if not matches:
+        raise AssertionError(f"matcher {name} not found")
+    return matches[0]
+
+
+def _is_isnull_true_variant(m):
+    """True if the matcher's condition is a single field__isnull=True check."""
+    condition = getattr(m, "condition", None)
+    children = getattr(condition, "children", None)
+    if not children:
+        return False
+    return any(str(k).endswith("__isnull") and v is True for k, v in children)
+
+
+class AllNoneGuardTests(TestCase):
+    """All-None lookups must skip the matcher; partial nulls keep matching."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed rows that today's NULL-lookup hijacks would wrongly bind."""
+        cls.site = Site.objects.create(name="ng-site", slug="ng-site")
+        mfr = Manufacturer.objects.create(name="ng-mfr", slug="ng-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="ng-dt", slug="ng-dt")
+        role = DeviceRole.objects.create(name="ng-role", slug="ng-role")
+        cls.dev = Device.objects.create(name="ng-dev", site=cls.site, device_type=cls.dt, role=role)
+        cls.mt = ModuleType.objects.create(manufacturer=mfr, model="ng-mt")
+        bay = ModuleBay.objects.create(device=cls.dev, name="ng-bay1")
+        # a module with NULL asset_tag — the row the unguarded matcher hijacks
+        cls.module = Module.objects.create(device=cls.dev, module_bay=bay, module_type=cls.mt)
+        # a masterless VC named differently from any payload below
+        cls.vc = VirtualChassis.objects.create(name="ng-vc-existing")
+        # a rack with NULL location — the multi-field clear-FK dedupe case
+        cls.rack = Rack.objects.create(name="ng-rack", site=cls.site)
+
+    def test_single_field_null_lookup_skips_matcher(self):
+        """asset_tag: None must not bind the NULL-asset_tag module."""
+        m = _matcher(Module, "unique_asset_tag")
+        self.assertIsNone(m.build_queryset({"asset_tag": None}))
+        self.assertIsNone(m.fingerprint({"asset_tag": None}))
+
+    def test_unique_master_null_lookup_skips_matcher(self):
+        """master: None must not bind an arbitrary masterless VC (any name)."""
+        found = find_existing_object(
+            {"name": "ng-vc-DIFFERENT", "master": None}, "dcim.virtualchassis"
+        )
+        self.assertIsNone(found)
+
+    def test_partial_null_multi_field_still_matches(self):
+        """Rack (location: None, name) keeps today's clear-FK dedupe."""
+        found = find_existing_object(
+            {"name": "ng-rack", "site": self.site.pk, "location": None}, "dcim.rack"
+        )
+        self.assertEqual(found, self.rack)
+
+    def test_macaddress_isnull_variant_matches_without_crash(self):
+        """Explicit-null assignment matches by MAC via the isnull variant."""
+        mac = MACAddress.objects.create(mac_address="00:11:22:33:44:55")
+        found = find_existing_object(
+            {
+                "mac_address": "00:11:22:33:44:55",
+                "assigned_object_type": None,
+                "assigned_object_id": None,
+            },
+            "dcim.macaddress",
+        )
+        self.assertEqual(found, mac)
+
+    def test_condition_scoped_null_matchers_survive(self):
+        """VM name/cluster-null style matchers still work under the guard."""
+        from virtualization.models import VirtualMachine
+        vm = VirtualMachine.objects.create(name="ng-vm")
+        found = find_existing_object({"name": "ng-vm"}, "virtualization.virtualmachine")
+        self.assertEqual(found, vm)
+
+    def test_gfk_null_payload_does_not_raise(self):
+        """Cleared generic refs must not 500 the matcher loop."""
+        found = find_existing_object(
+            {"name": "ng-cluster-x", "scope_type": None, "scope_id": None},
+            "virtualization.cluster",
+        )
+        self.assertIsNone(found)  # no such cluster; the point is: no exception
+
+    def test_none_keyed_fingerprint_fusion_removed(self):
+        """Two null-asset_tag modules in different bays share NO fingerprint."""
+        a = {"device": self.dev.pk, "module_bay": 1, "module_type": self.mt.pk, "asset_tag": None}
+        b = {"device": self.dev.pk, "module_bay": 2, "module_type": self.mt.pk, "asset_tag": None}
+        shared = set(fingerprints(a, "dcim.module")) & set(fingerprints(b, "dcim.module"))
+        self.assertEqual(shared, set(), shared)
+
+    def test_partial_null_fingerprint_preserved(self):
+        """A partial-null fingerprint must survive (all-None, not any-None, skips)."""
+        m = _matcher(
+            MACAddress,
+            "logical_mac_address_within_parent",
+            predicate=_is_isnull_true_variant,
+        )
+        fp = m.fingerprint({
+            "mac_address": "00:11:22:33:44:66",
+            "assigned_object_type": None,
+            "assigned_object_id": None,
+        })
+        self.assertIsNotNone(fp)
+
+    def test_insensitive_ref_none_fingerprint_does_not_raise(self):
+        """A None value in a case-insensitive ref must not crash fingerprinting."""
+        fps = fingerprints({"name": None, "site": self.site.pk, "tenant": None}, "dcim.device")
+        self.assertIsInstance(fps, list)

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_module_adoption.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_module_adoption.py
@@ -1,0 +1,163 @@
+"""E2E: duplicate module creates adopt the existing module at apply time."""
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class ModuleAdoptionE2ETests(APITestCase):
+    """Plan-ahead duplicate module CREATEs must adopt, not discard or crash."""
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.site = Site.objects.create(name="ma-site", slug="ma-site")
+        mfr = Manufacturer.objects.create(name="ma-mfr", slug="ma-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="ma-dt", slug="ma-dt")
+        self.role = DeviceRole.objects.create(name="ma-role", slug="ma-role")
+        self.mt = ModuleType.objects.create(manufacturer=mfr, model="ma-linecard")
+        self.dev = Device.objects.create(
+            name="ma-rtr", site=self.site, device_type=self.dt, role=self.role
+        )
+        self.bay = ModuleBay.objects.create(device=self.dev, name="ma-bay1")
+
+    def _dev_ref(self):
+        return {"name": "ma-rtr", "site": {"name": "ma-site"}}
+
+    def _module_entity(self, extra=None):
+        entity = {
+            "device": self._dev_ref(),
+            "module_bay": {"name": "ma-bay1", "device": self._dev_ref()},
+            "module_type": {"manufacturer": {"name": "ma-mfr"}, "model": "ma-linecard"},
+            "status": "active",
+        }
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "dcim.module", "entity": {"module": entity}}
+
+    def _subbay_entity(self):
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "ma-sub1",
+            "module": {
+                "device": self._dev_ref(),
+                "module_bay": {"name": "ma-bay1", "device": self._dev_ref()},
+                "module_type": {"manufacturer": {"name": "ma-mfr"}, "model": "ma-linecard"},
+            },
+        }}}
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIn("change_set", r.json(), r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def test_plan_ahead_duplicate_adopts_and_applies_payload(self):
+        """Both changesets planned before either apply: adopt, don't discard."""
+        cs_a = self._diff(self._module_entity())
+        # round B diverges on serial — the load-bearing lossiness probe
+        cs_b = self._diff(self._subbay_entity())
+        cs_a2 = self._diff(self._module_entity({"serial": "SER-B99"}))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+        self._apply(cs_a2)
+
+        modules = Module.objects.filter(module_bay=self.bay)
+        self.assertEqual(modules.count(), 1)
+        module = modules.first()
+        self.assertEqual(module.serial, "SER-B99")  # applied, not discarded
+        sub = ModuleBay.objects.get(name="ma-sub1")
+        self.assertEqual(sub.module_id, module.pk)  # nesting restored
+
+        # converged: re-plan of both entities is empty
+        for payload in (self._module_entity({"serial": "SER-B99"}), self._subbay_entity()):
+            cs = self._diff(payload)
+            non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+            self.assertEqual(non_noop, [], non_noop)
+
+    def test_null_asset_tag_create_does_not_relocate(self):
+        """The hazard pin: asset_tag null must not adopt an unrelated module."""
+        other_dev = Device.objects.create(
+            name="ma-other", site=self.site, device_type=self.dt, role=self.role
+        )
+        other_bay = ModuleBay.objects.create(device=other_dev, name="ma-obay")
+        other_module = Module.objects.create(
+            device=other_dev, module_bay=other_bay, module_type=self.mt
+        )
+        cs = self._diff(self._module_entity({"asset_tag": None}))
+        self._apply(cs)
+        other_module.refresh_from_db()
+        self.assertEqual(other_module.device_id, other_dev.pk)  # untouched
+        self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)
+
+    def test_occupied_bay_update_last_writer_wins(self):
+        """A planned UPDATE on an occupied bay applies last-writer-wins module_type."""
+        Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
+        mt2 = ModuleType.objects.create(
+            manufacturer=Manufacturer.objects.get(name="ma-mfr"), model="ma-linecard-v2"
+        )
+        payload = self._module_entity()
+        payload["entity"]["module"]["module_type"]["model"] = "ma-linecard-v2"
+        cs = self._diff(payload)
+        self._apply(cs)
+        modules = Module.objects.filter(module_bay=self.bay)
+        self.assertEqual(modules.count(), 1)
+        self.assertEqual(modules.first().module_type_id, mt2.pk)  # last writer wins
+
+    def test_invalid_adoption_payload_aborts_changeset_atomically(self):
+        """
+        A 400 against the adopted instance rolls back sibling changes.
+
+        Hand-crafted changeset (deterministic): a device/bay-mismatched module
+        CREATE plus an innocent sibling site CREATE. Today the mismatch is
+        swallowed (ValidationError fallback returns the existing module) and
+        the changeset succeeds with the sibling applied; with adoption the
+        mismatch surfaces as 400 and the whole changeset rolls back.
+        """
+        Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
+        wrong_dev = Device.objects.create(
+            name="ma-wrong", site=self.site, device_type=self.dt, role=self.role
+        )
+        cs = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {"id": str(uuid.uuid4()), "change_type": "create", "object_type": "dcim.site",
+                 "ref_id": "s1", "data": {"name": "ma-sibling-site", "slug": "ma-sibling-site"}},
+                {"id": str(uuid.uuid4()), "change_type": "create", "object_type": "dcim.module",
+                 "ref_id": "m1", "data": {"device": wrong_dev.pk, "module_bay": self.bay.pk,
+                                          "module_type": self.mt.pk, "status": "active"}},
+            ],
+        }
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertFalse(Site.objects.filter(name="ma-sibling-site").exists())  # atomic abort
+
+    def test_miss_then_create_still_works(self):
+        """Find-first miss on an empty bay falls through to a normal create."""
+        cs = self._diff(self._module_entity())
+        self._apply(cs)
+        self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_matcher_none_guard.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_matcher_none_guard.py
@@ -1,0 +1,138 @@
+"""Unit tests for the all-None matcher guard and None-safe data preparation."""
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    MACAddress,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+    Rack,
+    Site,
+    VirtualChassis,
+)
+from django.test import TestCase
+
+from netbox_diode_plugin.api.matcher import find_existing_object, fingerprints, get_model_matchers
+
+
+def _matcher(model_class, name, predicate=None):
+    """
+    Return the matcher registered under the given name.
+
+    Some object types register more than one matcher under the same
+    name (e.g. dcim.macaddress's parented vs. isnull variants both use
+    "logical_mac_address_within_parent"). Pass a predicate to select
+    among same-named matches; otherwise the first match wins.
+    """
+    matches = [m for m in get_model_matchers(model_class) if getattr(m, "name", None) == name]
+    if predicate is not None:
+        matches = [m for m in matches if predicate(m)]
+    if not matches:
+        raise AssertionError(f"matcher {name} not found")
+    return matches[0]
+
+
+def _is_isnull_true_variant(m):
+    """True if the matcher's condition is a single field__isnull=True check."""
+    condition = getattr(m, "condition", None)
+    children = getattr(condition, "children", None)
+    if not children:
+        return False
+    return any(str(k).endswith("__isnull") and v is True for k, v in children)
+
+
+class AllNoneGuardTests(TestCase):
+    """All-None lookups must skip the matcher; partial nulls keep matching."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed rows that today's NULL-lookup hijacks would wrongly bind."""
+        cls.site = Site.objects.create(name="ng-site", slug="ng-site")
+        mfr = Manufacturer.objects.create(name="ng-mfr", slug="ng-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="ng-dt", slug="ng-dt")
+        role = DeviceRole.objects.create(name="ng-role", slug="ng-role")
+        cls.dev = Device.objects.create(name="ng-dev", site=cls.site, device_type=cls.dt, role=role)
+        cls.mt = ModuleType.objects.create(manufacturer=mfr, model="ng-mt")
+        bay = ModuleBay.objects.create(device=cls.dev, name="ng-bay1")
+        # a module with NULL asset_tag — the row the unguarded matcher hijacks
+        cls.module = Module.objects.create(device=cls.dev, module_bay=bay, module_type=cls.mt)
+        # a masterless VC named differently from any payload below
+        cls.vc = VirtualChassis.objects.create(name="ng-vc-existing")
+        # a rack with NULL location — the multi-field clear-FK dedupe case
+        cls.rack = Rack.objects.create(name="ng-rack", site=cls.site)
+
+    def test_single_field_null_lookup_skips_matcher(self):
+        """asset_tag: None must not bind the NULL-asset_tag module."""
+        m = _matcher(Module, "unique_asset_tag")
+        self.assertIsNone(m.build_queryset({"asset_tag": None}))
+        self.assertIsNone(m.fingerprint({"asset_tag": None}))
+
+    def test_unique_master_null_lookup_skips_matcher(self):
+        """master: None must not bind an arbitrary masterless VC (any name)."""
+        found = find_existing_object(
+            {"name": "ng-vc-DIFFERENT", "master": None}, "dcim.virtualchassis"
+        )
+        self.assertIsNone(found)
+
+    def test_partial_null_multi_field_still_matches(self):
+        """Rack (location: None, name) keeps today's clear-FK dedupe."""
+        found = find_existing_object(
+            {"name": "ng-rack", "site": self.site.pk, "location": None}, "dcim.rack"
+        )
+        self.assertEqual(found, self.rack)
+
+    def test_macaddress_isnull_variant_matches_without_crash(self):
+        """Explicit-null assignment matches by MAC via the isnull variant."""
+        mac = MACAddress.objects.create(mac_address="00:11:22:33:44:55")
+        found = find_existing_object(
+            {
+                "mac_address": "00:11:22:33:44:55",
+                "assigned_object_type": None,
+                "assigned_object_id": None,
+            },
+            "dcim.macaddress",
+        )
+        self.assertEqual(found, mac)
+
+    def test_condition_scoped_null_matchers_survive(self):
+        """VM name/cluster-null style matchers still work under the guard."""
+        from virtualization.models import VirtualMachine
+        vm = VirtualMachine.objects.create(name="ng-vm")
+        found = find_existing_object({"name": "ng-vm"}, "virtualization.virtualmachine")
+        self.assertEqual(found, vm)
+
+    def test_gfk_null_payload_does_not_raise(self):
+        """Cleared generic refs must not 500 the matcher loop."""
+        found = find_existing_object(
+            {"name": "ng-cluster-x", "scope_type": None, "scope_id": None},
+            "virtualization.cluster",
+        )
+        self.assertIsNone(found)  # no such cluster; the point is: no exception
+
+    def test_none_keyed_fingerprint_fusion_removed(self):
+        """Two null-asset_tag modules in different bays share NO fingerprint."""
+        a = {"device": self.dev.pk, "module_bay": 1, "module_type": self.mt.pk, "asset_tag": None}
+        b = {"device": self.dev.pk, "module_bay": 2, "module_type": self.mt.pk, "asset_tag": None}
+        shared = set(fingerprints(a, "dcim.module")) & set(fingerprints(b, "dcim.module"))
+        self.assertEqual(shared, set(), shared)
+
+    def test_partial_null_fingerprint_preserved(self):
+        """A partial-null fingerprint must survive (all-None, not any-None, skips)."""
+        m = _matcher(
+            MACAddress,
+            "logical_mac_address_within_parent",
+            predicate=_is_isnull_true_variant,
+        )
+        fp = m.fingerprint({
+            "mac_address": "00:11:22:33:44:66",
+            "assigned_object_type": None,
+            "assigned_object_id": None,
+        })
+        self.assertIsNotNone(fp)
+
+    def test_insensitive_ref_none_fingerprint_does_not_raise(self):
+        """A None value in a case-insensitive ref must not crash fingerprinting."""
+        fps = fingerprints({"name": None, "site": self.site.pk, "tenant": None}, "dcim.device")
+        self.assertIsInstance(fps, list)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_module_adoption.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_module_adoption.py
@@ -1,0 +1,163 @@
+"""E2E: duplicate module creates adopt the existing module at apply time."""
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class ModuleAdoptionE2ETests(APITestCase):
+    """Plan-ahead duplicate module CREATEs must adopt, not discard or crash."""
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.site = Site.objects.create(name="ma-site", slug="ma-site")
+        mfr = Manufacturer.objects.create(name="ma-mfr", slug="ma-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="ma-dt", slug="ma-dt")
+        self.role = DeviceRole.objects.create(name="ma-role", slug="ma-role")
+        self.mt = ModuleType.objects.create(manufacturer=mfr, model="ma-linecard")
+        self.dev = Device.objects.create(
+            name="ma-rtr", site=self.site, device_type=self.dt, role=self.role
+        )
+        self.bay = ModuleBay.objects.create(device=self.dev, name="ma-bay1")
+
+    def _dev_ref(self):
+        return {"name": "ma-rtr", "site": {"name": "ma-site"}}
+
+    def _module_entity(self, extra=None):
+        entity = {
+            "device": self._dev_ref(),
+            "module_bay": {"name": "ma-bay1", "device": self._dev_ref()},
+            "module_type": {"manufacturer": {"name": "ma-mfr"}, "model": "ma-linecard"},
+            "status": "active",
+        }
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "dcim.module", "entity": {"module": entity}}
+
+    def _subbay_entity(self):
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "ma-sub1",
+            "module": {
+                "device": self._dev_ref(),
+                "module_bay": {"name": "ma-bay1", "device": self._dev_ref()},
+                "module_type": {"manufacturer": {"name": "ma-mfr"}, "model": "ma-linecard"},
+            },
+        }}}
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIn("change_set", r.json(), r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def test_plan_ahead_duplicate_adopts_and_applies_payload(self):
+        """Both changesets planned before either apply: adopt, don't discard."""
+        cs_a = self._diff(self._module_entity())
+        # round B diverges on serial — the load-bearing lossiness probe
+        cs_b = self._diff(self._subbay_entity())
+        cs_a2 = self._diff(self._module_entity({"serial": "SER-B99"}))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+        self._apply(cs_a2)
+
+        modules = Module.objects.filter(module_bay=self.bay)
+        self.assertEqual(modules.count(), 1)
+        module = modules.first()
+        self.assertEqual(module.serial, "SER-B99")  # applied, not discarded
+        sub = ModuleBay.objects.get(name="ma-sub1")
+        self.assertEqual(sub.module_id, module.pk)  # nesting restored
+
+        # converged: re-plan of both entities is empty
+        for payload in (self._module_entity({"serial": "SER-B99"}), self._subbay_entity()):
+            cs = self._diff(payload)
+            non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+            self.assertEqual(non_noop, [], non_noop)
+
+    def test_null_asset_tag_create_does_not_relocate(self):
+        """The hazard pin: asset_tag null must not adopt an unrelated module."""
+        other_dev = Device.objects.create(
+            name="ma-other", site=self.site, device_type=self.dt, role=self.role
+        )
+        other_bay = ModuleBay.objects.create(device=other_dev, name="ma-obay")
+        other_module = Module.objects.create(
+            device=other_dev, module_bay=other_bay, module_type=self.mt
+        )
+        cs = self._diff(self._module_entity({"asset_tag": None}))
+        self._apply(cs)
+        other_module.refresh_from_db()
+        self.assertEqual(other_module.device_id, other_dev.pk)  # untouched
+        self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)
+
+    def test_occupied_bay_update_last_writer_wins(self):
+        """A planned UPDATE on an occupied bay applies last-writer-wins module_type."""
+        Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
+        mt2 = ModuleType.objects.create(
+            manufacturer=Manufacturer.objects.get(name="ma-mfr"), model="ma-linecard-v2"
+        )
+        payload = self._module_entity()
+        payload["entity"]["module"]["module_type"]["model"] = "ma-linecard-v2"
+        cs = self._diff(payload)
+        self._apply(cs)
+        modules = Module.objects.filter(module_bay=self.bay)
+        self.assertEqual(modules.count(), 1)
+        self.assertEqual(modules.first().module_type_id, mt2.pk)  # last writer wins
+
+    def test_invalid_adoption_payload_aborts_changeset_atomically(self):
+        """
+        A 400 against the adopted instance rolls back sibling changes.
+
+        Hand-crafted changeset (deterministic): a device/bay-mismatched module
+        CREATE plus an innocent sibling site CREATE. Today the mismatch is
+        swallowed (ValidationError fallback returns the existing module) and
+        the changeset succeeds with the sibling applied; with adoption the
+        mismatch surfaces as 400 and the whole changeset rolls back.
+        """
+        Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
+        wrong_dev = Device.objects.create(
+            name="ma-wrong", site=self.site, device_type=self.dt, role=self.role
+        )
+        cs = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {"id": str(uuid.uuid4()), "change_type": "create", "object_type": "dcim.site",
+                 "ref_id": "s1", "data": {"name": "ma-sibling-site", "slug": "ma-sibling-site"}},
+                {"id": str(uuid.uuid4()), "change_type": "create", "object_type": "dcim.module",
+                 "ref_id": "m1", "data": {"device": wrong_dev.pk, "module_bay": self.bay.pk,
+                                          "module_type": self.mt.pk, "status": "active"}},
+            ],
+        }
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertFalse(Site.objects.filter(name="ma-sibling-site").exists())  # atomic abort
+
+    def test_miss_then_create_still_works(self):
+        """Find-first miss on an empty bay falls through to a normal create."""
+        cs = self._diff(self._module_entity())
+        self._apply(cs)
+        self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_matcher_none_guard.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_matcher_none_guard.py
@@ -1,0 +1,101 @@
+"""Unit tests for the all-None matcher guard and None-safe data preparation."""
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Location,
+    MACAddress,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+    Rack,
+    Site,
+    VirtualChassis,
+)
+from django.test import TestCase
+
+from netbox_diode_plugin.api.matcher import find_existing_object, fingerprints, get_model_matchers
+
+
+def _matcher(model_class, name):
+    for m in get_model_matchers(model_class):
+        if getattr(m, "name", None) == name:
+            return m
+    raise AssertionError(f"matcher {name} not found")
+
+
+class AllNoneGuardTests(TestCase):
+    """All-None lookups must skip the matcher; partial nulls keep matching."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed rows that today's NULL-lookup hijacks would wrongly bind."""
+        cls.site = Site.objects.create(name="ng-site", slug="ng-site")
+        mfr = Manufacturer.objects.create(name="ng-mfr", slug="ng-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="ng-dt", slug="ng-dt")
+        role = DeviceRole.objects.create(name="ng-role", slug="ng-role")
+        cls.dev = Device.objects.create(name="ng-dev", site=cls.site, device_type=cls.dt, role=role)
+        cls.mt = ModuleType.objects.create(manufacturer=mfr, model="ng-mt")
+        bay = ModuleBay.objects.create(device=cls.dev, name="ng-bay1")
+        # a module with NULL asset_tag — the row the unguarded matcher hijacks
+        cls.module = Module.objects.create(device=cls.dev, module_bay=bay, module_type=cls.mt)
+        # a masterless VC named differently from any payload below
+        cls.vc = VirtualChassis.objects.create(name="ng-vc-existing")
+        # a rack with NULL location — the multi-field clear-FK dedupe case
+        cls.rack = Rack.objects.create(name="ng-rack", site=cls.site)
+
+    def test_single_field_null_lookup_skips_matcher(self):
+        """asset_tag: None must not bind the NULL-asset_tag module."""
+        m = _matcher(Module, "unique_asset_tag")
+        self.assertIsNone(m.build_queryset({"asset_tag": None}))
+        self.assertIsNone(m.fingerprint({"asset_tag": None}))
+
+    def test_unique_master_null_lookup_skips_matcher(self):
+        """master: None must not bind an arbitrary masterless VC (any name)."""
+        found = find_existing_object(
+            {"name": "ng-vc-DIFFERENT", "master": None}, "dcim.virtualchassis"
+        )
+        self.assertIsNone(found)
+
+    def test_partial_null_multi_field_still_matches(self):
+        """Rack (location: None, name) keeps today's clear-FK dedupe."""
+        found = find_existing_object(
+            {"name": "ng-rack", "site": self.site.pk, "location": None}, "dcim.rack"
+        )
+        self.assertEqual(found, self.rack)
+
+    def test_macaddress_isnull_variant_matches_without_crash(self):
+        """Explicit-null assignment matches by MAC via the isnull variant."""
+        mac = MACAddress.objects.create(mac_address="00:11:22:33:44:55")
+        found = find_existing_object(
+            {
+                "mac_address": "00:11:22:33:44:55",
+                "assigned_object_type": None,
+                "assigned_object_id": None,
+            },
+            "dcim.macaddress",
+        )
+        self.assertEqual(found, mac)
+
+    def test_condition_scoped_null_matchers_survive(self):
+        """VM name/cluster-null style matchers still work under the guard."""
+        from virtualization.models import VirtualMachine
+        vm = VirtualMachine.objects.create(name="ng-vm")
+        found = find_existing_object({"name": "ng-vm"}, "virtualization.virtualmachine")
+        self.assertEqual(found, vm)
+
+    def test_gfk_null_payload_does_not_raise(self):
+        """Cleared generic refs must not 500 the matcher loop."""
+        found = find_existing_object(
+            {"name": "ng-cluster-x", "scope_type": None, "scope_id": None},
+            "virtualization.cluster",
+        )
+        self.assertIsNone(found)  # no such cluster; the point is: no exception
+
+    def test_none_keyed_fingerprint_fusion_removed(self):
+        """Two null-asset_tag modules in different bays share NO fingerprint."""
+        a = {"device": self.dev.pk, "module_bay": 1, "module_type": self.mt.pk, "asset_tag": None}
+        b = {"device": self.dev.pk, "module_bay": 2, "module_type": self.mt.pk, "asset_tag": None}
+        shared = set(fingerprints(a, "dcim.module")) & set(fingerprints(b, "dcim.module"))
+        self.assertEqual(shared, set(), shared)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_matcher_none_guard.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_matcher_none_guard.py
@@ -3,7 +3,6 @@ from dcim.models import (
     Device,
     DeviceRole,
     DeviceType,
-    Location,
     MACAddress,
     Manufacturer,
     Module,
@@ -18,11 +17,30 @@ from django.test import TestCase
 from netbox_diode_plugin.api.matcher import find_existing_object, fingerprints, get_model_matchers
 
 
-def _matcher(model_class, name):
-    for m in get_model_matchers(model_class):
-        if getattr(m, "name", None) == name:
-            return m
-    raise AssertionError(f"matcher {name} not found")
+def _matcher(model_class, name, predicate=None):
+    """
+    Return the matcher registered under the given name.
+
+    Some object types register more than one matcher under the same
+    name (e.g. dcim.macaddress's parented vs. isnull variants both use
+    "logical_mac_address_within_parent"). Pass a predicate to select
+    among same-named matches; otherwise the first match wins.
+    """
+    matches = [m for m in get_model_matchers(model_class) if getattr(m, "name", None) == name]
+    if predicate is not None:
+        matches = [m for m in matches if predicate(m)]
+    if not matches:
+        raise AssertionError(f"matcher {name} not found")
+    return matches[0]
+
+
+def _is_isnull_true_variant(m):
+    """True if the matcher's condition is a single field__isnull=True check."""
+    condition = getattr(m, "condition", None)
+    children = getattr(condition, "children", None)
+    if not children:
+        return False
+    return any(str(k).endswith("__isnull") and v is True for k, v in children)
 
 
 class AllNoneGuardTests(TestCase):
@@ -99,3 +117,22 @@ class AllNoneGuardTests(TestCase):
         b = {"device": self.dev.pk, "module_bay": 2, "module_type": self.mt.pk, "asset_tag": None}
         shared = set(fingerprints(a, "dcim.module")) & set(fingerprints(b, "dcim.module"))
         self.assertEqual(shared, set(), shared)
+
+    def test_partial_null_fingerprint_preserved(self):
+        """A partial-null fingerprint must survive (all-None, not any-None, skips)."""
+        m = _matcher(
+            MACAddress,
+            "logical_mac_address_within_parent",
+            predicate=_is_isnull_true_variant,
+        )
+        fp = m.fingerprint({
+            "mac_address": "00:11:22:33:44:66",
+            "assigned_object_type": None,
+            "assigned_object_id": None,
+        })
+        self.assertIsNotNone(fp)
+
+    def test_insensitive_ref_none_fingerprint_does_not_raise(self):
+        """A None value in a case-insensitive ref must not crash fingerprinting."""
+        fps = fingerprints({"name": None, "site": self.site.pk, "tenant": None}, "dcim.device")
+        self.assertIsInstance(fps, list)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_module_adoption.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_module_adoption.py
@@ -1,4 +1,5 @@
 """E2E: duplicate module creates adopt the existing module at apply time."""
+import uuid
 from types import SimpleNamespace
 from unittest import mock
 
@@ -66,6 +67,7 @@ class ModuleAdoptionE2ETests(APITestCase):
     def _diff(self, payload):
         r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
         self.assertEqual(r.status_code, 200, r.content)
+        self.assertIn("change_set", r.json(), r.content)
         return r.json().get("change_set", {})
 
     def _apply(self, cs, expect=200):
@@ -112,14 +114,11 @@ class ModuleAdoptionE2ETests(APITestCase):
         self.assertEqual(other_module.device_id, other_dev.pk)  # untouched
         self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)
 
-    def test_occupied_bay_adopts_last_writer_wins_children_unchanged(self):
-        """Occupied-bay CREATE adopt-updates incl. module_type; children stay."""
+    def test_occupied_bay_update_last_writer_wins(self):
+        """A planned UPDATE on an occupied bay applies last-writer-wins module_type."""
         Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
         mt2 = ModuleType.objects.create(
             manufacturer=Manufacturer.objects.get(name="ma-mfr"), model="ma-linecard-v2"
-        )
-        children_before = set(
-            ModuleBay.objects.filter(device=self.dev).values_list("pk", flat=True)
         )
         payload = self._module_entity()
         payload["entity"]["module"]["module_type"]["model"] = "ma-linecard-v2"
@@ -128,10 +127,6 @@ class ModuleAdoptionE2ETests(APITestCase):
         modules = Module.objects.filter(module_bay=self.bay)
         self.assertEqual(modules.count(), 1)
         self.assertEqual(modules.first().module_type_id, mt2.pk)  # last writer wins
-        children_after = set(
-            ModuleBay.objects.filter(device=self.dev).values_list("pk", flat=True)
-        )
-        self.assertEqual(children_before, children_after)  # no re-instantiation
 
     def test_invalid_adoption_payload_aborts_changeset_atomically(self):
         """
@@ -143,17 +138,16 @@ class ModuleAdoptionE2ETests(APITestCase):
         the changeset succeeds with the sibling applied; with adoption the
         mismatch surfaces as 400 and the whole changeset rolls back.
         """
-        import uuid as _uuid
         Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
         wrong_dev = Device.objects.create(
             name="ma-wrong", site=self.site, device_type=self.dt, role=self.role
         )
         cs = {
-            "id": str(_uuid.uuid4()),
+            "id": str(uuid.uuid4()),
             "changes": [
-                {"id": str(_uuid.uuid4()), "change_type": "create", "object_type": "dcim.site",
+                {"id": str(uuid.uuid4()), "change_type": "create", "object_type": "dcim.site",
                  "ref_id": "s1", "data": {"name": "ma-sibling-site", "slug": "ma-sibling-site"}},
-                {"id": str(_uuid.uuid4()), "change_type": "create", "object_type": "dcim.module",
+                {"id": str(uuid.uuid4()), "change_type": "create", "object_type": "dcim.module",
                  "ref_id": "m1", "data": {"device": wrong_dev.pk, "module_bay": self.bay.pk,
                                           "module_type": self.mt.pk, "status": "active"}},
             ],

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_module_adoption.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_module_adoption.py
@@ -1,0 +1,169 @@
+"""E2E: duplicate module creates adopt the existing module at apply time."""
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class ModuleAdoptionE2ETests(APITestCase):
+    """Plan-ahead duplicate module CREATEs must adopt, not discard or crash."""
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.site = Site.objects.create(name="ma-site", slug="ma-site")
+        mfr = Manufacturer.objects.create(name="ma-mfr", slug="ma-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="ma-dt", slug="ma-dt")
+        self.role = DeviceRole.objects.create(name="ma-role", slug="ma-role")
+        self.mt = ModuleType.objects.create(manufacturer=mfr, model="ma-linecard")
+        self.dev = Device.objects.create(
+            name="ma-rtr", site=self.site, device_type=self.dt, role=self.role
+        )
+        self.bay = ModuleBay.objects.create(device=self.dev, name="ma-bay1")
+
+    def _dev_ref(self):
+        return {"name": "ma-rtr", "site": {"name": "ma-site"}}
+
+    def _module_entity(self, extra=None):
+        entity = {
+            "device": self._dev_ref(),
+            "module_bay": {"name": "ma-bay1", "device": self._dev_ref()},
+            "module_type": {"manufacturer": {"name": "ma-mfr"}, "model": "ma-linecard"},
+            "status": "active",
+        }
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "dcim.module", "entity": {"module": entity}}
+
+    def _subbay_entity(self):
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "ma-sub1",
+            "module": {
+                "device": self._dev_ref(),
+                "module_bay": {"name": "ma-bay1", "device": self._dev_ref()},
+                "module_type": {"manufacturer": {"name": "ma-mfr"}, "model": "ma-linecard"},
+            },
+        }}}
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def test_plan_ahead_duplicate_adopts_and_applies_payload(self):
+        """Both changesets planned before either apply: adopt, don't discard."""
+        cs_a = self._diff(self._module_entity())
+        # round B diverges on serial — the load-bearing lossiness probe
+        cs_b = self._diff(self._subbay_entity())
+        cs_a2 = self._diff(self._module_entity({"serial": "SER-B99"}))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+        self._apply(cs_a2)
+
+        modules = Module.objects.filter(module_bay=self.bay)
+        self.assertEqual(modules.count(), 1)
+        module = modules.first()
+        self.assertEqual(module.serial, "SER-B99")  # applied, not discarded
+        sub = ModuleBay.objects.get(name="ma-sub1")
+        self.assertEqual(sub.module_id, module.pk)  # nesting restored
+
+        # converged: re-plan of both entities is empty
+        for payload in (self._module_entity({"serial": "SER-B99"}), self._subbay_entity()):
+            cs = self._diff(payload)
+            non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+            self.assertEqual(non_noop, [], non_noop)
+
+    def test_null_asset_tag_create_does_not_relocate(self):
+        """The hazard pin: asset_tag null must not adopt an unrelated module."""
+        other_dev = Device.objects.create(
+            name="ma-other", site=self.site, device_type=self.dt, role=self.role
+        )
+        other_bay = ModuleBay.objects.create(device=other_dev, name="ma-obay")
+        other_module = Module.objects.create(
+            device=other_dev, module_bay=other_bay, module_type=self.mt
+        )
+        cs = self._diff(self._module_entity({"asset_tag": None}))
+        self._apply(cs)
+        other_module.refresh_from_db()
+        self.assertEqual(other_module.device_id, other_dev.pk)  # untouched
+        self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)
+
+    def test_occupied_bay_adopts_last_writer_wins_children_unchanged(self):
+        """Occupied-bay CREATE adopt-updates incl. module_type; children stay."""
+        Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
+        mt2 = ModuleType.objects.create(
+            manufacturer=Manufacturer.objects.get(name="ma-mfr"), model="ma-linecard-v2"
+        )
+        children_before = set(
+            ModuleBay.objects.filter(device=self.dev).values_list("pk", flat=True)
+        )
+        payload = self._module_entity()
+        payload["entity"]["module"]["module_type"]["model"] = "ma-linecard-v2"
+        cs = self._diff(payload)
+        self._apply(cs)
+        modules = Module.objects.filter(module_bay=self.bay)
+        self.assertEqual(modules.count(), 1)
+        self.assertEqual(modules.first().module_type_id, mt2.pk)  # last writer wins
+        children_after = set(
+            ModuleBay.objects.filter(device=self.dev).values_list("pk", flat=True)
+        )
+        self.assertEqual(children_before, children_after)  # no re-instantiation
+
+    def test_invalid_adoption_payload_aborts_changeset_atomically(self):
+        """
+        A 400 against the adopted instance rolls back sibling changes.
+
+        Hand-crafted changeset (deterministic): a device/bay-mismatched module
+        CREATE plus an innocent sibling site CREATE. Today the mismatch is
+        swallowed (ValidationError fallback returns the existing module) and
+        the changeset succeeds with the sibling applied; with adoption the
+        mismatch surfaces as 400 and the whole changeset rolls back.
+        """
+        import uuid as _uuid
+        Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
+        wrong_dev = Device.objects.create(
+            name="ma-wrong", site=self.site, device_type=self.dt, role=self.role
+        )
+        cs = {
+            "id": str(_uuid.uuid4()),
+            "changes": [
+                {"id": str(_uuid.uuid4()), "change_type": "create", "object_type": "dcim.site",
+                 "ref_id": "s1", "data": {"name": "ma-sibling-site", "slug": "ma-sibling-site"}},
+                {"id": str(_uuid.uuid4()), "change_type": "create", "object_type": "dcim.module",
+                 "ref_id": "m1", "data": {"device": wrong_dev.pk, "module_bay": self.bay.pk,
+                                          "module_type": self.mt.pk, "status": "active"}},
+            ],
+        }
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertFalse(Site.objects.filter(name="ma-sibling-site").exists())  # atomic abort
+
+    def test_miss_then_create_still_works(self):
+        """Find-first miss on an empty bay falls through to a normal create."""
+        cs = self._diff(self._module_entity())
+        self._apply(cs)
+        self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)


### PR DESCRIPTION
Fixes MON-305.

## Problem

Two related defects around NULL handling in object matching:

1. **Duplicate module creates.** In plan-ahead ingest topologies (plan-all-then-apply-all, e.g. BulkPlanView + BulkApplyView), a sub-ModuleBay's nested `module=` ref plans a second `dcim.module` CREATE for a bay whose module was created by an earlier changeset in the same run. Since v1.12.0 the failed INSERT is recovered by adopting the existing module, but the recovery is lossy (the second CREATE's divergent fields are silently discarded for that round) and noisy (a failed INSERT plus a swallowed Postgres error per duplicate). Agents work around it by dropping the sub-bay's `module=` parent link, losing UI nesting.
2. **NULL-lookup hijacks.** A matcher fed an explicit null in its unique field binds an arbitrary row: `asset_tag: null` adopts and physically relocates an unrelated module, `master: null` binds an arbitrary masterless VirtualChassis of any name, `rd: null` binds an unrelated rd-null VRF. A sibling defect fuses two different-identity entities that share only a None-keyed fingerprint (e.g. two null-asset_tag modules), failing the plan with a merge-conflict 400. Explicitly-cleared generic refs (`assigned_object`, `scope`) crash `content_type_id(None)` and 500 the plan.

## Fix

**All-None matcher guard (`ObjectMatchCriteria`), landed first:** a matcher is skipped (queryset and fingerprint) only when **every** referenced lookup value is None. Partial-null lookups keep today's behavior byte-identically (Django renders `=None` as `IS NULL`, which live clear-FK dedupe depends on — e.g. rack `location: null`). Includes None-safe ContentType preparation (cleared generic refs no longer 500) and a None-safe case-insensitive fingerprint path (a null in an insensitive ref no longer crashes). Consequence worth knowing: the `logical_mac_address_within_parent` isnull-variant's queryset path is functional for the first time — explicit-null MAC assignments now match by MAC + assigned-object-isnull (its path previously crashed before querying; absent-key payloads are unaffected).

**`dcim.module` joins `_REQUIRES_PRE_SAVE_MATCH`:** the applier's find-first pass converts the plan-ahead duplicate CREATE into a partial update of the bay's module via the DB-backed `unique_module_bay` matcher — payload applied instead of discarded, sub-bay nesting restored, idempotent, no failed-INSERT noise.

## Behavior changes

- **Occupied-bay CREATEs adopt-update, last-writer-wins including `module_type`** (previously the incoming payload was silently discarded for that round). A type swap retains the old type's auto-created children and does not instantiate the new type's templates — parity with today's plan-time UPDATE semantics.
- **Validation failures against the adopted instance now surface as a 400 that aborts the whole changeset atomically** — sibling changes in the same changeset roll back, and retries fail deterministically until the producer fixes the payload. Previously the same changeset returned 200 with the bad payload silently dropped. Other changesets in a bulk batch are unaffected (207 multi-status). This is the most visible change for producers.
- These semantics apply to raw `apply-change-set` clients as well, not only the diode pipeline.
- A real-value `asset_tag` match may physically move a module at apply time (plan-time already had move semantics).
- IntegrityError noise is gone for the plan-ahead duplicate; genuine conflict races can still surface one as a generic 400.

## Tests

- Unit (guard): hijack skips pinned at matcher level (`asset_tag`/`master`); partial-null multi-field dedupe preserved (rack); macaddress isnull-variant matches without crashing; condition-scoped null matchers unaffected; cleared-GFK payloads no longer raise; None-fingerprint fusion removed; partial-null fingerprints preserved (mutation-tested: `all`→`any` fails).
- E2E (adoption): the plan-ahead repro with load-bearing asserts (divergent payload applied, re-plan empty); null-asset_tag relocation hazard pin; occupied-bay last-writer-wins; deterministic atomic-abort test (400 + sibling rolled back, previously 200 + sibling applied); miss-then-create.
- Byte-identical across the `v4.4.x`/`v4.5.x`/`v4.6.x` trees; green on **v4.6.0, v4.5.5, v4.4.10** plus existing matcher/apply/update suites.
- Verified end-to-end through the real ingest pipeline (SDK → gRPC ingress → reconciler → plugin → NetBox): a device + linecard + sub-bay carrying its `module=` parent link + installed transceiver lands with correct nesting, and a second identical ingest converges with no changes.

## Follow-up

Agent-side (tracked in MON-305): with nesting proven end-to-end, discovery agents can drop the strip-the-parent-link workaround for transceiver sub-bays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
