### PR TITLE
fix(matcher): adopt duplicate prefix creates via pre-save match

### DIFF
--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -104,6 +104,12 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 #     (mac_address, assigned_object_type, assigned_object_id).
 #   - dcim.modulebay: matched by (name, device); NetBox's parent-aware
 #     constraint does not catch unscoped duplicates the matcher dedupes.
+#   - ipam.prefix: NetBox has no unique constraint on prefix, nor on
+#     (prefix, vrf) - Prefix.Meta carries only ordering and indexes.
+#     Duplicate detection lives solely in Prefix.clean(), behind
+#     ENFORCE_GLOBAL_UNIQUE or the VRF's enforce_unique flag, and the
+#     applier saves through DRF serializers without calling full_clean(),
+#     so that check never runs either.
 #   - ipam.vlan: NetBox's (group, vid) constraint does not enforce
 #     uniqueness when group is NULL.
 #   - ipam.vlangroup: NetBox does not enforce uniqueness of name when
@@ -125,6 +131,7 @@ _REQUIRES_PRE_SAVE_MATCH = frozenset({
     "dcim.cable",
     "dcim.macaddress",
     "dcim.modulebay",
+    "ipam.prefix",
     "ipam.vlan",
     "ipam.vlangroup",
     "ipam.vrf",

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_prefix_adoption.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_prefix_adoption.py
@@ -10,7 +10,8 @@ from netbox_diode_plugin.plugin_config import get_diode_user
 
 
 class PrefixAdoptionE2ETests(APITestCase):
-    """Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
+    """
+    Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
 
     NetBox permits duplicate prefixes: Prefix.Meta declares only ordering and
     indexes, and the duplicate check in Prefix.clean() is gated on
@@ -58,7 +59,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         return r
 
     def test_plan_ahead_duplicate_within_vrf_adopts(self):
-        """Two changesets planned before either apply yield one prefix, not two.
+        """
+        Two changesets planned before either apply yield one prefix, not two.
 
         This is the reported shape: both plans see no existing prefix, so both
         emit CREATE, and without the pre-save match both inserts succeed.
@@ -79,7 +81,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         self.assertEqual(non_noop, [], non_noop)
 
     def test_plan_ahead_duplicate_in_global_table_adopts(self):
-        """The vrf-is-NULL matcher needs the same protection as the VRF one.
+        """
+        The vrf-is-NULL matcher needs the same protection as the VRF one.
 
         ipam.prefix has two logical matchers, split on whether vrf is NULL, so
         a global-table prefix takes a different path and is covered separately.
@@ -95,7 +98,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         )
 
     def test_same_prefix_in_different_vrfs_stays_distinct(self):
-        """The hazard pin: adoption must not collapse genuinely distinct rows.
+        """
+        The hazard pin: adoption must not collapse genuinely distinct rows.
 
         The same network in two different VRFs is two legitimate objects. If
         the pre-save match ignored the VRF it would adopt across them, which
@@ -127,7 +131,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         )
 
     def test_global_and_vrf_prefix_stay_distinct(self):
-        """A prefix in the global table and the same one in a VRF are distinct.
+        """
+        A prefix in the global table and the same one in a VRF are distinct.
 
         The two matchers are conditioned on vrf being NULL or NOT NULL, so this
         pins that the global-table row is not adopted by the VRF-scoped one.

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_prefix_adoption.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_prefix_adoption.py
@@ -1,0 +1,143 @@
+"""E2E: duplicate prefix creates adopt the existing prefix at apply time."""
+from types import SimpleNamespace
+from unittest import mock
+
+from ipam.models import VRF, Prefix
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class PrefixAdoptionE2ETests(APITestCase):
+    """Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
+
+    NetBox permits duplicate prefixes: Prefix.Meta declares only ordering and
+    indexes, and the duplicate check in Prefix.clean() is gated on
+    ENFORCE_GLOBAL_UNIQUE or the VRF's enforce_unique flag, neither of which
+    the applier reaches because it saves through DRF serializers without
+    full_clean(). So nothing below the matcher stops a second insert, which is
+    why ipam.prefix needs the pre-save match.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.vrf = VRF.objects.create(name="pa-vrf", rd="64805:7")
+
+    def _prefix_entity(self, prefix="10.9.16.0/22", vrf=True, extra=None):
+        entity = {"prefix": prefix}
+        if vrf:
+            entity["vrf"] = {"name": "pa-vrf", "rd": "64805:7"}
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "ipam.prefix", "entity": {"prefix": entity}}
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIn("change_set", r.json(), r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def test_plan_ahead_duplicate_within_vrf_adopts(self):
+        """Two changesets planned before either apply yield one prefix, not two.
+
+        This is the reported shape: both plans see no existing prefix, so both
+        emit CREATE, and without the pre-save match both inserts succeed.
+        """
+        cs_a = self._diff(self._prefix_entity())
+        cs_b = self._diff(self._prefix_entity(extra={"description": "second planner"}))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+
+        prefixes = Prefix.objects.filter(prefix="10.9.16.0/22", vrf=self.vrf)
+        self.assertEqual(prefixes.count(), 1)
+        self.assertEqual(prefixes.first().description, "second planner")
+
+        # converged: re-planning the same entity produces no real change
+        cs = self._diff(self._prefix_entity(extra={"description": "second planner"}))
+        non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+        self.assertEqual(non_noop, [], non_noop)
+
+    def test_plan_ahead_duplicate_in_global_table_adopts(self):
+        """The vrf-is-NULL matcher needs the same protection as the VRF one.
+
+        ipam.prefix has two logical matchers, split on whether vrf is NULL, so
+        a global-table prefix takes a different path and is covered separately.
+        """
+        cs_a = self._diff(self._prefix_entity(prefix="10.9.20.0/22", vrf=False))
+        cs_b = self._diff(self._prefix_entity(prefix="10.9.20.0/22", vrf=False))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.20.0/22", vrf__isnull=True).count(), 1
+        )
+
+    def test_same_prefix_in_different_vrfs_stays_distinct(self):
+        """The hazard pin: adoption must not collapse genuinely distinct rows.
+
+        The same network in two different VRFs is two legitimate objects. If
+        the pre-save match ignored the VRF it would adopt across them, which
+        would be worse than the duplicate it exists to prevent.
+        """
+        other = VRF.objects.create(name="pa-vrf-b", rd="64805:8")
+        self._apply(self._diff(self._prefix_entity()))
+        self._apply(
+            self._diff(
+                {
+                    "timestamp": 1,
+                    "object_type": "ipam.prefix",
+                    "entity": {
+                        "prefix": {
+                            "prefix": "10.9.16.0/22",
+                            "vrf": {"name": "pa-vrf-b", "rd": "64805:8"},
+                        }
+                    },
+                }
+            )
+        )
+
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.16.0/22").count(), 2)
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.16.0/22", vrf=self.vrf).count(), 1
+        )
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.16.0/22", vrf=other).count(), 1
+        )
+
+    def test_global_and_vrf_prefix_stay_distinct(self):
+        """A prefix in the global table and the same one in a VRF are distinct.
+
+        The two matchers are conditioned on vrf being NULL or NOT NULL, so this
+        pins that the global-table row is not adopted by the VRF-scoped one.
+        """
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.24.0/22", vrf=False)))
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.24.0/22")))
+
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.24.0/22").count(), 2)
+
+    def test_miss_then_create_still_works(self):
+        """Find-first miss on an empty table falls through to a normal create."""
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.28.0/22")))
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.28.0/22").count(), 1)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_prefix_adoption.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_prefix_adoption.py
@@ -10,7 +10,8 @@ from netbox_diode_plugin.plugin_config import get_diode_user
 
 
 class PrefixAdoptionE2ETests(APITestCase):
-    """Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
+    """
+    Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
 
     NetBox permits duplicate prefixes: Prefix.Meta declares only ordering and
     indexes, and the duplicate check in Prefix.clean() is gated on
@@ -58,7 +59,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         return r
 
     def test_plan_ahead_duplicate_within_vrf_adopts(self):
-        """Two changesets planned before either apply yield one prefix, not two.
+        """
+        Two changesets planned before either apply yield one prefix, not two.
 
         This is the reported shape: both plans see no existing prefix, so both
         emit CREATE, and without the pre-save match both inserts succeed.
@@ -79,7 +81,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         self.assertEqual(non_noop, [], non_noop)
 
     def test_plan_ahead_duplicate_in_global_table_adopts(self):
-        """The vrf-is-NULL matcher needs the same protection as the VRF one.
+        """
+        The vrf-is-NULL matcher needs the same protection as the VRF one.
 
         ipam.prefix has two logical matchers, split on whether vrf is NULL, so
         a global-table prefix takes a different path and is covered separately.
@@ -95,7 +98,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         )
 
     def test_same_prefix_in_different_vrfs_stays_distinct(self):
-        """The hazard pin: adoption must not collapse genuinely distinct rows.
+        """
+        The hazard pin: adoption must not collapse genuinely distinct rows.
 
         The same network in two different VRFs is two legitimate objects. If
         the pre-save match ignored the VRF it would adopt across them, which
@@ -127,7 +131,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         )
 
     def test_global_and_vrf_prefix_stay_distinct(self):
-        """A prefix in the global table and the same one in a VRF are distinct.
+        """
+        A prefix in the global table and the same one in a VRF are distinct.
 
         The two matchers are conditioned on vrf being NULL or NOT NULL, so this
         pins that the global-table row is not adopted by the VRF-scoped one.

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_prefix_adoption.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_prefix_adoption.py
@@ -1,0 +1,143 @@
+"""E2E: duplicate prefix creates adopt the existing prefix at apply time."""
+from types import SimpleNamespace
+from unittest import mock
+
+from ipam.models import VRF, Prefix
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class PrefixAdoptionE2ETests(APITestCase):
+    """Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
+
+    NetBox permits duplicate prefixes: Prefix.Meta declares only ordering and
+    indexes, and the duplicate check in Prefix.clean() is gated on
+    ENFORCE_GLOBAL_UNIQUE or the VRF's enforce_unique flag, neither of which
+    the applier reaches because it saves through DRF serializers without
+    full_clean(). So nothing below the matcher stops a second insert, which is
+    why ipam.prefix needs the pre-save match.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.vrf = VRF.objects.create(name="pa-vrf", rd="64805:7")
+
+    def _prefix_entity(self, prefix="10.9.16.0/22", vrf=True, extra=None):
+        entity = {"prefix": prefix}
+        if vrf:
+            entity["vrf"] = {"name": "pa-vrf", "rd": "64805:7"}
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "ipam.prefix", "entity": {"prefix": entity}}
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIn("change_set", r.json(), r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def test_plan_ahead_duplicate_within_vrf_adopts(self):
+        """Two changesets planned before either apply yield one prefix, not two.
+
+        This is the reported shape: both plans see no existing prefix, so both
+        emit CREATE, and without the pre-save match both inserts succeed.
+        """
+        cs_a = self._diff(self._prefix_entity())
+        cs_b = self._diff(self._prefix_entity(extra={"description": "second planner"}))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+
+        prefixes = Prefix.objects.filter(prefix="10.9.16.0/22", vrf=self.vrf)
+        self.assertEqual(prefixes.count(), 1)
+        self.assertEqual(prefixes.first().description, "second planner")
+
+        # converged: re-planning the same entity produces no real change
+        cs = self._diff(self._prefix_entity(extra={"description": "second planner"}))
+        non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+        self.assertEqual(non_noop, [], non_noop)
+
+    def test_plan_ahead_duplicate_in_global_table_adopts(self):
+        """The vrf-is-NULL matcher needs the same protection as the VRF one.
+
+        ipam.prefix has two logical matchers, split on whether vrf is NULL, so
+        a global-table prefix takes a different path and is covered separately.
+        """
+        cs_a = self._diff(self._prefix_entity(prefix="10.9.20.0/22", vrf=False))
+        cs_b = self._diff(self._prefix_entity(prefix="10.9.20.0/22", vrf=False))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.20.0/22", vrf__isnull=True).count(), 1
+        )
+
+    def test_same_prefix_in_different_vrfs_stays_distinct(self):
+        """The hazard pin: adoption must not collapse genuinely distinct rows.
+
+        The same network in two different VRFs is two legitimate objects. If
+        the pre-save match ignored the VRF it would adopt across them, which
+        would be worse than the duplicate it exists to prevent.
+        """
+        other = VRF.objects.create(name="pa-vrf-b", rd="64805:8")
+        self._apply(self._diff(self._prefix_entity()))
+        self._apply(
+            self._diff(
+                {
+                    "timestamp": 1,
+                    "object_type": "ipam.prefix",
+                    "entity": {
+                        "prefix": {
+                            "prefix": "10.9.16.0/22",
+                            "vrf": {"name": "pa-vrf-b", "rd": "64805:8"},
+                        }
+                    },
+                }
+            )
+        )
+
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.16.0/22").count(), 2)
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.16.0/22", vrf=self.vrf).count(), 1
+        )
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.16.0/22", vrf=other).count(), 1
+        )
+
+    def test_global_and_vrf_prefix_stay_distinct(self):
+        """A prefix in the global table and the same one in a VRF are distinct.
+
+        The two matchers are conditioned on vrf being NULL or NOT NULL, so this
+        pins that the global-table row is not adopted by the VRF-scoped one.
+        """
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.24.0/22", vrf=False)))
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.24.0/22")))
+
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.24.0/22").count(), 2)
+
+    def test_miss_then_create_still_works(self):
+        """Find-first miss on an empty table falls through to a normal create."""
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.28.0/22")))
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.28.0/22").count(), 1)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_prefix_adoption.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_prefix_adoption.py
@@ -10,7 +10,8 @@ from netbox_diode_plugin.plugin_config import get_diode_user
 
 
 class PrefixAdoptionE2ETests(APITestCase):
-    """Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
+    """
+    Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
 
     NetBox permits duplicate prefixes: Prefix.Meta declares only ordering and
     indexes, and the duplicate check in Prefix.clean() is gated on
@@ -58,7 +59,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         return r
 
     def test_plan_ahead_duplicate_within_vrf_adopts(self):
-        """Two changesets planned before either apply yield one prefix, not two.
+        """
+        Two changesets planned before either apply yield one prefix, not two.
 
         This is the reported shape: both plans see no existing prefix, so both
         emit CREATE, and without the pre-save match both inserts succeed.
@@ -79,7 +81,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         self.assertEqual(non_noop, [], non_noop)
 
     def test_plan_ahead_duplicate_in_global_table_adopts(self):
-        """The vrf-is-NULL matcher needs the same protection as the VRF one.
+        """
+        The vrf-is-NULL matcher needs the same protection as the VRF one.
 
         ipam.prefix has two logical matchers, split on whether vrf is NULL, so
         a global-table prefix takes a different path and is covered separately.
@@ -95,7 +98,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         )
 
     def test_same_prefix_in_different_vrfs_stays_distinct(self):
-        """The hazard pin: adoption must not collapse genuinely distinct rows.
+        """
+        The hazard pin: adoption must not collapse genuinely distinct rows.
 
         The same network in two different VRFs is two legitimate objects. If
         the pre-save match ignored the VRF it would adopt across them, which
@@ -127,7 +131,8 @@ class PrefixAdoptionE2ETests(APITestCase):
         )
 
     def test_global_and_vrf_prefix_stay_distinct(self):
-        """A prefix in the global table and the same one in a VRF are distinct.
+        """
+        A prefix in the global table and the same one in a VRF are distinct.
 
         The two matchers are conditioned on vrf being NULL or NOT NULL, so this
         pins that the global-table row is not adopted by the VRF-scoped one.

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_prefix_adoption.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_prefix_adoption.py
@@ -1,0 +1,143 @@
+"""E2E: duplicate prefix creates adopt the existing prefix at apply time."""
+from types import SimpleNamespace
+from unittest import mock
+
+from ipam.models import VRF, Prefix
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class PrefixAdoptionE2ETests(APITestCase):
+    """Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
+
+    NetBox permits duplicate prefixes: Prefix.Meta declares only ordering and
+    indexes, and the duplicate check in Prefix.clean() is gated on
+    ENFORCE_GLOBAL_UNIQUE or the VRF's enforce_unique flag, neither of which
+    the applier reaches because it saves through DRF serializers without
+    full_clean(). So nothing below the matcher stops a second insert, which is
+    why ipam.prefix needs the pre-save match.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.vrf = VRF.objects.create(name="pa-vrf", rd="64805:7")
+
+    def _prefix_entity(self, prefix="10.9.16.0/22", vrf=True, extra=None):
+        entity = {"prefix": prefix}
+        if vrf:
+            entity["vrf"] = {"name": "pa-vrf", "rd": "64805:7"}
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "ipam.prefix", "entity": {"prefix": entity}}
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIn("change_set", r.json(), r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def test_plan_ahead_duplicate_within_vrf_adopts(self):
+        """Two changesets planned before either apply yield one prefix, not two.
+
+        This is the reported shape: both plans see no existing prefix, so both
+        emit CREATE, and without the pre-save match both inserts succeed.
+        """
+        cs_a = self._diff(self._prefix_entity())
+        cs_b = self._diff(self._prefix_entity(extra={"description": "second planner"}))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+
+        prefixes = Prefix.objects.filter(prefix="10.9.16.0/22", vrf=self.vrf)
+        self.assertEqual(prefixes.count(), 1)
+        self.assertEqual(prefixes.first().description, "second planner")
+
+        # converged: re-planning the same entity produces no real change
+        cs = self._diff(self._prefix_entity(extra={"description": "second planner"}))
+        non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+        self.assertEqual(non_noop, [], non_noop)
+
+    def test_plan_ahead_duplicate_in_global_table_adopts(self):
+        """The vrf-is-NULL matcher needs the same protection as the VRF one.
+
+        ipam.prefix has two logical matchers, split on whether vrf is NULL, so
+        a global-table prefix takes a different path and is covered separately.
+        """
+        cs_a = self._diff(self._prefix_entity(prefix="10.9.20.0/22", vrf=False))
+        cs_b = self._diff(self._prefix_entity(prefix="10.9.20.0/22", vrf=False))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.20.0/22", vrf__isnull=True).count(), 1
+        )
+
+    def test_same_prefix_in_different_vrfs_stays_distinct(self):
+        """The hazard pin: adoption must not collapse genuinely distinct rows.
+
+        The same network in two different VRFs is two legitimate objects. If
+        the pre-save match ignored the VRF it would adopt across them, which
+        would be worse than the duplicate it exists to prevent.
+        """
+        other = VRF.objects.create(name="pa-vrf-b", rd="64805:8")
+        self._apply(self._diff(self._prefix_entity()))
+        self._apply(
+            self._diff(
+                {
+                    "timestamp": 1,
+                    "object_type": "ipam.prefix",
+                    "entity": {
+                        "prefix": {
+                            "prefix": "10.9.16.0/22",
+                            "vrf": {"name": "pa-vrf-b", "rd": "64805:8"},
+                        }
+                    },
+                }
+            )
+        )
+
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.16.0/22").count(), 2)
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.16.0/22", vrf=self.vrf).count(), 1
+        )
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.16.0/22", vrf=other).count(), 1
+        )
+
+    def test_global_and_vrf_prefix_stay_distinct(self):
+        """A prefix in the global table and the same one in a VRF are distinct.
+
+        The two matchers are conditioned on vrf being NULL or NOT NULL, so this
+        pins that the global-table row is not adopted by the VRF-scoped one.
+        """
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.24.0/22", vrf=False)))
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.24.0/22")))
+
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.24.0/22").count(), 2)
+
+    def test_miss_then_create_still_works(self):
+        """Find-first miss on an empty table falls through to a normal create."""
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.28.0/22")))
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.28.0/22").count(), 1)


### PR DESCRIPTION
## Summary

`ipam.prefix` meets the criteria `_REQUIRES_PRE_SAVE_MATCH` exists for, but was absent from the set. This adds it, with a gap entry in the comment block and adoption tests.

Found while investigating netboxlabs/orb-agent#512, where snmp-discovery produced duplicate prefixes in NetBox.

## Why prefix qualifies

The set's own comment states the criterion: object types whose logical match criteria are **not** backed by a DB unique constraint, where the applier must therefore look up an existing row before `serializer.save()`, because the `IntegrityError` fallback in `_create_or_find_instance` cannot catch a duplicate that inserts cleanly.

Prefix has nothing behind it at any layer:

- `Prefix.Meta` declares only `ordering` and `indexes`. There is no `unique_together` and no `constraints`, so no unique constraint on `prefix` or on `(prefix, vrf)`. NetBox permits duplicate prefixes by design.
- Duplicate detection lives solely in `Prefix.clean()`, behind `ENFORCE_GLOBAL_UNIQUE` or the VRF's `enforce_unique` flag. The applier saves through DRF serializers and never calls `full_clean()`, so that check never runs regardless of how those are configured.
- Consistent with this, the matcher registry gives `ipam.prefix` only *logical* matchers and no `builtin` one, because the generator found no unique constraint to derive from. Compare `ipam.vrf`, which gets `unique_rd | builtin`.

So `save()` always succeeds and two planners that each emit CREATE both insert.

## The reported symptom

Two `ipam.prefix` rows with the same network, the same VRF and the same RD, created in the same second, from a payload that emitted the prefix exactly once. Every other object in that payload was protected — device by name, interface by a real `(device, name)` constraint, IP address by a stable match — which is exactly why prefixes were the only type that duplicated.

## Tests

`test_prefix_adoption.py`, modelled on `test_module_adoption.py`, byte-identical across the three version directories per the convention that change established.

Both logical matchers are covered, since they are split on whether `vrf` is NULL and take different paths:

- duplicate planned-ahead CREATE within a VRF adopts, and the second planner's payload is applied rather than discarded
- duplicate planned-ahead CREATE in the global table adopts
- convergence: re-planning the adopted entity yields no non-noop change

Two cases pin what adoption must **not** collapse, since a matcher that over-adopts would be worse than the duplicate it prevents:

- the same network in two different VRFs stays two objects
- the same network in the global table versus inside a VRF stays two objects

Plus the find-first miss falling through to a normal create.

## Scope

Deliberately prefix only. `ipam.ipaddress`, `ipam.iprange`, `ipam.aggregate`, `ipam.service` and `ipam.fhrpgroup` also have logical matchers and are also absent from the set, and may well have the same gap — but each needs its own check that NetBox genuinely lacks the constraint and that a duplicate is reachable, rather than being assumed from the pattern. Worth a follow-up audit; not folded in here.

This closes the common race (concurrent plan, sequential apply), as the set's comment notes. It does not close TOCTOU under truly simultaneous apply, which would need a constraint or a coordinating lock.

## Verification status

Honest caveat: **I could not run the test suite locally.** It runs via docker-compose against a real NetBox and the registry is unreachable from my environment. The change and tests are syntax-checked only; correctness of the tests themselves rests on CI across the three NetBox versions. Please treat the CI result as the first real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)