### PR TITLE
fix(differ): let a submitted driver value drop the fields it forbids

### DIFF
--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -68,6 +68,19 @@ _VLAN_QINQ_RULES = {
     "cvlan": [],
 }
 
+# One policy for the whole registry, deliberately: the driver value wins over the
+# dependent fields it forbids for every entry below, with no per-driver scoping.
+# The rules encode NetBox's data model (Interface.clean() / VLAN.clean() and the
+# dcim serializer's validate()), not which serializer happens to police it, and
+# NetBox rejects the WHOLE entity where it does police it.
+#
+# Measured cost of that uniformity: virtualization.vminterface is the one entry
+# whose serializer does NO mode/VLAN validation, so a CREATE naming mode "access"
+# with tagged VLANs used to be stored as submitted. It now loses the tagged VLANs.
+# That is intended, not incidental: mode "access" with tagged VLANs is meaningless
+# either way, and the shared BaseInterface.save() clears tagged_vlans for any
+# non-tagged mode on every later save anyway (`not self._state.adding`), so the
+# stored state was one ordinary NetBox save away from disappearing.
 _CHANGESET_NORMALIZERS = {
     "dcim.interface": {"mode": _INTERFACE_MODE_VLAN_RULES, "type": _INTERFACE_TYPE_RF_RULES},
     "virtualization.vminterface": {"mode": _INTERFACE_MODE_VLAN_RULES},
@@ -75,27 +88,73 @@ _CHANGESET_NORMALIZERS = {
 }
 
 
-def normalize_changeset(object_type: str, prechange: dict, entity: dict) -> None:
+def normalize_changeset(object_type: str, prechange: dict, entity: dict) -> dict[str, str]:
     """
-    Clear stale dependent fields the effective driver value forbids.
+    Clear the dependent fields the effective driver value forbids.
 
-    Mutates ``entity`` in place. No-op unless ``object_type`` is registered and an
-    existing row (non-empty ``prechange``) is present. A dependent field is cleared
-    only when it is NOT explicitly present in ``entity`` (respect producer intent)
-    and its existing value is non-empty (idempotency). Clearing uses ``[]`` for
+    Mutates ``entity`` in place. No-op unless ``object_type`` is registered.
+
+    The effective driver value WINS over every dependent field it forbids: the
+    field is cleared on a create (empty ``prechange``) as well as on an update,
+    and whether or not the producer submitted it explicitly. A payload naming
+    ``mode: access`` while also naming tagged VLANs is self-contradictory, and
+    NetBox answers it by rejecting the WHOLE entity (400 ``tagged_vlans:
+    "Interface mode does not support tagged vlans"``); dropping the one field the
+    mode forbids costs less than losing the entity. This is deliberately the
+    opposite of respecting producer intent for a forbidden field.
+
+    Producer intent still governs everything the driver value permits: a field a
+    driver value ALLOWS is never touched (explicit ``tagged_vlans`` under ``mode:
+    tagged`` survives), and an unrecognised driver value forbids nothing at all
+    (fail open). A value that is already empty is left exactly as submitted, so
+    clearing can never turn a no-change into a change. Clearing uses ``[]`` for
     many-valued refs and ``None`` for single refs.
+
+    Returns ``{field: reason}`` for the submitted values it discarded — empty
+    when nothing was submitted, so the caller can tell an actual drop of producer
+    data from the injection of a clear for a stale stored value.
     """
     rules_by_driver = _CHANGESET_NORMALIZERS.get(object_type)
-    if not rules_by_driver or not prechange:
-        return
+    if not rules_by_driver:
+        return {}
+    dropped = {}
     for driver_field, value_map in rules_by_driver.items():
-        effective = entity.get(driver_field, prechange.get(driver_field))
-        for dependent in value_map.get(effective or "", ()):
-            if dependent in entity:
-                continue
-            if prechange.get(dependent):
-                ref = get_json_ref_info(object_type, dependent)
-                entity[dependent] = [] if (ref and ref.is_many) else None
+        effective = entity.get(driver_field, prechange.get(driver_field)) or ""
+        for dependent in value_map.get(effective, ()):
+            submitted = dependent in entity
+            if submitted:
+                # An already-empty submitted value needs no clearing, and
+                # rewriting it could only manufacture a spurious change.
+                if not entity[dependent]:
+                    continue
+            elif not prechange.get(dependent):
+                continue  # nothing stored, nothing stale to clear
+            ref = get_json_ref_info(object_type, dependent)
+            entity[dependent] = [] if (ref and ref.is_many) else None
+            if submitted:
+                dropped[dependent] = (
+                    f"Dropped: {driver_field} '{effective}' does not support this field."
+                )
+    return dropped
+
+
+def _apply_driver_field_policy(
+    object_type: str, prechange_data: dict, entity: dict, new_refs: list[str], warnings: dict,
+) -> list[str]:
+    """
+    Let the submitted driver value win over the dependent fields it forbids.
+
+    Returns ``new_refs`` with the dropped fields' unresolved-reference paths
+    removed: a dropped field is gone from the payload — a create strips the
+    emptied value out of ``change.data`` altogether — so the applier must not
+    walk a path the payload no longer carries. Every discarded submitted value
+    is reported as a change set warning rather than dropped silently.
+    """
+    dropped = normalize_changeset(object_type, prechange_data, entity)
+    if not dropped:
+        return new_refs
+    _merge_warnings(warnings, object_type, {k: [v] for k, v in dropped.items()})
+    return [r for r in new_refs if r.split(".", 1)[0] not in dropped]
 
 
 _prechange_cache = contextvars.ContextVar("diode_prechange_cache", default=None)
@@ -335,7 +394,13 @@ def _generate_changeset(entity: dict, object_type: str) -> ChangeSetResult:
                 entity = _partially_merge(prechange_data, entity, instance)
                 _align_cable_ends(prechange_data, entity)
                 _apply_merge_semantics(object_type, prechange_data, entity)
-                normalize_changeset(object_type, prechange_data, entity)
+        # Outside the "existing row" branch on purpose: a submitted driver value
+        # forbids its dependent fields on a create too, and NetBox rejects the
+        # whole entity for the contradiction rather than just the field.
+        new_refs = _apply_driver_field_policy(
+            object_type, prechange_data, entity, new_refs, warnings,
+        )
+        if instance:
             changed_data = shallow_compare_dict(
                 prechange_data, entity,
             )

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -8,8 +8,6 @@ import datetime
 import logging
 from collections import defaultdict
 
-from dcim.choices import InterfaceTypeChoices
-from dcim.constants import WIRELESS_IFACE_TYPES
 from django.contrib.contenttypes.models import ContentType
 from extras.choices import CustomFieldTypeChoices
 from rest_framework import serializers
@@ -26,135 +24,14 @@ from .common import (
     harmonize_formats,
     sort_ints_first,
 )
+from .field_policy import normalize_changeset
 from .matcher import _get_active_branch_schema
-from .plugin_utils import get_json_ref_info, get_primary_value, legal_fields
+from .plugin_utils import get_primary_value, legal_fields
 from .profile import profiled
 from .supported_models import extract_supported_models
 from .transformer import _get_custom_fields_for_model, cleanup_unresolved_references, set_custom_field_defaults, transform_proto_json
 
 logger = logging.getLogger(__name__)
-
-
-# --- Changeset normalization ------------------------------------------------
-# Mirror NetBox model save()-time normalization that the DRF serializer validates
-# against: when a driver field takes a value that forbids a dependent field, the
-# stale dependent value must be cleared so the merged partial-update state is legal.
-#
-# object_type -> driver_field -> { driver_value : [dependent fields to clear] }
-# Values verified against NetBox model clean() / serializer validate() (v4.4 / v4.5.5 / v4.6.0).
-_INTERFACE_MODE_VLAN_RULES = {
-    "": ["untagged_vlan", "tagged_vlans", "qinq_svlan"],  # routed / no 802.1Q
-    "access": ["tagged_vlans", "qinq_svlan"],
-    "tagged": ["qinq_svlan"],
-    "tagged-all": ["tagged_vlans", "qinq_svlan"],
-    "q-in-q": [],
-}
-
-# rf_channel / rf_channel_frequency / rf_channel_width / rf_role may be set only on
-# wireless interface types (Interface.clean(); is_wireless == type in WIRELESS_IFACE_TYPES).
-# Keyed on every non-wireless type (complement of the wireless allow-set) so a type
-# change away from wireless clears the stale rf fields. All four are null=True -> None.
-_RF_FIELDS = ["rf_channel", "rf_channel_frequency", "rf_channel_width", "rf_role"]
-_INTERFACE_TYPE_RF_RULES = {
-    t: _RF_FIELDS for t in InterfaceTypeChoices.values() if t not in WIRELESS_IFACE_TYPES
-}
-
-# ipam.vlan: qinq_svlan may be set only on a Q-in-Q customer VLAN (qinq_role == 'cvlan');
-# VLAN.clean() rejects a stale qinq_svlan for any other role. (The reciprocal
-# "customer VLAN requires an svlan" is a presence rule, not ours -> 'cvlan' maps to [].)
-_VLAN_QINQ_RULES = {
-    "": ["qinq_svlan"],
-    "svlan": ["qinq_svlan"],
-    "cvlan": [],
-}
-
-# One policy for the whole registry, deliberately: the driver value wins over the
-# dependent fields it forbids for every entry below, with no per-driver scoping.
-# The rules encode NetBox's data model (Interface.clean() / VLAN.clean() and the
-# dcim serializer's validate()), not which serializer happens to police it, and
-# NetBox rejects the WHOLE entity where it does police it.
-#
-# Measured cost of that uniformity: virtualization.vminterface is the one entry
-# whose serializer does NO mode/VLAN validation, so a CREATE naming mode "access"
-# with tagged VLANs used to be stored as submitted. It now loses the tagged VLANs.
-# That is intended, not incidental: mode "access" with tagged VLANs is meaningless
-# either way, and the shared BaseInterface.save() clears tagged_vlans for any
-# non-tagged mode on every later save anyway (`not self._state.adding`), so the
-# stored state was one ordinary NetBox save away from disappearing.
-_CHANGESET_NORMALIZERS = {
-    "dcim.interface": {"mode": _INTERFACE_MODE_VLAN_RULES, "type": _INTERFACE_TYPE_RF_RULES},
-    "virtualization.vminterface": {"mode": _INTERFACE_MODE_VLAN_RULES},
-    "ipam.vlan": {"qinq_role": _VLAN_QINQ_RULES},
-}
-
-
-def normalize_changeset(object_type: str, prechange: dict, entity: dict) -> dict[str, str]:
-    """
-    Clear the dependent fields the effective driver value forbids.
-
-    Mutates ``entity`` in place. No-op unless ``object_type`` is registered.
-
-    The effective driver value WINS over every dependent field it forbids: the
-    field is cleared on a create (empty ``prechange``) as well as on an update,
-    and whether or not the producer submitted it explicitly. A payload naming
-    ``mode: access`` while also naming tagged VLANs is self-contradictory, and
-    NetBox answers it by rejecting the WHOLE entity (400 ``tagged_vlans:
-    "Interface mode does not support tagged vlans"``); dropping the one field the
-    mode forbids costs less than losing the entity. This is deliberately the
-    opposite of respecting producer intent for a forbidden field.
-
-    Producer intent still governs everything the driver value permits: a field a
-    driver value ALLOWS is never touched (explicit ``tagged_vlans`` under ``mode:
-    tagged`` survives), and an unrecognised driver value forbids nothing at all
-    (fail open). A value that is already empty is left exactly as submitted, so
-    clearing can never turn a no-change into a change. Clearing uses ``[]`` for
-    many-valued refs and ``None`` for single refs.
-
-    Returns ``{field: reason}`` for the submitted values it discarded — empty
-    when nothing was submitted, so the caller can tell an actual drop of producer
-    data from the injection of a clear for a stale stored value.
-    """
-    rules_by_driver = _CHANGESET_NORMALIZERS.get(object_type)
-    if not rules_by_driver:
-        return {}
-    dropped = {}
-    for driver_field, value_map in rules_by_driver.items():
-        effective = entity.get(driver_field, prechange.get(driver_field)) or ""
-        for dependent in value_map.get(effective, ()):
-            submitted = dependent in entity
-            if submitted:
-                # An already-empty submitted value needs no clearing, and
-                # rewriting it could only manufacture a spurious change.
-                if not entity[dependent]:
-                    continue
-            elif not prechange.get(dependent):
-                continue  # nothing stored, nothing stale to clear
-            ref = get_json_ref_info(object_type, dependent)
-            entity[dependent] = [] if (ref and ref.is_many) else None
-            if submitted:
-                dropped[dependent] = (
-                    f"Dropped: {driver_field} '{effective}' does not support this field."
-                )
-    return dropped
-
-
-def _apply_driver_field_policy(
-    object_type: str, prechange_data: dict, entity: dict, new_refs: list[str], warnings: dict,
-) -> list[str]:
-    """
-    Let the submitted driver value win over the dependent fields it forbids.
-
-    Returns ``new_refs`` with the dropped fields' unresolved-reference paths
-    removed: a dropped field is gone from the payload — a create strips the
-    emptied value out of ``change.data`` altogether — so the applier must not
-    walk a path the payload no longer carries. Every discarded submitted value
-    is reported as a change set warning rather than dropped silently.
-    """
-    dropped = normalize_changeset(object_type, prechange_data, entity)
-    if not dropped:
-        return new_refs
-    _merge_warnings(warnings, object_type, {k: [v] for k, v in dropped.items()})
-    return [r for r in new_refs if r.split(".", 1)[0] not in dropped]
 
 
 _prechange_cache = contextvars.ContextVar("diode_prechange_cache", default=None)
@@ -394,13 +271,7 @@ def _generate_changeset(entity: dict, object_type: str) -> ChangeSetResult:
                 entity = _partially_merge(prechange_data, entity, instance)
                 _align_cable_ends(prechange_data, entity)
                 _apply_merge_semantics(object_type, prechange_data, entity)
-        # Outside the "existing row" branch on purpose: a submitted driver value
-        # forbids its dependent fields on a create too, and NetBox rejects the
-        # whole entity for the contradiction rather than just the field.
-        new_refs = _apply_driver_field_policy(
-            object_type, prechange_data, entity, new_refs, warnings,
-        )
-        if instance:
+                normalize_changeset(object_type, prechange_data, entity)
             changed_data = shallow_compare_dict(
                 prechange_data, entity,
             )

--- a/netbox_diode_plugin/api/field_policy.py
+++ b/netbox_diode_plugin/api/field_policy.py
@@ -136,12 +136,13 @@ def match_participating_fields(object_type: str) -> frozenset:
     No ``dcim.interface`` or ``virtualization.vminterface`` field in the registry is
     read by any matcher (those match on device/VM plus name), so this costs the
     motivating cases nothing.
+
+    A failed model lookup PROPAGATES. Answering "no field participates" would license
+    every drop this gate exists to refuse, and ``lru_cache`` would keep serving that
+    answer long after the database recovered; ``lru_cache`` does not cache exceptions,
+    so the next call retries a lookup that failed transiently.
     """
-    try:
-        model_class = get_object_type_model(object_type)
-    except Exception:  # unknown/unavailable type -> claim nothing, fail closed below
-        logger.warning(f"match_participating_fields: cannot resolve model for {object_type}")
-        return frozenset()
+    model_class = get_object_type_model(object_type)
     names = set()
     for matcher in get_model_matchers(model_class):
         # ObjectMatchCriteria._get_refs() already unions fields with the names its

--- a/netbox_diode_plugin/api/field_policy.py
+++ b/netbox_diode_plugin/api/field_policy.py
@@ -9,6 +9,7 @@ from dcim.choices import InterfaceTypeChoices
 from dcim.constants import WIRELESS_IFACE_TYPES
 from django.db.models import Q
 
+from .common import UnresolvedReference
 from .matcher import get_model_matchers
 from .plugin_utils import get_json_ref_info, get_object_type_model
 
@@ -74,11 +75,12 @@ _DRIVER_FIELD_RULES = {
 # whole entity graph, twice: once BEFORE fingerprint dedupe and once on the merged
 # nodes after it (see transform_proto_json for why both are needed). A driver value
 # the producer SUBMITTED wins over a field it forbids that the producer also
-# submitted: the dependent field is removed from the payload and the removal is
+# submitted: the dependent field is removed from the payload, the reference edges it
+# created are released, any child node left unreachable is pruned, and the removal is
 # reported as a warning. This is what rescues a self-contradictory payload from a 400
 # that costs the whole entity. The pass is idempotent — once a field is gone there is
 # nothing left to drop and nothing new to warn about — so running it twice reports one
-# warning per field.
+# warning per field and prunes each node once.
 #
 # Phase 2 — normalize_changeset(), run by the differ once an existing row has been
 # matched. It clears a STORED dependent value the effective driver value forbids, so
@@ -164,11 +166,110 @@ def _drop_reason(driver_field: str, driver_value: str) -> str:
     )
 
 
+def _ref_uuids(value) -> set[str]:
+    """Every node uuid an (arbitrarily nested) field value points at."""
+    if isinstance(value, UnresolvedReference):
+        return {value.uuid}
+    if isinstance(value, dict):
+        found = set()
+        for item in value.values():
+            found |= _ref_uuids(item)
+        return found
+    if isinstance(value, list | tuple | set | frozenset):
+        found = set()
+        for item in value:
+            found |= _ref_uuids(item)
+        return found
+    return set()
+
+
+def _node_ref_uuids(node: dict) -> set[str]:
+    """Every uuid the node's payload fields still point at (underscore keys excluded)."""
+    found = set()
+    for key, value in node.items():
+        if key.startswith("_"):
+            continue
+        found |= _ref_uuids(value)
+    return found
+
+
+def _outgoing_edges(node: dict) -> set[str]:
+    """
+    The uuids this node keeps alive.
+
+    A node's ``_refs`` is the set of nodes it depends on, and ``_topo_sort`` orders
+    the graph by it. For a post-create step that set also holds the uuid of the node
+    it completes (its ``_instance``); that edge is excluded here, because a post-create
+    step hangs OFF its object rather than being a reason for the object to exist.
+    """
+    refs = set(node.get("_refs") or ())
+    if node.get("_is_post_create"):
+        refs.discard(node.get("_instance"))
+    return refs
+
+
+def _referenced_uuids(entities) -> set[str]:
+    """Every uuid some node in ``entities`` references."""
+    referenced = set()
+    for entity in entities:
+        referenced |= _outgoing_edges(entity)
+    return referenced
+
+
+def _prune_orphaned_nodes(entities: list[dict], referenced_before: set[str]) -> list[dict]:
+    """
+    Drop child nodes that nothing surviving references any more.
+
+    A dropped dependent field can be a NESTED reference — ``tagged_vlans`` is the
+    motivating one — and by the time the policy runs, ``_transform_proto_json_1`` has
+    already turned each item into its own node and recorded the edge in the parent's
+    ``_refs``. Deleting only the field leaves those nodes and edges in the graph, so
+    resolution still plans a CREATE for them: measured on v4.5.5, an access-mode
+    interface submitting ``tagged_vlans`` [vid 621] applied 200, ended with no tagged
+    VLANs, and left VLAN 621 in NetBox — a VLAN manufactured out of a field the change
+    set said it had dropped.
+
+    Pruning is reference-counted, because over-pruning is worse than the orphan. The
+    same VLAN can be the interface's ``untagged_vlan`` as well as one of its tagged
+    ones, or be tagged by a second interface in the same graph, or belong to a group,
+    and after fingerprint dedupe all of those are edges into ONE node. So a node goes
+    only when:
+
+      * something referenced it BEFORE the drops (``referenced_before``) — that is what
+        makes it a nested child rather than a root. A root is the entity's own primary
+        object or a post-create step, and is never pruned; and
+      * nothing that survives references it now.
+
+    Removal is transitive (a pruned VLAN's group may itself become unreachable) and a
+    post-create step follows the node it completes. Anything left referencing a pruned
+    uuid would surface as an unresolved reference from ``_check_unresolved_refs``, so
+    the two conditions are deliberately conservative: unsure means keep.
+    """
+    by_uuid = {entity["_uuid"]: entity for entity in entities}
+    alive = set(by_uuid)
+    while True:
+        referenced = _referenced_uuids(by_uuid[uuid] for uuid in alive)
+        doomed = set()
+        for uuid in alive:
+            entity = by_uuid[uuid]
+            if entity.get("_is_post_create"):
+                if entity.get("_instance") not in alive:
+                    doomed.add(uuid)
+            elif uuid in referenced_before and uuid not in referenced:
+                doomed.add(uuid)
+        if not doomed:
+            break
+        alive -= doomed
+        logger.debug(f"Pruned {len(doomed)} node(s) orphaned by a driver-field drop")
+    return [entity for entity in entities if entity["_uuid"] in alive]
+
+
 def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, str]:
     """
     Remove the submitted fields the SUBMITTED driver value forbids.
 
-    Mutates ``entity`` in place, deleting each forbidden field, and returns
+    Mutates ``entity`` in place, deleting each forbidden field and releasing the
+    reference edges that field contributed to the node's ``_refs``, and returns
     ``{field: reason}`` for what it removed. No-op unless ``object_type`` is
     registered.
 
@@ -188,6 +289,7 @@ def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, st
     if not rules_by_driver:
         return {}
     dropped = {}
+    released = set()
     for driver_field, value_map in rules_by_driver.items():
         if driver_field not in entity:
             continue  # nothing submitted -> nothing wins
@@ -208,29 +310,46 @@ def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, st
                     f"'{driver_value}' but participates in matching; left for NetBox to reject"
                 )
                 continue
+            released |= _ref_uuids(entity[dependent])
             del entity[dependent]
             dropped[dependent] = _drop_reason(driver_field, driver_value)
+    if released and "_refs" in entity:
+        # Release only the edges NOTHING else on this node needs. The same VLAN node
+        # can be reached from untagged_vlan and from tagged_vlans at once (after
+        # fingerprint dedupe, routinely), and dropping the tagged_vlans edge must not
+        # take the untagged_vlan edge with it.
+        entity["_refs"] = set(entity["_refs"]) - (released - _node_ref_uuids(entity))
     return dropped
 
 
-def apply_submitted_driver_field_policy(entities: list[dict]) -> None:
+def apply_submitted_driver_field_policy(entities: list[dict]) -> list[dict]:
     """
     Phase 1: let each submitted driver value win over the fields it forbids.
 
-    Takes transformed entity nodes and mutates them in place. Every dropped value is
-    recorded in the node's ``_warnings``, which the differ surfaces on the change set,
-    so producer data is never discarded silently.
+    Takes transformed entity nodes and returns the surviving graph: the same list
+    minus any child node a drop left unreachable (see ``_prune_orphaned_nodes``).
+    Nodes are mutated in place, so a caller holding a reference to one still sees the
+    drop. Every dropped value is recorded in the node's ``_warnings``, which the differ
+    surfaces on the change set, so producer data is never discarded silently.
 
     Safe to run more than once over the same graph, which the transformer does: a field
-    that is already gone drops nothing and warns nothing.
+    that is already gone drops nothing, warns nothing and releases nothing.
     """
+    # Snapshot the reference graph BEFORE any drop. A node something referenced then was
+    # created as a nested child of that reference; a node nothing referenced is a root
+    # (the entity's own primary object, or a post-create step) and is never pruned.
+    referenced_before = _referenced_uuids(entities)
+    refs_released = False
     for entity in entities:
         object_type = entity.get("_object_type")
         if object_type not in _DRIVER_FIELD_RULES:
             continue
+        refs_before = set(entity.get("_refs") or ())
         dropped = submitted_driver_field_drops(object_type, entity)
         if not dropped:
             continue
+        if set(entity.get("_refs") or ()) != refs_before:
+            refs_released = True
         entity_warnings = entity.setdefault("_warnings", {})
         for field, reason in dropped.items():
             messages = entity_warnings.setdefault(field, [])
@@ -240,6 +359,9 @@ def apply_submitted_driver_field_policy(entities: list[dict]) -> None:
             if reason not in messages:
                 messages.append(reason)
         logger.debug(f"Dropped {sorted(dropped)} from {object_type}: forbidden by the submitted driver value")
+    if not refs_released:
+        return entities
+    return _prune_orphaned_nodes(entities, referenced_before)
 
 
 def normalize_changeset(object_type: str, prechange: dict, entity: dict) -> None:

--- a/netbox_diode_plugin/api/field_policy.py
+++ b/netbox_diode_plugin/api/field_policy.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# Copyright 2025 NetBox Labs Inc
+"""Diode NetBox Plugin - API - Driver field policy."""
+
+import logging
+
+from dcim.choices import InterfaceTypeChoices
+from dcim.constants import WIRELESS_IFACE_TYPES
+
+from .plugin_utils import get_json_ref_info
+
+logger = logging.getLogger(__name__)
+
+# --- Driver field policy -----------------------------------------------------
+# A few NetBox fields are legal only for particular values of another field on the
+# same object: a "driver" field whose value forbids a set of "dependent" fields.
+# NetBox enforces that at the model (Interface.clean() / VLAN.clean()) and, for
+# dcim.interface, in the serializer's validate() — and where it enforces it, it
+# rejects the WHOLE entity rather than ignoring the surplus field.
+#
+# object_type -> driver_field -> { driver_value : [dependent fields forbidden] }
+# Values verified against NetBox model clean() / serializer validate()
+# (v4.4.10 / v4.5.5 / v4.6.0).
+_INTERFACE_MODE_VLAN_RULES = {
+    "": ["untagged_vlan", "tagged_vlans", "qinq_svlan"],  # routed / no 802.1Q
+    "access": ["tagged_vlans", "qinq_svlan"],
+    "tagged": ["qinq_svlan"],
+    "tagged-all": ["tagged_vlans", "qinq_svlan"],
+    "q-in-q": [],
+}
+
+# rf_channel / rf_channel_frequency / rf_channel_width / rf_role may be set only on
+# wireless interface types (Interface.clean(); is_wireless == type in WIRELESS_IFACE_TYPES).
+# Keyed on every non-wireless type (complement of the wireless allow-set) so a type
+# change away from wireless clears the stale rf fields.
+_RF_FIELDS = ["rf_channel", "rf_channel_frequency", "rf_channel_width", "rf_role"]
+_INTERFACE_TYPE_RF_RULES = {
+    t: _RF_FIELDS for t in InterfaceTypeChoices.values() if t not in WIRELESS_IFACE_TYPES
+}
+
+# ipam.vlan: qinq_svlan may be set only on a Q-in-Q customer VLAN (qinq_role == 'cvlan');
+# VLAN.clean() rejects a stale qinq_svlan for any other role. (The reciprocal
+# "customer VLAN requires an svlan" is a presence rule, not ours -> 'cvlan' maps to [].)
+_VLAN_QINQ_RULES = {
+    "": ["qinq_svlan"],
+    "svlan": ["qinq_svlan"],
+    "cvlan": [],
+}
+
+# One registry, applied uniformly: the rules encode NetBox's data model, not which
+# serializer happens to police it, and NetBox rejects the WHOLE entity wherever it
+# does police it. See the two phases below for what "applied" means on each side.
+#
+# Measured cost of that uniformity, on v4.5.5: virtualization.vminterface is the one
+# entry whose serializer does NO mode/VLAN validation, so a CREATE naming mode
+# "access" with tagged VLANs was stored as submitted (develop keeps tagged=[2701]).
+# It now loses those VLANs, with a warning. That is the only payload measured where
+# NetBox would have kept the data: dcim.interface answers the same contradiction with
+# a 400 that costs the whole interface, VLAN.clean() rejects a stale qinq_svlan, and
+# BaseInterface.save() drops a non-tagged interface's tagged VLANs on every later save
+# anyway (`not self._state.adding`), so the stored state was one save from vanishing.
+_DRIVER_FIELD_RULES = {
+    "dcim.interface": {"mode": _INTERFACE_MODE_VLAN_RULES, "type": _INTERFACE_TYPE_RF_RULES},
+    "virtualization.vminterface": {"mode": _INTERFACE_MODE_VLAN_RULES},
+    "ipam.vlan": {"qinq_role": _VLAN_QINQ_RULES},
+}
+
+# The policy runs in two phases, on purpose:
+#
+# Phase 1 — apply_submitted_driver_field_policy(), run by the transformer for every
+# entity BEFORE any fingerprinting. A driver value the producer SUBMITTED wins over
+# a field it forbids that the producer also submitted: the dependent field is
+# removed from the payload and the removal is reported as a warning. This is what
+# rescues a self-contradictory payload from a 400 that costs the whole entity.
+#
+# Phase 2 — normalize_changeset(), run by the differ once an existing row has been
+# matched. It clears a STORED dependent value the effective driver value forbids, so
+# the merged partial-update state stays legal. It never touches a field the payload
+# still carries, which after phase 1 means either the driver value permits it or the
+# producer submitted no driver value at all.
+#
+# Neither phase writes a value into a payload that did not carry the field unless
+# there is a non-empty STORED value to clear; that is what makes re-ingest converge.
+# Phase 1 removes rather than blanks precisely so it cannot guess wrong about the
+# empty representation a field ends up storing: measured on v4.5.5, dcim.interface
+# rf_role stores '' when it is submitted as null but NULL when it is not submitted at
+# all — the same column, two empty values, so no single blank matches both, and a
+# blank that does not match diffs against the stored one on every later ingest.
+
+
+def _drop_reason(driver_field: str, driver_value: str) -> str:
+    """Explain a phase 1 drop, including when the submitted driver value is empty."""
+    if driver_value:
+        return (
+            f"Dropped: submitted {driver_field} '{driver_value}' does not support this field."
+        )
+    return (
+        f"Dropped: the submitted {driver_field} is empty, which does not support this field."
+    )
+
+
+def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, str]:
+    """
+    Remove the submitted fields the SUBMITTED driver value forbids.
+
+    Mutates ``entity`` in place, deleting each forbidden field, and returns
+    ``{field: reason}`` for what it removed. No-op unless ``object_type`` is
+    registered.
+
+    The driver field must be explicitly present in ``entity``: the policy is that
+    a submitted driver value wins over the fields it forbids, so with no submitted
+    driver value there is nothing to win and producer data is left alone (a create
+    that simply omits ``mode`` keeps the VLANs NetBox would have stored). A value
+    that is absent or already empty is not touched either — there is nothing to
+    drop, and rewriting it could only manufacture a spurious change.
+
+    Forbidden fields are DELETED rather than blanked. The payload then reads as if
+    the producer had never sent the field: nothing is submitted to NetBox for a
+    create, and phase 2 remains free to clear a non-empty stored value with the
+    empty representation that field actually accepts.
+    """
+    rules_by_driver = _DRIVER_FIELD_RULES.get(object_type)
+    if not rules_by_driver:
+        return {}
+    dropped = {}
+    for driver_field, value_map in rules_by_driver.items():
+        if driver_field not in entity:
+            continue  # nothing submitted -> nothing wins
+        submitted = entity[driver_field]
+        if submitted is not None and not isinstance(submitted, str):
+            # Every driver field is a NetBox CharField; anything else is not a
+            # value we can reason about, so fail open and let NetBox judge it.
+            continue
+        driver_value = submitted or ""
+        for dependent in value_map.get(driver_value, ()):
+            if not entity.get(dependent):
+                continue  # not submitted, or submitted empty -> nothing to drop
+            del entity[dependent]
+            dropped[dependent] = _drop_reason(driver_field, driver_value)
+    return dropped
+
+
+def apply_submitted_driver_field_policy(entities: list[dict]) -> None:
+    """
+    Phase 1: let each submitted driver value win over the fields it forbids.
+
+    Runs before fingerprinting, so it must be given transformed entity nodes.
+    Every dropped value is recorded in the node's ``_warnings``, which the differ
+    surfaces on the change set, so producer data is never discarded silently.
+    """
+    for entity in entities:
+        object_type = entity.get("_object_type")
+        if object_type not in _DRIVER_FIELD_RULES:
+            continue
+        dropped = submitted_driver_field_drops(object_type, entity)
+        if not dropped:
+            continue
+        entity_warnings = entity.setdefault("_warnings", {})
+        for field, reason in dropped.items():
+            entity_warnings.setdefault(field, []).append(reason)
+        logger.debug(f"Dropped {sorted(dropped)} from {object_type}: forbidden by the submitted driver value")
+
+
+def normalize_changeset(object_type: str, prechange: dict, entity: dict) -> None:
+    """
+    Phase 2: clear stale STORED dependent fields the effective driver value forbids.
+
+    Mutates ``entity`` in place. No-op unless ``object_type`` is registered and an
+    existing row (non-empty ``prechange``) is present. A dependent field is cleared
+    only when it is NOT explicitly present in ``entity`` (respect producer intent;
+    phase 1 has already removed whatever a submitted driver value forbids) and its
+    existing value is non-empty (idempotency: once NetBox stores the empty value,
+    nothing is injected again, so re-ingest converges). Clearing uses ``[]`` for
+    many-valued refs and ``None`` for single refs.
+    """
+    rules_by_driver = _DRIVER_FIELD_RULES.get(object_type)
+    if not rules_by_driver or not prechange:
+        return
+    for driver_field, value_map in rules_by_driver.items():
+        effective = entity.get(driver_field, prechange.get(driver_field))
+        if effective is not None and not isinstance(effective, str):
+            continue  # not a driver value we can reason about; fail open
+        for dependent in value_map.get(effective or "", ()):
+            if dependent in entity:
+                continue
+            if prechange.get(dependent):
+                ref = get_json_ref_info(object_type, dependent)
+                entity[dependent] = [] if (ref and ref.is_many) else None

--- a/netbox_diode_plugin/api/field_policy.py
+++ b/netbox_diode_plugin/api/field_policy.py
@@ -208,6 +208,11 @@ def _outgoing_edges(node: dict) -> set[str]:
     return refs
 
 
+def referenced_uuids(entities) -> set[str]:
+    """Public alias: the reference graph the transformer snapshots before any drop."""
+    return _referenced_uuids(entities)
+
+
 def _referenced_uuids(entities) -> set[str]:
     """Every uuid some node in ``entities`` references."""
     referenced = set()
@@ -322,23 +327,20 @@ def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, st
     return dropped
 
 
-def apply_submitted_driver_field_policy(entities: list[dict]) -> list[dict]:
+def apply_submitted_driver_field_policy(entities: list[dict]) -> bool:
     """
     Phase 1: let each submitted driver value win over the fields it forbids.
 
-    Takes transformed entity nodes and returns the surviving graph: the same list
-    minus any child node a drop left unreachable (see ``_prune_orphaned_nodes``).
-    Nodes are mutated in place, so a caller holding a reference to one still sees the
-    drop. Every dropped value is recorded in the node's ``_warnings``, which the differ
+    Mutates the nodes in place and returns whether any reference edge was released,
+    i.e. whether a later prune has anything to do. It does NOT prune: see
+    ``prune_orphaned_nodes`` and the ordering note there for why that has to wait.
+
+    Every dropped value is recorded in the node's ``_warnings``, which the differ
     surfaces on the change set, so producer data is never discarded silently.
 
     Safe to run more than once over the same graph, which the transformer does: a field
     that is already gone drops nothing, warns nothing and releases nothing.
     """
-    # Snapshot the reference graph BEFORE any drop. A node something referenced then was
-    # created as a nested child of that reference; a node nothing referenced is a root
-    # (the entity's own primary object, or a post-create step) and is never pruned.
-    referenced_before = _referenced_uuids(entities)
     refs_released = False
     for entity in entities:
         object_type = entity.get("_object_type")
@@ -359,8 +361,32 @@ def apply_submitted_driver_field_policy(entities: list[dict]) -> list[dict]:
             if reason not in messages:
                 messages.append(reason)
         logger.debug(f"Dropped {sorted(dropped)} from {object_type}: forbidden by the submitted driver value")
-    if not refs_released:
-        return entities
+    return refs_released
+
+
+def prune_orphaned_nodes(entities: list[dict], referenced_before: set) -> list[dict]:
+    """
+    Drop the child nodes the policy's releases left unreachable.
+
+    Separate from the drop, and run ONCE after deduplication, because pruning inside
+    the pre-dedupe pass destroys a duplicate representation before
+    ``_fingerprint_dedupe`` can merge it. Measured: an interface with mode "access",
+    ``untagged_vlan {vid 3992}`` and ``tagged_vlans [{vid 3992, name "v3992"}]`` --
+    two child nodes for one VLAN, the richer one inside the field the mode forbids.
+    Pruning per pass removed the named copy before the merge, leaving a survivor with
+    a vid and no name, and the whole entity became
+    ``400 {"ipam.vlan": {"name": ["This field cannot be blank."]}}`` forever -- an error
+    that also misdirects, blaming a blank VLAN name for an interface mode contradiction.
+    The quieter form of the same mechanism silently loses any field stated only on the
+    dropped occurrence (a ``description`` carried only in ``tagged_vlans``).
+    Deferring the sweep lets dedupe merge first, so the survivor keeps what the pruned
+    copy contributed and only genuinely unreachable nodes go.
+
+    ``referenced_before`` is the reference graph snapshotted BEFORE any drop: a node
+    something referenced then was created as a nested child of that reference, while a
+    node nothing referenced is a root (the entity's own primary object, or a post-create
+    step) and is never pruned.
+    """
     return _prune_orphaned_nodes(entities, referenced_before)
 
 

--- a/netbox_diode_plugin/api/field_policy.py
+++ b/netbox_diode_plugin/api/field_policy.py
@@ -3,11 +3,14 @@
 """Diode NetBox Plugin - API - Driver field policy."""
 
 import logging
+from functools import lru_cache
 
 from dcim.choices import InterfaceTypeChoices
 from dcim.constants import WIRELESS_IFACE_TYPES
+from django.db.models import Q
 
-from .plugin_utils import get_json_ref_info
+from .matcher import get_model_matchers
+from .plugin_utils import get_json_ref_info, get_object_type_model
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +91,64 @@ _DRIVER_FIELD_RULES = {
 # blank that does not match diffs against the stored one on every later ingest.
 
 
+def _q_field_refs(condition) -> set[str]:
+    """Field names a matcher's ``condition`` Q object reads, lookups stripped."""
+    refs = set()
+    if condition is None:
+        return refs
+    children = getattr(condition, "children", None)
+    if children is None:
+        return refs
+    for child in children:
+        if isinstance(child, Q):
+            refs |= _q_field_refs(child)
+        elif isinstance(child, (tuple, list)) and child:
+            refs.add(str(child[0]).split("__", 1)[0])
+    return refs
+
+
+@lru_cache(maxsize=256)
+def match_participating_fields(object_type: str) -> frozenset:
+    """
+    Every field name any matcher for ``object_type`` reads, conditions included.
+
+    Phase 1 must never drop one of these. A matcher is how the plugin decides WHICH
+    row a payload is talking about, so removing a field it reads does not just change
+    what gets written -- it changes what gets matched, and the entity silently lands
+    on a different object.
+
+    Measured, and the reason this gate exists: ``ipam.vlan.qinq_svlan`` is read by
+    four matchers (``ipam_vlan_unique_qinq_svlan_vid`` and ``..._name`` through their
+    fields; ``logical_vlan_vid_no_group_or_svlan_or_site`` and ``logical_vlan_in_site``
+    through a ``qinq_svlan IS NULL`` condition). Dropping it pre-match made a
+    contradictory VLAN payload satisfy the vid-only criterion, so it adopted and
+    renamed an unrelated VLAN that merely shared the vid -- or inserted a duplicate
+    row and then converged onto it, which no re-ingest check can see. Dropping it
+    post-match instead re-planned a CREATE forever. Neither placement is safe, so a
+    match-participating field is simply never dropped and NetBox's own error stands.
+
+    No ``dcim.interface`` or ``virtualization.vminterface`` field in the registry is
+    read by any matcher (those match on device/VM plus name), so this costs the
+    motivating cases nothing.
+    """
+    try:
+        model_class = get_object_type_model(object_type)
+    except Exception:  # unknown/unavailable type -> claim nothing, fail closed below
+        logger.warning(f"match_participating_fields: cannot resolve model for {object_type}")
+        return frozenset()
+    names = set()
+    for matcher in get_model_matchers(model_class):
+        # ObjectMatchCriteria._get_refs() already unions fields with the names its
+        # expressions reference; other matcher classes only carry plain fields.
+        get_refs = getattr(matcher, "_get_refs", None)
+        if callable(get_refs):
+            names |= set(get_refs())
+        else:
+            names.update(getattr(matcher, "fields", None) or ())
+        names |= _q_field_refs(getattr(matcher, "condition", None))
+    return frozenset(names)
+
+
 def _drop_reason(driver_field: str, driver_value: str) -> str:
     """Explain a phase 1 drop, including when the submitted driver value is empty."""
     if driver_value:
@@ -135,6 +196,14 @@ def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, st
         for dependent in value_map.get(driver_value, ()):
             if not entity.get(dependent):
                 continue  # not submitted, or submitted empty -> nothing to drop
+            if dependent in match_participating_fields(object_type):
+                # Identity field: dropping it would change which row we mean.
+                # See match_participating_fields.
+                logger.debug(
+                    f"{object_type}.{dependent} is forbidden by {driver_field} "
+                    f"'{driver_value}' but participates in matching; left for NetBox to reject"
+                )
+                continue
             del entity[dependent]
             dropped[dependent] = _drop_reason(driver_field, driver_value)
     return dropped

--- a/netbox_diode_plugin/api/field_policy.py
+++ b/netbox_diode_plugin/api/field_policy.py
@@ -70,11 +70,15 @@ _DRIVER_FIELD_RULES = {
 
 # The policy runs in two phases, on purpose:
 #
-# Phase 1 — apply_submitted_driver_field_policy(), run by the transformer for every
-# entity BEFORE any fingerprinting. A driver value the producer SUBMITTED wins over
-# a field it forbids that the producer also submitted: the dependent field is
-# removed from the payload and the removal is reported as a warning. This is what
-# rescues a self-contradictory payload from a 400 that costs the whole entity.
+# Phase 1 — apply_submitted_driver_field_policy(), run by the transformer over the
+# whole entity graph, twice: once BEFORE fingerprint dedupe and once on the merged
+# nodes after it (see transform_proto_json for why both are needed). A driver value
+# the producer SUBMITTED wins over a field it forbids that the producer also
+# submitted: the dependent field is removed from the payload and the removal is
+# reported as a warning. This is what rescues a self-contradictory payload from a 400
+# that costs the whole entity. The pass is idempotent — once a field is gone there is
+# nothing left to drop and nothing new to warn about — so running it twice reports one
+# warning per field.
 #
 # Phase 2 — normalize_changeset(), run by the differ once an existing row has been
 # matched. It clears a STORED dependent value the effective driver value forbids, so
@@ -213,9 +217,12 @@ def apply_submitted_driver_field_policy(entities: list[dict]) -> None:
     """
     Phase 1: let each submitted driver value win over the fields it forbids.
 
-    Runs before fingerprinting, so it must be given transformed entity nodes.
-    Every dropped value is recorded in the node's ``_warnings``, which the differ
-    surfaces on the change set, so producer data is never discarded silently.
+    Takes transformed entity nodes and mutates them in place. Every dropped value is
+    recorded in the node's ``_warnings``, which the differ surfaces on the change set,
+    so producer data is never discarded silently.
+
+    Safe to run more than once over the same graph, which the transformer does: a field
+    that is already gone drops nothing and warns nothing.
     """
     for entity in entities:
         object_type = entity.get("_object_type")
@@ -226,7 +233,12 @@ def apply_submitted_driver_field_policy(entities: list[dict]) -> None:
             continue
         entity_warnings = entity.setdefault("_warnings", {})
         for field, reason in dropped.items():
-            entity_warnings.setdefault(field, []).append(reason)
+            messages = entity_warnings.setdefault(field, [])
+            # One drop of one field is one message. This pass runs twice and
+            # _merge_nodes unions the warnings of merged duplicates, so the same
+            # sentence can arrive from more than one of those steps.
+            if reason not in messages:
+                messages.append(reason)
         logger.debug(f"Dropped {sorted(dropped)} from {object_type}: forbidden by the submitted driver value")
 
 

--- a/netbox_diode_plugin/api/field_policy.py
+++ b/netbox_diode_plugin/api/field_policy.py
@@ -72,15 +72,14 @@ _DRIVER_FIELD_RULES = {
 # The policy runs in two phases, on purpose:
 #
 # Phase 1 — apply_submitted_driver_field_policy(), run by the transformer over the
-# whole entity graph, twice: once BEFORE fingerprint dedupe and once on the merged
-# nodes after it (see transform_proto_json for why both are needed). A driver value
-# the producer SUBMITTED wins over a field it forbids that the producer also
-# submitted: the dependent field is removed from the payload, the reference edges it
-# created are released, any child node left unreachable is pruned, and the removal is
-# reported as a warning. This is what rescues a self-contradictory payload from a 400
-# that costs the whole entity. The pass is idempotent — once a field is gone there is
-# nothing left to drop and nothing new to warn about — so running it twice reports one
-# warning per field and prunes each node once.
+# whole entity graph before fingerprint dedupe, and again on each node dedupe merges
+# (see transform_proto_json). A driver value the producer SUBMITTED wins over a field
+# it forbids that the producer also submitted: the dependent field is removed from the
+# payload, the reference edges it created are released, any child node left unreachable
+# is pruned, and the removal is reported as a warning. This is what rescues a
+# self-contradictory payload from a 400 that costs the whole entity. The pass is
+# idempotent — once a field is gone there is nothing left to drop and nothing new to
+# warn about — so however often it runs, each field is reported once.
 #
 # Phase 2 — normalize_changeset(), run by the differ once an existing row has been
 # matched. It clears a STORED dependent value the effective driver value forbids, so
@@ -214,6 +213,43 @@ def referenced_uuids(entities) -> set[str]:
     return _referenced_uuids(entities)
 
 
+@lru_cache(maxsize=16)
+def droppable_dependent_fields(object_type: str) -> frozenset:
+    """
+    Fields of ``object_type`` that SOME driver value could remove.
+
+    A disagreement between two duplicate nodes over one of these is not necessarily a
+    disagreement about real data: a driver value the merge has not reached yet may
+    delete the field outright and settle it. Fields the gate protects are excluded —
+    they can never be dropped, so a conflict on one is final.
+    """
+    rules_by_driver = _DRIVER_FIELD_RULES.get(object_type)
+    if not rules_by_driver:
+        return frozenset()
+    names = set()
+    for value_map in rules_by_driver.values():
+        for dependents in value_map.values():
+            names.update(dependents)
+    return frozenset(names - match_participating_fields(object_type))
+
+
+def release_rejected_edges(node: dict, rejected_values: list) -> None:
+    """
+    Release the edges only a rejected duplicate value contributed.
+
+    ``_merge_nodes`` unions ``_refs``, so a value it declines to merge would otherwise
+    keep its child nodes reachable and have them created anyway — the same manufactured
+    VLAN ``_prune_orphaned_nodes`` exists to prevent. Only edges nothing else on the
+    node still needs are released.
+    """
+    released = set()
+    for value in rejected_values:
+        released |= _ref_uuids(value)
+    released -= _node_ref_uuids(node)
+    if released and "_refs" in node:
+        node["_refs"] = set(node["_refs"]) - released
+
+
 def _referenced_uuids(entities) -> set[str]:
     """Every uuid some node in ``entities`` references."""
     referenced = set()
@@ -339,8 +375,9 @@ def apply_submitted_driver_field_policy(entities: list[dict]) -> bool:
     Every dropped value is recorded in the node's ``_warnings``, which the differ
     surfaces on the change set, so producer data is never discarded silently.
 
-    Safe to run more than once over the same graph, which the transformer does: a field
-    that is already gone drops nothing, warns nothing and releases nothing.
+    Safe to run any number of times over the same graph, which the transformer does
+    (once up front, then on every node fingerprint dedupe merges): a field that is
+    already gone drops nothing, warns nothing and releases nothing.
     """
     refs_released = False
     for entity in entities:
@@ -356,7 +393,7 @@ def apply_submitted_driver_field_policy(entities: list[dict]) -> bool:
         entity_warnings = entity.setdefault("_warnings", {})
         for field, reason in dropped.items():
             messages = entity_warnings.setdefault(field, [])
-            # One drop of one field is one message. This pass runs twice and
+            # One drop of one field is one message. The pass runs repeatedly and
             # _merge_nodes unions the warnings of merged duplicates, so the same
             # sentence can arrive from more than one of those steps.
             if reason not in messages:

--- a/netbox_diode_plugin/api/field_policy.py
+++ b/netbox_diode_plugin/api/field_policy.py
@@ -15,16 +15,11 @@ from .plugin_utils import get_json_ref_info, get_object_type_model
 
 logger = logging.getLogger(__name__)
 
-# --- Driver field policy -----------------------------------------------------
-# A few NetBox fields are legal only for particular values of another field on the
-# same object: a "driver" field whose value forbids a set of "dependent" fields.
-# NetBox enforces that at the model (Interface.clean() / VLAN.clean()) and, for
-# dcim.interface, in the serializer's validate() — and where it enforces it, it
-# rejects the WHOLE entity rather than ignoring the surplus field.
+# A few NetBox fields are legal only for particular values of another field on the same
+# object: a "driver" field whose value forbids a set of "dependent" fields. Wherever
+# NetBox polices this it rejects the WHOLE entity rather than ignoring the surplus field.
 #
-# object_type -> driver_field -> { driver_value : [dependent fields forbidden] }
-# Values verified against NetBox model clean() / serializer validate()
-# (v4.4.10 / v4.5.5 / v4.6.0).
+# object_type -> driver_field -> { driver_value: [forbidden] }, per NetBox's clean().
 _INTERFACE_MODE_VLAN_RULES = {
     "": ["untagged_vlan", "tagged_vlans", "qinq_svlan"],  # routed / no 802.1Q
     "access": ["tagged_vlans", "qinq_svlan"],
@@ -33,67 +28,37 @@ _INTERFACE_MODE_VLAN_RULES = {
     "q-in-q": [],
 }
 
-# rf_channel / rf_channel_frequency / rf_channel_width / rf_role may be set only on
-# wireless interface types (Interface.clean(); is_wireless == type in WIRELESS_IFACE_TYPES).
-# Keyed on every non-wireless type (complement of the wireless allow-set) so a type
+# rf_* is wireless-only. Keyed on the complement of the wireless allow-set, so a type
 # change away from wireless clears the stale rf fields.
 _RF_FIELDS = ["rf_channel", "rf_channel_frequency", "rf_channel_width", "rf_role"]
 _INTERFACE_TYPE_RF_RULES = {
     t: _RF_FIELDS for t in InterfaceTypeChoices.values() if t not in WIRELESS_IFACE_TYPES
 }
 
-# ipam.vlan: qinq_svlan may be set only on a Q-in-Q customer VLAN (qinq_role == 'cvlan');
-# VLAN.clean() rejects a stale qinq_svlan for any other role. (The reciprocal
-# "customer VLAN requires an svlan" is a presence rule, not ours -> 'cvlan' maps to [].)
+# qinq_svlan is customer-VLAN-only. The reciprocal "customer VLAN requires an svlan" is
+# a presence rule, not ours, so 'cvlan' maps to [].
 _VLAN_QINQ_RULES = {
     "": ["qinq_svlan"],
     "svlan": ["qinq_svlan"],
     "cvlan": [],
 }
 
-# One registry, applied uniformly: the rules encode NetBox's data model, not which
-# serializer happens to police it, and NetBox rejects the WHOLE entity wherever it
-# does police it. See the two phases below for what "applied" means on each side.
-#
-# Measured cost of that uniformity, on v4.5.5: virtualization.vminterface is the one
-# entry whose serializer does NO mode/VLAN validation, so a CREATE naming mode
-# "access" with tagged VLANs was stored as submitted (develop keeps tagged=[2701]).
-# It now loses those VLANs, with a warning. That is the only payload measured where
-# NetBox would have kept the data: dcim.interface answers the same contradiction with
-# a 400 that costs the whole interface, VLAN.clean() rejects a stale qinq_svlan, and
-# BaseInterface.save() drops a non-tagged interface's tagged VLANs on every later save
-# anyway (`not self._state.adding`), so the stored state was one save from vanishing.
+# Applied uniformly: the rules encode NetBox's data model, not which serializer happens
+# to police it. virtualization.vminterface validates nothing, so it is the only place a
+# create loses VLANs NetBox would have stored -- accepted, because BaseInterface.save()
+# drops a non-tagged interface's tagged VLANs on every later save anyway.
 _DRIVER_FIELD_RULES = {
     "dcim.interface": {"mode": _INTERFACE_MODE_VLAN_RULES, "type": _INTERFACE_TYPE_RF_RULES},
     "virtualization.vminterface": {"mode": _INTERFACE_MODE_VLAN_RULES},
     "ipam.vlan": {"qinq_role": _VLAN_QINQ_RULES},
 }
 
-# The policy runs in two phases, on purpose:
-#
-# Phase 1 — apply_submitted_driver_field_policy(), run by the transformer over the
-# whole entity graph before fingerprint dedupe, and again on each node dedupe merges
-# (see transform_proto_json). A driver value the producer SUBMITTED wins over a field
-# it forbids that the producer also submitted: the dependent field is removed from the
-# payload, the reference edges it created are released, any child node left unreachable
-# is pruned, and the removal is reported as a warning. This is what rescues a
-# self-contradictory payload from a 400 that costs the whole entity. The pass is
-# idempotent — once a field is gone there is nothing left to drop and nothing new to
-# warn about — so however often it runs, each field is reported once.
-#
-# Phase 2 — normalize_changeset(), run by the differ once an existing row has been
-# matched. It clears a STORED dependent value the effective driver value forbids, so
-# the merged partial-update state stays legal. It never touches a field the payload
-# still carries, which after phase 1 means either the driver value permits it or the
-# producer submitted no driver value at all.
-#
-# Neither phase writes a value into a payload that did not carry the field unless
-# there is a non-empty STORED value to clear; that is what makes re-ingest converge.
-# Phase 1 removes rather than blanks precisely so it cannot guess wrong about the
-# empty representation a field ends up storing: measured on v4.5.5, dcim.interface
-# rf_role stores '' when it is submitted as null but NULL when it is not submitted at
-# all — the same column, two empty values, so no single blank matches both, and a
-# blank that does not match diffs against the stored one on every later ingest.
+# Phase 1 (apply_submitted_driver_field_policy, in the transformer) lets a SUBMITTED
+# driver value delete the fields it forbids, rescuing a self-contradictory payload from
+# a 400 that costs the whole entity. Phase 2 (normalize_changeset) clears a STORED value
+# the effective driver value forbids, and stays in the differ because it needs the
+# matched row. Neither invents a field the payload did not carry unless there is a
+# non-empty stored value to clear, which is what makes re-ingest converge.
 
 
 def _q_field_refs(condition) -> set[str]:
@@ -117,29 +82,13 @@ def match_participating_fields(object_type: str) -> frozenset:
     """
     Every field name any matcher for ``object_type`` reads, conditions included.
 
-    Phase 1 must never drop one of these. A matcher is how the plugin decides WHICH
-    row a payload is talking about, so removing a field it reads does not just change
-    what gets written -- it changes what gets matched, and the entity silently lands
-    on a different object.
+    Phase 1 must never drop one of these: a matcher decides WHICH row a payload means,
+    so removing a field it reads lands the entity on a different object. Four VLAN
+    matchers read ``ipam.vlan.qinq_svlan``; dropping it let a contradictory payload
+    satisfy the vid-only criterion and rename an unrelated same-vid row.
 
-    Measured, and the reason this gate exists: ``ipam.vlan.qinq_svlan`` is read by
-    four matchers (``ipam_vlan_unique_qinq_svlan_vid`` and ``..._name`` through their
-    fields; ``logical_vlan_vid_no_group_or_svlan_or_site`` and ``logical_vlan_in_site``
-    through a ``qinq_svlan IS NULL`` condition). Dropping it pre-match made a
-    contradictory VLAN payload satisfy the vid-only criterion, so it adopted and
-    renamed an unrelated VLAN that merely shared the vid -- or inserted a duplicate
-    row and then converged onto it, which no re-ingest check can see. Dropping it
-    post-match instead re-planned a CREATE forever. Neither placement is safe, so a
-    match-participating field is simply never dropped and NetBox's own error stands.
-
-    No ``dcim.interface`` or ``virtualization.vminterface`` field in the registry is
-    read by any matcher (those match on device/VM plus name), so this costs the
-    motivating cases nothing.
-
-    A failed model lookup PROPAGATES. Answering "no field participates" would license
-    every drop this gate exists to refuse, and ``lru_cache`` would keep serving that
-    answer long after the database recovered; ``lru_cache`` does not cache exceptions,
-    so the next call retries a lookup that failed transiently.
+    A failed lookup PROPAGATES: "no field participates" would license every drop the
+    gate refuses, and ``lru_cache`` would serve it after the database recovered.
     """
     model_class = get_object_type_model(object_type)
     names = set()
@@ -197,10 +146,8 @@ def _outgoing_edges(node: dict) -> set[str]:
     """
     The uuids this node keeps alive.
 
-    A node's ``_refs`` is the set of nodes it depends on, and ``_topo_sort`` orders
-    the graph by it. For a post-create step that set also holds the uuid of the node
-    it completes (its ``_instance``); that edge is excluded here, because a post-create
-    step hangs OFF its object rather than being a reason for the object to exist.
+    Its ``_refs``, minus (for a post-create step) the node it completes, which it hangs
+    off rather than keeps alive.
     """
     refs = set(node.get("_refs") or ())
     if node.get("_is_post_create"):
@@ -208,20 +155,14 @@ def _outgoing_edges(node: dict) -> set[str]:
     return refs
 
 
-def referenced_uuids(entities) -> set[str]:
-    """Public alias: the reference graph the transformer snapshots before any drop."""
-    return _referenced_uuids(entities)
-
-
 @lru_cache(maxsize=16)
 def droppable_dependent_fields(object_type: str) -> frozenset:
     """
     Fields of ``object_type`` that SOME driver value could remove.
 
-    A disagreement between two duplicate nodes over one of these is not necessarily a
-    disagreement about real data: a driver value the merge has not reached yet may
-    delete the field outright and settle it. Fields the gate protects are excluded —
-    they can never be dropped, so a conflict on one is final.
+    Two duplicates disagreeing over one of these may not be disagreeing about real data:
+    a driver value the merge has not reached yet may delete the field and settle it.
+    Gate-protected fields are excluded, so a conflict on one is final.
     """
     rules_by_driver = _DRIVER_FIELD_RULES.get(object_type)
     if not rules_by_driver:
@@ -237,10 +178,8 @@ def release_rejected_edges(node: dict, rejected_values: list) -> None:
     """
     Release the edges only a rejected duplicate value contributed.
 
-    ``_merge_nodes`` unions ``_refs``, so a value it declines to merge would otherwise
-    keep its child nodes reachable and have them created anyway — the same manufactured
-    VLAN ``_prune_orphaned_nodes`` exists to prevent. Only edges nothing else on the
-    node still needs are released.
+    ``_merge_nodes`` unions ``_refs``, so a declined value would otherwise keep its
+    children reachable and have them created anyway. Only edges nothing else needs go.
     """
     released = set()
     for value in rejected_values:
@@ -250,7 +189,7 @@ def release_rejected_edges(node: dict, rejected_values: list) -> None:
         node["_refs"] = set(node["_refs"]) - released
 
 
-def _referenced_uuids(entities) -> set[str]:
+def referenced_uuids(entities) -> set[str]:
     """Every uuid some node in ``entities`` references."""
     referenced = set()
     for entity in entities:
@@ -258,39 +197,27 @@ def _referenced_uuids(entities) -> set[str]:
     return referenced
 
 
-def _prune_orphaned_nodes(entities: list[dict], referenced_before: set[str]) -> list[dict]:
+def prune_orphaned_nodes(entities: list[dict], referenced_before: set) -> list[dict]:
     """
-    Drop child nodes that nothing surviving references any more.
+    Drop the child nodes a drop left unreachable.
 
-    A dropped dependent field can be a NESTED reference — ``tagged_vlans`` is the
-    motivating one — and by the time the policy runs, ``_transform_proto_json_1`` has
-    already turned each item into its own node and recorded the edge in the parent's
-    ``_refs``. Deleting only the field leaves those nodes and edges in the graph, so
-    resolution still plans a CREATE for them: measured on v4.5.5, an access-mode
-    interface submitting ``tagged_vlans`` [vid 621] applied 200, ended with no tagged
-    VLANs, and left VLAN 621 in NetBox — a VLAN manufactured out of a field the change
-    set said it had dropped.
+    A dropped dependent field is often a NESTED reference whose items are already nodes
+    with edges in ``_refs``; deleting only the field leaves those behind and resolution
+    still creates them -- a VLAN manufactured out of a field the change set dropped.
 
-    Pruning is reference-counted, because over-pruning is worse than the orphan. The
-    same VLAN can be the interface's ``untagged_vlan`` as well as one of its tagged
-    ones, or be tagged by a second interface in the same graph, or belong to a group,
-    and after fingerprint dedupe all of those are edges into ONE node. So a node goes
-    only when:
-
-      * something referenced it BEFORE the drops (``referenced_before``) — that is what
-        makes it a nested child rather than a root. A root is the entity's own primary
-        object or a post-create step, and is never pruned; and
-      * nothing that survives references it now.
-
-    Removal is transitive (a pruned VLAN's group may itself become unreachable) and a
-    post-create step follows the node it completes. Anything left referencing a pruned
-    uuid would surface as an unresolved reference from ``_check_unresolved_refs``, so
-    the two conditions are deliberately conservative: unsure means keep.
+    Reference-counted and transitive, because over-pruning is worse than the orphan: one
+    VLAN node is routinely reached from ``untagged_vlan``, ``tagged_vlans``, a second
+    interface and a group at once. A node goes only if something referenced it BEFORE
+    the drops (``referenced_before`` -- what makes it a child and not a root) and nothing
+    surviving references it now. Unsure means keep. Run ONCE, after dedupe, never inside
+    a pass: pruning the copy inside the forbidden field before the merge leaves a
+    survivor missing a required ``name`` (a permanent 400 blaming a blank VLAN name for
+    a mode contradiction) or a ``description``.
     """
     by_uuid = {entity["_uuid"]: entity for entity in entities}
     alive = set(by_uuid)
     while True:
-        referenced = _referenced_uuids(by_uuid[uuid] for uuid in alive)
+        referenced = referenced_uuids(by_uuid[uuid] for uuid in alive)
         doomed = set()
         for uuid in alive:
             entity = by_uuid[uuid]
@@ -310,22 +237,13 @@ def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, st
     """
     Remove the submitted fields the SUBMITTED driver value forbids.
 
-    Mutates ``entity`` in place, deleting each forbidden field and releasing the
-    reference edges that field contributed to the node's ``_refs``, and returns
-    ``{field: reason}`` for what it removed. No-op unless ``object_type`` is
-    registered.
-
-    The driver field must be explicitly present in ``entity``: the policy is that
-    a submitted driver value wins over the fields it forbids, so with no submitted
-    driver value there is nothing to win and producer data is left alone (a create
-    that simply omits ``mode`` keeps the VLANs NetBox would have stored). A value
-    that is absent or already empty is not touched either — there is nothing to
-    drop, and rewriting it could only manufacture a spurious change.
-
-    Forbidden fields are DELETED rather than blanked. The payload then reads as if
-    the producer had never sent the field: nothing is submitted to NetBox for a
-    create, and phase 2 remains free to clear a non-empty stored value with the
-    empty representation that field actually accepts.
+    Mutates ``entity`` in place, deleting each forbidden field and releasing the edges it
+    contributed to ``_refs``; returns ``{field: reason}``. The driver field must be
+    PRESENT: with no submitted driver value nothing wins, so producer data is left alone
+    (a create omitting ``mode`` keeps the VLANs NetBox would have stored). Forbidden
+    fields are DELETED, not blanked -- the same column stores different empty values
+    depending on whether the field was submitted at all, so a guessed blank diffs against
+    the stored one forever, and deletion leaves phase 2 free to clear it properly.
     """
     rules_by_driver = _DRIVER_FIELD_RULES.get(object_type)
     if not rules_by_driver:
@@ -337,16 +255,13 @@ def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, st
             continue  # nothing submitted -> nothing wins
         submitted = entity[driver_field]
         if submitted is not None and not isinstance(submitted, str):
-            # Every driver field is a NetBox CharField; anything else is not a
-            # value we can reason about, so fail open and let NetBox judge it.
-            continue
+            continue  # not a CharField value we can reason about; let NetBox judge it
         driver_value = submitted or ""
         for dependent in value_map.get(driver_value, ()):
             if not entity.get(dependent):
                 continue  # not submitted, or submitted empty -> nothing to drop
             if dependent in match_participating_fields(object_type):
                 # Identity field: dropping it would change which row we mean.
-                # See match_participating_fields.
                 logger.debug(
                     f"{object_type}.{dependent} is forbidden by {driver_field} "
                     f"'{driver_value}' but participates in matching; left for NetBox to reject"
@@ -356,10 +271,8 @@ def submitted_driver_field_drops(object_type: str, entity: dict) -> dict[str, st
             del entity[dependent]
             dropped[dependent] = _drop_reason(driver_field, driver_value)
     if released and "_refs" in entity:
-        # Release only the edges NOTHING else on this node needs. The same VLAN node
-        # can be reached from untagged_vlan and from tagged_vlans at once (after
-        # fingerprint dedupe, routinely), and dropping the tagged_vlans edge must not
-        # take the untagged_vlan edge with it.
+        # Only edges NOTHING else on this node needs: one VLAN node is routinely both
+        # untagged_vlan and a tagged one.
         entity["_refs"] = set(entity["_refs"]) - (released - _node_ref_uuids(entity))
     return dropped
 
@@ -368,16 +281,10 @@ def apply_submitted_driver_field_policy(entities: list[dict]) -> bool:
     """
     Phase 1: let each submitted driver value win over the fields it forbids.
 
-    Mutates the nodes in place and returns whether any reference edge was released,
-    i.e. whether a later prune has anything to do. It does NOT prune: see
-    ``prune_orphaned_nodes`` and the ordering note there for why that has to wait.
-
-    Every dropped value is recorded in the node's ``_warnings``, which the differ
-    surfaces on the change set, so producer data is never discarded silently.
-
-    Safe to run any number of times over the same graph, which the transformer does
-    (once up front, then on every node fingerprint dedupe merges): a field that is
-    already gone drops nothing, warns nothing and releases nothing.
+    Mutates the nodes in place; returns whether any edge was released, i.e. whether a
+    later prune has anything to do. It does NOT prune. Every drop is recorded in
+    ``_warnings`` so nothing is discarded silently, and the pass is idempotent -- the
+    transformer runs it once up front and again on every node dedupe merges.
     """
     refs_released = False
     for entity in entities:
@@ -393,52 +300,22 @@ def apply_submitted_driver_field_policy(entities: list[dict]) -> bool:
         entity_warnings = entity.setdefault("_warnings", {})
         for field, reason in dropped.items():
             messages = entity_warnings.setdefault(field, [])
-            # One drop of one field is one message. The pass runs repeatedly and
-            # _merge_nodes unions the warnings of merged duplicates, so the same
-            # sentence can arrive from more than one of those steps.
+            # One drop of one field is one message; the pass runs repeatedly and
+            # _merge_nodes unions merged duplicates' warnings.
             if reason not in messages:
                 messages.append(reason)
         logger.debug(f"Dropped {sorted(dropped)} from {object_type}: forbidden by the submitted driver value")
     return refs_released
 
 
-def prune_orphaned_nodes(entities: list[dict], referenced_before: set) -> list[dict]:
-    """
-    Drop the child nodes the policy's releases left unreachable.
-
-    Separate from the drop, and run ONCE after deduplication, because pruning inside
-    the pre-dedupe pass destroys a duplicate representation before
-    ``_fingerprint_dedupe`` can merge it. Measured: an interface with mode "access",
-    ``untagged_vlan {vid 3992}`` and ``tagged_vlans [{vid 3992, name "v3992"}]`` --
-    two child nodes for one VLAN, the richer one inside the field the mode forbids.
-    Pruning per pass removed the named copy before the merge, leaving a survivor with
-    a vid and no name, and the whole entity became
-    ``400 {"ipam.vlan": {"name": ["This field cannot be blank."]}}`` forever -- an error
-    that also misdirects, blaming a blank VLAN name for an interface mode contradiction.
-    The quieter form of the same mechanism silently loses any field stated only on the
-    dropped occurrence (a ``description`` carried only in ``tagged_vlans``).
-    Deferring the sweep lets dedupe merge first, so the survivor keeps what the pruned
-    copy contributed and only genuinely unreachable nodes go.
-
-    ``referenced_before`` is the reference graph snapshotted BEFORE any drop: a node
-    something referenced then was created as a nested child of that reference, while a
-    node nothing referenced is a root (the entity's own primary object, or a post-create
-    step) and is never pruned.
-    """
-    return _prune_orphaned_nodes(entities, referenced_before)
-
-
 def normalize_changeset(object_type: str, prechange: dict, entity: dict) -> None:
     """
     Phase 2: clear stale STORED dependent fields the effective driver value forbids.
 
-    Mutates ``entity`` in place. No-op unless ``object_type`` is registered and an
-    existing row (non-empty ``prechange``) is present. A dependent field is cleared
-    only when it is NOT explicitly present in ``entity`` (respect producer intent;
-    phase 1 has already removed whatever a submitted driver value forbids) and its
-    existing value is non-empty (idempotency: once NetBox stores the empty value,
-    nothing is injected again, so re-ingest converges). Clearing uses ``[]`` for
-    many-valued refs and ``None`` for single refs.
+    Mutates ``entity`` in place; no-op without a registered type and a non-empty
+    ``prechange``. A field is cleared only when it is NOT present in ``entity`` (producer
+    intent; phase 1 removed what a submitted driver value forbids) and its stored value
+    is non-empty, so re-ingest converges. ``[]`` for many-valued refs, ``None`` for one.
     """
     rules_by_driver = _DRIVER_FIELD_RULES.get(object_type)
     if not rules_by_driver or not prechange:

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -136,7 +136,11 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
 
     entities = _topo_sort(entities)
     # Let a submitted driver value win over the fields it forbids BEFORE anything else
-    # looks at those fields. Two orderings matter and this position satisfies both:
+    # looks at those fields. The policy runs on BOTH sides of _fingerprint_dedupe
+    # because duplicate representations of one object break the contradiction in two
+    # different ways, and each pass catches only its own.
+    #
+    # Three orderings matter and this position satisfies all three:
     #
     #   before _fingerprint_dedupe, because two nodes for the SAME object that carry the
     #   same submitted driver value but DIFFERENT forbidden values are duplicates that
@@ -153,6 +157,18 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     apply_submitted_driver_field_policy(entities)
     deduplicated = _fingerprint_dedupe(entities)
     deduplicated = _topo_sort(deduplicated)
+    # ... and AFTER dedupe, because duplicates can also SPLIT the contradiction instead
+    # of repeating it: phase 1 needs the driver field PRESENT in the node it is looking
+    # at, so a node carrying mode "access" with no VLANs and a node carrying
+    # tagged_vlans with no mode each pass the pre-dedupe check untouched, and
+    # _merge_nodes then combines them INTO the contradiction. Measured on v4.5.5: one
+    # graph naming Gi1/0/20 twice (the nested copy reached through the device's
+    # primary_ip4 assignment) merged to data keys [..., mode, ..., tagged_vlans, ...]
+    # with change_set.warnings None, and apply was a 400 "Interface mode does not
+    # support tagged vlans". Both passes are needed and neither is redundant; the
+    # policy is idempotent, so the field a pre-dedupe drop already removed is not
+    # dropped or warned about twice.
+    apply_submitted_driver_field_policy(deduplicated)
     _set_auto_slugs(deduplicated, supported_models)
     _handle_cached_scope(deduplicated, supported_models)
     resolved = _resolve_existing_references(deduplicated)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -141,32 +141,20 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     entities = _transform_proto_json_1(proto_json, object_type, supported_models)
 
     entities = _topo_sort(entities)
-    # Phase 1 of the driver field policy, before anything else reads the fields it may
-    # remove -- and in particular before _resolve_existing_references, because a dropped
-    # field can itself be a match criterion and dropping it after the lookup strands the
-    # entity as an unmatchable CREATE that re-plans on every ingest.
-    #
-    # This pre-dedupe pass handles nodes that carry the contradiction on their own: two
-    # duplicates that each name the same driver value with DIFFERENT forbidden values
-    # would otherwise reach _merge_nodes and be rejected outright ("Conflicting values
-    # for 'tagged_vlans'"), losing the whole entity. Duplicates that SPLIT the
-    # contradiction -- one node with the driver value, another with the forbidden field --
-    # only become contradictory as they merge, so _fingerprint_dedupe normalizes each
-    # merged node itself and reports back whether it released any edge.
-    #
-    # `referenced_before` is the reference graph before any drop; the prune sweep needs
-    # it to tell a nested child from a root.
+    # Phase 1 of the driver field policy. It runs before _resolve_existing_references
+    # because a dropped field can itself be a match criterion, and dropping it after the
+    # lookup strands the entity as a CREATE that re-plans on every ingest. This pass
+    # settles nodes that carry the contradiction on their own; duplicates that SPLIT it
+    # only become contradictory as they merge, which _fingerprint_dedupe handles.
+    # `referenced_before` is the reference graph before any drop, which the prune sweep
+    # needs to tell a nested child from a root.
     referenced_before = referenced_uuids(entities)
     released = apply_submitted_driver_field_policy(entities)
     deduplicated, merge_released = _fingerprint_dedupe(entities)
-    # Every merge is done and every merged node is normalized, so a conflict dedupe held
-    # back is a disagreement no driver value settled.
+    # Everything is merged and normalized, so a conflict dedupe held back is real.
     raise_unsettled_conflicts(deduplicated)
     deduplicated = _topo_sort(deduplicated)
-    # ONE sweep, here and never inside a pass: pruning per pass removes a duplicate child
-    # before _fingerprint_dedupe can merge it, and the survivor then loses whatever the
-    # pruned copy alone carried -- a required `name` (permanent 400) or a description
-    # (silent loss). See prune_orphaned_nodes.
+    # ONE sweep, never inside a pass: see prune_orphaned_nodes.
     if released or merge_released:
         deduplicated = prune_orphaned_nodes(deduplicated, referenced_before)
     _set_auto_slugs(deduplicated, supported_models)
@@ -613,8 +601,8 @@ def _fingerprint_dedupe(entities: list[dict]) -> tuple[list[dict], bool]: # noqa
 
     *list must be in topo order by reference already*
 
-    Returns the deduplicated entities and whether normalizing a merged node released
-    any reference edge, i.e. whether the caller's prune sweep has anything to do.
+    Also returns whether normalizing a merged node released any reference edge, i.e.
+    whether the caller's prune sweep has anything to do.
     """
     by_uuid = {}
     by_fp = {}
@@ -647,13 +635,10 @@ def _fingerprint_dedupe(entities: list[dict]) -> tuple[list[dict], bool]: # noqa
             new_refs[entity['_uuid']] = existing['_uuid']
             merged = _merge_nodes(existing, entity)
             _update_unresolved_refs(merged, new_refs)
-            # Normalize the merged node NOW, before the next duplicate is compared
-            # against it. A merge is where duplicates that each carry only half of a
-            # contradiction become contradictory, and leaving the merged node
-            # contradictory makes the outcome depend on how many duplicates follow:
-            # the third one carrying a different forbidden value would conflict with
-            # the second and reject the whole entity. It drops but never prunes --
-            # pruning waits for the caller's single post-dedupe sweep.
+            # Normalize NOW, before the next duplicate is compared against this node. A
+            # merge is where duplicates each carrying half a contradiction become
+            # contradictory, and leaving it there makes the outcome depend on how many
+            # duplicates follow. Drops only: the prune is the caller's one sweep.
             refs_released = apply_submitted_driver_field_policy([merged]) or refs_released
             for fp in fps:
                 by_fp[fp] = existing_uuid
@@ -684,10 +669,9 @@ def _merge_nodes(a: dict, b: dict) -> dict:
             error = _conflict_error(a, k, merged[k], v)
             if k not in droppable:
                 raise serializers.ValidationError(error)
-            # A driver value on a duplicate this merge has not reached yet can delete
-            # this field outright, which settles the disagreement. Raising now would
-            # make the outcome depend on the order the duplicates happen to arrive in,
-            # so the error waits until the graph is merged and normalized.
+            # A driver value on a duplicate not reached yet can delete this field and
+            # settle the disagreement, so raising now would make the outcome depend on
+            # the order the duplicates arrive in. See raise_unsettled_conflicts.
             deferred.setdefault(k, error)
             rejected.append(v)
             continue
@@ -701,10 +685,8 @@ def _merge_nodes(a: dict, b: dict) -> dict:
 
 def _union_warnings(merged: dict, a: dict, b: dict) -> None:
     """Union both nodes' _warnings per field instead of preferring a's."""
-    # Underscore keys are otherwise "prefer a's value", which would silently discard the
-    # warnings recorded on b -- including a driver-field drop the policy made before
-    # dedupe. A drop the operator never hears about is the thing the warning exists to
-    # prevent, so warnings are unioned per field like _refs.
+    # Underscore keys are otherwise "prefer a's value", which would discard a drop b
+    # recorded before dedupe -- and a drop nobody hears about defeats the warning.
     merged_warnings = copy.deepcopy(a.get('_warnings') or {})
     for field, msgs in (b.get('_warnings') or {}).items():
         for msg in msgs:
@@ -731,9 +713,9 @@ def raise_unsettled_conflicts(entities: list[dict]) -> None:
     """
     Raise the duplicate-merge conflicts no driver value settled.
 
-    A conflict on a field the policy could drop is held during dedupe; here the graph is
-    fully merged and normalized, so a field that is still present was never dropped and
-    the disagreement was real after all.
+    A conflict on a droppable field is held during dedupe; by here the graph is merged
+    and normalized, so a field still present was never dropped and the disagreement was
+    real after all.
     """
     for entity in entities:
         deferred = entity.pop('_deferred_conflicts', None)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -135,15 +135,26 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     entities = _transform_proto_json_1(proto_json, object_type, supported_models)
 
     entities = _topo_sort(entities)
+    # Let a submitted driver value win over the fields it forbids BEFORE anything else
+    # looks at those fields. Two orderings matter and this position satisfies both:
+    #
+    #   before _fingerprint_dedupe, because two nodes for the SAME object that carry the
+    #   same submitted driver value but DIFFERENT forbidden values are duplicates that
+    #   _merge_nodes would reject outright ("Conflicting values for 'tagged_vlans'"),
+    #   rejecting the whole entity -- the exact payload this policy exists to rescue.
+    #   Measured: one graph nesting Gi1/0/9 twice, mode "access", tagged_vlans [301] and
+    #   [302], was a 400 with the policy running after dedupe and applies with it here.
+    #   A field the driver value ALLOWS still conflicts, and must: mode "tagged" with
+    #   [401] vs [402] is a genuine disagreement nothing can discard.
+    #
+    #   before _resolve_existing_references, because a dropped field can itself be a
+    #   match criterion (ipam.vlan matches on qinq_svlan), and dropping it after the
+    #   lookup strands the entity as an unmatchable CREATE that re-plans every ingest.
+    apply_submitted_driver_field_policy(entities)
     deduplicated = _fingerprint_dedupe(entities)
     deduplicated = _topo_sort(deduplicated)
     _set_auto_slugs(deduplicated, supported_models)
     _handle_cached_scope(deduplicated, supported_models)
-    # Let a submitted driver value win over the fields it forbids BEFORE existing
-    # objects are matched: a dropped field can itself be a match criterion (ipam.vlan
-    # matches on qinq_svlan), and dropping it after the lookup strands the entity as
-    # an unmatchable CREATE that re-plans on every ingest.
-    apply_submitted_driver_field_policy(deduplicated)
     resolved = _resolve_existing_references(deduplicated)
     _strip_cached_scope(resolved)
     defaulted = _set_defaults(resolved, supported_models)
@@ -633,6 +644,17 @@ def _merge_nodes(a: dict, b: dict) -> dict:
     """
     merged = copy.deepcopy(a)
     merged['_refs'] = a['_refs'] | b['_refs']
+    # Underscore keys are otherwise "prefer a's value", which would silently discard
+    # the warnings recorded on b -- including a driver-field drop the policy made
+    # before dedupe. A drop the operator never hears about is the thing the warning
+    # exists to prevent, so warnings are unioned per field like _refs.
+    merged_warnings = copy.deepcopy(a.get('_warnings') or {})
+    for field, msgs in (b.get('_warnings') or {}).items():
+        for msg in msgs:
+            if msg not in merged_warnings.setdefault(field, []):
+                merged_warnings[field].append(msg)
+    if merged_warnings:
+        merged['_warnings'] = merged_warnings
 
     for k, v in b.items():
         if k.startswith("_"):

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -633,7 +633,12 @@ def _fingerprint_dedupe(entities: list[dict]) -> tuple[list[dict], bool]: # noqa
         else:
             existing = by_uuid[existing_uuid]
             new_refs[entity['_uuid']] = existing['_uuid']
+            refs_before = existing['_refs'] | entity['_refs']
             merged = _merge_nodes(existing, entity)
+            # A deferred conflict releases the rejected value's edges, which the caller's
+            # prune sweep must hear about too -- not only the drops below.
+            if merged['_refs'] != refs_before:
+                refs_released = True
             _update_unresolved_refs(merged, new_refs)
             # Normalize NOW, before the next duplicate is compared against this node. A
             # merge is where duplicates each carrying half a contradiction become

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -27,6 +27,7 @@ from .common import (
     sort_ints_first,
 )
 from .compat import apply_entity_migrations
+from .field_policy import apply_submitted_driver_field_policy
 from .matcher import find_existing_object, fingerprints
 from .plugin_utils import (
     CUSTOM_FIELD_OBJECT_REFERENCE_TYPE,
@@ -138,6 +139,11 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     deduplicated = _topo_sort(deduplicated)
     _set_auto_slugs(deduplicated, supported_models)
     _handle_cached_scope(deduplicated, supported_models)
+    # Let a submitted driver value win over the fields it forbids BEFORE existing
+    # objects are matched: a dropped field can itself be a match criterion (ipam.vlan
+    # matches on qinq_svlan), and dropping it after the lookup strands the entity as
+    # an unmatchable CREATE that re-plans on every ingest.
+    apply_submitted_driver_field_policy(deduplicated)
     resolved = _resolve_existing_references(deduplicated)
     _strip_cached_scope(resolved)
     defaulted = _set_defaults(resolved, supported_models)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -665,14 +665,15 @@ def _merge_nodes(a: dict, b: dict) -> dict:
     _union_warnings(merged, a, b)
 
     deferred = dict(a.get('_deferred_conflicts') or {})
-    droppable = droppable_dependent_fields(a.get('_object_type') or '')
     rejected = []
     for k, v in b.items():
         if k.startswith("_"):
             continue
         if k in merged and merged[k] != v:
             error = _conflict_error(a, k, merged[k], v)
-            if k not in droppable:
+            # Consulted only on an actual conflict: the gate reads the content-type
+            # table, and a conflict-free duplicate merge must not depend on it.
+            if k not in droppable_dependent_fields(a.get('_object_type') or ''):
                 raise serializers.ValidationError(error)
             # A driver value on a duplicate not reached yet can delete this field and
             # settle the disagreement, so raising now would make the outcome depend on

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -154,7 +154,7 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     #   before _resolve_existing_references, because a dropped field can itself be a
     #   match criterion (ipam.vlan matches on qinq_svlan), and dropping it after the
     #   lookup strands the entity as an unmatchable CREATE that re-plans every ingest.
-    apply_submitted_driver_field_policy(entities)
+    entities = apply_submitted_driver_field_policy(entities)
     deduplicated = _fingerprint_dedupe(entities)
     deduplicated = _topo_sort(deduplicated)
     # ... and AFTER dedupe, because duplicates can also SPLIT the contradiction instead
@@ -168,7 +168,7 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     # support tagged vlans". Both passes are needed and neither is redundant; the
     # policy is idempotent, so the field a pre-dedupe drop already removed is not
     # dropped or warned about twice.
-    apply_submitted_driver_field_policy(deduplicated)
+    deduplicated = apply_submitted_driver_field_policy(deduplicated)
     _set_auto_slugs(deduplicated, supported_models)
     _handle_cached_scope(deduplicated, supported_models)
     resolved = _resolve_existing_references(deduplicated)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -27,7 +27,11 @@ from .common import (
     sort_ints_first,
 )
 from .compat import apply_entity_migrations
-from .field_policy import apply_submitted_driver_field_policy
+from .field_policy import (
+    apply_submitted_driver_field_policy,
+    prune_orphaned_nodes,
+    referenced_uuids,
+)
 from .matcher import find_existing_object, fingerprints
 from .plugin_utils import (
     CUSTOM_FIELD_OBJECT_REFERENCE_TYPE,
@@ -154,7 +158,10 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     #   before _resolve_existing_references, because a dropped field can itself be a
     #   match criterion (ipam.vlan matches on qinq_svlan), and dropping it after the
     #   lookup strands the entity as an unmatchable CREATE that re-plans every ingest.
-    entities = apply_submitted_driver_field_policy(entities)
+    # Snapshot the reference graph before anything is dropped; the single prune sweep
+    # below needs it to tell a nested child from a root.
+    referenced_before = referenced_uuids(entities)
+    released = apply_submitted_driver_field_policy(entities)
     deduplicated = _fingerprint_dedupe(entities)
     deduplicated = _topo_sort(deduplicated)
     # ... and AFTER dedupe, because duplicates can also SPLIT the contradiction instead
@@ -168,7 +175,13 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     # support tagged vlans". Both passes are needed and neither is redundant; the
     # policy is idempotent, so the field a pre-dedupe drop already removed is not
     # dropped or warned about twice.
-    deduplicated = apply_submitted_driver_field_policy(deduplicated)
+    released = apply_submitted_driver_field_policy(deduplicated) or released
+    # ONE sweep, here and not inside either pass: pruning per pass removes a duplicate
+    # child before _fingerprint_dedupe can merge it, and the survivor then loses whatever
+    # the pruned copy alone carried -- a required `name` (permanent 400) or a description
+    # (silent loss). See prune_orphaned_nodes.
+    if released:
+        deduplicated = prune_orphaned_nodes(deduplicated, referenced_before)
     _set_auto_slugs(deduplicated, supported_models)
     _handle_cached_scope(deduplicated, supported_models)
     resolved = _resolve_existing_references(deduplicated)

--- a/netbox_diode_plugin/api/transformer.py
+++ b/netbox_diode_plugin/api/transformer.py
@@ -29,8 +29,10 @@ from .common import (
 from .compat import apply_entity_migrations
 from .field_policy import (
     apply_submitted_driver_field_policy,
+    droppable_dependent_fields,
     prune_orphaned_nodes,
     referenced_uuids,
+    release_rejected_edges,
 )
 from .matcher import find_existing_object, fingerprints
 from .plugin_utils import (
@@ -139,48 +141,33 @@ def transform_proto_json(proto_json: dict, object_type: str, supported_models: d
     entities = _transform_proto_json_1(proto_json, object_type, supported_models)
 
     entities = _topo_sort(entities)
-    # Let a submitted driver value win over the fields it forbids BEFORE anything else
-    # looks at those fields. The policy runs on BOTH sides of _fingerprint_dedupe
-    # because duplicate representations of one object break the contradiction in two
-    # different ways, and each pass catches only its own.
+    # Phase 1 of the driver field policy, before anything else reads the fields it may
+    # remove -- and in particular before _resolve_existing_references, because a dropped
+    # field can itself be a match criterion and dropping it after the lookup strands the
+    # entity as an unmatchable CREATE that re-plans on every ingest.
     #
-    # Three orderings matter and this position satisfies all three:
+    # This pre-dedupe pass handles nodes that carry the contradiction on their own: two
+    # duplicates that each name the same driver value with DIFFERENT forbidden values
+    # would otherwise reach _merge_nodes and be rejected outright ("Conflicting values
+    # for 'tagged_vlans'"), losing the whole entity. Duplicates that SPLIT the
+    # contradiction -- one node with the driver value, another with the forbidden field --
+    # only become contradictory as they merge, so _fingerprint_dedupe normalizes each
+    # merged node itself and reports back whether it released any edge.
     #
-    #   before _fingerprint_dedupe, because two nodes for the SAME object that carry the
-    #   same submitted driver value but DIFFERENT forbidden values are duplicates that
-    #   _merge_nodes would reject outright ("Conflicting values for 'tagged_vlans'"),
-    #   rejecting the whole entity -- the exact payload this policy exists to rescue.
-    #   Measured: one graph nesting Gi1/0/9 twice, mode "access", tagged_vlans [301] and
-    #   [302], was a 400 with the policy running after dedupe and applies with it here.
-    #   A field the driver value ALLOWS still conflicts, and must: mode "tagged" with
-    #   [401] vs [402] is a genuine disagreement nothing can discard.
-    #
-    #   before _resolve_existing_references, because a dropped field can itself be a
-    #   match criterion (ipam.vlan matches on qinq_svlan), and dropping it after the
-    #   lookup strands the entity as an unmatchable CREATE that re-plans every ingest.
-    # Snapshot the reference graph before anything is dropped; the single prune sweep
-    # below needs it to tell a nested child from a root.
+    # `referenced_before` is the reference graph before any drop; the prune sweep needs
+    # it to tell a nested child from a root.
     referenced_before = referenced_uuids(entities)
     released = apply_submitted_driver_field_policy(entities)
-    deduplicated = _fingerprint_dedupe(entities)
+    deduplicated, merge_released = _fingerprint_dedupe(entities)
+    # Every merge is done and every merged node is normalized, so a conflict dedupe held
+    # back is a disagreement no driver value settled.
+    raise_unsettled_conflicts(deduplicated)
     deduplicated = _topo_sort(deduplicated)
-    # ... and AFTER dedupe, because duplicates can also SPLIT the contradiction instead
-    # of repeating it: phase 1 needs the driver field PRESENT in the node it is looking
-    # at, so a node carrying mode "access" with no VLANs and a node carrying
-    # tagged_vlans with no mode each pass the pre-dedupe check untouched, and
-    # _merge_nodes then combines them INTO the contradiction. Measured on v4.5.5: one
-    # graph naming Gi1/0/20 twice (the nested copy reached through the device's
-    # primary_ip4 assignment) merged to data keys [..., mode, ..., tagged_vlans, ...]
-    # with change_set.warnings None, and apply was a 400 "Interface mode does not
-    # support tagged vlans". Both passes are needed and neither is redundant; the
-    # policy is idempotent, so the field a pre-dedupe drop already removed is not
-    # dropped or warned about twice.
-    released = apply_submitted_driver_field_policy(deduplicated) or released
-    # ONE sweep, here and not inside either pass: pruning per pass removes a duplicate
-    # child before _fingerprint_dedupe can merge it, and the survivor then loses whatever
-    # the pruned copy alone carried -- a required `name` (permanent 400) or a description
+    # ONE sweep, here and never inside a pass: pruning per pass removes a duplicate child
+    # before _fingerprint_dedupe can merge it, and the survivor then loses whatever the
+    # pruned copy alone carried -- a required `name` (permanent 400) or a description
     # (silent loss). See prune_orphaned_nodes.
-    if released:
+    if released or merge_released:
         deduplicated = prune_orphaned_nodes(deduplicated, referenced_before)
     _set_auto_slugs(deduplicated, supported_models)
     _handle_cached_scope(deduplicated, supported_models)
@@ -620,16 +607,20 @@ def _generate_slug(object_type, data):
     return None
 
 @profiled("fingerprint_dedupe")
-def _fingerprint_dedupe(entities: list[dict]) -> list[dict]: # noqa: C901
+def _fingerprint_dedupe(entities: list[dict]) -> tuple[list[dict], bool]: # noqa: C901
     """
     Deduplicates/merges entities by fingerprint.
 
     *list must be in topo order by reference already*
+
+    Returns the deduplicated entities and whether normalizing a merged node released
+    any reference edge, i.e. whether the caller's prune sweep has anything to do.
     """
     by_uuid = {}
     by_fp = {}
     deduplicated = []
     new_refs = {} # uuid -> uuid
+    refs_released = False
 
     for entity in entities:
         if entity.get('_is_post_create'):
@@ -656,12 +647,20 @@ def _fingerprint_dedupe(entities: list[dict]) -> list[dict]: # noqa: C901
             new_refs[entity['_uuid']] = existing['_uuid']
             merged = _merge_nodes(existing, entity)
             _update_unresolved_refs(merged, new_refs)
+            # Normalize the merged node NOW, before the next duplicate is compared
+            # against it. A merge is where duplicates that each carry only half of a
+            # contradiction become contradictory, and leaving the merged node
+            # contradictory makes the outcome depend on how many duplicates follow:
+            # the third one carrying a different forbidden value would conflict with
+            # the second and reject the whole entity. It drops but never prunes --
+            # pruning waits for the caller's single post-dedupe sweep.
+            refs_released = apply_submitted_driver_field_policy([merged]) or refs_released
             for fp in fps:
                 by_fp[fp] = existing_uuid
             by_uuid[existing_uuid] = merged
             deduplicated.append(existing_uuid)
 
-    return [by_uuid[u] for u in deduplicated]
+    return [by_uuid[u] for u in deduplicated], refs_released
 
 def _merge_nodes(a: dict, b: dict) -> dict:
     """
@@ -673,10 +672,39 @@ def _merge_nodes(a: dict, b: dict) -> dict:
     """
     merged = copy.deepcopy(a)
     merged['_refs'] = a['_refs'] | b['_refs']
-    # Underscore keys are otherwise "prefer a's value", which would silently discard
-    # the warnings recorded on b -- including a driver-field drop the policy made
-    # before dedupe. A drop the operator never hears about is the thing the warning
-    # exists to prevent, so warnings are unioned per field like _refs.
+    _union_warnings(merged, a, b)
+
+    deferred = dict(a.get('_deferred_conflicts') or {})
+    droppable = droppable_dependent_fields(a.get('_object_type') or '')
+    rejected = []
+    for k, v in b.items():
+        if k.startswith("_"):
+            continue
+        if k in merged and merged[k] != v:
+            error = _conflict_error(a, k, merged[k], v)
+            if k not in droppable:
+                raise serializers.ValidationError(error)
+            # A driver value on a duplicate this merge has not reached yet can delete
+            # this field outright, which settles the disagreement. Raising now would
+            # make the outcome depend on the order the duplicates happen to arrive in,
+            # so the error waits until the graph is merged and normalized.
+            deferred.setdefault(k, error)
+            rejected.append(v)
+            continue
+        merged[k] = v
+    if rejected:
+        release_rejected_edges(merged, rejected)
+    if deferred:
+        merged['_deferred_conflicts'] = deferred
+    return merged
+
+
+def _union_warnings(merged: dict, a: dict, b: dict) -> None:
+    """Union both nodes' _warnings per field instead of preferring a's."""
+    # Underscore keys are otherwise "prefer a's value", which would silently discard the
+    # warnings recorded on b -- including a driver-field drop the policy made before
+    # dedupe. A drop the operator never hears about is the thing the warning exists to
+    # prevent, so warnings are unioned per field like _refs.
     merged_warnings = copy.deepcopy(a.get('_warnings') or {})
     for field, msgs in (b.get('_warnings') or {}).items():
         for msg in msgs:
@@ -685,21 +713,35 @@ def _merge_nodes(a: dict, b: dict) -> dict:
     if merged_warnings:
         merged['_warnings'] = merged_warnings
 
-    for k, v in b.items():
-        if k.startswith("_"):
+
+def _conflict_error(a: dict, field: str, mine, theirs) -> dict:
+    """The error body for two duplicate nodes disagreeing about ``field``."""
+    ov = {
+        ok: v for ok, v in a.items()
+        if ok != field and not ok.startswith("_")
+    }
+    return {
+        NON_FIELD_ERRORS: [
+            f"Conflicting values for '{field}' merging duplicate {a.get('_object_type')},"
+            f" `{mine}` != `{theirs}` other values : {ov}"]
+    }
+
+
+def raise_unsettled_conflicts(entities: list[dict]) -> None:
+    """
+    Raise the duplicate-merge conflicts no driver value settled.
+
+    A conflict on a field the policy could drop is held during dedupe; here the graph is
+    fully merged and normalized, so a field that is still present was never dropped and
+    the disagreement was real after all.
+    """
+    for entity in entities:
+        deferred = entity.pop('_deferred_conflicts', None)
+        if not deferred:
             continue
-        if k in merged and merged[k] != v:
-            ov = {
-                ok: v for ok, v in a.items()
-                if ok != k and not ok.startswith("_")
-            }
-            raise serializers.ValidationError({
-                NON_FIELD_ERRORS: [
-                    f"Conflicting values for '{k}' merging duplicate {a.get('_object_type')},"
-                    f" `{merged[k]}` != `{v}` other values : {ov}"]
-            })
-        merged[k] = v
-    return merged
+        for field, error in deferred.items():
+            if field in entity:
+                raise serializers.ValidationError(error)
 
 
 def _update_unresolved_refs(entity, new_refs):

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase
 from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
+from netbox_diode_plugin.api import field_policy
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.common import UnresolvedReference
 from netbox_diode_plugin.api.differ import normalize_changeset
@@ -208,6 +209,53 @@ class NormalizeChangesetTests(SimpleTestCase):
                     for dependent in dependents:
                         with self.subTest(object_type=object_type, dependent=dependent):
                             self.assertNotIn(dependent, matched)
+
+    def _flaky_model_lookup(self, fail_calls=1):
+        """A get_object_type_model that fails its first ``fail_calls`` calls, then works."""
+        real = field_policy.get_object_type_model
+        calls = []
+
+        def flaky(object_type):
+            calls.append(object_type)
+            if len(calls) <= fail_calls:
+                raise RuntimeError("content type lookup unavailable")
+            return real(object_type)
+
+        match_participating_fields.cache_clear()
+        self.addCleanup(match_participating_fields.cache_clear)
+        return flaky, calls
+
+    def test_a_model_lookup_failure_refuses_the_drop_instead_of_licensing_it(self):
+        """A failed model lookup propagates; it never answers "nothing participates"."""
+        # The gate answers "which fields decide WHICH row this payload means". An empty
+        # answer means "none of them", which licenses every drop the gate exists to
+        # refuse -- so a lookup failure must not produce one.
+        flaky, calls = self._flaky_model_lookup()
+        entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+        with mock.patch.object(field_policy, "get_object_type_model", flaky):
+            with self.assertRaises(RuntimeError):
+                submitted_driver_field_drops("ipam.vlan", entity)
+            # nothing was dropped on the way out
+            self.assertEqual(entity, {"qinq_role": "svlan", "qinq_svlan": 7})
+            self.assertEqual(calls, ["ipam.vlan"])
+
+    def test_a_model_lookup_failure_is_not_cached_as_nothing_participates(self):
+        """The recovery half: a transient failure must not poison the lru_cache."""
+        # lru_cache does not cache exceptions, so the next call retries. Returning an
+        # empty frozenset instead would be cached until eviction or restart, and every
+        # later request would treat qinq_svlan as droppable after the database had
+        # recovered -- re-enabling the same-vid wrong-row mutation this gate prevents.
+        flaky, calls = self._flaky_model_lookup()
+        with mock.patch.object(field_policy, "get_object_type_model", flaky):
+            with self.assertRaises(RuntimeError):
+                match_participating_fields("ipam.vlan")
+            # the healthy retry sees the truth
+            self.assertIn("qinq_svlan", match_participating_fields("ipam.vlan"))
+            entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+            out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+        self.assertEqual(len(calls), 2)   # retried once, then served from cache
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
         """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
@@ -537,6 +585,29 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertNotIn("rf_role", iface)
         self.assertEqual(iface["_refs"], {"v1"})
+
+    def test_a_gate_failure_takes_the_whole_pass_down_instead_of_dropping(self):
+        """The graph-level pass does not swallow a gate failure into a silent drop."""
+        real = field_policy.get_object_type_model
+
+        def broken(object_type):
+            raise RuntimeError("content type lookup unavailable")
+
+        match_participating_fields.cache_clear()
+        self.addCleanup(match_participating_fields.cache_clear)
+        svlan = self._node("ipam.vlan", "s1", vid=900, name="s900")
+        vlan = self._node("ipam.vlan", "v1", refs={"s1"}, vid=101, name="v101",
+                          qinq_role="svlan", qinq_svlan=self._ref("s1"))
+        with mock.patch.object(field_policy, "get_object_type_model", broken):
+            with self.assertRaises(RuntimeError):
+                apply_submitted_driver_field_policy([svlan, vlan])
+        self.assertEqual(vlan["qinq_svlan"], self._ref("s1"))
+        self.assertEqual(vlan["_refs"], {"s1"})
+        self.assertEqual(vlan["_warnings"], {})
+        # and with the lookup healthy again the gate still refuses the drop
+        self.assertEqual(self._uuids(self._policy([svlan, vlan])), ["s1", "v1"])
+        self.assertEqual(vlan["qinq_svlan"], self._ref("s1"))
+        self.assertIs(real, field_policy.get_object_type_model)
 
     def test_one_drop_is_reported_once_when_the_policy_runs_twice(self):
         """The policy is idempotent: a second pass re-reports nothing."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -715,6 +715,47 @@ class DedupeDriverFieldPolicyTests(TestCase):
         raise_unsettled_conflicts(out)
         self.assertEqual(out[0]["_refs"], {"d1"})
 
+    def _shared_vlan_fragments(self):
+        """
+        Fragments whose surviving VLAN is ALSO the untagged one.
+
+        Dropping tagged_vlans then releases no edge -- untagged_vlan still needs it --
+        so the only edge phase 1 gives up is the one the rejected duplicate contributed.
+        """
+        shared = UnresolvedReference(object_type="ipam.vlan", uuid="v1")
+        other = UnresolvedReference(object_type="ipam.vlan", uuid="v2")
+        return [
+            self._iface("i0", _refs={"d1", "v1"}, untagged_vlan=shared, tagged_vlans=[shared]),
+            self._iface("i1", _refs={"d1", "v2"}, tagged_vlans=[other]),
+            self._iface("i2", mode="access"),
+        ]
+
+    def test_a_rejected_values_edge_release_is_reported_to_the_prune_sweep(self):
+        """Dedupe must report the edges the merge released, not only the ones drops did."""
+        out, released = _fingerprint_dedupe(self._shared_vlan_fragments())
+        raise_unsettled_conflicts(out)
+        node = out[0]
+        self.assertNotIn("tagged_vlans", node)
+        self.assertEqual(node["untagged_vlan"].uuid, "v1")
+        self.assertEqual(node["_refs"], {"d1", "v1"})   # the rejected copy's v2 is gone
+        # The drop itself released nothing, so if the merge's release is not reported the
+        # caller skips its one prune sweep and v2 survives as a manufactured VLAN.
+        self.assertTrue(released)
+
+    def test_the_orphan_of_a_rejected_value_is_pruned(self):
+        """Phase 1 in full: only the rejected duplicate's VLAN node disappears."""
+        vlans = [{"_object_type": "ipam.vlan", "_uuid": uuid, "_refs": set(),
+                  "vid": vid, "name": f"dedupe-v{vid}", "status": "active"}
+                 for uuid, vid in (("v1", 981), ("v2", 982))]
+        entities = vlans + self._shared_vlan_fragments()
+        referenced_before = referenced_uuids(entities)
+        released = apply_submitted_driver_field_policy(entities)
+        deduplicated, merge_released = _fingerprint_dedupe(entities)
+        raise_unsettled_conflicts(deduplicated)
+        if released or merge_released:
+            deduplicated = prune_orphaned_nodes(deduplicated, referenced_before)
+        self.assertEqual({entity["_uuid"] for entity in deduplicated}, {"v1", "i0"})
+
 
 class InterfaceModeClearE2ETests(APITestCase):
     """End-to-end: seed an existing interface, ingest a mode change, assert clear."""
@@ -1706,6 +1747,67 @@ class InterfaceModeClearE2ETests(APITestCase):
         """Three disagreeing copies, then the mode: still one access interface."""
         self._assert_fragments_converge("Gi2/0/8", "n8", 68, [751, 752, 753],
                                         driver_last=True)
+
+    def _shared_vlan_fragment_payload(self, name, octet, field, untagged, keep, reject):
+        """
+        Fragments of one interface where the survivor's VLAN is needed twice.
+
+        ``field`` is the forbidden field the copies split; the first copy also points
+        ``untagged_vlan`` at the same VLAN, which mode "access" permits, so dropping
+        ``field`` releases no edge of its own.
+        """
+        def copy(**extra):
+            return {"device": self._device(), "name": name, "type": "1000base-t", **extra}
+
+        dev = dict(self._device())
+        dev["primary_ip4"] = {
+            "address": f"10.6.{octet}.10/24",
+            "assigned_object_interface": copy(untagged_vlan=untagged, **{field: keep}),
+        }
+        dev["primary_ip6"] = {
+            "address": f"2001:db8:6{octet}::11/64",
+            "assigned_object_interface": copy(**{field: reject}),
+        }
+        dev["oob_ip"] = {
+            "address": f"10.6.{octet}.12/24",
+            "assigned_object_interface": copy(mode="access"),
+        }
+        return {"timestamp": 1, "object_type": "dcim.interface", "entity": {
+            "interface": {"device": dev, "name": name, "type": "1000base-t"}}}
+
+    def _assert_rejected_vlan_is_never_created(self, name, octet, field, keep_vid, reject_vid):
+        """The VLAN only a REJECTED duplicate value referenced must not be created."""
+        from ipam.models import VLAN
+        keep = {"vid": keep_vid, "name": f"rej-v{keep_vid}", "status": "active"}
+        reject = {"vid": reject_vid, "name": f"rej-v{reject_vid}", "status": "active"}
+        many = field == "tagged_vlans"
+        payload = self._shared_vlan_fragment_payload(
+            name, octet, field, dict(keep),
+            [dict(keep)] if many else dict(keep),
+            [dict(reject)] if many else dict(reject),
+        )
+        cs = self._plan(payload)
+        planned = [c.get("data", {}).get("vid") for c in cs["changes"]
+                   if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(planned, [keep_vid], planned)
+        self._converge(payload, f"a rejected duplicate's {field}")
+        self.assertTrue(VLAN.objects.filter(vid=keep_vid).exists())
+        self.assertFalse(VLAN.objects.filter(vid=reject_vid).exists())
+        iface = Interface.objects.get(name=name, device__name=self._device()["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.untagged_vlan.vid, keep_vid)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_rejected_duplicates_tagged_vlan_is_never_created(self):
+        """The survivor is also the untagged VLAN, so only the merge released an edge."""
+        # Without the merge's release reaching the prune gate the change set still plans
+        # a create for the rejected copy's VLAN: the interface comes out correct while an
+        # extra VLAN is manufactured out of a value nothing kept.
+        self._assert_rejected_vlan_is_never_created("Gi3/0/1", 71, "tagged_vlans", 671, 672)
+
+    def test_a_rejected_duplicates_qinq_svlan_is_never_created(self):
+        """The same shape on a different forbidden field the interface policy drops."""
+        self._assert_rejected_vlan_is_never_created("Gi3/0/2", 72, "qinq_svlan", 681, 682)
 
     def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
         """A VLAN that is the entity's own primary object is never pruned."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -8,9 +8,11 @@ from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.common import UnresolvedReference
 from netbox_diode_plugin.api.differ import normalize_changeset
 from netbox_diode_plugin.api.field_policy import (
     _DRIVER_FIELD_RULES,
+    apply_submitted_driver_field_policy,
     match_participating_fields,
     submitted_driver_field_drops,
 )
@@ -406,6 +408,129 @@ class NormalizeChangesetTests(SimpleTestCase):
                             )
                         pairs += 1
         self.assertGreater(pairs, 100)  # the map is generated; guard against an empty sweep
+
+
+class DriverFieldPolicyPruneTests(SimpleTestCase):
+    """Which graph edges and child nodes a phase 1 drop takes with it -- and which it must not."""
+
+    def _ref(self, uuid, object_type="ipam.vlan"):
+        return UnresolvedReference(object_type=object_type, uuid=uuid)
+
+    def _node(self, object_type, uuid, refs=(), **fields):
+        node = {"_object_type": object_type, "_uuid": uuid, "_refs": set(refs), "_warnings": {}}
+        node.update(fields)
+        return node
+
+    def _uuids(self, entities):
+        return sorted(e["_uuid"] for e in entities)
+
+    def test_a_dropped_nested_reference_takes_its_child_node_with_it(self):
+        """The child node a dropped tagged_vlans created is pruned, and so is its edge."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1"])
+        self.assertNotIn("tagged_vlans", iface)
+        self.assertEqual(iface["_refs"], set())
+
+    def test_a_child_the_same_node_still_references_is_kept(self):
+        """One VLAN node reached by BOTH untagged_vlan and tagged_vlans survives the drop."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", mode="access",
+                           untagged_vlan=self._ref("v1"), tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertEqual(iface["_refs"], {"v1"})       # the untagged_vlan edge stands
+        self.assertEqual(iface["untagged_vlan"], self._ref("v1"))
+
+    def test_a_child_another_node_still_references_is_kept(self):
+        """A second interface still tagging the VLAN keeps its node alive."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        dropped = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                             mode="access", tagged_vlans=[self._ref("v1")])
+        keeper = self._node("dcim.interface", "i2", refs={"v1"}, name="Eth2",
+                            mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, dropped, keeper])
+        self.assertEqual(self._uuids(out), ["i1", "i2", "v1"])
+        self.assertEqual(dropped["_refs"], set())
+        self.assertEqual(keeper["_refs"], {"v1"})
+
+    def test_pruning_is_transitive(self):
+        """A pruned child's own children go too, once nothing reaches them."""
+        group = self._node("ipam.vlangroup", "g1", name="g1", slug="g1")
+        vlan = self._node("ipam.vlan", "v1", refs={"g1"}, vid=101, name="v101",
+                          group=self._ref("g1", "ipam.vlangroup"))
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([group, vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1"])
+
+    def test_a_grandchild_something_surviving_needs_is_kept(self):
+        """Transitivity stops at the first node another survivor still references."""
+        group = self._node("ipam.vlangroup", "g1", name="g1", slug="g1")
+        dropped_vlan = self._node("ipam.vlan", "v1", refs={"g1"}, vid=101, name="v101",
+                                  group=self._ref("g1", "ipam.vlangroup"))
+        kept_vlan = self._node("ipam.vlan", "v2", refs={"g1"}, vid=102, name="v102",
+                               group=self._ref("g1", "ipam.vlangroup"))
+        iface = self._node("dcim.interface", "i1", refs={"v1", "v2"}, name="Eth1", mode="access",
+                           untagged_vlan=self._ref("v2"), tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([group, dropped_vlan, kept_vlan, iface])
+        self.assertEqual(self._uuids(out), ["g1", "i1", "v2"])
+        self.assertEqual(iface["_refs"], {"v2"})
+
+    def test_a_post_create_step_and_its_children_are_never_collateral(self):
+        """A post-create node hangs off its object; a drop elsewhere leaves it alone."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        mac = self._node("dcim.macaddress", "m1", mac_address="00:00:00:00:00:01")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        post_create = self._node(
+            "dcim.interface", "pc1", refs={"i1", "m1"},
+            primary_mac_address=self._ref("m1", "dcim.macaddress"),
+        )
+        post_create["_is_post_create"] = True
+        post_create["_instance"] = "i1"
+        out = apply_submitted_driver_field_policy([vlan, mac, iface, post_create])
+        self.assertEqual(self._uuids(out), ["i1", "m1", "pc1"])
+
+    def test_a_root_node_is_never_pruned(self):
+        """A node nothing referenced is the entity's own object: it survives a drop on itself."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertIn("i1", self._uuids(out))
+
+    def test_no_drop_prunes_nothing(self):
+        """With nothing to drop the policy is a pure no-op over the graph."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertEqual(iface["tagged_vlans"], [self._ref("v1")])
+        self.assertEqual(iface["_warnings"], {})
+
+    def test_a_drop_with_no_nested_reference_prunes_nothing(self):
+        """Dropping a plain scalar (rf_role) releases no edge and no node."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", type="1000base-t",
+                           rf_role="ap", mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertNotIn("rf_role", iface)
+        self.assertEqual(iface["_refs"], {"v1"})
+
+    def test_one_drop_is_reported_once_when_the_policy_runs_twice(self):
+        """The policy is idempotent: a second pass re-reports nothing."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        entities = apply_submitted_driver_field_policy([vlan, iface])
+        again = apply_submitted_driver_field_policy(entities)
+        self.assertEqual(self._uuids(again), ["i1"])
+        self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
 
 
 class InterfaceModeClearE2ETests(APITestCase):
@@ -1153,3 +1278,121 @@ class InterfaceModeClearE2ETests(APITestCase):
         self._apply(cs)
         iface = Interface.objects.get(name="Gi1/0/22", device__name=dev["name"])
         self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    # --- P2-B: the orphan child nodes a drop leaves behind --------------------
+
+    def test_dropping_tagged_vlans_creates_no_orphan_vlan(self):
+        """A dropped nested reference takes its child node with it: no VLAN is manufactured."""
+        # Measured before the fix: planned non-noop ipam.vlan changes = [("create", 621)],
+        # apply 200, VLAN 621 present in NetBox afterwards while the interface had mode
+        # access and tagged_vlans count 0 -- the payload silently created a VLAN it could
+        # not use, and the warning claimed the field had been dropped.
+        from ipam.models import VLAN
+        payload = self._iface_payload(
+            name="Gi1/0/21", type="1000base-t", mode="access",
+            tagged_vlans=[{"vid": 621, "name": "p2b-orphan", "status": "active"}],
+        )
+        cs = self._plan(payload)
+        vlan_changes = [(c["change_type"], c.get("data", {}).get("vid"))
+                        for c in cs["changes"]
+                        if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(vlan_changes, [], vlan_changes)
+        self._apply(cs)
+        self.assertFalse(VLAN.objects.filter(vid=621).exists())
+        iface = Interface.objects.get(name="Gi1/0/21")
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- over-pruning: three ways a dropped child is still needed -------------
+
+    def test_a_vlan_that_is_also_the_untagged_vlan_survives_the_drop(self):
+        """The same VLAN named as both untagged_vlan and a tagged VLAN is still created."""
+        from ipam.models import VLAN
+        payload = self._iface_payload(
+            name="Gi1/0/30", type="1000base-t", mode="access",
+            untagged_vlan={"vid": 632, "name": "keep-v632", "status": "active"},
+            tagged_vlans=[{"vid": 632, "name": "keep-v632", "status": "active"}],
+        )
+        self._converge(payload, "shared untagged/tagged VLAN")
+        self.assertTrue(VLAN.objects.filter(vid=632).exists())
+        iface = Interface.objects.get(name="Gi1/0/30")
+        self.assertEqual(iface.untagged_vlan.vid, 632)   # allowed by 'access' -> linked
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # forbidden -> dropped
+
+    def test_a_shared_vlan_survives_a_drop_on_the_merged_node(self):
+        """After the merge one VLAN node is both untagged_vlan and a tagged VLAN: it survives."""
+        # This is the case a per-node reference count exists for. The outer node carries
+        # mode "access" and untagged_vlan 631; the nested duplicate carries tagged_vlans
+        # [631] and no mode. Fingerprint dedupe collapses the two VLAN nodes into ONE, so
+        # the merged interface points at that single node from both fields. Releasing the
+        # tagged_vlans edge must not release the untagged_vlan edge with it -- if it does,
+        # the node is pruned and untagged_vlan is left dangling.
+        from ipam.models import VLAN
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.31.31/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/31", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 631, "name": "keep-v631", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/31", "type": "1000base-t", "mode": "access",
+            "untagged_vlan": {"vid": 631, "name": "keep-v631", "status": "active"},
+        }}}
+        self._converge(payload, "shared VLAN node after merge")
+        self.assertTrue(VLAN.objects.filter(vid=631).exists())
+        iface = Interface.objects.get(name="Gi1/0/31", device__name=dev["name"])
+        self.assertEqual(iface.untagged_vlan.vid, 631)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_vlan_a_second_interface_still_tags_survives_the_drop(self):
+        """One VLAN node, two interfaces: the drop on one must not unmake it for the other."""
+        # Gi1/0/40 is named twice (outer node with mode "access", nested duplicate with
+        # tagged_vlans [641]) so the merged node loses tagged_vlans in the post-merge pass.
+        # Gi1/0/42, mode "tagged", legitimately tags the SAME VLAN, and dedupe gives both
+        # interfaces the same VLAN node. Pruning it would strand Gi1/0/42's reference.
+        from ipam.models import VLAN
+        dev = self._device()
+        vlan = {"vid": 641, "name": "keep-v641", "status": "active"}
+        dev_two = dict(
+            dev,
+            primary_ip4={
+                "address": "10.9.40.40/24",
+                "assigned_object_interface": {
+                    "device": dev, "name": "Gi1/0/40", "type": "1000base-t",
+                    "tagged_vlans": [dict(vlan)],
+                },
+            },
+            primary_ip6={
+                "address": "2001:db8:40::42/64",
+                "assigned_object_interface": {
+                    "device": dev, "name": "Gi1/0/42", "type": "1000base-t",
+                    "mode": "tagged", "tagged_vlans": [dict(vlan)],
+                },
+            },
+        )
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_two, "name": "Gi1/0/40", "type": "1000base-t", "mode": "access",
+        }}}
+        self._converge(payload, "VLAN shared by a second interface")
+        self.assertTrue(VLAN.objects.filter(vid=641).exists())
+        dropped_from = Interface.objects.get(name="Gi1/0/40", device__name=dev["name"])
+        self.assertEqual(dropped_from.mode, "access")
+        self.assertEqual(dropped_from.tagged_vlans.count(), 0)
+        kept_by = Interface.objects.get(name="Gi1/0/42", device__name=dev["name"])
+        self.assertEqual([v.vid for v in kept_by.tagged_vlans.all()], [641])
+
+    def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
+        """A VLAN that is the entity's own primary object is never pruned."""
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 651, "name": "own-right-v651", "status": "active",
+            "group": {"name": "own-right-group", "slug": "own-right-group"},
+        }}}
+        self._converge(payload, "ipam.vlan on its own")
+        vlan = VLAN.objects.get(vid=651, name="own-right-v651")
+        self.assertEqual(vlan.group.name, "own-right-group")

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -18,6 +18,11 @@ class NormalizeChangesetTests(SimpleTestCase):
         normalize_changeset(object_type, prechange, entity)
         return entity
 
+    def _drop(self, object_type, prechange, entity):
+        """Run the normalizer and return (entity, dropped-submitted-field map)."""
+        dropped = normalize_changeset(object_type, prechange, entity)
+        return entity, dropped
+
     def test_tagged_to_access_clears_tagged_vlans_keeps_untagged(self):
         """Mode tagged -> access clears tagged_vlans but leaves untagged_vlan untouched."""
         prechange = {"mode": "tagged", "tagged_vlans": [101, 102], "untagged_vlan": 5}
@@ -42,13 +47,40 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertEqual(out["tagged_vlans"], [])
         self.assertIsNone(out["qinq_svlan"])
 
-    def test_explicit_value_is_respected_not_overwritten(self):
-        """An explicitly submitted dependent field value is never overwritten."""
-        # producer explicitly sent tagged_vlans with an incompatible mode -> leave it
+    def test_explicit_forbidden_value_is_dropped_driver_wins(self):
+        """The submitted driver value wins: an explicit but forbidden value is dropped."""
+        # POLICY (reversed): a payload naming mode "access" AND naming tagged VLANs is
+        # self-contradictory. NetBox rejects the WHOLE entity for it, so the mode wins
+        # and the field it forbids is discarded — producer intent does NOT protect it.
         prechange = {"mode": "tagged", "tagged_vlans": [101]}
         entity = {"mode": "access", "tagged_vlans": [200]}
-        out = self._run("dcim.interface", prechange, entity)
+        out, dropped = self._drop("dcim.interface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertIn("tagged_vlans", dropped)
+        self.assertIn("mode", dropped["tagged_vlans"])
+        self.assertIn("access", dropped["tagged_vlans"])
+
+    def test_explicit_allowed_value_is_respected(self):
+        """Producer intent survives for everything the driver value ALLOWS."""
+        # mode "tagged" permits tagged_vlans, so an explicit list is kept verbatim and
+        # is not reported as dropped. This is the half of producer intent that stands.
+        out, dropped = self._drop(
+            "dcim.interface",
+            {"mode": "access", "tagged_vlans": []},
+            {"mode": "tagged", "tagged_vlans": [200]},
+        )
         self.assertEqual(out["tagged_vlans"], [200])
+        self.assertEqual(dropped, {})
+
+    def test_explicit_empty_forbidden_value_is_not_a_change(self):
+        """A submitted value that is already empty is left exactly as submitted."""
+        # Rewriting it would be pointless and could only manufacture a spurious
+        # change (e.g. [] -> None); nothing is reported as dropped either.
+        out, dropped = self._drop(
+            "dcim.interface", {}, {"mode": "access", "tagged_vlans": []}
+        )
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertEqual(dropped, {})
 
     def test_no_clear_when_prechange_field_already_empty(self):
         """Nothing is injected into entity when the prechange dependent field was already empty."""
@@ -79,11 +111,72 @@ class NormalizeChangesetTests(SimpleTestCase):
         out = self._run("dcim.device", prechange, entity)
         self.assertNotIn("tagged_vlans", out)
 
-    def test_create_no_prechange_is_noop(self):
-        """Create flows (empty prechange, no existing row) are a no-op."""
+    def test_create_drops_forbidden_submitted_value(self):
+        """A create is not exempt: mode "access" drops the tagged_vlans it forbids."""
+        # This is the corpus shape (interface "WirelessGigabitEthernet1/0/1"): a CREATE
+        # carrying mode "access" together with untagged_vlan AND tagged_vlans. Before
+        # the reversed policy this was a no-op and NetBox 400'd the whole entity.
+        entity = {
+            "mode": "access",
+            "untagged_vlan": 900,
+            "tagged_vlans": [101, 102],
+        }
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["tagged_vlans"], [])       # forbidden -> dropped
+        self.assertEqual(out["untagged_vlan"], 900)     # allowed for access -> kept
+        self.assertEqual(list(dropped), ["tagged_vlans"])
+
+    def test_create_injects_nothing_when_field_not_submitted(self):
+        """A create with nothing forbidden submitted stays untouched (nothing injected)."""
         entity = {"mode": "access"}
-        out = self._run("dcim.interface", {}, entity)
-        self.assertNotIn("tagged_vlans", out)
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertNotIn("tagged_vlans", out)  # no stored row, nothing to clear
+        self.assertNotIn("qinq_svlan", out)
+        self.assertEqual(dropped, {})
+
+    def test_create_unknown_mode_fails_open(self):
+        """An unrecognised driver value forbids nothing, on creates too."""
+        entity = {"mode": "future-mode", "tagged_vlans": [101]}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["tagged_vlans"], [101])
+        self.assertEqual(dropped, {})
+
+    def test_stale_clear_is_not_reported_as_dropped(self):
+        """Injecting a clear for a stale STORED value is not a drop of producer data."""
+        out, dropped = self._drop(
+            "dcim.interface", {"mode": "tagged", "tagged_vlans": [101]}, {"mode": "access"}
+        )
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertEqual(dropped, {})  # nothing was submitted, so nothing was discarded
+
+    def test_shared_policy_applies_to_interface_type_rf_fields(self):
+        """The reversed policy is registry-wide: dcim.interface "type" behaves the same."""
+        entity = {"type": "1000base-t", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertIsNone(out["rf_channel"])
+        self.assertIsNone(out["rf_role"])
+        self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
+
+    def test_shared_policy_keeps_rf_fields_on_a_wireless_type(self):
+        """A wireless type permits the rf fields, so an explicit create keeps them."""
+        entity = {"type": "ieee802.11ac", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["rf_channel"], "2.4g-1-2412-22")
+        self.assertEqual(dropped, {})
+
+    def test_shared_policy_applies_to_vlan_qinq_role(self):
+        """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
+        entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+        out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertIsNone(out["qinq_svlan"])
+        self.assertEqual(list(dropped), ["qinq_svlan"])
+
+    def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
+        """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
+        entity = {"qinq_role": "cvlan", "qinq_svlan": 7}
+        out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
 
     def test_unknown_mode_fails_open(self):
         """An unknown/unlisted mode value fails open and clears nothing."""
@@ -262,11 +355,12 @@ class InterfaceModeClearE2ETests(APITestCase):
         ch = [c for c in r.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
         self.assertTrue(all(c["change_type"] == "noop" for c in ch))
 
-    def test_explicit_incompatible_tagged_vlans_still_fails(self):
-        """Guard: an explicit incompatible mode/tagged_vlans combo must still be rejected."""
-        # Guard: a producer that explicitly sends mode=access WITH tagged_vlans is a
-        # producer-side error — the normalizer must NOT silently clear it; apply must
-        # fail and the DB must be unchanged.
+    def test_explicit_incompatible_tagged_vlans_is_dropped_not_rejected(self):
+        """An explicit incompatible mode/tagged_vlans update applies with the field dropped."""
+        # POLICY (reversed): this combination used to be left alone so NetBox could
+        # reject it, which cost the whole entity. The submitted mode now wins: the
+        # update applies, tagged_vlans is dropped, and the drop is surfaced as a
+        # warning on the change set rather than swallowed silently.
         create = {
             "name": "EthNeg", "type": "1000base-t", "device": self._device(),
             "mode": "tagged",
@@ -275,7 +369,7 @@ class InterfaceModeClearE2ETests(APITestCase):
         _, apply1 = self._diff_apply(create)
         self.assertEqual(apply1.status_code, 200)
         iface = Interface.objects.get(name="EthNeg")
-        before = set(iface.tagged_vlans.values_list("vid", flat=True))
+        self.assertEqual(iface.tagged_vlans.count(), 1)
 
         bad = {
             "name": "EthNeg", "type": "1000base-t", "device": self._device(),
@@ -284,12 +378,70 @@ class InterfaceModeClearE2ETests(APITestCase):
         }
         payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": bad}}
         r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
         cs = r1.json().get("change_set", {})
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
         r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
-        # NetBox rejects the incompatible combo: non-200, or 200 with an errors payload.
-        self.assertTrue(r2.status_code != 200 or r2.json().get("errors"))
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
         iface.refresh_from_db()
-        self.assertEqual(set(iface.tagged_vlans.values_list("vid", flat=True)), before)  # unchanged
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # the mode won; the field was dropped
+
+        # and the very same self-contradictory payload re-diffs as a NOOP
+        r3 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        ch = [c for c in r3.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in ch))
+
+    def test_corpus_create_access_mode_with_tagged_vlans_applies(self):
+        """A CREATE naming mode access, untagged_vlan AND tagged_vlans applies and is idempotent."""
+        # Reproduction of the corpus entity "WirelessGigabitEthernet1/0/1", which used to
+        # lose the whole interface to a 400 {"tagged_vlans": ["Interface mode does not
+        # support tagged vlans"]}. The create must now land with the mode honoured, the
+        # untagged VLAN attached and the forbidden tagged VLANs dropped.
+        create = {
+            "name": "WlAccess", "type": "other-wireless", "device": self._device(),
+            "mode": "access",
+            "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+            "untagged_vlan": {"vid": 900, "name": "v900"},
+            "tagged_vlans": [{"vid": 101, "name": "v101"}, {"vid": 102, "name": "v102"}],
+        }
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": create}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        # the create's CREATE change must not carry tagged_vlans at all, and must not
+        # leave a dangling unresolved-reference path for the field it no longer carries
+        iface_creates = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_creates)
+        for c in iface_creates:
+            self.assertNotIn("tagged_vlans", c.get("data", {}))
+            self.assertNotIn("tagged_vlans", c.get("new_refs", []))
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+        iface = Interface.objects.get(name="WlAccess")
+        self.assertEqual(iface.mode, "access")
+        self.assertIsNotNone(iface.untagged_vlan)
+        self.assertEqual(iface.untagged_vlan.vid, 900)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertEqual(iface.rf_channel, "2.4g-1-2412-22")  # wireless type keeps rf fields
+
+        # re-ingesting the identical payload is a no-op
+        r3 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r3.json().get("change_set", {}).get("changes", []), [])
+
+        # and submitting the forbidden field EMPTY under the same mode is a no-op too:
+        # clearing an already-empty submitted value must never plan an update
+        empty = dict(create, tagged_vlans=[])
+        r4 = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": empty}},
+            format="json", **self.auth,
+        )
+        self.assertEqual(r4.json().get("change_set", {}).get("changes", []), [])
 
     def test_qinq_to_access_clears_qinq_svlan_orm_seed(self):
         """E2E: an ORM-seeded q-in-q interface moving to access has qinq_svlan cleared."""
@@ -359,6 +511,33 @@ class InterfaceModeClearE2ETests(APITestCase):
             any(c.get("data", {}).get("tagged_vlans") == [] for c in vm_updates),
             "hook must emit tagged_vlans:[] for vminterface (DB-only assertion is vacuous here)",
         )
+
+    def test_vminterface_create_drops_tagged_vlans_netbox_would_have_kept(self):
+        """The uniform policy costs a vminterface its tagged VLANs, deliberately."""
+        # virtualization.vminterface is the one registry entry whose serializer does NO
+        # mode/VLAN validation: NetBox accepts mode "access" WITH tagged VLANs on a create
+        # and stores them (BaseInterface.save() only clears on a later save, guarded by
+        # `not self._state.adding`). The shared registry means the driver value wins here
+        # too, so the tagged VLANs are dropped. Pinned so the cost stays a decision.
+        vm = {"name": "drop-vm", "cluster": {"name": "drop-cl", "type": {"name": "drop-ct"}}}
+        create = {"name": "vmeth1", "virtual_machine": vm, "mode": "access",
+                  "tagged_vlans": [{"vid": 711, "name": "v711"}]}
+        payload = {"timestamp": 1, "object_type": "virtualization.vminterface",
+                   "entity": {"vm_interface": create}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json()["change_set"]
+        self.assertIn(
+            "tagged_vlans", cs.get("warnings", {}).get("virtualization.vminterface", {})
+        )
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth1")
+        self.assertEqual(vmi.mode, "access")
+        self.assertEqual(vmi.tagged_vlans.count(), 0)
 
     def test_interface_wireless_to_ethernet_clears_rf(self):
         """Type change wireless->ethernet clears stale rf_channel and rf_role."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -667,7 +667,7 @@ class DedupeDriverFieldPolicyTests(TestCase):
         # Normalizing only AFTER dedupe stops working at three: the merge of the first
         # two leaves the merged node holding both mode and tagged_vlans, and the third
         # fragment's different tagged_vlans then conflicts inside _merge_nodes, so the
-        # whole entity is rejected and the post-dedupe pass never runs. Normalizing the
+        # whole entity is rejected before any later pass runs. Normalizing the
         # merged node inside the loop is what makes the outcome independent of how many
         # duplicate representations the producer happened to send.
         for count in range(2, 7):
@@ -1465,7 +1465,7 @@ class InterfaceModeClearE2ETests(APITestCase):
         self.assertTrue(iface_changes)
         for change in iface_changes:
             self.assertNotIn("tagged_vlans", change.get("data", {}))
-        # reported exactly once, with both passes active
+        # reported exactly once, though two steps could each report it
         messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
         self.assertEqual(len(messages or []), 1, messages)
         self._apply(cs)
@@ -1476,13 +1476,13 @@ class InterfaceModeClearE2ETests(APITestCase):
             self.assertEqual(self._plan(payload).get("changes", []), [],
                              f"re-planned on quiet round {quiet}")
 
-    def test_a_drop_reported_by_both_passes_is_one_warning(self):
-        """Pass 1 drops from one node, pass 2 from the merged node: still one message."""
-        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans
-        # (pass 1 drops it and records the warning), the nested node carries a DIFFERENT
-        # tagged_vlans and no mode (pass 1 cannot see it; it survives the merge and pass 2
-        # drops it). Without dedupe on the message, change_set.warnings carried the same
-        # sentence twice for one field.
+    def test_a_drop_reported_by_two_steps_is_one_warning(self):
+        """The pre-dedupe pass drops from one node, the merge from another: one message."""
+        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans,
+        # so the pre-dedupe pass drops it and records the warning; the nested node carries
+        # a DIFFERENT tagged_vlans and no mode, so it survives untouched and is dropped
+        # when it merges. Without dedupe on the message, change_set.warnings carried the
+        # same sentence twice for one field.
         dev = self._device()
         dev_with_ip = dict(dev, primary_ip4={
             "address": "10.9.22.22/24",
@@ -1670,11 +1670,11 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     def test_three_fragments_of_one_interface_still_let_the_driver_win(self):
         """Root + two nested copies, each with a different forbidden VLAN: still one access iface."""
-        # This is the shape a single pre- and post-dedupe pass could not settle. The root
+        # This is the shape a pass on each side of dedupe could not settle. The root
         # fragment has no forbidden field and the nested copies have no submitted mode, so
         # the pre-dedupe pass drops nothing; dedupe merged root + copy 1 into the
         # contradiction and the SECOND copy's different tagged_vlans then conflicted inside
-        # _merge_nodes, rejecting the whole entity before the post-dedupe pass could run.
+        # _merge_nodes, rejecting the whole entity before the mode was ever considered.
         # One interface really can be reached three times: as the entity, as primary_ip4's
         # assigned interface, and as primary_ip6's.
         self._assert_fragments_converge("Gi2/0/3", "n3", 63, [701, 702])

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -906,6 +906,56 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     # --- N2: a dropped match criterion must be dropped BEFORE matching --------
 
+    def test_a_duplicate_node_with_a_different_forbidden_value_still_applies(self):
+        """Two nodes for ONE interface, same submitted mode, different forbidden VLANs."""
+        # The policy used to run AFTER _fingerprint_dedupe, so these two nodes reached
+        # _merge_nodes still carrying tagged_vlans and it rejected the whole entity with
+        # "Conflicting values for 'tagged_vlans'" -- the payload the policy exists to
+        # rescue. Running the policy first drops the forbidden field from both, so they
+        # merge cleanly. The graph nests the same interface twice via the device's
+        # primary_ip4 assignment, which is how one entity legitimately names it twice.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.9.9/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/9", "type": "1000base-t", "mode": "access",
+                "tagged_vlans": [{"vid": 302, "name": "dup-v302", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/9", "type": "1000base-t", "mode": "access",
+            "tagged_vlans": [{"vid": 301, "name": "dup-v301", "status": "active"}],
+        }}}
+        cs = self._plan(payload)
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+        for change in cs["changes"]:
+            if change["object_type"] == "dcim.interface":
+                self.assertNotIn("tagged_vlans", change.get("data", {}))
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/9", device__name=dev["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_duplicate_node_with_a_different_ALLOWED_value_still_conflicts(self):
+        """The control: a field the mode PERMITS is a genuine disagreement, still a 400."""
+        # This must NOT be rescued. mode "tagged" allows tagged_vlans, so [401] vs [402]
+        # is two sources disagreeing about real data and nothing can discard either.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.9.10/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/10", "type": "1000base-t", "mode": "tagged",
+                "tagged_vlans": [{"vid": 402, "name": "ctl-v402", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/10", "type": "1000base-t", "mode": "tagged",
+            "tagged_vlans": [{"vid": 401, "name": "ctl-v401", "status": "active"}],
+        }}}
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertIn("Conflicting values", str(r.content))
+
     def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
         """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""
         # The regression this pins: dropping qinq_svlan before matching made the entity

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -3,7 +3,8 @@ from types import SimpleNamespace
 from unittest import mock
 
 from dcim.models import Interface
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+from rest_framework import serializers
 from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
@@ -18,6 +19,10 @@ from netbox_diode_plugin.api.field_policy import (
     prune_orphaned_nodes,
     referenced_uuids,
     submitted_driver_field_drops,
+)
+from netbox_diode_plugin.api.transformer import (
+    _fingerprint_dedupe,
+    raise_unsettled_conflicts,
 )
 from netbox_diode_plugin.plugin_config import get_diode_user
 
@@ -618,6 +623,97 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         again = self._policy(entities)          # a second full pass changes nothing
         self.assertEqual(self._uuids(again), ["i1"])
         self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
+
+
+class DedupeDriverFieldPolicyTests(TestCase):
+    """_fingerprint_dedupe normalizes every node it merges, so the result is N-independent."""
+
+    def _iface(self, uuid, **fields):
+        node = {
+            "_object_type": "dcim.interface",
+            "_uuid": uuid,
+            "_refs": {"d1"},
+            "_warnings": {},
+            "name": "Gi1/0/1",
+            "device": UnresolvedReference(object_type="dcim.device", uuid="d1"),
+        }
+        node.update(fields)
+        return node
+
+    def _fragments(self, count):
+        """One driver-only fragment plus ``count - 1`` fragments, each with its own VLAN."""
+        nodes = [self._iface("i0", mode="access")]
+        for k in range(1, count):
+            nodes.append(self._iface(
+                f"i{k}", _refs={"d1", f"v{k}"},
+                tagged_vlans=[UnresolvedReference(object_type="ipam.vlan", uuid=f"v{k}")],
+            ))
+        return nodes
+
+    def _assert_normalized(self, out, released):
+        raise_unsettled_conflicts(out)                    # nothing left to disagree about
+        merged = {entity["_uuid"]: entity for entity in out}
+        self.assertEqual(len(merged), 1, merged)          # all fragments are one node
+        node = next(iter(merged.values()))
+        self.assertEqual(node["mode"], "access")
+        self.assertNotIn("tagged_vlans", node)            # forbidden -> gone
+        self.assertNotIn("_deferred_conflicts", node)     # and never leaks downstream
+        self.assertEqual(node["_refs"], {"d1"})           # every VLAN edge released
+        self.assertTrue(released)                         # so the caller's sweep runs
+        self.assertEqual(len(node["_warnings"]["tagged_vlans"]), 1)
+
+    def test_every_merged_node_is_normalized_before_the_next_duplicate_arrives(self):
+        """Two to six duplicate fragments all end at the same normalized node."""
+        # Normalizing only AFTER dedupe stops working at three: the merge of the first
+        # two leaves the merged node holding both mode and tagged_vlans, and the third
+        # fragment's different tagged_vlans then conflicts inside _merge_nodes, so the
+        # whole entity is rejected and the post-dedupe pass never runs. Normalizing the
+        # merged node inside the loop is what makes the outcome independent of how many
+        # duplicate representations the producer happened to send.
+        for count in range(2, 7):
+            with self.subTest(fragments=count):
+                self._assert_normalized(*_fingerprint_dedupe(self._fragments(count)))
+
+    def test_the_outcome_does_not_depend_on_fragment_order(self):
+        """The driver-carrying fragment arriving last must reach the same node."""
+        for count in range(2, 7):
+            with self.subTest(fragments=count):
+                self._assert_normalized(*_fingerprint_dedupe(self._fragments(count)[::-1]))
+
+    def test_the_merged_node_is_already_normalized_when_dedupe_returns(self):
+        """Which is why the transformer needs no separate post-dedupe pass."""
+        out, _ = _fingerprint_dedupe(self._fragments(3))
+        self.assertNotIn("tagged_vlans", out[0])
+        # a further pass over the result finds nothing left to do
+        self.assertFalse(apply_submitted_driver_field_policy(out))
+
+    def test_an_allowed_field_still_conflicts_after_a_merge(self):
+        """The control: mode "tagged" permits tagged_vlans, so disagreement is still an error."""
+        nodes = self._fragments(3)
+        for node in nodes:
+            node["mode"] = "tagged"
+        out, _ = _fingerprint_dedupe(nodes)
+        with self.assertRaises(serializers.ValidationError) as raised:
+            raise_unsettled_conflicts(out)
+        self.assertIn("Conflicting values", str(raised.exception))
+
+    def test_a_conflict_on_a_field_no_driver_value_can_drop_is_immediate(self):
+        """A field outside the registry is a plain disagreement: raised where it happens."""
+        # Deferral is only for fields a driver value could delete. Everything else keeps
+        # develop's behaviour, including the error's position in the pipeline.
+        nodes = [self._iface("i0", description="from A"),
+                 self._iface("i1", description="from B")]
+        with self.assertRaises(serializers.ValidationError):
+            _fingerprint_dedupe(nodes)
+
+    def test_a_deferred_conflict_releases_the_rejected_copys_edges(self):
+        """The value a deferred conflict declined must not keep its VLAN node alive."""
+        # _merge_nodes unions _refs, so without this the rejected tagged_vlans list would
+        # still reach resolution as an edge and the VLAN would be created anyway -- the
+        # manufactured VLAN the prune sweep exists to prevent, arriving by another route.
+        out, _ = _fingerprint_dedupe(self._fragments(3)[::-1])
+        raise_unsettled_conflicts(out)
+        self.assertEqual(out[0]["_refs"], {"d1"})
 
 
 class InterfaceModeClearE2ETests(APITestCase):
@@ -1512,6 +1608,104 @@ class InterfaceModeClearE2ETests(APITestCase):
         self.assertEqual(dropped_from.tagged_vlans.count(), 0)
         kept_by = Interface.objects.get(name="Gi1/0/42", device__name=dev["name"])
         self.assertEqual([v.vid for v in kept_by.tagged_vlans.all()], [641])
+
+    # --- N-way: one interface arriving as N duplicate fragments ---------------
+
+    def _tagged_copy(self, name, vid, tag):
+        """A duplicate fragment of ``name`` carrying one forbidden tagged VLAN."""
+        return {"device": self._device(), "name": name, "type": "1000base-t",
+                "tagged_vlans": [{"vid": vid, "name": f"{tag}-v{vid}", "status": "active"}]}
+
+    def _fragmented_payload(self, name, tag, octet, vids, driver_last=False):
+        """
+        One interface reached several times in a single payload.
+
+        Each nested copy hangs off a different device IP assignment and carries a
+        DIFFERENT forbidden tagged VLAN, so every merge is a fresh contradiction for the
+        policy to settle. ``driver_last`` moves mode "access" off the root fragment and
+        onto one more nested copy, so the driver value arrives only after the duplicates
+        have already disagreed.
+        """
+        copies = [self._tagged_copy(name, vid, tag) for vid in vids]
+        if driver_last:
+            copies.append({"device": self._device(), "name": name,
+                           "type": "1000base-t", "mode": "access"})
+        assert 2 <= len(copies) <= 4
+        addresses = [f"10.9.{octet}.10/24", f"2001:db8:{octet}::11/64",
+                     f"10.9.{octet}.12/24", f"10.9.{octet}.13/24"]
+        ips = [{"address": address, "assigned_object_interface": copy}
+               for address, copy in zip(addresses, copies, strict=False)]
+        dev = dict(self._device())
+        dev["primary_ip4"], dev["primary_ip6"] = ips[0], ips[1]
+        if len(ips) > 2:
+            dev["oob_ip"] = ips[2]
+        if len(ips) > 3:
+            dev["primary_ip4"]["nat_inside"] = ips[3]
+        root = {"device": dev, "name": name, "type": "1000base-t"}
+        if not driver_last:
+            root["mode"] = "access"
+        return {"timestamp": 1, "object_type": "dcim.interface",
+                "entity": {"interface": root}}
+
+    def _assert_fragments_converge(self, name, tag, octet, vids, driver_last=False):
+        """Plan, apply and re-plan a fragmented payload; assert one drop and no VLANs."""
+        from ipam.models import VLAN
+        payload = self._fragmented_payload(name, tag, octet, vids, driver_last)
+        cs = self._plan(payload)
+        iface_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_changes)
+        for change in iface_changes:
+            self.assertNotIn("tagged_vlans", change.get("data", {}))
+        messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
+        self.assertEqual(len(messages or []), 1, messages)
+        vlan_changes = [(c["change_type"], c.get("data", {}).get("vid"))
+                        for c in cs["changes"]
+                        if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(vlan_changes, [], vlan_changes)
+        self._converge(payload, f"fragments of {name}")
+        iface = Interface.objects.get(name=name, device__name=self._device()["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertFalse(VLAN.objects.filter(vid__in=vids).exists())
+
+    def test_three_fragments_of_one_interface_still_let_the_driver_win(self):
+        """Root + two nested copies, each with a different forbidden VLAN: still one access iface."""
+        # This is the shape a single pre- and post-dedupe pass could not settle. The root
+        # fragment has no forbidden field and the nested copies have no submitted mode, so
+        # the pre-dedupe pass drops nothing; dedupe merged root + copy 1 into the
+        # contradiction and the SECOND copy's different tagged_vlans then conflicted inside
+        # _merge_nodes, rejecting the whole entity before the post-dedupe pass could run.
+        # One interface really can be reached three times: as the entity, as primary_ip4's
+        # assigned interface, and as primary_ip6's.
+        self._assert_fragments_converge("Gi2/0/3", "n3", 63, [701, 702])
+
+    def test_four_fragments_of_one_interface_still_let_the_driver_win(self):
+        """A fourth copy, via the device's oob_ip, changes nothing."""
+        self._assert_fragments_converge("Gi2/0/4", "n4", 64, [711, 712, 713])
+
+    def test_five_fragments_of_one_interface_still_let_the_driver_win(self):
+        """A fifth copy, via primary_ip4's nat_inside, changes nothing either."""
+        self._assert_fragments_converge("Gi2/0/5", "n5", 65, [721, 722, 723, 724])
+
+    def test_reordering_the_same_fragments_does_not_change_the_outcome(self):
+        """The forbidden values swapped between fragments plan and converge identically."""
+        # Representation independence is the property under test: the same logical
+        # fragments in a different order must not produce a different answer.
+        self._assert_fragments_converge("Gi2/0/6", "n6", 66, [733, 732, 731])
+
+    def test_the_driver_fragment_arriving_last_still_wins(self):
+        """The mode arrives only after two duplicates have already disagreed."""
+        # Measured on the incremental normalization alone: the two tagged-only copies
+        # merge first, _merge_nodes rejects the second one's different tagged_vlans, and
+        # the fragment carrying mode "access" is never reached -- a 400 that depends
+        # purely on which copy the payload happened to nest first. Holding a conflict on
+        # a droppable field until the graph is merged is what removes that dependency.
+        self._assert_fragments_converge("Gi2/0/7", "n7", 67, [741, 742], driver_last=True)
+
+    def test_the_driver_fragment_arriving_last_of_five_still_wins(self):
+        """Three disagreeing copies, then the mode: still one access interface."""
+        self._assert_fragments_converge("Gi2/0/8", "n8", 68, [751, 752, 753],
+                                        driver_last=True)
 
     def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
         """A VLAN that is the entity's own primary object is never pruned."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -1088,3 +1088,68 @@ class InterfaceModeClearE2ETests(APITestCase):
         for quiet in range(1, 5):
             self.assertEqual(self._plan(payload).get("changes", []), [],
                              f"re-planned on quiet round {quiet}")
+
+    # --- P2-A: duplicate nodes that SPLIT the contradiction -------------------
+
+    def test_split_duplicate_nodes_do_not_merge_into_the_contradiction(self):
+        """Duplicate nodes that SPLIT mode and tagged_vlans still lose the forbidden field."""
+        # Measured on the pre-dedupe pass alone: neither node triggers the policy, because
+        # phase 1 needs the driver field PRESENT in the node it is looking at. The outer
+        # node carries mode "access" and no tagged_vlans; the nested one (reached through
+        # the device's primary_ip4 assignment) carries tagged_vlans and no mode. _merge_nodes
+        # then combined them INTO the contradiction -- merged data keys held both mode and
+        # tagged_vlans, change_set.warnings was None, and apply was a 400
+        # {"dcim.interface": {"tagged_vlans": ["Interface mode does not support tagged vlans"]}}.
+        # Running the policy a second time on the merged nodes is what closes it.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.20.20/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/20", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 520, "name": "split-v520", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/20", "type": "1000base-t", "mode": "access",
+        }}}
+        cs = self._plan(payload)
+        iface_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_changes)
+        for change in iface_changes:
+            self.assertNotIn("tagged_vlans", change.get("data", {}))
+        # reported exactly once, with both passes active
+        messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
+        self.assertEqual(len(messages or []), 1, messages)
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/20", device__name=dev["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    def test_a_drop_reported_by_both_passes_is_one_warning(self):
+        """Pass 1 drops from one node, pass 2 from the merged node: still one message."""
+        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans
+        # (pass 1 drops it and records the warning), the nested node carries a DIFFERENT
+        # tagged_vlans and no mode (pass 1 cannot see it; it survives the merge and pass 2
+        # drops it). Without dedupe on the message, change_set.warnings carried the same
+        # sentence twice for one field.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.22.22/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/22", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 522, "name": "mix-v522", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/22", "type": "1000base-t", "mode": "access",
+            "tagged_vlans": [{"vid": 523, "name": "mix-v523", "status": "active"}],
+        }}}
+        cs = self._plan(payload)
+        messages = cs["warnings"]["dcim.interface"]["tagged_vlans"]
+        self.assertEqual(len(messages), 1, messages)
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/22", device__name=dev["name"])
+        self.assertEqual(iface.tagged_vlans.count(), 0)

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -14,6 +14,8 @@ from netbox_diode_plugin.api.field_policy import (
     _DRIVER_FIELD_RULES,
     apply_submitted_driver_field_policy,
     match_participating_fields,
+    prune_orphaned_nodes,
+    referenced_uuids,
     submitted_driver_field_drops,
 )
 from netbox_diode_plugin.plugin_config import get_diode_user
@@ -424,12 +426,26 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
     def _uuids(self, entities):
         return sorted(e["_uuid"] for e in entities)
 
+    def _policy(self, entities):
+        """
+        Run the policy the way the transformer does: snapshot, drop, then ONE sweep.
+
+        The drop and the prune are deliberately separate calls -- pruning inside the
+        pass destroys a duplicate child before dedupe can merge it -- so this helper
+        keeps the unit tests exercising the same order the real pipeline uses.
+        """
+        referenced_before = referenced_uuids(entities)
+        released = apply_submitted_driver_field_policy(entities)
+        if not released:
+            return entities
+        return prune_orphaned_nodes(entities, referenced_before)
+
     def test_a_dropped_nested_reference_takes_its_child_node_with_it(self):
         """The child node a dropped tagged_vlans created is pruned, and so is its edge."""
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1"])
         self.assertNotIn("tagged_vlans", iface)
         self.assertEqual(iface["_refs"], set())
@@ -439,7 +455,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", mode="access",
                            untagged_vlan=self._ref("v1"), tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertEqual(iface["_refs"], {"v1"})       # the untagged_vlan edge stands
         self.assertEqual(iface["untagged_vlan"], self._ref("v1"))
@@ -451,7 +467,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                              mode="access", tagged_vlans=[self._ref("v1")])
         keeper = self._node("dcim.interface", "i2", refs={"v1"}, name="Eth2",
                             mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, dropped, keeper])
+        out = self._policy([vlan, dropped, keeper])
         self.assertEqual(self._uuids(out), ["i1", "i2", "v1"])
         self.assertEqual(dropped["_refs"], set())
         self.assertEqual(keeper["_refs"], {"v1"})
@@ -463,7 +479,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                           group=self._ref("g1", "ipam.vlangroup"))
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([group, vlan, iface])
+        out = self._policy([group, vlan, iface])
         self.assertEqual(self._uuids(out), ["i1"])
 
     def test_a_grandchild_something_surviving_needs_is_kept(self):
@@ -475,7 +491,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                                group=self._ref("g1", "ipam.vlangroup"))
         iface = self._node("dcim.interface", "i1", refs={"v1", "v2"}, name="Eth1", mode="access",
                            untagged_vlan=self._ref("v2"), tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([group, dropped_vlan, kept_vlan, iface])
+        out = self._policy([group, dropped_vlan, kept_vlan, iface])
         self.assertEqual(self._uuids(out), ["g1", "i1", "v2"])
         self.assertEqual(iface["_refs"], {"v2"})
 
@@ -491,7 +507,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         )
         post_create["_is_post_create"] = True
         post_create["_instance"] = "i1"
-        out = apply_submitted_driver_field_policy([vlan, mac, iface, post_create])
+        out = self._policy([vlan, mac, iface, post_create])
         self.assertEqual(self._uuids(out), ["i1", "m1", "pc1"])
 
     def test_a_root_node_is_never_pruned(self):
@@ -499,7 +515,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertIn("i1", self._uuids(out))
 
     def test_no_drop_prunes_nothing(self):
@@ -507,7 +523,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertEqual(iface["tagged_vlans"], [self._ref("v1")])
         self.assertEqual(iface["_warnings"], {})
@@ -517,7 +533,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", type="1000base-t",
                            rf_role="ap", mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertNotIn("rf_role", iface)
         self.assertEqual(iface["_refs"], {"v1"})
@@ -527,8 +543,8 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        entities = apply_submitted_driver_field_policy([vlan, iface])
-        again = apply_submitted_driver_field_policy(entities)
+        entities = self._policy([vlan, iface])
+        again = self._policy(entities)          # a second full pass changes nothing
         self.assertEqual(self._uuids(again), ["i1"])
         self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
 
@@ -1080,6 +1096,46 @@ class InterfaceModeClearE2ETests(APITestCase):
         r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
         self.assertEqual(r.status_code, 400, r.content)
         self.assertIn("Conflicting values", str(r.content))
+
+    def test_a_dropped_copy_still_contributes_before_it_is_pruned(self):
+        """The richer VLAN copy is inside the dropped field: it must merge, not vanish."""
+        # Pruning inside the pre-dedupe pass removed the named copy before
+        # _fingerprint_dedupe could merge it, leaving a survivor with a vid and no name:
+        # 400 {"ipam.vlan": {"name": ["This field cannot be blank."]}} on every round,
+        # blaming a blank VLAN name for an interface mode contradiction. Every earlier
+        # over-prune test specified the VLAN fully on BOTH sides, so the copies were
+        # interchangeable and losing one cost nothing -- this one makes them unequal,
+        # with the richer occurrence inside the field the mode forbids.
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": self._device(), "name": "Gi8/0/2", "type": "1000base-t",
+            "mode": "access",
+            "untagged_vlan": {"vid": 3992},
+            "tagged_vlans": [{"vid": 3992, "name": "v3992"}],
+        }}}
+        cs = self._plan(payload)
+        self._apply(cs)
+        vlan = VLAN.objects.get(vid=3992)
+        self.assertEqual(vlan.name, "v3992")  # inherited from the copy that was dropped
+        iface = Interface.objects.get(name="Gi8/0/2")
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.untagged_vlan.vid, 3992)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 4):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    def test_a_field_only_the_dropped_copy_carried_is_not_lost(self):
+        """The quiet form of the same mechanism: a description only on the tagged copy."""
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": self._device(), "name": "Gi8/0/3", "type": "1000base-t",
+            "mode": "access",
+            "untagged_vlan": {"vid": 3991, "name": "v3991"},
+            "tagged_vlans": [{"vid": 3991, "name": "v3991", "description": "ONLY-ON-TAGGED"}],
+        }}}
+        self._apply(self._plan(payload))
+        self.assertEqual(VLAN.objects.get(vid=3991).description, "ONLY-ON-TAGGED")
 
     def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
         """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -1,27 +1,36 @@
-"""Unit tests for the interface mode/VLAN changeset normalizer."""
+"""Unit tests for the driver-field policy (interface mode/type, VLAN qinq_role)."""
 from types import SimpleNamespace
 from unittest import mock
 
 from dcim.models import Interface
 from django.test import SimpleTestCase
+from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.differ import normalize_changeset
+from netbox_diode_plugin.api.field_policy import _DRIVER_FIELD_RULES, submitted_driver_field_drops
 from netbox_diode_plugin.plugin_config import get_diode_user
 
 
 class NormalizeChangesetTests(SimpleTestCase):
     """Pure-logic tests: no DB, operate on plain dicts."""
 
-    def _run(self, object_type, prechange, entity):
+    def _plan(self, object_type, prechange, entity):
+        """Run both policy phases in pipeline order and return (entity, dropped)."""
+        # Phase 1 runs in the transformer, before any fingerprinting; phase 2 runs
+        # in the differ once an existing row has been matched. Tests exercise them
+        # in that order so a unit result means the same thing an ingest would.
+        dropped = submitted_driver_field_drops(object_type, entity)
         normalize_changeset(object_type, prechange, entity)
-        return entity
+        return entity, dropped
+
+    def _run(self, object_type, prechange, entity):
+        return self._plan(object_type, prechange, entity)[0]
 
     def _drop(self, object_type, prechange, entity):
-        """Run the normalizer and return (entity, dropped-submitted-field map)."""
-        dropped = normalize_changeset(object_type, prechange, entity)
-        return entity, dropped
+        """Run both phases and return (entity, dropped-submitted-field map)."""
+        return self._plan(object_type, prechange, entity)
 
     def test_tagged_to_access_clears_tagged_vlans_keeps_untagged(self):
         """Mode tagged -> access clears tagged_vlans but leaves untagged_vlan untouched."""
@@ -122,7 +131,10 @@ class NormalizeChangesetTests(SimpleTestCase):
             "tagged_vlans": [101, 102],
         }
         out, dropped = self._drop("dcim.interface", {}, entity)
-        self.assertEqual(out["tagged_vlans"], [])       # forbidden -> dropped
+        # DROPPED, not blanked: with no stored row there is nothing to clear, so the
+        # payload must read as if the producer had never sent the field. Writing a
+        # blank here is what made the rf_* fields re-diff against NetBox's "" forever.
+        self.assertNotIn("tagged_vlans", out)           # forbidden -> dropped
         self.assertEqual(out["untagged_vlan"], 900)     # allowed for access -> kept
         self.assertEqual(list(dropped), ["tagged_vlans"])
 
@@ -153,8 +165,8 @@ class NormalizeChangesetTests(SimpleTestCase):
         """The reversed policy is registry-wide: dcim.interface "type" behaves the same."""
         entity = {"type": "1000base-t", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
         out, dropped = self._drop("dcim.interface", {}, entity)
-        self.assertIsNone(out["rf_channel"])
-        self.assertIsNone(out["rf_role"])
+        self.assertNotIn("rf_channel", out)
+        self.assertNotIn("rf_role", out)
         self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
 
     def test_shared_policy_keeps_rf_fields_on_a_wireless_type(self):
@@ -168,7 +180,7 @@ class NormalizeChangesetTests(SimpleTestCase):
         """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
         entity = {"qinq_role": "svlan", "qinq_svlan": 7}
         out, dropped = self._drop("ipam.vlan", {}, entity)
-        self.assertIsNone(out["qinq_svlan"])
+        self.assertNotIn("qinq_svlan", out)
         self.assertEqual(list(dropped), ["qinq_svlan"])
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
@@ -227,6 +239,139 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertNotIn("rf_channel", out)
 
 
+    # --- a driver value must be SUBMITTED to win (N3) -------------------------
+
+    def test_create_omitting_the_driver_field_keeps_its_dependent_fields(self):
+        """A create that simply omits mode keeps the VLANs NetBox would have stored."""
+        # The policy is that a SUBMITTED driver value wins over the fields it forbids.
+        # With no submitted driver value there is nothing to win, so producer data is
+        # left alone: mode absent must not read as mode "" and drop both VLAN fields.
+        entity = {"name": "vmeth0", "untagged_vlan": 601, "tagged_vlans": [602]}
+        out, dropped = self._drop("virtualization.vminterface", {}, entity)
+        self.assertEqual(out["untagged_vlan"], 601)
+        self.assertEqual(out["tagged_vlans"], [602])
+        self.assertEqual(dropped, {})
+
+    def test_explicitly_submitted_empty_driver_value_does_win(self):
+        """An explicitly submitted empty mode IS a submitted value, and forbids the VLANs."""
+        entity = {"name": "vmeth0", "mode": "", "untagged_vlan": 601, "tagged_vlans": [602]}
+        out, dropped = self._drop("virtualization.vminterface", {}, entity)
+        self.assertNotIn("untagged_vlan", out)
+        self.assertNotIn("tagged_vlans", out)
+        self.assertEqual(sorted(dropped), ["tagged_vlans", "untagged_vlan"])
+        # the reason must not claim a value that was never submitted
+        self.assertIn("empty", dropped["tagged_vlans"])
+        self.assertNotIn("''", dropped["tagged_vlans"])
+
+    def test_explicitly_submitted_null_driver_value_does_win(self):
+        """A submitted null mode is submitted too, and reads as no 802.1Q."""
+        out, dropped = self._drop("dcim.interface", {}, {"mode": None, "tagged_vlans": [602]})
+        self.assertNotIn("tagged_vlans", out)
+        self.assertEqual(list(dropped), ["tagged_vlans"])
+
+    def test_stored_driver_value_never_drops_submitted_data(self):
+        """A driver value that was only STORED does not drop submitted data."""
+        # The stored mode forbids tagged_vlans, but the producer submitted no mode, so
+        # there is no submitted driver value to win and the explicit list stands (NetBox
+        # judges it, exactly as it does on develop).
+        out, dropped = self._drop(
+            "dcim.interface", {"mode": "access", "tagged_vlans": [101]}, {"tagged_vlans": [102]},
+        )
+        self.assertEqual(out["tagged_vlans"], [102])
+        self.assertEqual(dropped, {})
+
+    def test_non_string_driver_value_fails_open_in_both_phases(self):
+        """A driver value that is not a string is not one we can reason about."""
+        # A malformed payload must not turn into a TypeError on an unhashable rule key.
+        out, dropped = self._drop(
+            "dcim.interface",
+            {"mode": "tagged", "tagged_vlans": [101]},
+            {"mode": {"vid": 5}, "tagged_vlans": [102]},
+        )
+        self.assertEqual(out["tagged_vlans"], [102])
+        self.assertEqual(dropped, {})
+
+    # --- the clear must converge against what NetBox actually stores (N1) -----
+
+    def test_submitted_forbidden_field_is_removed_not_blanked(self):
+        """A dropped field leaves the payload entirely; no blank is invented for it."""
+        out, dropped = self._drop("dcim.interface", {}, {"type": "1000base-t", "rf_role": "ap"})
+        self.assertNotIn("rf_role", out)
+        self.assertEqual(list(dropped), ["rf_role"])
+
+    def test_type_rf_clear_converges_against_the_blank_string_netbox_stores(self):
+        """The type/rf_* clear plans nothing once NetBox has stored '' for the rf fields."""
+        # rf_channel/rf_role are CharFields with null=False: NetBox coerces the submitted
+        # null to ''. Re-injecting None every round diffed '' vs None and emitted a
+        # spurious UPDATE on every ingest cycle forever.
+        payload = {"type": "1000base-t", "rf_role": "ap", "rf_channel": "2.4g-1-2412-22"}
+        stored = {"type": "ieee802.11ac", "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+                  "rf_channel_frequency": 2412, "rf_channel_width": 22}
+        round1, dropped = self._drop("dcim.interface", dict(stored), dict(payload))
+        self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
+        self.assertIsNone(round1["rf_role"])                            # stale value cleared
+        self.assertNotEqual(shallow_compare_dict(stored, round1), {})    # round 1 is a real change
+
+        stored2 = {"type": "1000base-t", "rf_role": "", "rf_channel": "",
+                   "rf_channel_frequency": None, "rf_channel_width": None}
+        round2, dropped2 = self._drop("dcim.interface", dict(stored2), dict(payload))
+        self.assertEqual(sorted(dropped2), ["rf_channel", "rf_role"])    # still reported
+        self.assertNotIn("rf_role", round2)                             # but nothing written
+        self.assertEqual(shallow_compare_dict(stored2, round2), {})      # -> empty plan
+
+    # --- every (driver value, dependent field) pair in the registry -----------
+
+    def _pair_sentinel(self, dependent):
+        """A non-empty submitted value for a dependent field (only truthiness matters)."""
+        return ["x"] if dependent == "tagged_vlans" else "x"
+
+    def _assert_pair_converges(self, object_type, driver_field, driver_value, dependent):
+        """Assert one (driver value, dependent field) pair drops, clears once, then converges."""
+        sentinel = self._pair_sentinel(dependent)
+        submitted = {driver_field: driver_value, dependent: sentinel}
+
+        # 1. a submitted driver value drops the field it forbids, and writes no blank
+        out, dropped = self._drop(object_type, {}, dict(submitted))
+        self.assertNotIn(dependent, out)
+        self.assertIn(dependent, dropped)
+
+        # 2. with no submitted driver value, submitted data survives untouched
+        out, dropped = self._drop(object_type, {}, {dependent: sentinel})
+        self.assertEqual(out[dependent], sentinel)
+        self.assertEqual(dropped, {})
+
+        # 3. a non-empty STORED value is cleared exactly once...
+        stored = {driver_field: driver_value, dependent: sentinel}
+        round1, _ = self._drop(object_type, dict(stored), dict(submitted))
+        self.assertNotEqual(shallow_compare_dict(stored, round1), {})
+
+        # ...and whichever empty representation NetBox then stores, the next round
+        # plans nothing at all for the field.
+        for netbox_stored in ("", None, [], (), {}):
+            with self.subTest(netbox_stored=netbox_stored):
+                stored2 = {driver_field: driver_value, dependent: netbox_stored}
+                round2, _ = self._drop(object_type, dict(stored2), dict(submitted))
+                self.assertNotIn(dependent, round2)
+                self.assertEqual(shallow_compare_dict(stored2, round2), {})
+
+    def test_every_registered_driver_value_dependent_pair_converges(self):
+        """Every (driver value, dependent field) pair in every rule map converges."""
+        # Exhaustive over the registry, including all ~100 non-wireless interface types
+        # in _INTERFACE_TYPE_RF_RULES, so a new rule cannot be added without meeting it.
+        pairs = 0
+        for object_type, rules in _DRIVER_FIELD_RULES.items():
+            for driver_field, value_map in rules.items():
+                for driver_value, dependents in value_map.items():
+                    for dependent in dependents:
+                        with self.subTest(object_type=object_type, driver_field=driver_field,
+                                          driver_value=driver_value, dependent=dependent):
+                            self._assert_pair_converges(
+                                object_type, driver_field, driver_value, dependent,
+                            )
+                        pairs += 1
+        self.assertGreater(pairs, 100)  # the map is generated; guard against an empty sweep
+
+
 class InterfaceModeClearE2ETests(APITestCase):
     """End-to-end: seed an existing interface, ingest a mode change, assert clear."""
 
@@ -262,6 +407,58 @@ class InterfaceModeClearE2ETests(APITestCase):
         cs = r1.json().get("change_set", {})
         r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
         return r1, r2
+
+    def _plan(self, payload):
+        """Generate a diff for a payload and return its change set."""
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs):
+        """Apply a change set and assert it landed without errors."""
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"), r.content)
+        return r
+
+    def _converge(self, payload, label, max_applies=2, quiet_rounds=4):
+        """
+        Apply a payload until its plan is empty, then assert it stays empty.
+
+        Returns the number of applies it took. An empty plan is the strongest
+        available statement of convergence: the change set carries no changes at
+        all, so re-ingest performs no write and logs no object change.
+        """
+        applies = 0
+        for _ in range(max_applies + 1):
+            cs = self._plan(payload)
+            if not cs.get("changes", []):
+                break
+            self._apply(cs)
+            applies += 1
+        else:
+            self.fail(f"{label} did not converge within {max_applies} applies")
+        self.assertLessEqual(applies, max_applies, f"{label} needed {applies} applies")
+        for quiet in range(1, quiet_rounds + 1):
+            self.assertEqual(
+                self._plan(payload).get("changes", []), [],
+                f"{label} re-planned on quiet round {quiet}",
+            )
+        return applies
+
+    def _iface_payload(self, **fields):
+        """Build a dcim.interface generate-diff payload for this test's device."""
+        entity = {"device": self._device()}
+        entity.update(fields)
+        return {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": entity}}
+
+    def _vm_payload(self, **fields):
+        """Build a virtualization.vminterface generate-diff payload."""
+        entity = {"virtual_machine": {"name": "obs3607-vm",
+                                      "cluster": {"name": "obs3607-cl", "type": {"name": "obs3607-ct"}}}}
+        entity.update(fields)
+        return {"timestamp": 1, "object_type": "virtualization.vminterface",
+                "entity": {"vm_interface": entity}}
 
     def test_tagged_to_access_clears_tagged_vlans_and_is_idempotent(self):
         """E2E: tagged -> access clears tagged_vlans, keeps untagged_vlan, and re-diffs as NOOP."""
@@ -585,3 +782,221 @@ class InterfaceModeClearE2ETests(APITestCase):
         cvlan.refresh_from_db()
         self.assertEqual(cvlan.qinq_role, "svlan")
         self.assertIsNone(cvlan.qinq_svlan)
+
+    # --- N1: the type/rf_* clear converges instead of writing every cycle -----
+
+    def test_type_change_rf_clear_converges_and_stops_writing(self):
+        """A non-wireless type reported with rf_* fields clears once, then plans nothing."""
+        # An interface exists as ieee802.11ac with rf_role/rf_channel set; the producer
+        # now reports it as 1000base-t while STILL reporting the rf fields. Round 1 must
+        # clear the stale values; every round after it must plan nothing. Blanking the
+        # submitted value instead of dropping it made rounds 2+ diff the injected None
+        # against the "" NetBox stores and emit a spurious UPDATE forever.
+        _, a1 = self._diff_apply({
+            "name": "Wl1", "type": "ieee802.11ac", "device": self._device(),
+            "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+        })
+        self.assertEqual(a1.status_code, 200)
+        iface = Interface.objects.get(name="Wl1")
+        self.assertEqual(iface.rf_role, "ap")
+        self.assertIsNotNone(iface.rf_channel_frequency)  # derived by Interface.save()
+
+        payload = self._iface_payload(
+            name="Wl1", type="1000base-t", rf_role="ap", rf_channel="2.4g-1-2412-22",
+        )
+        cs = self._plan(payload)
+        self.assertTrue([c for c in cs["changes"] if c["object_type"] == "dcim.interface"])
+        self.assertEqual(
+            sorted(cs.get("warnings", {}).get("dcim.interface", {})), ["rf_channel", "rf_role"],
+        )
+        self._apply(cs)
+        iface.refresh_from_db()
+        self.assertEqual(iface.type, "1000base-t")
+        self.assertEqual(iface.rf_role, "")        # what NetBox stores for these CharFields
+        self.assertEqual(iface.rf_channel, "")
+        self.assertIsNone(iface.rf_channel_frequency)
+        self.assertIsNone(iface.rf_channel_width)
+        last_updated = iface.last_updated
+
+        for quiet in range(1, 6):
+            cs = self._plan(payload)
+            self.assertEqual(cs.get("changes", []), [], f"re-planned on quiet round {quiet}")
+            # still reported by the producer, still dropped, never written again
+            self.assertEqual(
+                sorted(cs.get("warnings", {}).get("dcim.interface", {})),
+                ["rf_channel", "rf_role"],
+            )
+        iface.refresh_from_db()
+        self.assertEqual(iface.last_updated, last_updated)  # no write after round 1
+
+    # --- N3: a create that omits the driver field keeps its data --------------
+
+    def test_vminterface_create_without_mode_keeps_the_vlans_netbox_stores(self):
+        """A vminterface create omitting mode keeps its tagged VLANs, exactly as NetBox does."""
+        # NetBox nulls untagged_vlan itself in BaseInterface.save() but KEEPS tagged_vlans
+        # on a create (_state.adding is True), and the vminterface serializer validates
+        # neither. Nothing may be dropped here: no mode was submitted, so no driver value
+        # won anything, and the payload contradicted nothing.
+        payload = self._vm_payload(
+            name="vmeth0",
+            untagged_vlan={"vid": 3601, "name": "v3601"},
+            tagged_vlans=[{"vid": 3602, "name": "v3602"}],
+        )
+        cs = self._plan(payload)
+        self.assertNotIn("virtualization.vminterface", cs.get("warnings", {}))
+        self._apply(cs)
+
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth0")
+        self.assertFalse(vmi.mode)
+        self.assertIsNone(vmi.untagged_vlan)                                # NetBox's own save()
+        self.assertEqual([v.vid for v in vmi.tagged_vlans.all()], [3602])   # kept, not dropped
+
+    def test_modeless_untagged_vlan_replans_exactly_as_on_develop(self):
+        """A mode-less interface still reporting an untagged VLAN re-plans, as on develop."""
+        # Documented residual, NOT introduced by the driver-field policy: NetBox nulls
+        # untagged_vlan on EVERY save of a mode-less interface, so a producer that keeps
+        # reporting one keeps planning an update. Closing it would mean dropping submitted
+        # data with no submitted driver value to justify it, which is exactly the loss this
+        # scoping exists to prevent, so develop's behaviour is kept and pinned here.
+        payload = self._vm_payload(name="vmeth1", untagged_vlan={"vid": 3611, "name": "v3611"})
+        self._apply(self._plan(payload))
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth1")
+        self.assertIsNone(vmi.untagged_vlan)
+        vm_changes = [c for c in self._plan(payload).get("changes", [])
+                      if c["object_type"] == "virtualization.vminterface"]
+        self.assertTrue(vm_changes)  # re-plans; the policy deliberately does not silence it
+
+    # --- N2: a dropped match criterion must be dropped BEFORE matching --------
+
+    def test_vlan_qinq_role_create_applies_and_converges(self):
+        """A VLAN naming a service role with an svlan applies once, then plans nothing."""
+        # qinq_svlan is an ipam.vlan MATCH criterion (unique_qinq_svlan_vid, and the
+        # "qinq_svlan IS NULL" condition on the logical vid criteria). Dropping it after
+        # the existing-object lookup left the entity unmatchable, so it re-planned a
+        # CREATE and duplicated the row on every ingest. The policy runs before matching.
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 3971, "name": "n2-cvlan", "qinq_role": "svlan",
+            "qinq_svlan": {"vid": 3970, "name": "n2-svlan"},
+        }}}
+        cs = self._plan(payload)
+        self.assertIn("qinq_svlan", cs.get("warnings", {}).get("ipam.vlan", {}))
+        for change in cs["changes"]:
+            self.assertNotIn("qinq_svlan", change.get("data", {}))
+            self.assertNotIn("qinq_svlan", change.get("new_refs", []))
+        self._apply(cs)
+
+        from ipam.models import VLAN
+        vlan = VLAN.objects.get(vid=3971)
+        self.assertEqual(vlan.qinq_role, "svlan")
+        self.assertIsNone(vlan.qinq_svlan)
+
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+        self.assertEqual(VLAN.objects.filter(vid=3971).count(), 1)  # no duplicate rows
+
+    def test_vlan_customer_role_keeps_its_service_vlan_and_converges(self):
+        """qinq_role 'cvlan' permits qinq_svlan: it is kept, applied and converges."""
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 3973, "name": "n2-cust", "qinq_role": "cvlan",
+            "qinq_svlan": {"vid": 3972, "name": "n2-svc"},
+        }}}
+        cs = self._plan(payload)
+        self.assertNotIn("ipam.vlan", cs.get("warnings", {}))
+        self._apply(cs)
+        from ipam.models import VLAN
+        vlan = VLAN.objects.get(vid=3973)
+        self.assertEqual(vlan.qinq_svlan.vid, 3972)   # allowed -> kept verbatim
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- the whole mode rule map, end to end, over four quiet rounds ----------
+
+    def test_interface_mode_matrix_applies_and_converges(self):
+        """Every mode in the rule map applies with all three VLAN fields submitted, then converges."""
+        modes = list(_DRIVER_FIELD_RULES["dcim.interface"]["mode"])
+        self.assertEqual(len(modes), 5)
+        for i, mode in enumerate(modes):
+            with self.subTest(mode=mode):
+                payload = self._iface_payload(
+                    name=f"EthM{i}", type="1000base-t", mode=mode,
+                    untagged_vlan={"vid": 3700 + i, "name": f"u{i}"},
+                    tagged_vlans=[{"vid": 3710 + i, "name": f"t{i}"}],
+                    qinq_svlan={"vid": 3720 + i, "name": f"s{i}"},
+                )
+                self._converge(payload, f"dcim.interface mode {mode!r}")
+                iface = Interface.objects.get(name=f"EthM{i}")
+                forbidden = _DRIVER_FIELD_RULES["dcim.interface"]["mode"][mode]
+                if "tagged_vlans" in forbidden:
+                    self.assertEqual(iface.tagged_vlans.count(), 0)
+                else:
+                    self.assertEqual([v.vid for v in iface.tagged_vlans.all()], [3710 + i])
+                if "untagged_vlan" in forbidden:
+                    self.assertIsNone(iface.untagged_vlan)
+                else:
+                    self.assertEqual(iface.untagged_vlan.vid, 3700 + i)
+                if "qinq_svlan" in forbidden:
+                    self.assertIsNone(iface.qinq_svlan)
+                else:
+                    self.assertEqual(iface.qinq_svlan.vid, 3720 + i)
+
+    def test_vminterface_mode_matrix_applies_and_converges(self):
+        """Every mode in the rule map converges for vminterface too, where no serializer polices it."""
+        modes = list(_DRIVER_FIELD_RULES["virtualization.vminterface"]["mode"])
+        for i, mode in enumerate(modes):
+            with self.subTest(mode=mode):
+                payload = self._vm_payload(
+                    name=f"vmethM{i}", mode=mode,
+                    untagged_vlan={"vid": 3730 + i, "name": f"vu{i}"},
+                    tagged_vlans=[{"vid": 3740 + i, "name": f"vt{i}"}],
+                    qinq_svlan={"vid": 3750 + i, "name": f"vs{i}"},
+                )
+                self._converge(payload, f"virtualization.vminterface mode {mode!r}")
+                from virtualization.models import VMInterface
+                vmi = VMInterface.objects.get(name=f"vmethM{i}")
+                forbidden = _DRIVER_FIELD_RULES["virtualization.vminterface"]["mode"][mode]
+                if "tagged_vlans" in forbidden:
+                    self.assertEqual(vmi.tagged_vlans.count(), 0)
+                if "qinq_svlan" in forbidden:
+                    self.assertIsNone(vmi.qinq_svlan)
+
+    def test_interface_type_rf_matrix_applies_and_converges(self):
+        """Representative non-wireless types with all four rf_* fields submitted converge."""
+        # The type rule map is generated as the complement of the wireless allow-set, so
+        # every non-wireless value shares one code path; the exhaustive sweep over all of
+        # them is the unit test above. These are the shapes a producer actually sends.
+        for i, iface_type in enumerate(("1000base-t", "virtual", "lag")):
+            with self.subTest(type=iface_type):
+                payload = self._iface_payload(
+                    name=f"EthT{i}", type=iface_type, rf_role="ap",
+                    rf_channel="2.4g-1-2412-22", rf_channel_frequency=2412, rf_channel_width=22,
+                )
+                self._converge(payload, f"dcim.interface type {iface_type!r}")
+                iface = Interface.objects.get(name=f"EthT{i}")
+                self.assertEqual(iface.type, iface_type)
+                # Measured: a field the payload never carries lands as NULL, while a
+                # field submitted as null lands as '' (see the update case above) — the
+                # SAME CharField, two empty representations. No single blank a planner
+                # could write matches both, which is why the drop removes the field.
+                self.assertFalse(iface.rf_role)
+                self.assertFalse(iface.rf_channel)
+                self.assertIsNone(iface.rf_channel_frequency)
+                self.assertIsNone(iface.rf_channel_width)
+
+    def test_wireless_type_keeps_all_four_rf_fields_and_converges(self):
+        """A wireless type permits the rf fields: they are kept, applied and converge."""
+        payload = self._iface_payload(
+            name="EthW", type="ieee802.11ac", rf_role="ap", rf_channel="2.4g-1-2412-22",
+        )
+        cs = self._plan(payload)
+        self.assertNotIn("dcim.interface", cs.get("warnings", {}))
+        self._apply(cs)
+        iface = Interface.objects.get(name="EthW")
+        self.assertEqual(iface.rf_role, "ap")
+        self.assertEqual(iface.rf_channel, "2.4g-1-2412-22")
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_interface_mode_vlan_reconcile.py
@@ -9,7 +9,11 @@ from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.differ import normalize_changeset
-from netbox_diode_plugin.api.field_policy import _DRIVER_FIELD_RULES, submitted_driver_field_drops
+from netbox_diode_plugin.api.field_policy import (
+    _DRIVER_FIELD_RULES,
+    match_participating_fields,
+    submitted_driver_field_drops,
+)
 from netbox_diode_plugin.plugin_config import get_diode_user
 
 
@@ -176,12 +180,30 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertEqual(out["rf_channel"], "2.4g-1-2412-22")
         self.assertEqual(dropped, {})
 
-    def test_shared_policy_applies_to_vlan_qinq_role(self):
-        """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
+    def test_a_match_participating_field_is_never_dropped(self):
+        """ipam.vlan qinq_svlan is a match criterion, so the policy leaves it alone."""
+        # The reversal is NOT registry-wide. qinq_svlan is read by four ipam.vlan
+        # matchers, so dropping it changes which row the payload identifies: measured,
+        # it adopted and renamed an unrelated VLAN sharing the vid, or inserted a
+        # duplicate and converged onto it. NetBox's own 400 stands instead.
+        self.assertIn("qinq_svlan", match_participating_fields("ipam.vlan"))
         entity = {"qinq_role": "svlan", "qinq_svlan": 7}
         out, dropped = self._drop("ipam.vlan", {}, entity)
-        self.assertNotIn("qinq_svlan", out)
-        self.assertEqual(list(dropped), ["qinq_svlan"])
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+
+    def test_the_interface_policy_fields_are_not_match_criteria(self):
+        """The fields the policy does drop are not how any matcher identifies a row."""
+        # This is what makes the motivating cases safe to drop, and it is asserted
+        # rather than assumed: if a future matcher starts reading one of them, the
+        # gate above will silently start exempting it and this test says so first.
+        for object_type in ("dcim.interface", "virtualization.vminterface"):
+            matched = match_participating_fields(object_type)
+            for value_map in _DRIVER_FIELD_RULES[object_type].values():
+                for dependents in value_map.values():
+                    for dependent in dependents:
+                        with self.subTest(object_type=object_type, dependent=dependent):
+                            self.assertNotIn(dependent, matched)
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
         """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
@@ -329,6 +351,20 @@ class NormalizeChangesetTests(SimpleTestCase):
         """Assert one (driver value, dependent field) pair drops, clears once, then converges."""
         sentinel = self._pair_sentinel(dependent)
         submitted = {driver_field: driver_value, dependent: sentinel}
+
+        if dependent in match_participating_fields(object_type):
+            # Exempt: the field identifies the row, so phase 1 must not touch it and
+            # there is nothing for us to converge -- NetBox rejects the payload, which
+            # is develop's behaviour and the safe one. Phase 2 must still clear a stale
+            # STORED value the payload no longer carries.
+            out, dropped = self._drop(object_type, {}, dict(submitted))
+            self.assertEqual(out[dependent], sentinel)
+            self.assertEqual(dropped, {})
+            stored = {driver_field: driver_value, dependent: sentinel}
+            cleared, _ = self._drop(object_type, dict(stored), {driver_field: driver_value})
+            self.assertIn(dependent, cleared)
+            self.assertFalse(cleared[dependent])
+            return
 
         # 1. a submitted driver value drops the field it forbids, and writes no blank
         out, dropped = self._drop(object_type, {}, dict(submitted))
@@ -870,32 +906,34 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     # --- N2: a dropped match criterion must be dropped BEFORE matching --------
 
-    def test_vlan_qinq_role_create_applies_and_converges(self):
-        """A VLAN naming a service role with an svlan applies once, then plans nothing."""
-        # qinq_svlan is an ipam.vlan MATCH criterion (unique_qinq_svlan_vid, and the
-        # "qinq_svlan IS NULL" condition on the logical vid criteria). Dropping it after
-        # the existing-object lookup left the entity unmatchable, so it re-planned a
-        # CREATE and duplicated the row on every ingest. The policy runs before matching.
+    def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
+        """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""
+        # The regression this pins: dropping qinq_svlan before matching made the entity
+        # satisfy logical_vlan_vid_no_group_or_svlan_or_site ("vid where group IS NULL
+        # AND qinq_svlan IS NULL AND site IS NULL"), i.e. vid alone -- so it adopted
+        # whatever VLAN held that vid and renamed it. Measured: a seeded VLAN was
+        # silently renamed and re-roled where develop wrote nothing at all.
+        from ipam.models import VLAN
+        seeded = VLAN.objects.create(
+            vid=4091, name="lq-someone-elses-vlan", description="OWNED BY ANOTHER SOURCE",
+        )
         payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
-            "vid": 3971, "name": "n2-cvlan", "qinq_role": "svlan",
-            "qinq_svlan": {"vid": 3970, "name": "n2-svlan"},
+            "vid": 4091, "name": "lq-brand-new-svlan", "qinq_role": "svlan",
+            "qinq_svlan": {"vid": 4090, "name": "lq-parent"},
         }}}
         cs = self._plan(payload)
-        self.assertIn("qinq_svlan", cs.get("warnings", {}).get("ipam.vlan", {}))
-        for change in cs["changes"]:
-            self.assertNotIn("qinq_svlan", change.get("data", {}))
-            self.assertNotIn("qinq_svlan", change.get("new_refs", []))
-        self._apply(cs)
+        # nothing is dropped and nothing is warned about: the field identifies the row
+        self.assertNotIn("ipam.vlan", cs.get("warnings", {}))
 
-        from ipam.models import VLAN
-        vlan = VLAN.objects.get(vid=3971)
-        self.assertEqual(vlan.qinq_role, "svlan")
-        self.assertIsNone(vlan.qinq_svlan)
+        # NetBox rejects the contradiction, which is exactly develop's answer
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertNotEqual(r.status_code, 200, r.content)
 
-        for quiet in range(1, 5):
-            self.assertEqual(self._plan(payload).get("changes", []), [],
-                             f"re-planned on quiet round {quiet}")
-        self.assertEqual(VLAN.objects.filter(vid=3971).count(), 1)  # no duplicate rows
+        seeded.refresh_from_db()
+        self.assertEqual(seeded.name, "lq-someone-elses-vlan")
+        self.assertEqual(seeded.description, "OWNED BY ANOTHER SOURCE")
+        self.assertFalse(seeded.qinq_role)  # '' or None; both mean 'not a Q-in-Q VLAN'
+        self.assertEqual(VLAN.objects.filter(vid=4091).count(), 1)  # and no duplicate
 
     def test_vlan_customer_role_keeps_its_service_vlan_and_converges(self):
         """qinq_role 'cvlan' permits qinq_svlan: it is kept, applied and converges."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_updates_cases.json
@@ -2175,7 +2175,10 @@
         "lookup": {"name": "WirelessGigabitEthernet1/0/1"},
         "create_expect": {
             "name": "WirelessGigabitEthernet1/0/1",
-            "label": "Core Link 1"
+            "label": "Core Link 1",
+            "mode": "access",
+            "untagged_vlan.vid": 900,
+            "tagged_vlans.all": []
         },
         "create": {
             "interface": {
@@ -2305,6 +2308,10 @@
                         "status": "active",
                         "description": "Primary VDC"
                     }
+                ],
+                "tagged_vlans": [
+                    {"vid": 101, "name": "Voice VLAN", "status": "active"},
+                    {"vid": 102, "name": "Data VLAN", "status": "active"}
                 ]
             }    
         },
@@ -2436,11 +2443,18 @@
                         "status": "active",
                         "description": "Primary VDC"
                     }
+                ],
+                "tagged_vlans": [
+                    {"vid": 101, "name": "Voice VLAN", "status": "active"},
+                    {"vid": 102, "name": "Data VLAN", "status": "active"}
                 ]
             }    
         },
         "update_expect": {
-            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"]
+            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"],
+            "mode": "access",
+            "untagged_vlan.vid": 900,
+            "tagged_vlans.all": []
         }
     },
     {

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase
 from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
+from netbox_diode_plugin.api import field_policy
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.common import UnresolvedReference
 from netbox_diode_plugin.api.differ import normalize_changeset
@@ -208,6 +209,53 @@ class NormalizeChangesetTests(SimpleTestCase):
                     for dependent in dependents:
                         with self.subTest(object_type=object_type, dependent=dependent):
                             self.assertNotIn(dependent, matched)
+
+    def _flaky_model_lookup(self, fail_calls=1):
+        """A get_object_type_model that fails its first ``fail_calls`` calls, then works."""
+        real = field_policy.get_object_type_model
+        calls = []
+
+        def flaky(object_type):
+            calls.append(object_type)
+            if len(calls) <= fail_calls:
+                raise RuntimeError("content type lookup unavailable")
+            return real(object_type)
+
+        match_participating_fields.cache_clear()
+        self.addCleanup(match_participating_fields.cache_clear)
+        return flaky, calls
+
+    def test_a_model_lookup_failure_refuses_the_drop_instead_of_licensing_it(self):
+        """A failed model lookup propagates; it never answers "nothing participates"."""
+        # The gate answers "which fields decide WHICH row this payload means". An empty
+        # answer means "none of them", which licenses every drop the gate exists to
+        # refuse -- so a lookup failure must not produce one.
+        flaky, calls = self._flaky_model_lookup()
+        entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+        with mock.patch.object(field_policy, "get_object_type_model", flaky):
+            with self.assertRaises(RuntimeError):
+                submitted_driver_field_drops("ipam.vlan", entity)
+            # nothing was dropped on the way out
+            self.assertEqual(entity, {"qinq_role": "svlan", "qinq_svlan": 7})
+            self.assertEqual(calls, ["ipam.vlan"])
+
+    def test_a_model_lookup_failure_is_not_cached_as_nothing_participates(self):
+        """The recovery half: a transient failure must not poison the lru_cache."""
+        # lru_cache does not cache exceptions, so the next call retries. Returning an
+        # empty frozenset instead would be cached until eviction or restart, and every
+        # later request would treat qinq_svlan as droppable after the database had
+        # recovered -- re-enabling the same-vid wrong-row mutation this gate prevents.
+        flaky, calls = self._flaky_model_lookup()
+        with mock.patch.object(field_policy, "get_object_type_model", flaky):
+            with self.assertRaises(RuntimeError):
+                match_participating_fields("ipam.vlan")
+            # the healthy retry sees the truth
+            self.assertIn("qinq_svlan", match_participating_fields("ipam.vlan"))
+            entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+            out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+        self.assertEqual(len(calls), 2)   # retried once, then served from cache
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
         """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
@@ -537,6 +585,29 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertNotIn("rf_role", iface)
         self.assertEqual(iface["_refs"], {"v1"})
+
+    def test_a_gate_failure_takes_the_whole_pass_down_instead_of_dropping(self):
+        """The graph-level pass does not swallow a gate failure into a silent drop."""
+        real = field_policy.get_object_type_model
+
+        def broken(object_type):
+            raise RuntimeError("content type lookup unavailable")
+
+        match_participating_fields.cache_clear()
+        self.addCleanup(match_participating_fields.cache_clear)
+        svlan = self._node("ipam.vlan", "s1", vid=900, name="s900")
+        vlan = self._node("ipam.vlan", "v1", refs={"s1"}, vid=101, name="v101",
+                          qinq_role="svlan", qinq_svlan=self._ref("s1"))
+        with mock.patch.object(field_policy, "get_object_type_model", broken):
+            with self.assertRaises(RuntimeError):
+                apply_submitted_driver_field_policy([svlan, vlan])
+        self.assertEqual(vlan["qinq_svlan"], self._ref("s1"))
+        self.assertEqual(vlan["_refs"], {"s1"})
+        self.assertEqual(vlan["_warnings"], {})
+        # and with the lookup healthy again the gate still refuses the drop
+        self.assertEqual(self._uuids(self._policy([svlan, vlan])), ["s1", "v1"])
+        self.assertEqual(vlan["qinq_svlan"], self._ref("s1"))
+        self.assertIs(real, field_policy.get_object_type_model)
 
     def test_one_drop_is_reported_once_when_the_policy_runs_twice(self):
         """The policy is idempotent: a second pass re-reports nothing."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -715,6 +715,47 @@ class DedupeDriverFieldPolicyTests(TestCase):
         raise_unsettled_conflicts(out)
         self.assertEqual(out[0]["_refs"], {"d1"})
 
+    def _shared_vlan_fragments(self):
+        """
+        Fragments whose surviving VLAN is ALSO the untagged one.
+
+        Dropping tagged_vlans then releases no edge -- untagged_vlan still needs it --
+        so the only edge phase 1 gives up is the one the rejected duplicate contributed.
+        """
+        shared = UnresolvedReference(object_type="ipam.vlan", uuid="v1")
+        other = UnresolvedReference(object_type="ipam.vlan", uuid="v2")
+        return [
+            self._iface("i0", _refs={"d1", "v1"}, untagged_vlan=shared, tagged_vlans=[shared]),
+            self._iface("i1", _refs={"d1", "v2"}, tagged_vlans=[other]),
+            self._iface("i2", mode="access"),
+        ]
+
+    def test_a_rejected_values_edge_release_is_reported_to_the_prune_sweep(self):
+        """Dedupe must report the edges the merge released, not only the ones drops did."""
+        out, released = _fingerprint_dedupe(self._shared_vlan_fragments())
+        raise_unsettled_conflicts(out)
+        node = out[0]
+        self.assertNotIn("tagged_vlans", node)
+        self.assertEqual(node["untagged_vlan"].uuid, "v1")
+        self.assertEqual(node["_refs"], {"d1", "v1"})   # the rejected copy's v2 is gone
+        # The drop itself released nothing, so if the merge's release is not reported the
+        # caller skips its one prune sweep and v2 survives as a manufactured VLAN.
+        self.assertTrue(released)
+
+    def test_the_orphan_of_a_rejected_value_is_pruned(self):
+        """Phase 1 in full: only the rejected duplicate's VLAN node disappears."""
+        vlans = [{"_object_type": "ipam.vlan", "_uuid": uuid, "_refs": set(),
+                  "vid": vid, "name": f"dedupe-v{vid}", "status": "active"}
+                 for uuid, vid in (("v1", 981), ("v2", 982))]
+        entities = vlans + self._shared_vlan_fragments()
+        referenced_before = referenced_uuids(entities)
+        released = apply_submitted_driver_field_policy(entities)
+        deduplicated, merge_released = _fingerprint_dedupe(entities)
+        raise_unsettled_conflicts(deduplicated)
+        if released or merge_released:
+            deduplicated = prune_orphaned_nodes(deduplicated, referenced_before)
+        self.assertEqual({entity["_uuid"] for entity in deduplicated}, {"v1", "i0"})
+
 
 class InterfaceModeClearE2ETests(APITestCase):
     """End-to-end: seed an existing interface, ingest a mode change, assert clear."""
@@ -1706,6 +1747,67 @@ class InterfaceModeClearE2ETests(APITestCase):
         """Three disagreeing copies, then the mode: still one access interface."""
         self._assert_fragments_converge("Gi2/0/8", "n8", 68, [751, 752, 753],
                                         driver_last=True)
+
+    def _shared_vlan_fragment_payload(self, name, octet, field, untagged, keep, reject):
+        """
+        Fragments of one interface where the survivor's VLAN is needed twice.
+
+        ``field`` is the forbidden field the copies split; the first copy also points
+        ``untagged_vlan`` at the same VLAN, which mode "access" permits, so dropping
+        ``field`` releases no edge of its own.
+        """
+        def copy(**extra):
+            return {"device": self._device(), "name": name, "type": "1000base-t", **extra}
+
+        dev = dict(self._device())
+        dev["primary_ip4"] = {
+            "address": f"10.6.{octet}.10/24",
+            "assigned_object_interface": copy(untagged_vlan=untagged, **{field: keep}),
+        }
+        dev["primary_ip6"] = {
+            "address": f"2001:db8:6{octet}::11/64",
+            "assigned_object_interface": copy(**{field: reject}),
+        }
+        dev["oob_ip"] = {
+            "address": f"10.6.{octet}.12/24",
+            "assigned_object_interface": copy(mode="access"),
+        }
+        return {"timestamp": 1, "object_type": "dcim.interface", "entity": {
+            "interface": {"device": dev, "name": name, "type": "1000base-t"}}}
+
+    def _assert_rejected_vlan_is_never_created(self, name, octet, field, keep_vid, reject_vid):
+        """The VLAN only a REJECTED duplicate value referenced must not be created."""
+        from ipam.models import VLAN
+        keep = {"vid": keep_vid, "name": f"rej-v{keep_vid}", "status": "active"}
+        reject = {"vid": reject_vid, "name": f"rej-v{reject_vid}", "status": "active"}
+        many = field == "tagged_vlans"
+        payload = self._shared_vlan_fragment_payload(
+            name, octet, field, dict(keep),
+            [dict(keep)] if many else dict(keep),
+            [dict(reject)] if many else dict(reject),
+        )
+        cs = self._plan(payload)
+        planned = [c.get("data", {}).get("vid") for c in cs["changes"]
+                   if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(planned, [keep_vid], planned)
+        self._converge(payload, f"a rejected duplicate's {field}")
+        self.assertTrue(VLAN.objects.filter(vid=keep_vid).exists())
+        self.assertFalse(VLAN.objects.filter(vid=reject_vid).exists())
+        iface = Interface.objects.get(name=name, device__name=self._device()["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.untagged_vlan.vid, keep_vid)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_rejected_duplicates_tagged_vlan_is_never_created(self):
+        """The survivor is also the untagged VLAN, so only the merge released an edge."""
+        # Without the merge's release reaching the prune gate the change set still plans
+        # a create for the rejected copy's VLAN: the interface comes out correct while an
+        # extra VLAN is manufactured out of a value nothing kept.
+        self._assert_rejected_vlan_is_never_created("Gi3/0/1", 71, "tagged_vlans", 671, 672)
+
+    def test_a_rejected_duplicates_qinq_svlan_is_never_created(self):
+        """The same shape on a different forbidden field the interface policy drops."""
+        self._assert_rejected_vlan_is_never_created("Gi3/0/2", 72, "qinq_svlan", 681, 682)
 
     def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
         """A VLAN that is the entity's own primary object is never pruned."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -8,9 +8,11 @@ from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.common import UnresolvedReference
 from netbox_diode_plugin.api.differ import normalize_changeset
 from netbox_diode_plugin.api.field_policy import (
     _DRIVER_FIELD_RULES,
+    apply_submitted_driver_field_policy,
     match_participating_fields,
     submitted_driver_field_drops,
 )
@@ -406,6 +408,129 @@ class NormalizeChangesetTests(SimpleTestCase):
                             )
                         pairs += 1
         self.assertGreater(pairs, 100)  # the map is generated; guard against an empty sweep
+
+
+class DriverFieldPolicyPruneTests(SimpleTestCase):
+    """Which graph edges and child nodes a phase 1 drop takes with it -- and which it must not."""
+
+    def _ref(self, uuid, object_type="ipam.vlan"):
+        return UnresolvedReference(object_type=object_type, uuid=uuid)
+
+    def _node(self, object_type, uuid, refs=(), **fields):
+        node = {"_object_type": object_type, "_uuid": uuid, "_refs": set(refs), "_warnings": {}}
+        node.update(fields)
+        return node
+
+    def _uuids(self, entities):
+        return sorted(e["_uuid"] for e in entities)
+
+    def test_a_dropped_nested_reference_takes_its_child_node_with_it(self):
+        """The child node a dropped tagged_vlans created is pruned, and so is its edge."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1"])
+        self.assertNotIn("tagged_vlans", iface)
+        self.assertEqual(iface["_refs"], set())
+
+    def test_a_child_the_same_node_still_references_is_kept(self):
+        """One VLAN node reached by BOTH untagged_vlan and tagged_vlans survives the drop."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", mode="access",
+                           untagged_vlan=self._ref("v1"), tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertEqual(iface["_refs"], {"v1"})       # the untagged_vlan edge stands
+        self.assertEqual(iface["untagged_vlan"], self._ref("v1"))
+
+    def test_a_child_another_node_still_references_is_kept(self):
+        """A second interface still tagging the VLAN keeps its node alive."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        dropped = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                             mode="access", tagged_vlans=[self._ref("v1")])
+        keeper = self._node("dcim.interface", "i2", refs={"v1"}, name="Eth2",
+                            mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, dropped, keeper])
+        self.assertEqual(self._uuids(out), ["i1", "i2", "v1"])
+        self.assertEqual(dropped["_refs"], set())
+        self.assertEqual(keeper["_refs"], {"v1"})
+
+    def test_pruning_is_transitive(self):
+        """A pruned child's own children go too, once nothing reaches them."""
+        group = self._node("ipam.vlangroup", "g1", name="g1", slug="g1")
+        vlan = self._node("ipam.vlan", "v1", refs={"g1"}, vid=101, name="v101",
+                          group=self._ref("g1", "ipam.vlangroup"))
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([group, vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1"])
+
+    def test_a_grandchild_something_surviving_needs_is_kept(self):
+        """Transitivity stops at the first node another survivor still references."""
+        group = self._node("ipam.vlangroup", "g1", name="g1", slug="g1")
+        dropped_vlan = self._node("ipam.vlan", "v1", refs={"g1"}, vid=101, name="v101",
+                                  group=self._ref("g1", "ipam.vlangroup"))
+        kept_vlan = self._node("ipam.vlan", "v2", refs={"g1"}, vid=102, name="v102",
+                               group=self._ref("g1", "ipam.vlangroup"))
+        iface = self._node("dcim.interface", "i1", refs={"v1", "v2"}, name="Eth1", mode="access",
+                           untagged_vlan=self._ref("v2"), tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([group, dropped_vlan, kept_vlan, iface])
+        self.assertEqual(self._uuids(out), ["g1", "i1", "v2"])
+        self.assertEqual(iface["_refs"], {"v2"})
+
+    def test_a_post_create_step_and_its_children_are_never_collateral(self):
+        """A post-create node hangs off its object; a drop elsewhere leaves it alone."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        mac = self._node("dcim.macaddress", "m1", mac_address="00:00:00:00:00:01")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        post_create = self._node(
+            "dcim.interface", "pc1", refs={"i1", "m1"},
+            primary_mac_address=self._ref("m1", "dcim.macaddress"),
+        )
+        post_create["_is_post_create"] = True
+        post_create["_instance"] = "i1"
+        out = apply_submitted_driver_field_policy([vlan, mac, iface, post_create])
+        self.assertEqual(self._uuids(out), ["i1", "m1", "pc1"])
+
+    def test_a_root_node_is_never_pruned(self):
+        """A node nothing referenced is the entity's own object: it survives a drop on itself."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertIn("i1", self._uuids(out))
+
+    def test_no_drop_prunes_nothing(self):
+        """With nothing to drop the policy is a pure no-op over the graph."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertEqual(iface["tagged_vlans"], [self._ref("v1")])
+        self.assertEqual(iface["_warnings"], {})
+
+    def test_a_drop_with_no_nested_reference_prunes_nothing(self):
+        """Dropping a plain scalar (rf_role) releases no edge and no node."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", type="1000base-t",
+                           rf_role="ap", mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertNotIn("rf_role", iface)
+        self.assertEqual(iface["_refs"], {"v1"})
+
+    def test_one_drop_is_reported_once_when_the_policy_runs_twice(self):
+        """The policy is idempotent: a second pass re-reports nothing."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        entities = apply_submitted_driver_field_policy([vlan, iface])
+        again = apply_submitted_driver_field_policy(entities)
+        self.assertEqual(self._uuids(again), ["i1"])
+        self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
 
 
 class InterfaceModeClearE2ETests(APITestCase):
@@ -1153,3 +1278,121 @@ class InterfaceModeClearE2ETests(APITestCase):
         self._apply(cs)
         iface = Interface.objects.get(name="Gi1/0/22", device__name=dev["name"])
         self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    # --- P2-B: the orphan child nodes a drop leaves behind --------------------
+
+    def test_dropping_tagged_vlans_creates_no_orphan_vlan(self):
+        """A dropped nested reference takes its child node with it: no VLAN is manufactured."""
+        # Measured before the fix: planned non-noop ipam.vlan changes = [("create", 621)],
+        # apply 200, VLAN 621 present in NetBox afterwards while the interface had mode
+        # access and tagged_vlans count 0 -- the payload silently created a VLAN it could
+        # not use, and the warning claimed the field had been dropped.
+        from ipam.models import VLAN
+        payload = self._iface_payload(
+            name="Gi1/0/21", type="1000base-t", mode="access",
+            tagged_vlans=[{"vid": 621, "name": "p2b-orphan", "status": "active"}],
+        )
+        cs = self._plan(payload)
+        vlan_changes = [(c["change_type"], c.get("data", {}).get("vid"))
+                        for c in cs["changes"]
+                        if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(vlan_changes, [], vlan_changes)
+        self._apply(cs)
+        self.assertFalse(VLAN.objects.filter(vid=621).exists())
+        iface = Interface.objects.get(name="Gi1/0/21")
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- over-pruning: three ways a dropped child is still needed -------------
+
+    def test_a_vlan_that_is_also_the_untagged_vlan_survives_the_drop(self):
+        """The same VLAN named as both untagged_vlan and a tagged VLAN is still created."""
+        from ipam.models import VLAN
+        payload = self._iface_payload(
+            name="Gi1/0/30", type="1000base-t", mode="access",
+            untagged_vlan={"vid": 632, "name": "keep-v632", "status": "active"},
+            tagged_vlans=[{"vid": 632, "name": "keep-v632", "status": "active"}],
+        )
+        self._converge(payload, "shared untagged/tagged VLAN")
+        self.assertTrue(VLAN.objects.filter(vid=632).exists())
+        iface = Interface.objects.get(name="Gi1/0/30")
+        self.assertEqual(iface.untagged_vlan.vid, 632)   # allowed by 'access' -> linked
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # forbidden -> dropped
+
+    def test_a_shared_vlan_survives_a_drop_on_the_merged_node(self):
+        """After the merge one VLAN node is both untagged_vlan and a tagged VLAN: it survives."""
+        # This is the case a per-node reference count exists for. The outer node carries
+        # mode "access" and untagged_vlan 631; the nested duplicate carries tagged_vlans
+        # [631] and no mode. Fingerprint dedupe collapses the two VLAN nodes into ONE, so
+        # the merged interface points at that single node from both fields. Releasing the
+        # tagged_vlans edge must not release the untagged_vlan edge with it -- if it does,
+        # the node is pruned and untagged_vlan is left dangling.
+        from ipam.models import VLAN
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.31.31/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/31", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 631, "name": "keep-v631", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/31", "type": "1000base-t", "mode": "access",
+            "untagged_vlan": {"vid": 631, "name": "keep-v631", "status": "active"},
+        }}}
+        self._converge(payload, "shared VLAN node after merge")
+        self.assertTrue(VLAN.objects.filter(vid=631).exists())
+        iface = Interface.objects.get(name="Gi1/0/31", device__name=dev["name"])
+        self.assertEqual(iface.untagged_vlan.vid, 631)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_vlan_a_second_interface_still_tags_survives_the_drop(self):
+        """One VLAN node, two interfaces: the drop on one must not unmake it for the other."""
+        # Gi1/0/40 is named twice (outer node with mode "access", nested duplicate with
+        # tagged_vlans [641]) so the merged node loses tagged_vlans in the post-merge pass.
+        # Gi1/0/42, mode "tagged", legitimately tags the SAME VLAN, and dedupe gives both
+        # interfaces the same VLAN node. Pruning it would strand Gi1/0/42's reference.
+        from ipam.models import VLAN
+        dev = self._device()
+        vlan = {"vid": 641, "name": "keep-v641", "status": "active"}
+        dev_two = dict(
+            dev,
+            primary_ip4={
+                "address": "10.9.40.40/24",
+                "assigned_object_interface": {
+                    "device": dev, "name": "Gi1/0/40", "type": "1000base-t",
+                    "tagged_vlans": [dict(vlan)],
+                },
+            },
+            primary_ip6={
+                "address": "2001:db8:40::42/64",
+                "assigned_object_interface": {
+                    "device": dev, "name": "Gi1/0/42", "type": "1000base-t",
+                    "mode": "tagged", "tagged_vlans": [dict(vlan)],
+                },
+            },
+        )
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_two, "name": "Gi1/0/40", "type": "1000base-t", "mode": "access",
+        }}}
+        self._converge(payload, "VLAN shared by a second interface")
+        self.assertTrue(VLAN.objects.filter(vid=641).exists())
+        dropped_from = Interface.objects.get(name="Gi1/0/40", device__name=dev["name"])
+        self.assertEqual(dropped_from.mode, "access")
+        self.assertEqual(dropped_from.tagged_vlans.count(), 0)
+        kept_by = Interface.objects.get(name="Gi1/0/42", device__name=dev["name"])
+        self.assertEqual([v.vid for v in kept_by.tagged_vlans.all()], [641])
+
+    def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
+        """A VLAN that is the entity's own primary object is never pruned."""
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 651, "name": "own-right-v651", "status": "active",
+            "group": {"name": "own-right-group", "slug": "own-right-group"},
+        }}}
+        self._converge(payload, "ipam.vlan on its own")
+        vlan = VLAN.objects.get(vid=651, name="own-right-v651")
+        self.assertEqual(vlan.group.name, "own-right-group")

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -18,6 +18,11 @@ class NormalizeChangesetTests(SimpleTestCase):
         normalize_changeset(object_type, prechange, entity)
         return entity
 
+    def _drop(self, object_type, prechange, entity):
+        """Run the normalizer and return (entity, dropped-submitted-field map)."""
+        dropped = normalize_changeset(object_type, prechange, entity)
+        return entity, dropped
+
     def test_tagged_to_access_clears_tagged_vlans_keeps_untagged(self):
         """Mode tagged -> access clears tagged_vlans but leaves untagged_vlan untouched."""
         prechange = {"mode": "tagged", "tagged_vlans": [101, 102], "untagged_vlan": 5}
@@ -42,13 +47,40 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertEqual(out["tagged_vlans"], [])
         self.assertIsNone(out["qinq_svlan"])
 
-    def test_explicit_value_is_respected_not_overwritten(self):
-        """An explicitly submitted dependent field value is never overwritten."""
-        # producer explicitly sent tagged_vlans with an incompatible mode -> leave it
+    def test_explicit_forbidden_value_is_dropped_driver_wins(self):
+        """The submitted driver value wins: an explicit but forbidden value is dropped."""
+        # POLICY (reversed): a payload naming mode "access" AND naming tagged VLANs is
+        # self-contradictory. NetBox rejects the WHOLE entity for it, so the mode wins
+        # and the field it forbids is discarded — producer intent does NOT protect it.
         prechange = {"mode": "tagged", "tagged_vlans": [101]}
         entity = {"mode": "access", "tagged_vlans": [200]}
-        out = self._run("dcim.interface", prechange, entity)
+        out, dropped = self._drop("dcim.interface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertIn("tagged_vlans", dropped)
+        self.assertIn("mode", dropped["tagged_vlans"])
+        self.assertIn("access", dropped["tagged_vlans"])
+
+    def test_explicit_allowed_value_is_respected(self):
+        """Producer intent survives for everything the driver value ALLOWS."""
+        # mode "tagged" permits tagged_vlans, so an explicit list is kept verbatim and
+        # is not reported as dropped. This is the half of producer intent that stands.
+        out, dropped = self._drop(
+            "dcim.interface",
+            {"mode": "access", "tagged_vlans": []},
+            {"mode": "tagged", "tagged_vlans": [200]},
+        )
         self.assertEqual(out["tagged_vlans"], [200])
+        self.assertEqual(dropped, {})
+
+    def test_explicit_empty_forbidden_value_is_not_a_change(self):
+        """A submitted value that is already empty is left exactly as submitted."""
+        # Rewriting it would be pointless and could only manufacture a spurious
+        # change (e.g. [] -> None); nothing is reported as dropped either.
+        out, dropped = self._drop(
+            "dcim.interface", {}, {"mode": "access", "tagged_vlans": []}
+        )
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertEqual(dropped, {})
 
     def test_no_clear_when_prechange_field_already_empty(self):
         """Nothing is injected into entity when the prechange dependent field was already empty."""
@@ -79,11 +111,72 @@ class NormalizeChangesetTests(SimpleTestCase):
         out = self._run("dcim.device", prechange, entity)
         self.assertNotIn("tagged_vlans", out)
 
-    def test_create_no_prechange_is_noop(self):
-        """Create flows (empty prechange, no existing row) are a no-op."""
+    def test_create_drops_forbidden_submitted_value(self):
+        """A create is not exempt: mode "access" drops the tagged_vlans it forbids."""
+        # This is the corpus shape (interface "WirelessGigabitEthernet1/0/1"): a CREATE
+        # carrying mode "access" together with untagged_vlan AND tagged_vlans. Before
+        # the reversed policy this was a no-op and NetBox 400'd the whole entity.
+        entity = {
+            "mode": "access",
+            "untagged_vlan": 900,
+            "tagged_vlans": [101, 102],
+        }
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["tagged_vlans"], [])       # forbidden -> dropped
+        self.assertEqual(out["untagged_vlan"], 900)     # allowed for access -> kept
+        self.assertEqual(list(dropped), ["tagged_vlans"])
+
+    def test_create_injects_nothing_when_field_not_submitted(self):
+        """A create with nothing forbidden submitted stays untouched (nothing injected)."""
         entity = {"mode": "access"}
-        out = self._run("dcim.interface", {}, entity)
-        self.assertNotIn("tagged_vlans", out)
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertNotIn("tagged_vlans", out)  # no stored row, nothing to clear
+        self.assertNotIn("qinq_svlan", out)
+        self.assertEqual(dropped, {})
+
+    def test_create_unknown_mode_fails_open(self):
+        """An unrecognised driver value forbids nothing, on creates too."""
+        entity = {"mode": "future-mode", "tagged_vlans": [101]}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["tagged_vlans"], [101])
+        self.assertEqual(dropped, {})
+
+    def test_stale_clear_is_not_reported_as_dropped(self):
+        """Injecting a clear for a stale STORED value is not a drop of producer data."""
+        out, dropped = self._drop(
+            "dcim.interface", {"mode": "tagged", "tagged_vlans": [101]}, {"mode": "access"}
+        )
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertEqual(dropped, {})  # nothing was submitted, so nothing was discarded
+
+    def test_shared_policy_applies_to_interface_type_rf_fields(self):
+        """The reversed policy is registry-wide: dcim.interface "type" behaves the same."""
+        entity = {"type": "1000base-t", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertIsNone(out["rf_channel"])
+        self.assertIsNone(out["rf_role"])
+        self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
+
+    def test_shared_policy_keeps_rf_fields_on_a_wireless_type(self):
+        """A wireless type permits the rf fields, so an explicit create keeps them."""
+        entity = {"type": "ieee802.11ac", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["rf_channel"], "2.4g-1-2412-22")
+        self.assertEqual(dropped, {})
+
+    def test_shared_policy_applies_to_vlan_qinq_role(self):
+        """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
+        entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+        out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertIsNone(out["qinq_svlan"])
+        self.assertEqual(list(dropped), ["qinq_svlan"])
+
+    def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
+        """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
+        entity = {"qinq_role": "cvlan", "qinq_svlan": 7}
+        out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
 
     def test_unknown_mode_fails_open(self):
         """An unknown/unlisted mode value fails open and clears nothing."""
@@ -262,11 +355,12 @@ class InterfaceModeClearE2ETests(APITestCase):
         ch = [c for c in r.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
         self.assertTrue(all(c["change_type"] == "noop" for c in ch))
 
-    def test_explicit_incompatible_tagged_vlans_still_fails(self):
-        """Guard: an explicit incompatible mode/tagged_vlans combo must still be rejected."""
-        # Guard: a producer that explicitly sends mode=access WITH tagged_vlans is a
-        # producer-side error — the normalizer must NOT silently clear it; apply must
-        # fail and the DB must be unchanged.
+    def test_explicit_incompatible_tagged_vlans_is_dropped_not_rejected(self):
+        """An explicit incompatible mode/tagged_vlans update applies with the field dropped."""
+        # POLICY (reversed): this combination used to be left alone so NetBox could
+        # reject it, which cost the whole entity. The submitted mode now wins: the
+        # update applies, tagged_vlans is dropped, and the drop is surfaced as a
+        # warning on the change set rather than swallowed silently.
         create = {
             "name": "EthNeg", "type": "1000base-t", "device": self._device(),
             "mode": "tagged",
@@ -275,7 +369,7 @@ class InterfaceModeClearE2ETests(APITestCase):
         _, apply1 = self._diff_apply(create)
         self.assertEqual(apply1.status_code, 200)
         iface = Interface.objects.get(name="EthNeg")
-        before = set(iface.tagged_vlans.values_list("vid", flat=True))
+        self.assertEqual(iface.tagged_vlans.count(), 1)
 
         bad = {
             "name": "EthNeg", "type": "1000base-t", "device": self._device(),
@@ -284,12 +378,70 @@ class InterfaceModeClearE2ETests(APITestCase):
         }
         payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": bad}}
         r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
         cs = r1.json().get("change_set", {})
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
         r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
-        # NetBox rejects the incompatible combo: non-200, or 200 with an errors payload.
-        self.assertTrue(r2.status_code != 200 or r2.json().get("errors"))
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
         iface.refresh_from_db()
-        self.assertEqual(set(iface.tagged_vlans.values_list("vid", flat=True)), before)  # unchanged
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # the mode won; the field was dropped
+
+        # and the very same self-contradictory payload re-diffs as a NOOP
+        r3 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        ch = [c for c in r3.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in ch))
+
+    def test_corpus_create_access_mode_with_tagged_vlans_applies(self):
+        """A CREATE naming mode access, untagged_vlan AND tagged_vlans applies and is idempotent."""
+        # Reproduction of the corpus entity "WirelessGigabitEthernet1/0/1", which used to
+        # lose the whole interface to a 400 {"tagged_vlans": ["Interface mode does not
+        # support tagged vlans"]}. The create must now land with the mode honoured, the
+        # untagged VLAN attached and the forbidden tagged VLANs dropped.
+        create = {
+            "name": "WlAccess", "type": "other-wireless", "device": self._device(),
+            "mode": "access",
+            "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+            "untagged_vlan": {"vid": 900, "name": "v900"},
+            "tagged_vlans": [{"vid": 101, "name": "v101"}, {"vid": 102, "name": "v102"}],
+        }
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": create}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        # the create's CREATE change must not carry tagged_vlans at all, and must not
+        # leave a dangling unresolved-reference path for the field it no longer carries
+        iface_creates = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_creates)
+        for c in iface_creates:
+            self.assertNotIn("tagged_vlans", c.get("data", {}))
+            self.assertNotIn("tagged_vlans", c.get("new_refs", []))
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+        iface = Interface.objects.get(name="WlAccess")
+        self.assertEqual(iface.mode, "access")
+        self.assertIsNotNone(iface.untagged_vlan)
+        self.assertEqual(iface.untagged_vlan.vid, 900)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertEqual(iface.rf_channel, "2.4g-1-2412-22")  # wireless type keeps rf fields
+
+        # re-ingesting the identical payload is a no-op
+        r3 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r3.json().get("change_set", {}).get("changes", []), [])
+
+        # and submitting the forbidden field EMPTY under the same mode is a no-op too:
+        # clearing an already-empty submitted value must never plan an update
+        empty = dict(create, tagged_vlans=[])
+        r4 = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": empty}},
+            format="json", **self.auth,
+        )
+        self.assertEqual(r4.json().get("change_set", {}).get("changes", []), [])
 
     def test_qinq_to_access_clears_qinq_svlan_orm_seed(self):
         """E2E: an ORM-seeded q-in-q interface moving to access has qinq_svlan cleared."""
@@ -359,6 +511,33 @@ class InterfaceModeClearE2ETests(APITestCase):
             any(c.get("data", {}).get("tagged_vlans") == [] for c in vm_updates),
             "hook must emit tagged_vlans:[] for vminterface (DB-only assertion is vacuous here)",
         )
+
+    def test_vminterface_create_drops_tagged_vlans_netbox_would_have_kept(self):
+        """The uniform policy costs a vminterface its tagged VLANs, deliberately."""
+        # virtualization.vminterface is the one registry entry whose serializer does NO
+        # mode/VLAN validation: NetBox accepts mode "access" WITH tagged VLANs on a create
+        # and stores them (BaseInterface.save() only clears on a later save, guarded by
+        # `not self._state.adding`). The shared registry means the driver value wins here
+        # too, so the tagged VLANs are dropped. Pinned so the cost stays a decision.
+        vm = {"name": "drop-vm", "cluster": {"name": "drop-cl", "type": {"name": "drop-ct"}}}
+        create = {"name": "vmeth1", "virtual_machine": vm, "mode": "access",
+                  "tagged_vlans": [{"vid": 711, "name": "v711"}]}
+        payload = {"timestamp": 1, "object_type": "virtualization.vminterface",
+                   "entity": {"vm_interface": create}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json()["change_set"]
+        self.assertIn(
+            "tagged_vlans", cs.get("warnings", {}).get("virtualization.vminterface", {})
+        )
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth1")
+        self.assertEqual(vmi.mode, "access")
+        self.assertEqual(vmi.tagged_vlans.count(), 0)
 
     def test_interface_wireless_to_ethernet_clears_rf(self):
         """Type change wireless->ethernet clears stale rf_channel and rf_role."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -667,7 +667,7 @@ class DedupeDriverFieldPolicyTests(TestCase):
         # Normalizing only AFTER dedupe stops working at three: the merge of the first
         # two leaves the merged node holding both mode and tagged_vlans, and the third
         # fragment's different tagged_vlans then conflicts inside _merge_nodes, so the
-        # whole entity is rejected and the post-dedupe pass never runs. Normalizing the
+        # whole entity is rejected before any later pass runs. Normalizing the
         # merged node inside the loop is what makes the outcome independent of how many
         # duplicate representations the producer happened to send.
         for count in range(2, 7):
@@ -1465,7 +1465,7 @@ class InterfaceModeClearE2ETests(APITestCase):
         self.assertTrue(iface_changes)
         for change in iface_changes:
             self.assertNotIn("tagged_vlans", change.get("data", {}))
-        # reported exactly once, with both passes active
+        # reported exactly once, though two steps could each report it
         messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
         self.assertEqual(len(messages or []), 1, messages)
         self._apply(cs)
@@ -1476,13 +1476,13 @@ class InterfaceModeClearE2ETests(APITestCase):
             self.assertEqual(self._plan(payload).get("changes", []), [],
                              f"re-planned on quiet round {quiet}")
 
-    def test_a_drop_reported_by_both_passes_is_one_warning(self):
-        """Pass 1 drops from one node, pass 2 from the merged node: still one message."""
-        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans
-        # (pass 1 drops it and records the warning), the nested node carries a DIFFERENT
-        # tagged_vlans and no mode (pass 1 cannot see it; it survives the merge and pass 2
-        # drops it). Without dedupe on the message, change_set.warnings carried the same
-        # sentence twice for one field.
+    def test_a_drop_reported_by_two_steps_is_one_warning(self):
+        """The pre-dedupe pass drops from one node, the merge from another: one message."""
+        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans,
+        # so the pre-dedupe pass drops it and records the warning; the nested node carries
+        # a DIFFERENT tagged_vlans and no mode, so it survives untouched and is dropped
+        # when it merges. Without dedupe on the message, change_set.warnings carried the
+        # same sentence twice for one field.
         dev = self._device()
         dev_with_ip = dict(dev, primary_ip4={
             "address": "10.9.22.22/24",
@@ -1670,11 +1670,11 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     def test_three_fragments_of_one_interface_still_let_the_driver_win(self):
         """Root + two nested copies, each with a different forbidden VLAN: still one access iface."""
-        # This is the shape a single pre- and post-dedupe pass could not settle. The root
+        # This is the shape a pass on each side of dedupe could not settle. The root
         # fragment has no forbidden field and the nested copies have no submitted mode, so
         # the pre-dedupe pass drops nothing; dedupe merged root + copy 1 into the
         # contradiction and the SECOND copy's different tagged_vlans then conflicted inside
-        # _merge_nodes, rejecting the whole entity before the post-dedupe pass could run.
+        # _merge_nodes, rejecting the whole entity before the mode was ever considered.
         # One interface really can be reached three times: as the entity, as primary_ip4's
         # assigned interface, and as primary_ip6's.
         self._assert_fragments_converge("Gi2/0/3", "n3", 63, [701, 702])

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -906,6 +906,56 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     # --- N2: a dropped match criterion must be dropped BEFORE matching --------
 
+    def test_a_duplicate_node_with_a_different_forbidden_value_still_applies(self):
+        """Two nodes for ONE interface, same submitted mode, different forbidden VLANs."""
+        # The policy used to run AFTER _fingerprint_dedupe, so these two nodes reached
+        # _merge_nodes still carrying tagged_vlans and it rejected the whole entity with
+        # "Conflicting values for 'tagged_vlans'" -- the payload the policy exists to
+        # rescue. Running the policy first drops the forbidden field from both, so they
+        # merge cleanly. The graph nests the same interface twice via the device's
+        # primary_ip4 assignment, which is how one entity legitimately names it twice.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.9.9/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/9", "type": "1000base-t", "mode": "access",
+                "tagged_vlans": [{"vid": 302, "name": "dup-v302", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/9", "type": "1000base-t", "mode": "access",
+            "tagged_vlans": [{"vid": 301, "name": "dup-v301", "status": "active"}],
+        }}}
+        cs = self._plan(payload)
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+        for change in cs["changes"]:
+            if change["object_type"] == "dcim.interface":
+                self.assertNotIn("tagged_vlans", change.get("data", {}))
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/9", device__name=dev["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_duplicate_node_with_a_different_ALLOWED_value_still_conflicts(self):
+        """The control: a field the mode PERMITS is a genuine disagreement, still a 400."""
+        # This must NOT be rescued. mode "tagged" allows tagged_vlans, so [401] vs [402]
+        # is two sources disagreeing about real data and nothing can discard either.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.9.10/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/10", "type": "1000base-t", "mode": "tagged",
+                "tagged_vlans": [{"vid": 402, "name": "ctl-v402", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/10", "type": "1000base-t", "mode": "tagged",
+            "tagged_vlans": [{"vid": 401, "name": "ctl-v401", "status": "active"}],
+        }}}
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertIn("Conflicting values", str(r.content))
+
     def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
         """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""
         # The regression this pins: dropping qinq_svlan before matching made the entity

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -3,7 +3,8 @@ from types import SimpleNamespace
 from unittest import mock
 
 from dcim.models import Interface
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+from rest_framework import serializers
 from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
@@ -18,6 +19,10 @@ from netbox_diode_plugin.api.field_policy import (
     prune_orphaned_nodes,
     referenced_uuids,
     submitted_driver_field_drops,
+)
+from netbox_diode_plugin.api.transformer import (
+    _fingerprint_dedupe,
+    raise_unsettled_conflicts,
 )
 from netbox_diode_plugin.plugin_config import get_diode_user
 
@@ -618,6 +623,97 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         again = self._policy(entities)          # a second full pass changes nothing
         self.assertEqual(self._uuids(again), ["i1"])
         self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
+
+
+class DedupeDriverFieldPolicyTests(TestCase):
+    """_fingerprint_dedupe normalizes every node it merges, so the result is N-independent."""
+
+    def _iface(self, uuid, **fields):
+        node = {
+            "_object_type": "dcim.interface",
+            "_uuid": uuid,
+            "_refs": {"d1"},
+            "_warnings": {},
+            "name": "Gi1/0/1",
+            "device": UnresolvedReference(object_type="dcim.device", uuid="d1"),
+        }
+        node.update(fields)
+        return node
+
+    def _fragments(self, count):
+        """One driver-only fragment plus ``count - 1`` fragments, each with its own VLAN."""
+        nodes = [self._iface("i0", mode="access")]
+        for k in range(1, count):
+            nodes.append(self._iface(
+                f"i{k}", _refs={"d1", f"v{k}"},
+                tagged_vlans=[UnresolvedReference(object_type="ipam.vlan", uuid=f"v{k}")],
+            ))
+        return nodes
+
+    def _assert_normalized(self, out, released):
+        raise_unsettled_conflicts(out)                    # nothing left to disagree about
+        merged = {entity["_uuid"]: entity for entity in out}
+        self.assertEqual(len(merged), 1, merged)          # all fragments are one node
+        node = next(iter(merged.values()))
+        self.assertEqual(node["mode"], "access")
+        self.assertNotIn("tagged_vlans", node)            # forbidden -> gone
+        self.assertNotIn("_deferred_conflicts", node)     # and never leaks downstream
+        self.assertEqual(node["_refs"], {"d1"})           # every VLAN edge released
+        self.assertTrue(released)                         # so the caller's sweep runs
+        self.assertEqual(len(node["_warnings"]["tagged_vlans"]), 1)
+
+    def test_every_merged_node_is_normalized_before_the_next_duplicate_arrives(self):
+        """Two to six duplicate fragments all end at the same normalized node."""
+        # Normalizing only AFTER dedupe stops working at three: the merge of the first
+        # two leaves the merged node holding both mode and tagged_vlans, and the third
+        # fragment's different tagged_vlans then conflicts inside _merge_nodes, so the
+        # whole entity is rejected and the post-dedupe pass never runs. Normalizing the
+        # merged node inside the loop is what makes the outcome independent of how many
+        # duplicate representations the producer happened to send.
+        for count in range(2, 7):
+            with self.subTest(fragments=count):
+                self._assert_normalized(*_fingerprint_dedupe(self._fragments(count)))
+
+    def test_the_outcome_does_not_depend_on_fragment_order(self):
+        """The driver-carrying fragment arriving last must reach the same node."""
+        for count in range(2, 7):
+            with self.subTest(fragments=count):
+                self._assert_normalized(*_fingerprint_dedupe(self._fragments(count)[::-1]))
+
+    def test_the_merged_node_is_already_normalized_when_dedupe_returns(self):
+        """Which is why the transformer needs no separate post-dedupe pass."""
+        out, _ = _fingerprint_dedupe(self._fragments(3))
+        self.assertNotIn("tagged_vlans", out[0])
+        # a further pass over the result finds nothing left to do
+        self.assertFalse(apply_submitted_driver_field_policy(out))
+
+    def test_an_allowed_field_still_conflicts_after_a_merge(self):
+        """The control: mode "tagged" permits tagged_vlans, so disagreement is still an error."""
+        nodes = self._fragments(3)
+        for node in nodes:
+            node["mode"] = "tagged"
+        out, _ = _fingerprint_dedupe(nodes)
+        with self.assertRaises(serializers.ValidationError) as raised:
+            raise_unsettled_conflicts(out)
+        self.assertIn("Conflicting values", str(raised.exception))
+
+    def test_a_conflict_on_a_field_no_driver_value_can_drop_is_immediate(self):
+        """A field outside the registry is a plain disagreement: raised where it happens."""
+        # Deferral is only for fields a driver value could delete. Everything else keeps
+        # develop's behaviour, including the error's position in the pipeline.
+        nodes = [self._iface("i0", description="from A"),
+                 self._iface("i1", description="from B")]
+        with self.assertRaises(serializers.ValidationError):
+            _fingerprint_dedupe(nodes)
+
+    def test_a_deferred_conflict_releases_the_rejected_copys_edges(self):
+        """The value a deferred conflict declined must not keep its VLAN node alive."""
+        # _merge_nodes unions _refs, so without this the rejected tagged_vlans list would
+        # still reach resolution as an edge and the VLAN would be created anyway -- the
+        # manufactured VLAN the prune sweep exists to prevent, arriving by another route.
+        out, _ = _fingerprint_dedupe(self._fragments(3)[::-1])
+        raise_unsettled_conflicts(out)
+        self.assertEqual(out[0]["_refs"], {"d1"})
 
 
 class InterfaceModeClearE2ETests(APITestCase):
@@ -1512,6 +1608,104 @@ class InterfaceModeClearE2ETests(APITestCase):
         self.assertEqual(dropped_from.tagged_vlans.count(), 0)
         kept_by = Interface.objects.get(name="Gi1/0/42", device__name=dev["name"])
         self.assertEqual([v.vid for v in kept_by.tagged_vlans.all()], [641])
+
+    # --- N-way: one interface arriving as N duplicate fragments ---------------
+
+    def _tagged_copy(self, name, vid, tag):
+        """A duplicate fragment of ``name`` carrying one forbidden tagged VLAN."""
+        return {"device": self._device(), "name": name, "type": "1000base-t",
+                "tagged_vlans": [{"vid": vid, "name": f"{tag}-v{vid}", "status": "active"}]}
+
+    def _fragmented_payload(self, name, tag, octet, vids, driver_last=False):
+        """
+        One interface reached several times in a single payload.
+
+        Each nested copy hangs off a different device IP assignment and carries a
+        DIFFERENT forbidden tagged VLAN, so every merge is a fresh contradiction for the
+        policy to settle. ``driver_last`` moves mode "access" off the root fragment and
+        onto one more nested copy, so the driver value arrives only after the duplicates
+        have already disagreed.
+        """
+        copies = [self._tagged_copy(name, vid, tag) for vid in vids]
+        if driver_last:
+            copies.append({"device": self._device(), "name": name,
+                           "type": "1000base-t", "mode": "access"})
+        assert 2 <= len(copies) <= 4
+        addresses = [f"10.9.{octet}.10/24", f"2001:db8:{octet}::11/64",
+                     f"10.9.{octet}.12/24", f"10.9.{octet}.13/24"]
+        ips = [{"address": address, "assigned_object_interface": copy}
+               for address, copy in zip(addresses, copies, strict=False)]
+        dev = dict(self._device())
+        dev["primary_ip4"], dev["primary_ip6"] = ips[0], ips[1]
+        if len(ips) > 2:
+            dev["oob_ip"] = ips[2]
+        if len(ips) > 3:
+            dev["primary_ip4"]["nat_inside"] = ips[3]
+        root = {"device": dev, "name": name, "type": "1000base-t"}
+        if not driver_last:
+            root["mode"] = "access"
+        return {"timestamp": 1, "object_type": "dcim.interface",
+                "entity": {"interface": root}}
+
+    def _assert_fragments_converge(self, name, tag, octet, vids, driver_last=False):
+        """Plan, apply and re-plan a fragmented payload; assert one drop and no VLANs."""
+        from ipam.models import VLAN
+        payload = self._fragmented_payload(name, tag, octet, vids, driver_last)
+        cs = self._plan(payload)
+        iface_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_changes)
+        for change in iface_changes:
+            self.assertNotIn("tagged_vlans", change.get("data", {}))
+        messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
+        self.assertEqual(len(messages or []), 1, messages)
+        vlan_changes = [(c["change_type"], c.get("data", {}).get("vid"))
+                        for c in cs["changes"]
+                        if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(vlan_changes, [], vlan_changes)
+        self._converge(payload, f"fragments of {name}")
+        iface = Interface.objects.get(name=name, device__name=self._device()["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertFalse(VLAN.objects.filter(vid__in=vids).exists())
+
+    def test_three_fragments_of_one_interface_still_let_the_driver_win(self):
+        """Root + two nested copies, each with a different forbidden VLAN: still one access iface."""
+        # This is the shape a single pre- and post-dedupe pass could not settle. The root
+        # fragment has no forbidden field and the nested copies have no submitted mode, so
+        # the pre-dedupe pass drops nothing; dedupe merged root + copy 1 into the
+        # contradiction and the SECOND copy's different tagged_vlans then conflicted inside
+        # _merge_nodes, rejecting the whole entity before the post-dedupe pass could run.
+        # One interface really can be reached three times: as the entity, as primary_ip4's
+        # assigned interface, and as primary_ip6's.
+        self._assert_fragments_converge("Gi2/0/3", "n3", 63, [701, 702])
+
+    def test_four_fragments_of_one_interface_still_let_the_driver_win(self):
+        """A fourth copy, via the device's oob_ip, changes nothing."""
+        self._assert_fragments_converge("Gi2/0/4", "n4", 64, [711, 712, 713])
+
+    def test_five_fragments_of_one_interface_still_let_the_driver_win(self):
+        """A fifth copy, via primary_ip4's nat_inside, changes nothing either."""
+        self._assert_fragments_converge("Gi2/0/5", "n5", 65, [721, 722, 723, 724])
+
+    def test_reordering_the_same_fragments_does_not_change_the_outcome(self):
+        """The forbidden values swapped between fragments plan and converge identically."""
+        # Representation independence is the property under test: the same logical
+        # fragments in a different order must not produce a different answer.
+        self._assert_fragments_converge("Gi2/0/6", "n6", 66, [733, 732, 731])
+
+    def test_the_driver_fragment_arriving_last_still_wins(self):
+        """The mode arrives only after two duplicates have already disagreed."""
+        # Measured on the incremental normalization alone: the two tagged-only copies
+        # merge first, _merge_nodes rejects the second one's different tagged_vlans, and
+        # the fragment carrying mode "access" is never reached -- a 400 that depends
+        # purely on which copy the payload happened to nest first. Holding a conflict on
+        # a droppable field until the graph is merged is what removes that dependency.
+        self._assert_fragments_converge("Gi2/0/7", "n7", 67, [741, 742], driver_last=True)
+
+    def test_the_driver_fragment_arriving_last_of_five_still_wins(self):
+        """Three disagreeing copies, then the mode: still one access interface."""
+        self._assert_fragments_converge("Gi2/0/8", "n8", 68, [751, 752, 753],
+                                        driver_last=True)
 
     def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
         """A VLAN that is the entity's own primary object is never pruned."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -1088,3 +1088,68 @@ class InterfaceModeClearE2ETests(APITestCase):
         for quiet in range(1, 5):
             self.assertEqual(self._plan(payload).get("changes", []), [],
                              f"re-planned on quiet round {quiet}")
+
+    # --- P2-A: duplicate nodes that SPLIT the contradiction -------------------
+
+    def test_split_duplicate_nodes_do_not_merge_into_the_contradiction(self):
+        """Duplicate nodes that SPLIT mode and tagged_vlans still lose the forbidden field."""
+        # Measured on the pre-dedupe pass alone: neither node triggers the policy, because
+        # phase 1 needs the driver field PRESENT in the node it is looking at. The outer
+        # node carries mode "access" and no tagged_vlans; the nested one (reached through
+        # the device's primary_ip4 assignment) carries tagged_vlans and no mode. _merge_nodes
+        # then combined them INTO the contradiction -- merged data keys held both mode and
+        # tagged_vlans, change_set.warnings was None, and apply was a 400
+        # {"dcim.interface": {"tagged_vlans": ["Interface mode does not support tagged vlans"]}}.
+        # Running the policy a second time on the merged nodes is what closes it.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.20.20/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/20", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 520, "name": "split-v520", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/20", "type": "1000base-t", "mode": "access",
+        }}}
+        cs = self._plan(payload)
+        iface_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_changes)
+        for change in iface_changes:
+            self.assertNotIn("tagged_vlans", change.get("data", {}))
+        # reported exactly once, with both passes active
+        messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
+        self.assertEqual(len(messages or []), 1, messages)
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/20", device__name=dev["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    def test_a_drop_reported_by_both_passes_is_one_warning(self):
+        """Pass 1 drops from one node, pass 2 from the merged node: still one message."""
+        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans
+        # (pass 1 drops it and records the warning), the nested node carries a DIFFERENT
+        # tagged_vlans and no mode (pass 1 cannot see it; it survives the merge and pass 2
+        # drops it). Without dedupe on the message, change_set.warnings carried the same
+        # sentence twice for one field.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.22.22/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/22", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 522, "name": "mix-v522", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/22", "type": "1000base-t", "mode": "access",
+            "tagged_vlans": [{"vid": 523, "name": "mix-v523", "status": "active"}],
+        }}}
+        cs = self._plan(payload)
+        messages = cs["warnings"]["dcim.interface"]["tagged_vlans"]
+        self.assertEqual(len(messages), 1, messages)
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/22", device__name=dev["name"])
+        self.assertEqual(iface.tagged_vlans.count(), 0)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -14,6 +14,8 @@ from netbox_diode_plugin.api.field_policy import (
     _DRIVER_FIELD_RULES,
     apply_submitted_driver_field_policy,
     match_participating_fields,
+    prune_orphaned_nodes,
+    referenced_uuids,
     submitted_driver_field_drops,
 )
 from netbox_diode_plugin.plugin_config import get_diode_user
@@ -424,12 +426,26 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
     def _uuids(self, entities):
         return sorted(e["_uuid"] for e in entities)
 
+    def _policy(self, entities):
+        """
+        Run the policy the way the transformer does: snapshot, drop, then ONE sweep.
+
+        The drop and the prune are deliberately separate calls -- pruning inside the
+        pass destroys a duplicate child before dedupe can merge it -- so this helper
+        keeps the unit tests exercising the same order the real pipeline uses.
+        """
+        referenced_before = referenced_uuids(entities)
+        released = apply_submitted_driver_field_policy(entities)
+        if not released:
+            return entities
+        return prune_orphaned_nodes(entities, referenced_before)
+
     def test_a_dropped_nested_reference_takes_its_child_node_with_it(self):
         """The child node a dropped tagged_vlans created is pruned, and so is its edge."""
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1"])
         self.assertNotIn("tagged_vlans", iface)
         self.assertEqual(iface["_refs"], set())
@@ -439,7 +455,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", mode="access",
                            untagged_vlan=self._ref("v1"), tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertEqual(iface["_refs"], {"v1"})       # the untagged_vlan edge stands
         self.assertEqual(iface["untagged_vlan"], self._ref("v1"))
@@ -451,7 +467,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                              mode="access", tagged_vlans=[self._ref("v1")])
         keeper = self._node("dcim.interface", "i2", refs={"v1"}, name="Eth2",
                             mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, dropped, keeper])
+        out = self._policy([vlan, dropped, keeper])
         self.assertEqual(self._uuids(out), ["i1", "i2", "v1"])
         self.assertEqual(dropped["_refs"], set())
         self.assertEqual(keeper["_refs"], {"v1"})
@@ -463,7 +479,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                           group=self._ref("g1", "ipam.vlangroup"))
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([group, vlan, iface])
+        out = self._policy([group, vlan, iface])
         self.assertEqual(self._uuids(out), ["i1"])
 
     def test_a_grandchild_something_surviving_needs_is_kept(self):
@@ -475,7 +491,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                                group=self._ref("g1", "ipam.vlangroup"))
         iface = self._node("dcim.interface", "i1", refs={"v1", "v2"}, name="Eth1", mode="access",
                            untagged_vlan=self._ref("v2"), tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([group, dropped_vlan, kept_vlan, iface])
+        out = self._policy([group, dropped_vlan, kept_vlan, iface])
         self.assertEqual(self._uuids(out), ["g1", "i1", "v2"])
         self.assertEqual(iface["_refs"], {"v2"})
 
@@ -491,7 +507,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         )
         post_create["_is_post_create"] = True
         post_create["_instance"] = "i1"
-        out = apply_submitted_driver_field_policy([vlan, mac, iface, post_create])
+        out = self._policy([vlan, mac, iface, post_create])
         self.assertEqual(self._uuids(out), ["i1", "m1", "pc1"])
 
     def test_a_root_node_is_never_pruned(self):
@@ -499,7 +515,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertIn("i1", self._uuids(out))
 
     def test_no_drop_prunes_nothing(self):
@@ -507,7 +523,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertEqual(iface["tagged_vlans"], [self._ref("v1")])
         self.assertEqual(iface["_warnings"], {})
@@ -517,7 +533,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", type="1000base-t",
                            rf_role="ap", mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertNotIn("rf_role", iface)
         self.assertEqual(iface["_refs"], {"v1"})
@@ -527,8 +543,8 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        entities = apply_submitted_driver_field_policy([vlan, iface])
-        again = apply_submitted_driver_field_policy(entities)
+        entities = self._policy([vlan, iface])
+        again = self._policy(entities)          # a second full pass changes nothing
         self.assertEqual(self._uuids(again), ["i1"])
         self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
 
@@ -1080,6 +1096,46 @@ class InterfaceModeClearE2ETests(APITestCase):
         r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
         self.assertEqual(r.status_code, 400, r.content)
         self.assertIn("Conflicting values", str(r.content))
+
+    def test_a_dropped_copy_still_contributes_before_it_is_pruned(self):
+        """The richer VLAN copy is inside the dropped field: it must merge, not vanish."""
+        # Pruning inside the pre-dedupe pass removed the named copy before
+        # _fingerprint_dedupe could merge it, leaving a survivor with a vid and no name:
+        # 400 {"ipam.vlan": {"name": ["This field cannot be blank."]}} on every round,
+        # blaming a blank VLAN name for an interface mode contradiction. Every earlier
+        # over-prune test specified the VLAN fully on BOTH sides, so the copies were
+        # interchangeable and losing one cost nothing -- this one makes them unequal,
+        # with the richer occurrence inside the field the mode forbids.
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": self._device(), "name": "Gi8/0/2", "type": "1000base-t",
+            "mode": "access",
+            "untagged_vlan": {"vid": 3992},
+            "tagged_vlans": [{"vid": 3992, "name": "v3992"}],
+        }}}
+        cs = self._plan(payload)
+        self._apply(cs)
+        vlan = VLAN.objects.get(vid=3992)
+        self.assertEqual(vlan.name, "v3992")  # inherited from the copy that was dropped
+        iface = Interface.objects.get(name="Gi8/0/2")
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.untagged_vlan.vid, 3992)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 4):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    def test_a_field_only_the_dropped_copy_carried_is_not_lost(self):
+        """The quiet form of the same mechanism: a description only on the tagged copy."""
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": self._device(), "name": "Gi8/0/3", "type": "1000base-t",
+            "mode": "access",
+            "untagged_vlan": {"vid": 3991, "name": "v3991"},
+            "tagged_vlans": [{"vid": 3991, "name": "v3991", "description": "ONLY-ON-TAGGED"}],
+        }}}
+        self._apply(self._plan(payload))
+        self.assertEqual(VLAN.objects.get(vid=3991).description, "ONLY-ON-TAGGED")
 
     def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
         """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -1,27 +1,36 @@
-"""Unit tests for the interface mode/VLAN changeset normalizer."""
+"""Unit tests for the driver-field policy (interface mode/type, VLAN qinq_role)."""
 from types import SimpleNamespace
 from unittest import mock
 
 from dcim.models import Interface
 from django.test import SimpleTestCase
+from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.differ import normalize_changeset
+from netbox_diode_plugin.api.field_policy import _DRIVER_FIELD_RULES, submitted_driver_field_drops
 from netbox_diode_plugin.plugin_config import get_diode_user
 
 
 class NormalizeChangesetTests(SimpleTestCase):
     """Pure-logic tests: no DB, operate on plain dicts."""
 
-    def _run(self, object_type, prechange, entity):
+    def _plan(self, object_type, prechange, entity):
+        """Run both policy phases in pipeline order and return (entity, dropped)."""
+        # Phase 1 runs in the transformer, before any fingerprinting; phase 2 runs
+        # in the differ once an existing row has been matched. Tests exercise them
+        # in that order so a unit result means the same thing an ingest would.
+        dropped = submitted_driver_field_drops(object_type, entity)
         normalize_changeset(object_type, prechange, entity)
-        return entity
+        return entity, dropped
+
+    def _run(self, object_type, prechange, entity):
+        return self._plan(object_type, prechange, entity)[0]
 
     def _drop(self, object_type, prechange, entity):
-        """Run the normalizer and return (entity, dropped-submitted-field map)."""
-        dropped = normalize_changeset(object_type, prechange, entity)
-        return entity, dropped
+        """Run both phases and return (entity, dropped-submitted-field map)."""
+        return self._plan(object_type, prechange, entity)
 
     def test_tagged_to_access_clears_tagged_vlans_keeps_untagged(self):
         """Mode tagged -> access clears tagged_vlans but leaves untagged_vlan untouched."""
@@ -122,7 +131,10 @@ class NormalizeChangesetTests(SimpleTestCase):
             "tagged_vlans": [101, 102],
         }
         out, dropped = self._drop("dcim.interface", {}, entity)
-        self.assertEqual(out["tagged_vlans"], [])       # forbidden -> dropped
+        # DROPPED, not blanked: with no stored row there is nothing to clear, so the
+        # payload must read as if the producer had never sent the field. Writing a
+        # blank here is what made the rf_* fields re-diff against NetBox's "" forever.
+        self.assertNotIn("tagged_vlans", out)           # forbidden -> dropped
         self.assertEqual(out["untagged_vlan"], 900)     # allowed for access -> kept
         self.assertEqual(list(dropped), ["tagged_vlans"])
 
@@ -153,8 +165,8 @@ class NormalizeChangesetTests(SimpleTestCase):
         """The reversed policy is registry-wide: dcim.interface "type" behaves the same."""
         entity = {"type": "1000base-t", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
         out, dropped = self._drop("dcim.interface", {}, entity)
-        self.assertIsNone(out["rf_channel"])
-        self.assertIsNone(out["rf_role"])
+        self.assertNotIn("rf_channel", out)
+        self.assertNotIn("rf_role", out)
         self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
 
     def test_shared_policy_keeps_rf_fields_on_a_wireless_type(self):
@@ -168,7 +180,7 @@ class NormalizeChangesetTests(SimpleTestCase):
         """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
         entity = {"qinq_role": "svlan", "qinq_svlan": 7}
         out, dropped = self._drop("ipam.vlan", {}, entity)
-        self.assertIsNone(out["qinq_svlan"])
+        self.assertNotIn("qinq_svlan", out)
         self.assertEqual(list(dropped), ["qinq_svlan"])
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
@@ -227,6 +239,139 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertNotIn("rf_channel", out)
 
 
+    # --- a driver value must be SUBMITTED to win (N3) -------------------------
+
+    def test_create_omitting_the_driver_field_keeps_its_dependent_fields(self):
+        """A create that simply omits mode keeps the VLANs NetBox would have stored."""
+        # The policy is that a SUBMITTED driver value wins over the fields it forbids.
+        # With no submitted driver value there is nothing to win, so producer data is
+        # left alone: mode absent must not read as mode "" and drop both VLAN fields.
+        entity = {"name": "vmeth0", "untagged_vlan": 601, "tagged_vlans": [602]}
+        out, dropped = self._drop("virtualization.vminterface", {}, entity)
+        self.assertEqual(out["untagged_vlan"], 601)
+        self.assertEqual(out["tagged_vlans"], [602])
+        self.assertEqual(dropped, {})
+
+    def test_explicitly_submitted_empty_driver_value_does_win(self):
+        """An explicitly submitted empty mode IS a submitted value, and forbids the VLANs."""
+        entity = {"name": "vmeth0", "mode": "", "untagged_vlan": 601, "tagged_vlans": [602]}
+        out, dropped = self._drop("virtualization.vminterface", {}, entity)
+        self.assertNotIn("untagged_vlan", out)
+        self.assertNotIn("tagged_vlans", out)
+        self.assertEqual(sorted(dropped), ["tagged_vlans", "untagged_vlan"])
+        # the reason must not claim a value that was never submitted
+        self.assertIn("empty", dropped["tagged_vlans"])
+        self.assertNotIn("''", dropped["tagged_vlans"])
+
+    def test_explicitly_submitted_null_driver_value_does_win(self):
+        """A submitted null mode is submitted too, and reads as no 802.1Q."""
+        out, dropped = self._drop("dcim.interface", {}, {"mode": None, "tagged_vlans": [602]})
+        self.assertNotIn("tagged_vlans", out)
+        self.assertEqual(list(dropped), ["tagged_vlans"])
+
+    def test_stored_driver_value_never_drops_submitted_data(self):
+        """A driver value that was only STORED does not drop submitted data."""
+        # The stored mode forbids tagged_vlans, but the producer submitted no mode, so
+        # there is no submitted driver value to win and the explicit list stands (NetBox
+        # judges it, exactly as it does on develop).
+        out, dropped = self._drop(
+            "dcim.interface", {"mode": "access", "tagged_vlans": [101]}, {"tagged_vlans": [102]},
+        )
+        self.assertEqual(out["tagged_vlans"], [102])
+        self.assertEqual(dropped, {})
+
+    def test_non_string_driver_value_fails_open_in_both_phases(self):
+        """A driver value that is not a string is not one we can reason about."""
+        # A malformed payload must not turn into a TypeError on an unhashable rule key.
+        out, dropped = self._drop(
+            "dcim.interface",
+            {"mode": "tagged", "tagged_vlans": [101]},
+            {"mode": {"vid": 5}, "tagged_vlans": [102]},
+        )
+        self.assertEqual(out["tagged_vlans"], [102])
+        self.assertEqual(dropped, {})
+
+    # --- the clear must converge against what NetBox actually stores (N1) -----
+
+    def test_submitted_forbidden_field_is_removed_not_blanked(self):
+        """A dropped field leaves the payload entirely; no blank is invented for it."""
+        out, dropped = self._drop("dcim.interface", {}, {"type": "1000base-t", "rf_role": "ap"})
+        self.assertNotIn("rf_role", out)
+        self.assertEqual(list(dropped), ["rf_role"])
+
+    def test_type_rf_clear_converges_against_the_blank_string_netbox_stores(self):
+        """The type/rf_* clear plans nothing once NetBox has stored '' for the rf fields."""
+        # rf_channel/rf_role are CharFields with null=False: NetBox coerces the submitted
+        # null to ''. Re-injecting None every round diffed '' vs None and emitted a
+        # spurious UPDATE on every ingest cycle forever.
+        payload = {"type": "1000base-t", "rf_role": "ap", "rf_channel": "2.4g-1-2412-22"}
+        stored = {"type": "ieee802.11ac", "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+                  "rf_channel_frequency": 2412, "rf_channel_width": 22}
+        round1, dropped = self._drop("dcim.interface", dict(stored), dict(payload))
+        self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
+        self.assertIsNone(round1["rf_role"])                            # stale value cleared
+        self.assertNotEqual(shallow_compare_dict(stored, round1), {})    # round 1 is a real change
+
+        stored2 = {"type": "1000base-t", "rf_role": "", "rf_channel": "",
+                   "rf_channel_frequency": None, "rf_channel_width": None}
+        round2, dropped2 = self._drop("dcim.interface", dict(stored2), dict(payload))
+        self.assertEqual(sorted(dropped2), ["rf_channel", "rf_role"])    # still reported
+        self.assertNotIn("rf_role", round2)                             # but nothing written
+        self.assertEqual(shallow_compare_dict(stored2, round2), {})      # -> empty plan
+
+    # --- every (driver value, dependent field) pair in the registry -----------
+
+    def _pair_sentinel(self, dependent):
+        """A non-empty submitted value for a dependent field (only truthiness matters)."""
+        return ["x"] if dependent == "tagged_vlans" else "x"
+
+    def _assert_pair_converges(self, object_type, driver_field, driver_value, dependent):
+        """Assert one (driver value, dependent field) pair drops, clears once, then converges."""
+        sentinel = self._pair_sentinel(dependent)
+        submitted = {driver_field: driver_value, dependent: sentinel}
+
+        # 1. a submitted driver value drops the field it forbids, and writes no blank
+        out, dropped = self._drop(object_type, {}, dict(submitted))
+        self.assertNotIn(dependent, out)
+        self.assertIn(dependent, dropped)
+
+        # 2. with no submitted driver value, submitted data survives untouched
+        out, dropped = self._drop(object_type, {}, {dependent: sentinel})
+        self.assertEqual(out[dependent], sentinel)
+        self.assertEqual(dropped, {})
+
+        # 3. a non-empty STORED value is cleared exactly once...
+        stored = {driver_field: driver_value, dependent: sentinel}
+        round1, _ = self._drop(object_type, dict(stored), dict(submitted))
+        self.assertNotEqual(shallow_compare_dict(stored, round1), {})
+
+        # ...and whichever empty representation NetBox then stores, the next round
+        # plans nothing at all for the field.
+        for netbox_stored in ("", None, [], (), {}):
+            with self.subTest(netbox_stored=netbox_stored):
+                stored2 = {driver_field: driver_value, dependent: netbox_stored}
+                round2, _ = self._drop(object_type, dict(stored2), dict(submitted))
+                self.assertNotIn(dependent, round2)
+                self.assertEqual(shallow_compare_dict(stored2, round2), {})
+
+    def test_every_registered_driver_value_dependent_pair_converges(self):
+        """Every (driver value, dependent field) pair in every rule map converges."""
+        # Exhaustive over the registry, including all ~100 non-wireless interface types
+        # in _INTERFACE_TYPE_RF_RULES, so a new rule cannot be added without meeting it.
+        pairs = 0
+        for object_type, rules in _DRIVER_FIELD_RULES.items():
+            for driver_field, value_map in rules.items():
+                for driver_value, dependents in value_map.items():
+                    for dependent in dependents:
+                        with self.subTest(object_type=object_type, driver_field=driver_field,
+                                          driver_value=driver_value, dependent=dependent):
+                            self._assert_pair_converges(
+                                object_type, driver_field, driver_value, dependent,
+                            )
+                        pairs += 1
+        self.assertGreater(pairs, 100)  # the map is generated; guard against an empty sweep
+
+
 class InterfaceModeClearE2ETests(APITestCase):
     """End-to-end: seed an existing interface, ingest a mode change, assert clear."""
 
@@ -262,6 +407,58 @@ class InterfaceModeClearE2ETests(APITestCase):
         cs = r1.json().get("change_set", {})
         r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
         return r1, r2
+
+    def _plan(self, payload):
+        """Generate a diff for a payload and return its change set."""
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs):
+        """Apply a change set and assert it landed without errors."""
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"), r.content)
+        return r
+
+    def _converge(self, payload, label, max_applies=2, quiet_rounds=4):
+        """
+        Apply a payload until its plan is empty, then assert it stays empty.
+
+        Returns the number of applies it took. An empty plan is the strongest
+        available statement of convergence: the change set carries no changes at
+        all, so re-ingest performs no write and logs no object change.
+        """
+        applies = 0
+        for _ in range(max_applies + 1):
+            cs = self._plan(payload)
+            if not cs.get("changes", []):
+                break
+            self._apply(cs)
+            applies += 1
+        else:
+            self.fail(f"{label} did not converge within {max_applies} applies")
+        self.assertLessEqual(applies, max_applies, f"{label} needed {applies} applies")
+        for quiet in range(1, quiet_rounds + 1):
+            self.assertEqual(
+                self._plan(payload).get("changes", []), [],
+                f"{label} re-planned on quiet round {quiet}",
+            )
+        return applies
+
+    def _iface_payload(self, **fields):
+        """Build a dcim.interface generate-diff payload for this test's device."""
+        entity = {"device": self._device()}
+        entity.update(fields)
+        return {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": entity}}
+
+    def _vm_payload(self, **fields):
+        """Build a virtualization.vminterface generate-diff payload."""
+        entity = {"virtual_machine": {"name": "obs3607-vm",
+                                      "cluster": {"name": "obs3607-cl", "type": {"name": "obs3607-ct"}}}}
+        entity.update(fields)
+        return {"timestamp": 1, "object_type": "virtualization.vminterface",
+                "entity": {"vm_interface": entity}}
 
     def test_tagged_to_access_clears_tagged_vlans_and_is_idempotent(self):
         """E2E: tagged -> access clears tagged_vlans, keeps untagged_vlan, and re-diffs as NOOP."""
@@ -585,3 +782,221 @@ class InterfaceModeClearE2ETests(APITestCase):
         cvlan.refresh_from_db()
         self.assertEqual(cvlan.qinq_role, "svlan")
         self.assertIsNone(cvlan.qinq_svlan)
+
+    # --- N1: the type/rf_* clear converges instead of writing every cycle -----
+
+    def test_type_change_rf_clear_converges_and_stops_writing(self):
+        """A non-wireless type reported with rf_* fields clears once, then plans nothing."""
+        # An interface exists as ieee802.11ac with rf_role/rf_channel set; the producer
+        # now reports it as 1000base-t while STILL reporting the rf fields. Round 1 must
+        # clear the stale values; every round after it must plan nothing. Blanking the
+        # submitted value instead of dropping it made rounds 2+ diff the injected None
+        # against the "" NetBox stores and emit a spurious UPDATE forever.
+        _, a1 = self._diff_apply({
+            "name": "Wl1", "type": "ieee802.11ac", "device": self._device(),
+            "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+        })
+        self.assertEqual(a1.status_code, 200)
+        iface = Interface.objects.get(name="Wl1")
+        self.assertEqual(iface.rf_role, "ap")
+        self.assertIsNotNone(iface.rf_channel_frequency)  # derived by Interface.save()
+
+        payload = self._iface_payload(
+            name="Wl1", type="1000base-t", rf_role="ap", rf_channel="2.4g-1-2412-22",
+        )
+        cs = self._plan(payload)
+        self.assertTrue([c for c in cs["changes"] if c["object_type"] == "dcim.interface"])
+        self.assertEqual(
+            sorted(cs.get("warnings", {}).get("dcim.interface", {})), ["rf_channel", "rf_role"],
+        )
+        self._apply(cs)
+        iface.refresh_from_db()
+        self.assertEqual(iface.type, "1000base-t")
+        self.assertEqual(iface.rf_role, "")        # what NetBox stores for these CharFields
+        self.assertEqual(iface.rf_channel, "")
+        self.assertIsNone(iface.rf_channel_frequency)
+        self.assertIsNone(iface.rf_channel_width)
+        last_updated = iface.last_updated
+
+        for quiet in range(1, 6):
+            cs = self._plan(payload)
+            self.assertEqual(cs.get("changes", []), [], f"re-planned on quiet round {quiet}")
+            # still reported by the producer, still dropped, never written again
+            self.assertEqual(
+                sorted(cs.get("warnings", {}).get("dcim.interface", {})),
+                ["rf_channel", "rf_role"],
+            )
+        iface.refresh_from_db()
+        self.assertEqual(iface.last_updated, last_updated)  # no write after round 1
+
+    # --- N3: a create that omits the driver field keeps its data --------------
+
+    def test_vminterface_create_without_mode_keeps_the_vlans_netbox_stores(self):
+        """A vminterface create omitting mode keeps its tagged VLANs, exactly as NetBox does."""
+        # NetBox nulls untagged_vlan itself in BaseInterface.save() but KEEPS tagged_vlans
+        # on a create (_state.adding is True), and the vminterface serializer validates
+        # neither. Nothing may be dropped here: no mode was submitted, so no driver value
+        # won anything, and the payload contradicted nothing.
+        payload = self._vm_payload(
+            name="vmeth0",
+            untagged_vlan={"vid": 3601, "name": "v3601"},
+            tagged_vlans=[{"vid": 3602, "name": "v3602"}],
+        )
+        cs = self._plan(payload)
+        self.assertNotIn("virtualization.vminterface", cs.get("warnings", {}))
+        self._apply(cs)
+
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth0")
+        self.assertFalse(vmi.mode)
+        self.assertIsNone(vmi.untagged_vlan)                                # NetBox's own save()
+        self.assertEqual([v.vid for v in vmi.tagged_vlans.all()], [3602])   # kept, not dropped
+
+    def test_modeless_untagged_vlan_replans_exactly_as_on_develop(self):
+        """A mode-less interface still reporting an untagged VLAN re-plans, as on develop."""
+        # Documented residual, NOT introduced by the driver-field policy: NetBox nulls
+        # untagged_vlan on EVERY save of a mode-less interface, so a producer that keeps
+        # reporting one keeps planning an update. Closing it would mean dropping submitted
+        # data with no submitted driver value to justify it, which is exactly the loss this
+        # scoping exists to prevent, so develop's behaviour is kept and pinned here.
+        payload = self._vm_payload(name="vmeth1", untagged_vlan={"vid": 3611, "name": "v3611"})
+        self._apply(self._plan(payload))
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth1")
+        self.assertIsNone(vmi.untagged_vlan)
+        vm_changes = [c for c in self._plan(payload).get("changes", [])
+                      if c["object_type"] == "virtualization.vminterface"]
+        self.assertTrue(vm_changes)  # re-plans; the policy deliberately does not silence it
+
+    # --- N2: a dropped match criterion must be dropped BEFORE matching --------
+
+    def test_vlan_qinq_role_create_applies_and_converges(self):
+        """A VLAN naming a service role with an svlan applies once, then plans nothing."""
+        # qinq_svlan is an ipam.vlan MATCH criterion (unique_qinq_svlan_vid, and the
+        # "qinq_svlan IS NULL" condition on the logical vid criteria). Dropping it after
+        # the existing-object lookup left the entity unmatchable, so it re-planned a
+        # CREATE and duplicated the row on every ingest. The policy runs before matching.
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 3971, "name": "n2-cvlan", "qinq_role": "svlan",
+            "qinq_svlan": {"vid": 3970, "name": "n2-svlan"},
+        }}}
+        cs = self._plan(payload)
+        self.assertIn("qinq_svlan", cs.get("warnings", {}).get("ipam.vlan", {}))
+        for change in cs["changes"]:
+            self.assertNotIn("qinq_svlan", change.get("data", {}))
+            self.assertNotIn("qinq_svlan", change.get("new_refs", []))
+        self._apply(cs)
+
+        from ipam.models import VLAN
+        vlan = VLAN.objects.get(vid=3971)
+        self.assertEqual(vlan.qinq_role, "svlan")
+        self.assertIsNone(vlan.qinq_svlan)
+
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+        self.assertEqual(VLAN.objects.filter(vid=3971).count(), 1)  # no duplicate rows
+
+    def test_vlan_customer_role_keeps_its_service_vlan_and_converges(self):
+        """qinq_role 'cvlan' permits qinq_svlan: it is kept, applied and converges."""
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 3973, "name": "n2-cust", "qinq_role": "cvlan",
+            "qinq_svlan": {"vid": 3972, "name": "n2-svc"},
+        }}}
+        cs = self._plan(payload)
+        self.assertNotIn("ipam.vlan", cs.get("warnings", {}))
+        self._apply(cs)
+        from ipam.models import VLAN
+        vlan = VLAN.objects.get(vid=3973)
+        self.assertEqual(vlan.qinq_svlan.vid, 3972)   # allowed -> kept verbatim
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- the whole mode rule map, end to end, over four quiet rounds ----------
+
+    def test_interface_mode_matrix_applies_and_converges(self):
+        """Every mode in the rule map applies with all three VLAN fields submitted, then converges."""
+        modes = list(_DRIVER_FIELD_RULES["dcim.interface"]["mode"])
+        self.assertEqual(len(modes), 5)
+        for i, mode in enumerate(modes):
+            with self.subTest(mode=mode):
+                payload = self._iface_payload(
+                    name=f"EthM{i}", type="1000base-t", mode=mode,
+                    untagged_vlan={"vid": 3700 + i, "name": f"u{i}"},
+                    tagged_vlans=[{"vid": 3710 + i, "name": f"t{i}"}],
+                    qinq_svlan={"vid": 3720 + i, "name": f"s{i}"},
+                )
+                self._converge(payload, f"dcim.interface mode {mode!r}")
+                iface = Interface.objects.get(name=f"EthM{i}")
+                forbidden = _DRIVER_FIELD_RULES["dcim.interface"]["mode"][mode]
+                if "tagged_vlans" in forbidden:
+                    self.assertEqual(iface.tagged_vlans.count(), 0)
+                else:
+                    self.assertEqual([v.vid for v in iface.tagged_vlans.all()], [3710 + i])
+                if "untagged_vlan" in forbidden:
+                    self.assertIsNone(iface.untagged_vlan)
+                else:
+                    self.assertEqual(iface.untagged_vlan.vid, 3700 + i)
+                if "qinq_svlan" in forbidden:
+                    self.assertIsNone(iface.qinq_svlan)
+                else:
+                    self.assertEqual(iface.qinq_svlan.vid, 3720 + i)
+
+    def test_vminterface_mode_matrix_applies_and_converges(self):
+        """Every mode in the rule map converges for vminterface too, where no serializer polices it."""
+        modes = list(_DRIVER_FIELD_RULES["virtualization.vminterface"]["mode"])
+        for i, mode in enumerate(modes):
+            with self.subTest(mode=mode):
+                payload = self._vm_payload(
+                    name=f"vmethM{i}", mode=mode,
+                    untagged_vlan={"vid": 3730 + i, "name": f"vu{i}"},
+                    tagged_vlans=[{"vid": 3740 + i, "name": f"vt{i}"}],
+                    qinq_svlan={"vid": 3750 + i, "name": f"vs{i}"},
+                )
+                self._converge(payload, f"virtualization.vminterface mode {mode!r}")
+                from virtualization.models import VMInterface
+                vmi = VMInterface.objects.get(name=f"vmethM{i}")
+                forbidden = _DRIVER_FIELD_RULES["virtualization.vminterface"]["mode"][mode]
+                if "tagged_vlans" in forbidden:
+                    self.assertEqual(vmi.tagged_vlans.count(), 0)
+                if "qinq_svlan" in forbidden:
+                    self.assertIsNone(vmi.qinq_svlan)
+
+    def test_interface_type_rf_matrix_applies_and_converges(self):
+        """Representative non-wireless types with all four rf_* fields submitted converge."""
+        # The type rule map is generated as the complement of the wireless allow-set, so
+        # every non-wireless value shares one code path; the exhaustive sweep over all of
+        # them is the unit test above. These are the shapes a producer actually sends.
+        for i, iface_type in enumerate(("1000base-t", "virtual", "lag")):
+            with self.subTest(type=iface_type):
+                payload = self._iface_payload(
+                    name=f"EthT{i}", type=iface_type, rf_role="ap",
+                    rf_channel="2.4g-1-2412-22", rf_channel_frequency=2412, rf_channel_width=22,
+                )
+                self._converge(payload, f"dcim.interface type {iface_type!r}")
+                iface = Interface.objects.get(name=f"EthT{i}")
+                self.assertEqual(iface.type, iface_type)
+                # Measured: a field the payload never carries lands as NULL, while a
+                # field submitted as null lands as '' (see the update case above) — the
+                # SAME CharField, two empty representations. No single blank a planner
+                # could write matches both, which is why the drop removes the field.
+                self.assertFalse(iface.rf_role)
+                self.assertFalse(iface.rf_channel)
+                self.assertIsNone(iface.rf_channel_frequency)
+                self.assertIsNone(iface.rf_channel_width)
+
+    def test_wireless_type_keeps_all_four_rf_fields_and_converges(self):
+        """A wireless type permits the rf fields: they are kept, applied and converge."""
+        payload = self._iface_payload(
+            name="EthW", type="ieee802.11ac", rf_role="ap", rf_channel="2.4g-1-2412-22",
+        )
+        cs = self._plan(payload)
+        self.assertNotIn("dcim.interface", cs.get("warnings", {}))
+        self._apply(cs)
+        iface = Interface.objects.get(name="EthW")
+        self.assertEqual(iface.rf_role, "ap")
+        self.assertEqual(iface.rf_channel, "2.4g-1-2412-22")
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_interface_mode_vlan_reconcile.py
@@ -9,7 +9,11 @@ from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.differ import normalize_changeset
-from netbox_diode_plugin.api.field_policy import _DRIVER_FIELD_RULES, submitted_driver_field_drops
+from netbox_diode_plugin.api.field_policy import (
+    _DRIVER_FIELD_RULES,
+    match_participating_fields,
+    submitted_driver_field_drops,
+)
 from netbox_diode_plugin.plugin_config import get_diode_user
 
 
@@ -176,12 +180,30 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertEqual(out["rf_channel"], "2.4g-1-2412-22")
         self.assertEqual(dropped, {})
 
-    def test_shared_policy_applies_to_vlan_qinq_role(self):
-        """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
+    def test_a_match_participating_field_is_never_dropped(self):
+        """ipam.vlan qinq_svlan is a match criterion, so the policy leaves it alone."""
+        # The reversal is NOT registry-wide. qinq_svlan is read by four ipam.vlan
+        # matchers, so dropping it changes which row the payload identifies: measured,
+        # it adopted and renamed an unrelated VLAN sharing the vid, or inserted a
+        # duplicate and converged onto it. NetBox's own 400 stands instead.
+        self.assertIn("qinq_svlan", match_participating_fields("ipam.vlan"))
         entity = {"qinq_role": "svlan", "qinq_svlan": 7}
         out, dropped = self._drop("ipam.vlan", {}, entity)
-        self.assertNotIn("qinq_svlan", out)
-        self.assertEqual(list(dropped), ["qinq_svlan"])
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+
+    def test_the_interface_policy_fields_are_not_match_criteria(self):
+        """The fields the policy does drop are not how any matcher identifies a row."""
+        # This is what makes the motivating cases safe to drop, and it is asserted
+        # rather than assumed: if a future matcher starts reading one of them, the
+        # gate above will silently start exempting it and this test says so first.
+        for object_type in ("dcim.interface", "virtualization.vminterface"):
+            matched = match_participating_fields(object_type)
+            for value_map in _DRIVER_FIELD_RULES[object_type].values():
+                for dependents in value_map.values():
+                    for dependent in dependents:
+                        with self.subTest(object_type=object_type, dependent=dependent):
+                            self.assertNotIn(dependent, matched)
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
         """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
@@ -329,6 +351,20 @@ class NormalizeChangesetTests(SimpleTestCase):
         """Assert one (driver value, dependent field) pair drops, clears once, then converges."""
         sentinel = self._pair_sentinel(dependent)
         submitted = {driver_field: driver_value, dependent: sentinel}
+
+        if dependent in match_participating_fields(object_type):
+            # Exempt: the field identifies the row, so phase 1 must not touch it and
+            # there is nothing for us to converge -- NetBox rejects the payload, which
+            # is develop's behaviour and the safe one. Phase 2 must still clear a stale
+            # STORED value the payload no longer carries.
+            out, dropped = self._drop(object_type, {}, dict(submitted))
+            self.assertEqual(out[dependent], sentinel)
+            self.assertEqual(dropped, {})
+            stored = {driver_field: driver_value, dependent: sentinel}
+            cleared, _ = self._drop(object_type, dict(stored), {driver_field: driver_value})
+            self.assertIn(dependent, cleared)
+            self.assertFalse(cleared[dependent])
+            return
 
         # 1. a submitted driver value drops the field it forbids, and writes no blank
         out, dropped = self._drop(object_type, {}, dict(submitted))
@@ -870,32 +906,34 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     # --- N2: a dropped match criterion must be dropped BEFORE matching --------
 
-    def test_vlan_qinq_role_create_applies_and_converges(self):
-        """A VLAN naming a service role with an svlan applies once, then plans nothing."""
-        # qinq_svlan is an ipam.vlan MATCH criterion (unique_qinq_svlan_vid, and the
-        # "qinq_svlan IS NULL" condition on the logical vid criteria). Dropping it after
-        # the existing-object lookup left the entity unmatchable, so it re-planned a
-        # CREATE and duplicated the row on every ingest. The policy runs before matching.
+    def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
+        """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""
+        # The regression this pins: dropping qinq_svlan before matching made the entity
+        # satisfy logical_vlan_vid_no_group_or_svlan_or_site ("vid where group IS NULL
+        # AND qinq_svlan IS NULL AND site IS NULL"), i.e. vid alone -- so it adopted
+        # whatever VLAN held that vid and renamed it. Measured: a seeded VLAN was
+        # silently renamed and re-roled where develop wrote nothing at all.
+        from ipam.models import VLAN
+        seeded = VLAN.objects.create(
+            vid=4091, name="lq-someone-elses-vlan", description="OWNED BY ANOTHER SOURCE",
+        )
         payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
-            "vid": 3971, "name": "n2-cvlan", "qinq_role": "svlan",
-            "qinq_svlan": {"vid": 3970, "name": "n2-svlan"},
+            "vid": 4091, "name": "lq-brand-new-svlan", "qinq_role": "svlan",
+            "qinq_svlan": {"vid": 4090, "name": "lq-parent"},
         }}}
         cs = self._plan(payload)
-        self.assertIn("qinq_svlan", cs.get("warnings", {}).get("ipam.vlan", {}))
-        for change in cs["changes"]:
-            self.assertNotIn("qinq_svlan", change.get("data", {}))
-            self.assertNotIn("qinq_svlan", change.get("new_refs", []))
-        self._apply(cs)
+        # nothing is dropped and nothing is warned about: the field identifies the row
+        self.assertNotIn("ipam.vlan", cs.get("warnings", {}))
 
-        from ipam.models import VLAN
-        vlan = VLAN.objects.get(vid=3971)
-        self.assertEqual(vlan.qinq_role, "svlan")
-        self.assertIsNone(vlan.qinq_svlan)
+        # NetBox rejects the contradiction, which is exactly develop's answer
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertNotEqual(r.status_code, 200, r.content)
 
-        for quiet in range(1, 5):
-            self.assertEqual(self._plan(payload).get("changes", []), [],
-                             f"re-planned on quiet round {quiet}")
-        self.assertEqual(VLAN.objects.filter(vid=3971).count(), 1)  # no duplicate rows
+        seeded.refresh_from_db()
+        self.assertEqual(seeded.name, "lq-someone-elses-vlan")
+        self.assertEqual(seeded.description, "OWNED BY ANOTHER SOURCE")
+        self.assertFalse(seeded.qinq_role)  # '' or None; both mean 'not a Q-in-Q VLAN'
+        self.assertEqual(VLAN.objects.filter(vid=4091).count(), 1)  # and no duplicate
 
     def test_vlan_customer_role_keeps_its_service_vlan_and_converges(self):
         """qinq_role 'cvlan' permits qinq_svlan: it is kept, applied and converges."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_updates_cases.json
@@ -2175,7 +2175,10 @@
         "lookup": {"name": "WirelessGigabitEthernet1/0/1"},
         "create_expect": {
             "name": "WirelessGigabitEthernet1/0/1",
-            "label": "Core Link 1"
+            "label": "Core Link 1",
+            "mode": "access",
+            "untagged_vlan.vid": 900,
+            "tagged_vlans.all": []
         },
         "create": {
             "interface": {
@@ -2305,6 +2308,10 @@
                         "status": "active",
                         "description": "Primary VDC"
                     }
+                ],
+                "tagged_vlans": [
+                    {"vid": 101, "name": "Voice VLAN", "status": "active"},
+                    {"vid": 102, "name": "Data VLAN", "status": "active"}
                 ]
             }    
         },
@@ -2436,11 +2443,18 @@
                         "status": "active",
                         "description": "Primary VDC"
                     }
+                ],
+                "tagged_vlans": [
+                    {"vid": 101, "name": "Voice VLAN", "status": "active"},
+                    {"vid": 102, "name": "Data VLAN", "status": "active"}
                 ]
             }    
         },
         "update_expect": {
-            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"]
+            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"],
+            "mode": "access",
+            "untagged_vlan.vid": 900,
+            "tagged_vlans.all": []
         }
     },
     {

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase
 from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
+from netbox_diode_plugin.api import field_policy
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.common import UnresolvedReference
 from netbox_diode_plugin.api.differ import normalize_changeset
@@ -208,6 +209,53 @@ class NormalizeChangesetTests(SimpleTestCase):
                     for dependent in dependents:
                         with self.subTest(object_type=object_type, dependent=dependent):
                             self.assertNotIn(dependent, matched)
+
+    def _flaky_model_lookup(self, fail_calls=1):
+        """A get_object_type_model that fails its first ``fail_calls`` calls, then works."""
+        real = field_policy.get_object_type_model
+        calls = []
+
+        def flaky(object_type):
+            calls.append(object_type)
+            if len(calls) <= fail_calls:
+                raise RuntimeError("content type lookup unavailable")
+            return real(object_type)
+
+        match_participating_fields.cache_clear()
+        self.addCleanup(match_participating_fields.cache_clear)
+        return flaky, calls
+
+    def test_a_model_lookup_failure_refuses_the_drop_instead_of_licensing_it(self):
+        """A failed model lookup propagates; it never answers "nothing participates"."""
+        # The gate answers "which fields decide WHICH row this payload means". An empty
+        # answer means "none of them", which licenses every drop the gate exists to
+        # refuse -- so a lookup failure must not produce one.
+        flaky, calls = self._flaky_model_lookup()
+        entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+        with mock.patch.object(field_policy, "get_object_type_model", flaky):
+            with self.assertRaises(RuntimeError):
+                submitted_driver_field_drops("ipam.vlan", entity)
+            # nothing was dropped on the way out
+            self.assertEqual(entity, {"qinq_role": "svlan", "qinq_svlan": 7})
+            self.assertEqual(calls, ["ipam.vlan"])
+
+    def test_a_model_lookup_failure_is_not_cached_as_nothing_participates(self):
+        """The recovery half: a transient failure must not poison the lru_cache."""
+        # lru_cache does not cache exceptions, so the next call retries. Returning an
+        # empty frozenset instead would be cached until eviction or restart, and every
+        # later request would treat qinq_svlan as droppable after the database had
+        # recovered -- re-enabling the same-vid wrong-row mutation this gate prevents.
+        flaky, calls = self._flaky_model_lookup()
+        with mock.patch.object(field_policy, "get_object_type_model", flaky):
+            with self.assertRaises(RuntimeError):
+                match_participating_fields("ipam.vlan")
+            # the healthy retry sees the truth
+            self.assertIn("qinq_svlan", match_participating_fields("ipam.vlan"))
+            entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+            out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+        self.assertEqual(len(calls), 2)   # retried once, then served from cache
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
         """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
@@ -537,6 +585,29 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertNotIn("rf_role", iface)
         self.assertEqual(iface["_refs"], {"v1"})
+
+    def test_a_gate_failure_takes_the_whole_pass_down_instead_of_dropping(self):
+        """The graph-level pass does not swallow a gate failure into a silent drop."""
+        real = field_policy.get_object_type_model
+
+        def broken(object_type):
+            raise RuntimeError("content type lookup unavailable")
+
+        match_participating_fields.cache_clear()
+        self.addCleanup(match_participating_fields.cache_clear)
+        svlan = self._node("ipam.vlan", "s1", vid=900, name="s900")
+        vlan = self._node("ipam.vlan", "v1", refs={"s1"}, vid=101, name="v101",
+                          qinq_role="svlan", qinq_svlan=self._ref("s1"))
+        with mock.patch.object(field_policy, "get_object_type_model", broken):
+            with self.assertRaises(RuntimeError):
+                apply_submitted_driver_field_policy([svlan, vlan])
+        self.assertEqual(vlan["qinq_svlan"], self._ref("s1"))
+        self.assertEqual(vlan["_refs"], {"s1"})
+        self.assertEqual(vlan["_warnings"], {})
+        # and with the lookup healthy again the gate still refuses the drop
+        self.assertEqual(self._uuids(self._policy([svlan, vlan])), ["s1", "v1"])
+        self.assertEqual(vlan["qinq_svlan"], self._ref("s1"))
+        self.assertIs(real, field_policy.get_object_type_model)
 
     def test_one_drop_is_reported_once_when_the_policy_runs_twice(self):
         """The policy is idempotent: a second pass re-reports nothing."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -715,6 +715,47 @@ class DedupeDriverFieldPolicyTests(TestCase):
         raise_unsettled_conflicts(out)
         self.assertEqual(out[0]["_refs"], {"d1"})
 
+    def _shared_vlan_fragments(self):
+        """
+        Fragments whose surviving VLAN is ALSO the untagged one.
+
+        Dropping tagged_vlans then releases no edge -- untagged_vlan still needs it --
+        so the only edge phase 1 gives up is the one the rejected duplicate contributed.
+        """
+        shared = UnresolvedReference(object_type="ipam.vlan", uuid="v1")
+        other = UnresolvedReference(object_type="ipam.vlan", uuid="v2")
+        return [
+            self._iface("i0", _refs={"d1", "v1"}, untagged_vlan=shared, tagged_vlans=[shared]),
+            self._iface("i1", _refs={"d1", "v2"}, tagged_vlans=[other]),
+            self._iface("i2", mode="access"),
+        ]
+
+    def test_a_rejected_values_edge_release_is_reported_to_the_prune_sweep(self):
+        """Dedupe must report the edges the merge released, not only the ones drops did."""
+        out, released = _fingerprint_dedupe(self._shared_vlan_fragments())
+        raise_unsettled_conflicts(out)
+        node = out[0]
+        self.assertNotIn("tagged_vlans", node)
+        self.assertEqual(node["untagged_vlan"].uuid, "v1")
+        self.assertEqual(node["_refs"], {"d1", "v1"})   # the rejected copy's v2 is gone
+        # The drop itself released nothing, so if the merge's release is not reported the
+        # caller skips its one prune sweep and v2 survives as a manufactured VLAN.
+        self.assertTrue(released)
+
+    def test_the_orphan_of_a_rejected_value_is_pruned(self):
+        """Phase 1 in full: only the rejected duplicate's VLAN node disappears."""
+        vlans = [{"_object_type": "ipam.vlan", "_uuid": uuid, "_refs": set(),
+                  "vid": vid, "name": f"dedupe-v{vid}", "status": "active"}
+                 for uuid, vid in (("v1", 981), ("v2", 982))]
+        entities = vlans + self._shared_vlan_fragments()
+        referenced_before = referenced_uuids(entities)
+        released = apply_submitted_driver_field_policy(entities)
+        deduplicated, merge_released = _fingerprint_dedupe(entities)
+        raise_unsettled_conflicts(deduplicated)
+        if released or merge_released:
+            deduplicated = prune_orphaned_nodes(deduplicated, referenced_before)
+        self.assertEqual({entity["_uuid"] for entity in deduplicated}, {"v1", "i0"})
+
 
 class InterfaceModeClearE2ETests(APITestCase):
     """End-to-end: seed an existing interface, ingest a mode change, assert clear."""
@@ -1706,6 +1747,67 @@ class InterfaceModeClearE2ETests(APITestCase):
         """Three disagreeing copies, then the mode: still one access interface."""
         self._assert_fragments_converge("Gi2/0/8", "n8", 68, [751, 752, 753],
                                         driver_last=True)
+
+    def _shared_vlan_fragment_payload(self, name, octet, field, untagged, keep, reject):
+        """
+        Fragments of one interface where the survivor's VLAN is needed twice.
+
+        ``field`` is the forbidden field the copies split; the first copy also points
+        ``untagged_vlan`` at the same VLAN, which mode "access" permits, so dropping
+        ``field`` releases no edge of its own.
+        """
+        def copy(**extra):
+            return {"device": self._device(), "name": name, "type": "1000base-t", **extra}
+
+        dev = dict(self._device())
+        dev["primary_ip4"] = {
+            "address": f"10.6.{octet}.10/24",
+            "assigned_object_interface": copy(untagged_vlan=untagged, **{field: keep}),
+        }
+        dev["primary_ip6"] = {
+            "address": f"2001:db8:6{octet}::11/64",
+            "assigned_object_interface": copy(**{field: reject}),
+        }
+        dev["oob_ip"] = {
+            "address": f"10.6.{octet}.12/24",
+            "assigned_object_interface": copy(mode="access"),
+        }
+        return {"timestamp": 1, "object_type": "dcim.interface", "entity": {
+            "interface": {"device": dev, "name": name, "type": "1000base-t"}}}
+
+    def _assert_rejected_vlan_is_never_created(self, name, octet, field, keep_vid, reject_vid):
+        """The VLAN only a REJECTED duplicate value referenced must not be created."""
+        from ipam.models import VLAN
+        keep = {"vid": keep_vid, "name": f"rej-v{keep_vid}", "status": "active"}
+        reject = {"vid": reject_vid, "name": f"rej-v{reject_vid}", "status": "active"}
+        many = field == "tagged_vlans"
+        payload = self._shared_vlan_fragment_payload(
+            name, octet, field, dict(keep),
+            [dict(keep)] if many else dict(keep),
+            [dict(reject)] if many else dict(reject),
+        )
+        cs = self._plan(payload)
+        planned = [c.get("data", {}).get("vid") for c in cs["changes"]
+                   if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(planned, [keep_vid], planned)
+        self._converge(payload, f"a rejected duplicate's {field}")
+        self.assertTrue(VLAN.objects.filter(vid=keep_vid).exists())
+        self.assertFalse(VLAN.objects.filter(vid=reject_vid).exists())
+        iface = Interface.objects.get(name=name, device__name=self._device()["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.untagged_vlan.vid, keep_vid)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_rejected_duplicates_tagged_vlan_is_never_created(self):
+        """The survivor is also the untagged VLAN, so only the merge released an edge."""
+        # Without the merge's release reaching the prune gate the change set still plans
+        # a create for the rejected copy's VLAN: the interface comes out correct while an
+        # extra VLAN is manufactured out of a value nothing kept.
+        self._assert_rejected_vlan_is_never_created("Gi3/0/1", 71, "tagged_vlans", 671, 672)
+
+    def test_a_rejected_duplicates_qinq_svlan_is_never_created(self):
+        """The same shape on a different forbidden field the interface policy drops."""
+        self._assert_rejected_vlan_is_never_created("Gi3/0/2", 72, "qinq_svlan", 681, 682)
 
     def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
         """A VLAN that is the entity's own primary object is never pruned."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -8,9 +8,11 @@ from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.common import UnresolvedReference
 from netbox_diode_plugin.api.differ import normalize_changeset
 from netbox_diode_plugin.api.field_policy import (
     _DRIVER_FIELD_RULES,
+    apply_submitted_driver_field_policy,
     match_participating_fields,
     submitted_driver_field_drops,
 )
@@ -406,6 +408,129 @@ class NormalizeChangesetTests(SimpleTestCase):
                             )
                         pairs += 1
         self.assertGreater(pairs, 100)  # the map is generated; guard against an empty sweep
+
+
+class DriverFieldPolicyPruneTests(SimpleTestCase):
+    """Which graph edges and child nodes a phase 1 drop takes with it -- and which it must not."""
+
+    def _ref(self, uuid, object_type="ipam.vlan"):
+        return UnresolvedReference(object_type=object_type, uuid=uuid)
+
+    def _node(self, object_type, uuid, refs=(), **fields):
+        node = {"_object_type": object_type, "_uuid": uuid, "_refs": set(refs), "_warnings": {}}
+        node.update(fields)
+        return node
+
+    def _uuids(self, entities):
+        return sorted(e["_uuid"] for e in entities)
+
+    def test_a_dropped_nested_reference_takes_its_child_node_with_it(self):
+        """The child node a dropped tagged_vlans created is pruned, and so is its edge."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1"])
+        self.assertNotIn("tagged_vlans", iface)
+        self.assertEqual(iface["_refs"], set())
+
+    def test_a_child_the_same_node_still_references_is_kept(self):
+        """One VLAN node reached by BOTH untagged_vlan and tagged_vlans survives the drop."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", mode="access",
+                           untagged_vlan=self._ref("v1"), tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertEqual(iface["_refs"], {"v1"})       # the untagged_vlan edge stands
+        self.assertEqual(iface["untagged_vlan"], self._ref("v1"))
+
+    def test_a_child_another_node_still_references_is_kept(self):
+        """A second interface still tagging the VLAN keeps its node alive."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        dropped = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                             mode="access", tagged_vlans=[self._ref("v1")])
+        keeper = self._node("dcim.interface", "i2", refs={"v1"}, name="Eth2",
+                            mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, dropped, keeper])
+        self.assertEqual(self._uuids(out), ["i1", "i2", "v1"])
+        self.assertEqual(dropped["_refs"], set())
+        self.assertEqual(keeper["_refs"], {"v1"})
+
+    def test_pruning_is_transitive(self):
+        """A pruned child's own children go too, once nothing reaches them."""
+        group = self._node("ipam.vlangroup", "g1", name="g1", slug="g1")
+        vlan = self._node("ipam.vlan", "v1", refs={"g1"}, vid=101, name="v101",
+                          group=self._ref("g1", "ipam.vlangroup"))
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([group, vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1"])
+
+    def test_a_grandchild_something_surviving_needs_is_kept(self):
+        """Transitivity stops at the first node another survivor still references."""
+        group = self._node("ipam.vlangroup", "g1", name="g1", slug="g1")
+        dropped_vlan = self._node("ipam.vlan", "v1", refs={"g1"}, vid=101, name="v101",
+                                  group=self._ref("g1", "ipam.vlangroup"))
+        kept_vlan = self._node("ipam.vlan", "v2", refs={"g1"}, vid=102, name="v102",
+                               group=self._ref("g1", "ipam.vlangroup"))
+        iface = self._node("dcim.interface", "i1", refs={"v1", "v2"}, name="Eth1", mode="access",
+                           untagged_vlan=self._ref("v2"), tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([group, dropped_vlan, kept_vlan, iface])
+        self.assertEqual(self._uuids(out), ["g1", "i1", "v2"])
+        self.assertEqual(iface["_refs"], {"v2"})
+
+    def test_a_post_create_step_and_its_children_are_never_collateral(self):
+        """A post-create node hangs off its object; a drop elsewhere leaves it alone."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        mac = self._node("dcim.macaddress", "m1", mac_address="00:00:00:00:00:01")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        post_create = self._node(
+            "dcim.interface", "pc1", refs={"i1", "m1"},
+            primary_mac_address=self._ref("m1", "dcim.macaddress"),
+        )
+        post_create["_is_post_create"] = True
+        post_create["_instance"] = "i1"
+        out = apply_submitted_driver_field_policy([vlan, mac, iface, post_create])
+        self.assertEqual(self._uuids(out), ["i1", "m1", "pc1"])
+
+    def test_a_root_node_is_never_pruned(self):
+        """A node nothing referenced is the entity's own object: it survives a drop on itself."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertIn("i1", self._uuids(out))
+
+    def test_no_drop_prunes_nothing(self):
+        """With nothing to drop the policy is a pure no-op over the graph."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertEqual(iface["tagged_vlans"], [self._ref("v1")])
+        self.assertEqual(iface["_warnings"], {})
+
+    def test_a_drop_with_no_nested_reference_prunes_nothing(self):
+        """Dropping a plain scalar (rf_role) releases no edge and no node."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", type="1000base-t",
+                           rf_role="ap", mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = apply_submitted_driver_field_policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertNotIn("rf_role", iface)
+        self.assertEqual(iface["_refs"], {"v1"})
+
+    def test_one_drop_is_reported_once_when_the_policy_runs_twice(self):
+        """The policy is idempotent: a second pass re-reports nothing."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        entities = apply_submitted_driver_field_policy([vlan, iface])
+        again = apply_submitted_driver_field_policy(entities)
+        self.assertEqual(self._uuids(again), ["i1"])
+        self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
 
 
 class InterfaceModeClearE2ETests(APITestCase):
@@ -1153,3 +1278,121 @@ class InterfaceModeClearE2ETests(APITestCase):
         self._apply(cs)
         iface = Interface.objects.get(name="Gi1/0/22", device__name=dev["name"])
         self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    # --- P2-B: the orphan child nodes a drop leaves behind --------------------
+
+    def test_dropping_tagged_vlans_creates_no_orphan_vlan(self):
+        """A dropped nested reference takes its child node with it: no VLAN is manufactured."""
+        # Measured before the fix: planned non-noop ipam.vlan changes = [("create", 621)],
+        # apply 200, VLAN 621 present in NetBox afterwards while the interface had mode
+        # access and tagged_vlans count 0 -- the payload silently created a VLAN it could
+        # not use, and the warning claimed the field had been dropped.
+        from ipam.models import VLAN
+        payload = self._iface_payload(
+            name="Gi1/0/21", type="1000base-t", mode="access",
+            tagged_vlans=[{"vid": 621, "name": "p2b-orphan", "status": "active"}],
+        )
+        cs = self._plan(payload)
+        vlan_changes = [(c["change_type"], c.get("data", {}).get("vid"))
+                        for c in cs["changes"]
+                        if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(vlan_changes, [], vlan_changes)
+        self._apply(cs)
+        self.assertFalse(VLAN.objects.filter(vid=621).exists())
+        iface = Interface.objects.get(name="Gi1/0/21")
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- over-pruning: three ways a dropped child is still needed -------------
+
+    def test_a_vlan_that_is_also_the_untagged_vlan_survives_the_drop(self):
+        """The same VLAN named as both untagged_vlan and a tagged VLAN is still created."""
+        from ipam.models import VLAN
+        payload = self._iface_payload(
+            name="Gi1/0/30", type="1000base-t", mode="access",
+            untagged_vlan={"vid": 632, "name": "keep-v632", "status": "active"},
+            tagged_vlans=[{"vid": 632, "name": "keep-v632", "status": "active"}],
+        )
+        self._converge(payload, "shared untagged/tagged VLAN")
+        self.assertTrue(VLAN.objects.filter(vid=632).exists())
+        iface = Interface.objects.get(name="Gi1/0/30")
+        self.assertEqual(iface.untagged_vlan.vid, 632)   # allowed by 'access' -> linked
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # forbidden -> dropped
+
+    def test_a_shared_vlan_survives_a_drop_on_the_merged_node(self):
+        """After the merge one VLAN node is both untagged_vlan and a tagged VLAN: it survives."""
+        # This is the case a per-node reference count exists for. The outer node carries
+        # mode "access" and untagged_vlan 631; the nested duplicate carries tagged_vlans
+        # [631] and no mode. Fingerprint dedupe collapses the two VLAN nodes into ONE, so
+        # the merged interface points at that single node from both fields. Releasing the
+        # tagged_vlans edge must not release the untagged_vlan edge with it -- if it does,
+        # the node is pruned and untagged_vlan is left dangling.
+        from ipam.models import VLAN
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.31.31/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/31", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 631, "name": "keep-v631", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/31", "type": "1000base-t", "mode": "access",
+            "untagged_vlan": {"vid": 631, "name": "keep-v631", "status": "active"},
+        }}}
+        self._converge(payload, "shared VLAN node after merge")
+        self.assertTrue(VLAN.objects.filter(vid=631).exists())
+        iface = Interface.objects.get(name="Gi1/0/31", device__name=dev["name"])
+        self.assertEqual(iface.untagged_vlan.vid, 631)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_vlan_a_second_interface_still_tags_survives_the_drop(self):
+        """One VLAN node, two interfaces: the drop on one must not unmake it for the other."""
+        # Gi1/0/40 is named twice (outer node with mode "access", nested duplicate with
+        # tagged_vlans [641]) so the merged node loses tagged_vlans in the post-merge pass.
+        # Gi1/0/42, mode "tagged", legitimately tags the SAME VLAN, and dedupe gives both
+        # interfaces the same VLAN node. Pruning it would strand Gi1/0/42's reference.
+        from ipam.models import VLAN
+        dev = self._device()
+        vlan = {"vid": 641, "name": "keep-v641", "status": "active"}
+        dev_two = dict(
+            dev,
+            primary_ip4={
+                "address": "10.9.40.40/24",
+                "assigned_object_interface": {
+                    "device": dev, "name": "Gi1/0/40", "type": "1000base-t",
+                    "tagged_vlans": [dict(vlan)],
+                },
+            },
+            primary_ip6={
+                "address": "2001:db8:40::42/64",
+                "assigned_object_interface": {
+                    "device": dev, "name": "Gi1/0/42", "type": "1000base-t",
+                    "mode": "tagged", "tagged_vlans": [dict(vlan)],
+                },
+            },
+        )
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_two, "name": "Gi1/0/40", "type": "1000base-t", "mode": "access",
+        }}}
+        self._converge(payload, "VLAN shared by a second interface")
+        self.assertTrue(VLAN.objects.filter(vid=641).exists())
+        dropped_from = Interface.objects.get(name="Gi1/0/40", device__name=dev["name"])
+        self.assertEqual(dropped_from.mode, "access")
+        self.assertEqual(dropped_from.tagged_vlans.count(), 0)
+        kept_by = Interface.objects.get(name="Gi1/0/42", device__name=dev["name"])
+        self.assertEqual([v.vid for v in kept_by.tagged_vlans.all()], [641])
+
+    def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
+        """A VLAN that is the entity's own primary object is never pruned."""
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 651, "name": "own-right-v651", "status": "active",
+            "group": {"name": "own-right-group", "slug": "own-right-group"},
+        }}}
+        self._converge(payload, "ipam.vlan on its own")
+        vlan = VLAN.objects.get(vid=651, name="own-right-v651")
+        self.assertEqual(vlan.group.name, "own-right-group")

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -18,6 +18,11 @@ class NormalizeChangesetTests(SimpleTestCase):
         normalize_changeset(object_type, prechange, entity)
         return entity
 
+    def _drop(self, object_type, prechange, entity):
+        """Run the normalizer and return (entity, dropped-submitted-field map)."""
+        dropped = normalize_changeset(object_type, prechange, entity)
+        return entity, dropped
+
     def test_tagged_to_access_clears_tagged_vlans_keeps_untagged(self):
         """Mode tagged -> access clears tagged_vlans but leaves untagged_vlan untouched."""
         prechange = {"mode": "tagged", "tagged_vlans": [101, 102], "untagged_vlan": 5}
@@ -42,13 +47,40 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertEqual(out["tagged_vlans"], [])
         self.assertIsNone(out["qinq_svlan"])
 
-    def test_explicit_value_is_respected_not_overwritten(self):
-        """An explicitly submitted dependent field value is never overwritten."""
-        # producer explicitly sent tagged_vlans with an incompatible mode -> leave it
+    def test_explicit_forbidden_value_is_dropped_driver_wins(self):
+        """The submitted driver value wins: an explicit but forbidden value is dropped."""
+        # POLICY (reversed): a payload naming mode "access" AND naming tagged VLANs is
+        # self-contradictory. NetBox rejects the WHOLE entity for it, so the mode wins
+        # and the field it forbids is discarded — producer intent does NOT protect it.
         prechange = {"mode": "tagged", "tagged_vlans": [101]}
         entity = {"mode": "access", "tagged_vlans": [200]}
-        out = self._run("dcim.interface", prechange, entity)
+        out, dropped = self._drop("dcim.interface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertIn("tagged_vlans", dropped)
+        self.assertIn("mode", dropped["tagged_vlans"])
+        self.assertIn("access", dropped["tagged_vlans"])
+
+    def test_explicit_allowed_value_is_respected(self):
+        """Producer intent survives for everything the driver value ALLOWS."""
+        # mode "tagged" permits tagged_vlans, so an explicit list is kept verbatim and
+        # is not reported as dropped. This is the half of producer intent that stands.
+        out, dropped = self._drop(
+            "dcim.interface",
+            {"mode": "access", "tagged_vlans": []},
+            {"mode": "tagged", "tagged_vlans": [200]},
+        )
         self.assertEqual(out["tagged_vlans"], [200])
+        self.assertEqual(dropped, {})
+
+    def test_explicit_empty_forbidden_value_is_not_a_change(self):
+        """A submitted value that is already empty is left exactly as submitted."""
+        # Rewriting it would be pointless and could only manufacture a spurious
+        # change (e.g. [] -> None); nothing is reported as dropped either.
+        out, dropped = self._drop(
+            "dcim.interface", {}, {"mode": "access", "tagged_vlans": []}
+        )
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertEqual(dropped, {})
 
     def test_no_clear_when_prechange_field_already_empty(self):
         """Nothing is injected into entity when the prechange dependent field was already empty."""
@@ -79,11 +111,72 @@ class NormalizeChangesetTests(SimpleTestCase):
         out = self._run("dcim.device", prechange, entity)
         self.assertNotIn("tagged_vlans", out)
 
-    def test_create_no_prechange_is_noop(self):
-        """Create flows (empty prechange, no existing row) are a no-op."""
+    def test_create_drops_forbidden_submitted_value(self):
+        """A create is not exempt: mode "access" drops the tagged_vlans it forbids."""
+        # This is the corpus shape (interface "WirelessGigabitEthernet1/0/1"): a CREATE
+        # carrying mode "access" together with untagged_vlan AND tagged_vlans. Before
+        # the reversed policy this was a no-op and NetBox 400'd the whole entity.
+        entity = {
+            "mode": "access",
+            "untagged_vlan": 900,
+            "tagged_vlans": [101, 102],
+        }
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["tagged_vlans"], [])       # forbidden -> dropped
+        self.assertEqual(out["untagged_vlan"], 900)     # allowed for access -> kept
+        self.assertEqual(list(dropped), ["tagged_vlans"])
+
+    def test_create_injects_nothing_when_field_not_submitted(self):
+        """A create with nothing forbidden submitted stays untouched (nothing injected)."""
         entity = {"mode": "access"}
-        out = self._run("dcim.interface", {}, entity)
-        self.assertNotIn("tagged_vlans", out)
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertNotIn("tagged_vlans", out)  # no stored row, nothing to clear
+        self.assertNotIn("qinq_svlan", out)
+        self.assertEqual(dropped, {})
+
+    def test_create_unknown_mode_fails_open(self):
+        """An unrecognised driver value forbids nothing, on creates too."""
+        entity = {"mode": "future-mode", "tagged_vlans": [101]}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["tagged_vlans"], [101])
+        self.assertEqual(dropped, {})
+
+    def test_stale_clear_is_not_reported_as_dropped(self):
+        """Injecting a clear for a stale STORED value is not a drop of producer data."""
+        out, dropped = self._drop(
+            "dcim.interface", {"mode": "tagged", "tagged_vlans": [101]}, {"mode": "access"}
+        )
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertEqual(dropped, {})  # nothing was submitted, so nothing was discarded
+
+    def test_shared_policy_applies_to_interface_type_rf_fields(self):
+        """The reversed policy is registry-wide: dcim.interface "type" behaves the same."""
+        entity = {"type": "1000base-t", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertIsNone(out["rf_channel"])
+        self.assertIsNone(out["rf_role"])
+        self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
+
+    def test_shared_policy_keeps_rf_fields_on_a_wireless_type(self):
+        """A wireless type permits the rf fields, so an explicit create keeps them."""
+        entity = {"type": "ieee802.11ac", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["rf_channel"], "2.4g-1-2412-22")
+        self.assertEqual(dropped, {})
+
+    def test_shared_policy_applies_to_vlan_qinq_role(self):
+        """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
+        entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+        out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertIsNone(out["qinq_svlan"])
+        self.assertEqual(list(dropped), ["qinq_svlan"])
+
+    def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
+        """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
+        entity = {"qinq_role": "cvlan", "qinq_svlan": 7}
+        out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
 
     def test_unknown_mode_fails_open(self):
         """An unknown/unlisted mode value fails open and clears nothing."""
@@ -262,11 +355,12 @@ class InterfaceModeClearE2ETests(APITestCase):
         ch = [c for c in r.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
         self.assertTrue(all(c["change_type"] == "noop" for c in ch))
 
-    def test_explicit_incompatible_tagged_vlans_still_fails(self):
-        """Guard: an explicit incompatible mode/tagged_vlans combo must still be rejected."""
-        # Guard: a producer that explicitly sends mode=access WITH tagged_vlans is a
-        # producer-side error — the normalizer must NOT silently clear it; apply must
-        # fail and the DB must be unchanged.
+    def test_explicit_incompatible_tagged_vlans_is_dropped_not_rejected(self):
+        """An explicit incompatible mode/tagged_vlans update applies with the field dropped."""
+        # POLICY (reversed): this combination used to be left alone so NetBox could
+        # reject it, which cost the whole entity. The submitted mode now wins: the
+        # update applies, tagged_vlans is dropped, and the drop is surfaced as a
+        # warning on the change set rather than swallowed silently.
         create = {
             "name": "EthNeg", "type": "1000base-t", "device": self._device(),
             "mode": "tagged",
@@ -275,7 +369,7 @@ class InterfaceModeClearE2ETests(APITestCase):
         _, apply1 = self._diff_apply(create)
         self.assertEqual(apply1.status_code, 200)
         iface = Interface.objects.get(name="EthNeg")
-        before = set(iface.tagged_vlans.values_list("vid", flat=True))
+        self.assertEqual(iface.tagged_vlans.count(), 1)
 
         bad = {
             "name": "EthNeg", "type": "1000base-t", "device": self._device(),
@@ -284,12 +378,70 @@ class InterfaceModeClearE2ETests(APITestCase):
         }
         payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": bad}}
         r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
         cs = r1.json().get("change_set", {})
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
         r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
-        # NetBox rejects the incompatible combo: non-200, or 200 with an errors payload.
-        self.assertTrue(r2.status_code != 200 or r2.json().get("errors"))
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
         iface.refresh_from_db()
-        self.assertEqual(set(iface.tagged_vlans.values_list("vid", flat=True)), before)  # unchanged
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # the mode won; the field was dropped
+
+        # and the very same self-contradictory payload re-diffs as a NOOP
+        r3 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        ch = [c for c in r3.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in ch))
+
+    def test_corpus_create_access_mode_with_tagged_vlans_applies(self):
+        """A CREATE naming mode access, untagged_vlan AND tagged_vlans applies and is idempotent."""
+        # Reproduction of the corpus entity "WirelessGigabitEthernet1/0/1", which used to
+        # lose the whole interface to a 400 {"tagged_vlans": ["Interface mode does not
+        # support tagged vlans"]}. The create must now land with the mode honoured, the
+        # untagged VLAN attached and the forbidden tagged VLANs dropped.
+        create = {
+            "name": "WlAccess", "type": "other-wireless", "device": self._device(),
+            "mode": "access",
+            "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+            "untagged_vlan": {"vid": 900, "name": "v900"},
+            "tagged_vlans": [{"vid": 101, "name": "v101"}, {"vid": 102, "name": "v102"}],
+        }
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": create}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        # the create's CREATE change must not carry tagged_vlans at all, and must not
+        # leave a dangling unresolved-reference path for the field it no longer carries
+        iface_creates = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_creates)
+        for c in iface_creates:
+            self.assertNotIn("tagged_vlans", c.get("data", {}))
+            self.assertNotIn("tagged_vlans", c.get("new_refs", []))
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+        iface = Interface.objects.get(name="WlAccess")
+        self.assertEqual(iface.mode, "access")
+        self.assertIsNotNone(iface.untagged_vlan)
+        self.assertEqual(iface.untagged_vlan.vid, 900)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertEqual(iface.rf_channel, "2.4g-1-2412-22")  # wireless type keeps rf fields
+
+        # re-ingesting the identical payload is a no-op
+        r3 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r3.json().get("change_set", {}).get("changes", []), [])
+
+        # and submitting the forbidden field EMPTY under the same mode is a no-op too:
+        # clearing an already-empty submitted value must never plan an update
+        empty = dict(create, tagged_vlans=[])
+        r4 = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": empty}},
+            format="json", **self.auth,
+        )
+        self.assertEqual(r4.json().get("change_set", {}).get("changes", []), [])
 
     def test_qinq_to_access_clears_qinq_svlan_orm_seed(self):
         """E2E: an ORM-seeded q-in-q interface moving to access has qinq_svlan cleared."""
@@ -359,6 +511,33 @@ class InterfaceModeClearE2ETests(APITestCase):
             any(c.get("data", {}).get("tagged_vlans") == [] for c in vm_updates),
             "hook must emit tagged_vlans:[] for vminterface (DB-only assertion is vacuous here)",
         )
+
+    def test_vminterface_create_drops_tagged_vlans_netbox_would_have_kept(self):
+        """The uniform policy costs a vminterface its tagged VLANs, deliberately."""
+        # virtualization.vminterface is the one registry entry whose serializer does NO
+        # mode/VLAN validation: NetBox accepts mode "access" WITH tagged VLANs on a create
+        # and stores them (BaseInterface.save() only clears on a later save, guarded by
+        # `not self._state.adding`). The shared registry means the driver value wins here
+        # too, so the tagged VLANs are dropped. Pinned so the cost stays a decision.
+        vm = {"name": "drop-vm", "cluster": {"name": "drop-cl", "type": {"name": "drop-ct"}}}
+        create = {"name": "vmeth1", "virtual_machine": vm, "mode": "access",
+                  "tagged_vlans": [{"vid": 711, "name": "v711"}]}
+        payload = {"timestamp": 1, "object_type": "virtualization.vminterface",
+                   "entity": {"vm_interface": create}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json()["change_set"]
+        self.assertIn(
+            "tagged_vlans", cs.get("warnings", {}).get("virtualization.vminterface", {})
+        )
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth1")
+        self.assertEqual(vmi.mode, "access")
+        self.assertEqual(vmi.tagged_vlans.count(), 0)
 
     def test_interface_wireless_to_ethernet_clears_rf(self):
         """Type change wireless->ethernet clears stale rf_channel and rf_role."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -667,7 +667,7 @@ class DedupeDriverFieldPolicyTests(TestCase):
         # Normalizing only AFTER dedupe stops working at three: the merge of the first
         # two leaves the merged node holding both mode and tagged_vlans, and the third
         # fragment's different tagged_vlans then conflicts inside _merge_nodes, so the
-        # whole entity is rejected and the post-dedupe pass never runs. Normalizing the
+        # whole entity is rejected before any later pass runs. Normalizing the
         # merged node inside the loop is what makes the outcome independent of how many
         # duplicate representations the producer happened to send.
         for count in range(2, 7):
@@ -1465,7 +1465,7 @@ class InterfaceModeClearE2ETests(APITestCase):
         self.assertTrue(iface_changes)
         for change in iface_changes:
             self.assertNotIn("tagged_vlans", change.get("data", {}))
-        # reported exactly once, with both passes active
+        # reported exactly once, though two steps could each report it
         messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
         self.assertEqual(len(messages or []), 1, messages)
         self._apply(cs)
@@ -1476,13 +1476,13 @@ class InterfaceModeClearE2ETests(APITestCase):
             self.assertEqual(self._plan(payload).get("changes", []), [],
                              f"re-planned on quiet round {quiet}")
 
-    def test_a_drop_reported_by_both_passes_is_one_warning(self):
-        """Pass 1 drops from one node, pass 2 from the merged node: still one message."""
-        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans
-        # (pass 1 drops it and records the warning), the nested node carries a DIFFERENT
-        # tagged_vlans and no mode (pass 1 cannot see it; it survives the merge and pass 2
-        # drops it). Without dedupe on the message, change_set.warnings carried the same
-        # sentence twice for one field.
+    def test_a_drop_reported_by_two_steps_is_one_warning(self):
+        """The pre-dedupe pass drops from one node, the merge from another: one message."""
+        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans,
+        # so the pre-dedupe pass drops it and records the warning; the nested node carries
+        # a DIFFERENT tagged_vlans and no mode, so it survives untouched and is dropped
+        # when it merges. Without dedupe on the message, change_set.warnings carried the
+        # same sentence twice for one field.
         dev = self._device()
         dev_with_ip = dict(dev, primary_ip4={
             "address": "10.9.22.22/24",
@@ -1670,11 +1670,11 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     def test_three_fragments_of_one_interface_still_let_the_driver_win(self):
         """Root + two nested copies, each with a different forbidden VLAN: still one access iface."""
-        # This is the shape a single pre- and post-dedupe pass could not settle. The root
+        # This is the shape a pass on each side of dedupe could not settle. The root
         # fragment has no forbidden field and the nested copies have no submitted mode, so
         # the pre-dedupe pass drops nothing; dedupe merged root + copy 1 into the
         # contradiction and the SECOND copy's different tagged_vlans then conflicted inside
-        # _merge_nodes, rejecting the whole entity before the post-dedupe pass could run.
+        # _merge_nodes, rejecting the whole entity before the mode was ever considered.
         # One interface really can be reached three times: as the entity, as primary_ip4's
         # assigned interface, and as primary_ip6's.
         self._assert_fragments_converge("Gi2/0/3", "n3", 63, [701, 702])

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -906,6 +906,56 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     # --- N2: a dropped match criterion must be dropped BEFORE matching --------
 
+    def test_a_duplicate_node_with_a_different_forbidden_value_still_applies(self):
+        """Two nodes for ONE interface, same submitted mode, different forbidden VLANs."""
+        # The policy used to run AFTER _fingerprint_dedupe, so these two nodes reached
+        # _merge_nodes still carrying tagged_vlans and it rejected the whole entity with
+        # "Conflicting values for 'tagged_vlans'" -- the payload the policy exists to
+        # rescue. Running the policy first drops the forbidden field from both, so they
+        # merge cleanly. The graph nests the same interface twice via the device's
+        # primary_ip4 assignment, which is how one entity legitimately names it twice.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.9.9/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/9", "type": "1000base-t", "mode": "access",
+                "tagged_vlans": [{"vid": 302, "name": "dup-v302", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/9", "type": "1000base-t", "mode": "access",
+            "tagged_vlans": [{"vid": 301, "name": "dup-v301", "status": "active"}],
+        }}}
+        cs = self._plan(payload)
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+        for change in cs["changes"]:
+            if change["object_type"] == "dcim.interface":
+                self.assertNotIn("tagged_vlans", change.get("data", {}))
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/9", device__name=dev["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_duplicate_node_with_a_different_ALLOWED_value_still_conflicts(self):
+        """The control: a field the mode PERMITS is a genuine disagreement, still a 400."""
+        # This must NOT be rescued. mode "tagged" allows tagged_vlans, so [401] vs [402]
+        # is two sources disagreeing about real data and nothing can discard either.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.9.10/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/10", "type": "1000base-t", "mode": "tagged",
+                "tagged_vlans": [{"vid": 402, "name": "ctl-v402", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/10", "type": "1000base-t", "mode": "tagged",
+            "tagged_vlans": [{"vid": 401, "name": "ctl-v401", "status": "active"}],
+        }}}
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertIn("Conflicting values", str(r.content))
+
     def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
         """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""
         # The regression this pins: dropping qinq_svlan before matching made the entity

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -3,7 +3,8 @@ from types import SimpleNamespace
 from unittest import mock
 
 from dcim.models import Interface
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+from rest_framework import serializers
 from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
@@ -18,6 +19,10 @@ from netbox_diode_plugin.api.field_policy import (
     prune_orphaned_nodes,
     referenced_uuids,
     submitted_driver_field_drops,
+)
+from netbox_diode_plugin.api.transformer import (
+    _fingerprint_dedupe,
+    raise_unsettled_conflicts,
 )
 from netbox_diode_plugin.plugin_config import get_diode_user
 
@@ -618,6 +623,97 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         again = self._policy(entities)          # a second full pass changes nothing
         self.assertEqual(self._uuids(again), ["i1"])
         self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
+
+
+class DedupeDriverFieldPolicyTests(TestCase):
+    """_fingerprint_dedupe normalizes every node it merges, so the result is N-independent."""
+
+    def _iface(self, uuid, **fields):
+        node = {
+            "_object_type": "dcim.interface",
+            "_uuid": uuid,
+            "_refs": {"d1"},
+            "_warnings": {},
+            "name": "Gi1/0/1",
+            "device": UnresolvedReference(object_type="dcim.device", uuid="d1"),
+        }
+        node.update(fields)
+        return node
+
+    def _fragments(self, count):
+        """One driver-only fragment plus ``count - 1`` fragments, each with its own VLAN."""
+        nodes = [self._iface("i0", mode="access")]
+        for k in range(1, count):
+            nodes.append(self._iface(
+                f"i{k}", _refs={"d1", f"v{k}"},
+                tagged_vlans=[UnresolvedReference(object_type="ipam.vlan", uuid=f"v{k}")],
+            ))
+        return nodes
+
+    def _assert_normalized(self, out, released):
+        raise_unsettled_conflicts(out)                    # nothing left to disagree about
+        merged = {entity["_uuid"]: entity for entity in out}
+        self.assertEqual(len(merged), 1, merged)          # all fragments are one node
+        node = next(iter(merged.values()))
+        self.assertEqual(node["mode"], "access")
+        self.assertNotIn("tagged_vlans", node)            # forbidden -> gone
+        self.assertNotIn("_deferred_conflicts", node)     # and never leaks downstream
+        self.assertEqual(node["_refs"], {"d1"})           # every VLAN edge released
+        self.assertTrue(released)                         # so the caller's sweep runs
+        self.assertEqual(len(node["_warnings"]["tagged_vlans"]), 1)
+
+    def test_every_merged_node_is_normalized_before_the_next_duplicate_arrives(self):
+        """Two to six duplicate fragments all end at the same normalized node."""
+        # Normalizing only AFTER dedupe stops working at three: the merge of the first
+        # two leaves the merged node holding both mode and tagged_vlans, and the third
+        # fragment's different tagged_vlans then conflicts inside _merge_nodes, so the
+        # whole entity is rejected and the post-dedupe pass never runs. Normalizing the
+        # merged node inside the loop is what makes the outcome independent of how many
+        # duplicate representations the producer happened to send.
+        for count in range(2, 7):
+            with self.subTest(fragments=count):
+                self._assert_normalized(*_fingerprint_dedupe(self._fragments(count)))
+
+    def test_the_outcome_does_not_depend_on_fragment_order(self):
+        """The driver-carrying fragment arriving last must reach the same node."""
+        for count in range(2, 7):
+            with self.subTest(fragments=count):
+                self._assert_normalized(*_fingerprint_dedupe(self._fragments(count)[::-1]))
+
+    def test_the_merged_node_is_already_normalized_when_dedupe_returns(self):
+        """Which is why the transformer needs no separate post-dedupe pass."""
+        out, _ = _fingerprint_dedupe(self._fragments(3))
+        self.assertNotIn("tagged_vlans", out[0])
+        # a further pass over the result finds nothing left to do
+        self.assertFalse(apply_submitted_driver_field_policy(out))
+
+    def test_an_allowed_field_still_conflicts_after_a_merge(self):
+        """The control: mode "tagged" permits tagged_vlans, so disagreement is still an error."""
+        nodes = self._fragments(3)
+        for node in nodes:
+            node["mode"] = "tagged"
+        out, _ = _fingerprint_dedupe(nodes)
+        with self.assertRaises(serializers.ValidationError) as raised:
+            raise_unsettled_conflicts(out)
+        self.assertIn("Conflicting values", str(raised.exception))
+
+    def test_a_conflict_on_a_field_no_driver_value_can_drop_is_immediate(self):
+        """A field outside the registry is a plain disagreement: raised where it happens."""
+        # Deferral is only for fields a driver value could delete. Everything else keeps
+        # develop's behaviour, including the error's position in the pipeline.
+        nodes = [self._iface("i0", description="from A"),
+                 self._iface("i1", description="from B")]
+        with self.assertRaises(serializers.ValidationError):
+            _fingerprint_dedupe(nodes)
+
+    def test_a_deferred_conflict_releases_the_rejected_copys_edges(self):
+        """The value a deferred conflict declined must not keep its VLAN node alive."""
+        # _merge_nodes unions _refs, so without this the rejected tagged_vlans list would
+        # still reach resolution as an edge and the VLAN would be created anyway -- the
+        # manufactured VLAN the prune sweep exists to prevent, arriving by another route.
+        out, _ = _fingerprint_dedupe(self._fragments(3)[::-1])
+        raise_unsettled_conflicts(out)
+        self.assertEqual(out[0]["_refs"], {"d1"})
 
 
 class InterfaceModeClearE2ETests(APITestCase):
@@ -1512,6 +1608,104 @@ class InterfaceModeClearE2ETests(APITestCase):
         self.assertEqual(dropped_from.tagged_vlans.count(), 0)
         kept_by = Interface.objects.get(name="Gi1/0/42", device__name=dev["name"])
         self.assertEqual([v.vid for v in kept_by.tagged_vlans.all()], [641])
+
+    # --- N-way: one interface arriving as N duplicate fragments ---------------
+
+    def _tagged_copy(self, name, vid, tag):
+        """A duplicate fragment of ``name`` carrying one forbidden tagged VLAN."""
+        return {"device": self._device(), "name": name, "type": "1000base-t",
+                "tagged_vlans": [{"vid": vid, "name": f"{tag}-v{vid}", "status": "active"}]}
+
+    def _fragmented_payload(self, name, tag, octet, vids, driver_last=False):
+        """
+        One interface reached several times in a single payload.
+
+        Each nested copy hangs off a different device IP assignment and carries a
+        DIFFERENT forbidden tagged VLAN, so every merge is a fresh contradiction for the
+        policy to settle. ``driver_last`` moves mode "access" off the root fragment and
+        onto one more nested copy, so the driver value arrives only after the duplicates
+        have already disagreed.
+        """
+        copies = [self._tagged_copy(name, vid, tag) for vid in vids]
+        if driver_last:
+            copies.append({"device": self._device(), "name": name,
+                           "type": "1000base-t", "mode": "access"})
+        assert 2 <= len(copies) <= 4
+        addresses = [f"10.9.{octet}.10/24", f"2001:db8:{octet}::11/64",
+                     f"10.9.{octet}.12/24", f"10.9.{octet}.13/24"]
+        ips = [{"address": address, "assigned_object_interface": copy}
+               for address, copy in zip(addresses, copies, strict=False)]
+        dev = dict(self._device())
+        dev["primary_ip4"], dev["primary_ip6"] = ips[0], ips[1]
+        if len(ips) > 2:
+            dev["oob_ip"] = ips[2]
+        if len(ips) > 3:
+            dev["primary_ip4"]["nat_inside"] = ips[3]
+        root = {"device": dev, "name": name, "type": "1000base-t"}
+        if not driver_last:
+            root["mode"] = "access"
+        return {"timestamp": 1, "object_type": "dcim.interface",
+                "entity": {"interface": root}}
+
+    def _assert_fragments_converge(self, name, tag, octet, vids, driver_last=False):
+        """Plan, apply and re-plan a fragmented payload; assert one drop and no VLANs."""
+        from ipam.models import VLAN
+        payload = self._fragmented_payload(name, tag, octet, vids, driver_last)
+        cs = self._plan(payload)
+        iface_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_changes)
+        for change in iface_changes:
+            self.assertNotIn("tagged_vlans", change.get("data", {}))
+        messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
+        self.assertEqual(len(messages or []), 1, messages)
+        vlan_changes = [(c["change_type"], c.get("data", {}).get("vid"))
+                        for c in cs["changes"]
+                        if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(vlan_changes, [], vlan_changes)
+        self._converge(payload, f"fragments of {name}")
+        iface = Interface.objects.get(name=name, device__name=self._device()["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertFalse(VLAN.objects.filter(vid__in=vids).exists())
+
+    def test_three_fragments_of_one_interface_still_let_the_driver_win(self):
+        """Root + two nested copies, each with a different forbidden VLAN: still one access iface."""
+        # This is the shape a single pre- and post-dedupe pass could not settle. The root
+        # fragment has no forbidden field and the nested copies have no submitted mode, so
+        # the pre-dedupe pass drops nothing; dedupe merged root + copy 1 into the
+        # contradiction and the SECOND copy's different tagged_vlans then conflicted inside
+        # _merge_nodes, rejecting the whole entity before the post-dedupe pass could run.
+        # One interface really can be reached three times: as the entity, as primary_ip4's
+        # assigned interface, and as primary_ip6's.
+        self._assert_fragments_converge("Gi2/0/3", "n3", 63, [701, 702])
+
+    def test_four_fragments_of_one_interface_still_let_the_driver_win(self):
+        """A fourth copy, via the device's oob_ip, changes nothing."""
+        self._assert_fragments_converge("Gi2/0/4", "n4", 64, [711, 712, 713])
+
+    def test_five_fragments_of_one_interface_still_let_the_driver_win(self):
+        """A fifth copy, via primary_ip4's nat_inside, changes nothing either."""
+        self._assert_fragments_converge("Gi2/0/5", "n5", 65, [721, 722, 723, 724])
+
+    def test_reordering_the_same_fragments_does_not_change_the_outcome(self):
+        """The forbidden values swapped between fragments plan and converge identically."""
+        # Representation independence is the property under test: the same logical
+        # fragments in a different order must not produce a different answer.
+        self._assert_fragments_converge("Gi2/0/6", "n6", 66, [733, 732, 731])
+
+    def test_the_driver_fragment_arriving_last_still_wins(self):
+        """The mode arrives only after two duplicates have already disagreed."""
+        # Measured on the incremental normalization alone: the two tagged-only copies
+        # merge first, _merge_nodes rejects the second one's different tagged_vlans, and
+        # the fragment carrying mode "access" is never reached -- a 400 that depends
+        # purely on which copy the payload happened to nest first. Holding a conflict on
+        # a droppable field until the graph is merged is what removes that dependency.
+        self._assert_fragments_converge("Gi2/0/7", "n7", 67, [741, 742], driver_last=True)
+
+    def test_the_driver_fragment_arriving_last_of_five_still_wins(self):
+        """Three disagreeing copies, then the mode: still one access interface."""
+        self._assert_fragments_converge("Gi2/0/8", "n8", 68, [751, 752, 753],
+                                        driver_last=True)
 
     def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
         """A VLAN that is the entity's own primary object is never pruned."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -1088,3 +1088,68 @@ class InterfaceModeClearE2ETests(APITestCase):
         for quiet in range(1, 5):
             self.assertEqual(self._plan(payload).get("changes", []), [],
                              f"re-planned on quiet round {quiet}")
+
+    # --- P2-A: duplicate nodes that SPLIT the contradiction -------------------
+
+    def test_split_duplicate_nodes_do_not_merge_into_the_contradiction(self):
+        """Duplicate nodes that SPLIT mode and tagged_vlans still lose the forbidden field."""
+        # Measured on the pre-dedupe pass alone: neither node triggers the policy, because
+        # phase 1 needs the driver field PRESENT in the node it is looking at. The outer
+        # node carries mode "access" and no tagged_vlans; the nested one (reached through
+        # the device's primary_ip4 assignment) carries tagged_vlans and no mode. _merge_nodes
+        # then combined them INTO the contradiction -- merged data keys held both mode and
+        # tagged_vlans, change_set.warnings was None, and apply was a 400
+        # {"dcim.interface": {"tagged_vlans": ["Interface mode does not support tagged vlans"]}}.
+        # Running the policy a second time on the merged nodes is what closes it.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.20.20/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/20", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 520, "name": "split-v520", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/20", "type": "1000base-t", "mode": "access",
+        }}}
+        cs = self._plan(payload)
+        iface_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_changes)
+        for change in iface_changes:
+            self.assertNotIn("tagged_vlans", change.get("data", {}))
+        # reported exactly once, with both passes active
+        messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
+        self.assertEqual(len(messages or []), 1, messages)
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/20", device__name=dev["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    def test_a_drop_reported_by_both_passes_is_one_warning(self):
+        """Pass 1 drops from one node, pass 2 from the merged node: still one message."""
+        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans
+        # (pass 1 drops it and records the warning), the nested node carries a DIFFERENT
+        # tagged_vlans and no mode (pass 1 cannot see it; it survives the merge and pass 2
+        # drops it). Without dedupe on the message, change_set.warnings carried the same
+        # sentence twice for one field.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.22.22/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/22", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 522, "name": "mix-v522", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/22", "type": "1000base-t", "mode": "access",
+            "tagged_vlans": [{"vid": 523, "name": "mix-v523", "status": "active"}],
+        }}}
+        cs = self._plan(payload)
+        messages = cs["warnings"]["dcim.interface"]["tagged_vlans"]
+        self.assertEqual(len(messages), 1, messages)
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/22", device__name=dev["name"])
+        self.assertEqual(iface.tagged_vlans.count(), 0)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -14,6 +14,8 @@ from netbox_diode_plugin.api.field_policy import (
     _DRIVER_FIELD_RULES,
     apply_submitted_driver_field_policy,
     match_participating_fields,
+    prune_orphaned_nodes,
+    referenced_uuids,
     submitted_driver_field_drops,
 )
 from netbox_diode_plugin.plugin_config import get_diode_user
@@ -424,12 +426,26 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
     def _uuids(self, entities):
         return sorted(e["_uuid"] for e in entities)
 
+    def _policy(self, entities):
+        """
+        Run the policy the way the transformer does: snapshot, drop, then ONE sweep.
+
+        The drop and the prune are deliberately separate calls -- pruning inside the
+        pass destroys a duplicate child before dedupe can merge it -- so this helper
+        keeps the unit tests exercising the same order the real pipeline uses.
+        """
+        referenced_before = referenced_uuids(entities)
+        released = apply_submitted_driver_field_policy(entities)
+        if not released:
+            return entities
+        return prune_orphaned_nodes(entities, referenced_before)
+
     def test_a_dropped_nested_reference_takes_its_child_node_with_it(self):
         """The child node a dropped tagged_vlans created is pruned, and so is its edge."""
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1"])
         self.assertNotIn("tagged_vlans", iface)
         self.assertEqual(iface["_refs"], set())
@@ -439,7 +455,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", mode="access",
                            untagged_vlan=self._ref("v1"), tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertEqual(iface["_refs"], {"v1"})       # the untagged_vlan edge stands
         self.assertEqual(iface["untagged_vlan"], self._ref("v1"))
@@ -451,7 +467,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                              mode="access", tagged_vlans=[self._ref("v1")])
         keeper = self._node("dcim.interface", "i2", refs={"v1"}, name="Eth2",
                             mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, dropped, keeper])
+        out = self._policy([vlan, dropped, keeper])
         self.assertEqual(self._uuids(out), ["i1", "i2", "v1"])
         self.assertEqual(dropped["_refs"], set())
         self.assertEqual(keeper["_refs"], {"v1"})
@@ -463,7 +479,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                           group=self._ref("g1", "ipam.vlangroup"))
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([group, vlan, iface])
+        out = self._policy([group, vlan, iface])
         self.assertEqual(self._uuids(out), ["i1"])
 
     def test_a_grandchild_something_surviving_needs_is_kept(self):
@@ -475,7 +491,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
                                group=self._ref("g1", "ipam.vlangroup"))
         iface = self._node("dcim.interface", "i1", refs={"v1", "v2"}, name="Eth1", mode="access",
                            untagged_vlan=self._ref("v2"), tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([group, dropped_vlan, kept_vlan, iface])
+        out = self._policy([group, dropped_vlan, kept_vlan, iface])
         self.assertEqual(self._uuids(out), ["g1", "i1", "v2"])
         self.assertEqual(iface["_refs"], {"v2"})
 
@@ -491,7 +507,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         )
         post_create["_is_post_create"] = True
         post_create["_instance"] = "i1"
-        out = apply_submitted_driver_field_policy([vlan, mac, iface, post_create])
+        out = self._policy([vlan, mac, iface, post_create])
         self.assertEqual(self._uuids(out), ["i1", "m1", "pc1"])
 
     def test_a_root_node_is_never_pruned(self):
@@ -499,7 +515,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertIn("i1", self._uuids(out))
 
     def test_no_drop_prunes_nothing(self):
@@ -507,7 +523,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertEqual(iface["tagged_vlans"], [self._ref("v1")])
         self.assertEqual(iface["_warnings"], {})
@@ -517,7 +533,7 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", type="1000base-t",
                            rf_role="ap", mode="tagged", tagged_vlans=[self._ref("v1")])
-        out = apply_submitted_driver_field_policy([vlan, iface])
+        out = self._policy([vlan, iface])
         self.assertEqual(self._uuids(out), ["i1", "v1"])
         self.assertNotIn("rf_role", iface)
         self.assertEqual(iface["_refs"], {"v1"})
@@ -527,8 +543,8 @@ class DriverFieldPolicyPruneTests(SimpleTestCase):
         vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
         iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
                            mode="access", tagged_vlans=[self._ref("v1")])
-        entities = apply_submitted_driver_field_policy([vlan, iface])
-        again = apply_submitted_driver_field_policy(entities)
+        entities = self._policy([vlan, iface])
+        again = self._policy(entities)          # a second full pass changes nothing
         self.assertEqual(self._uuids(again), ["i1"])
         self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
 
@@ -1080,6 +1096,46 @@ class InterfaceModeClearE2ETests(APITestCase):
         r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
         self.assertEqual(r.status_code, 400, r.content)
         self.assertIn("Conflicting values", str(r.content))
+
+    def test_a_dropped_copy_still_contributes_before_it_is_pruned(self):
+        """The richer VLAN copy is inside the dropped field: it must merge, not vanish."""
+        # Pruning inside the pre-dedupe pass removed the named copy before
+        # _fingerprint_dedupe could merge it, leaving a survivor with a vid and no name:
+        # 400 {"ipam.vlan": {"name": ["This field cannot be blank."]}} on every round,
+        # blaming a blank VLAN name for an interface mode contradiction. Every earlier
+        # over-prune test specified the VLAN fully on BOTH sides, so the copies were
+        # interchangeable and losing one cost nothing -- this one makes them unequal,
+        # with the richer occurrence inside the field the mode forbids.
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": self._device(), "name": "Gi8/0/2", "type": "1000base-t",
+            "mode": "access",
+            "untagged_vlan": {"vid": 3992},
+            "tagged_vlans": [{"vid": 3992, "name": "v3992"}],
+        }}}
+        cs = self._plan(payload)
+        self._apply(cs)
+        vlan = VLAN.objects.get(vid=3992)
+        self.assertEqual(vlan.name, "v3992")  # inherited from the copy that was dropped
+        iface = Interface.objects.get(name="Gi8/0/2")
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.untagged_vlan.vid, 3992)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 4):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    def test_a_field_only_the_dropped_copy_carried_is_not_lost(self):
+        """The quiet form of the same mechanism: a description only on the tagged copy."""
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": self._device(), "name": "Gi8/0/3", "type": "1000base-t",
+            "mode": "access",
+            "untagged_vlan": {"vid": 3991, "name": "v3991"},
+            "tagged_vlans": [{"vid": 3991, "name": "v3991", "description": "ONLY-ON-TAGGED"}],
+        }}}
+        self._apply(self._plan(payload))
+        self.assertEqual(VLAN.objects.get(vid=3991).description, "ONLY-ON-TAGGED")
 
     def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
         """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -1,27 +1,36 @@
-"""Unit tests for the interface mode/VLAN changeset normalizer."""
+"""Unit tests for the driver-field policy (interface mode/type, VLAN qinq_role)."""
 from types import SimpleNamespace
 from unittest import mock
 
 from dcim.models import Interface
 from django.test import SimpleTestCase
+from utilities.data import shallow_compare_dict
 from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.differ import normalize_changeset
+from netbox_diode_plugin.api.field_policy import _DRIVER_FIELD_RULES, submitted_driver_field_drops
 from netbox_diode_plugin.plugin_config import get_diode_user
 
 
 class NormalizeChangesetTests(SimpleTestCase):
     """Pure-logic tests: no DB, operate on plain dicts."""
 
-    def _run(self, object_type, prechange, entity):
+    def _plan(self, object_type, prechange, entity):
+        """Run both policy phases in pipeline order and return (entity, dropped)."""
+        # Phase 1 runs in the transformer, before any fingerprinting; phase 2 runs
+        # in the differ once an existing row has been matched. Tests exercise them
+        # in that order so a unit result means the same thing an ingest would.
+        dropped = submitted_driver_field_drops(object_type, entity)
         normalize_changeset(object_type, prechange, entity)
-        return entity
+        return entity, dropped
+
+    def _run(self, object_type, prechange, entity):
+        return self._plan(object_type, prechange, entity)[0]
 
     def _drop(self, object_type, prechange, entity):
-        """Run the normalizer and return (entity, dropped-submitted-field map)."""
-        dropped = normalize_changeset(object_type, prechange, entity)
-        return entity, dropped
+        """Run both phases and return (entity, dropped-submitted-field map)."""
+        return self._plan(object_type, prechange, entity)
 
     def test_tagged_to_access_clears_tagged_vlans_keeps_untagged(self):
         """Mode tagged -> access clears tagged_vlans but leaves untagged_vlan untouched."""
@@ -122,7 +131,10 @@ class NormalizeChangesetTests(SimpleTestCase):
             "tagged_vlans": [101, 102],
         }
         out, dropped = self._drop("dcim.interface", {}, entity)
-        self.assertEqual(out["tagged_vlans"], [])       # forbidden -> dropped
+        # DROPPED, not blanked: with no stored row there is nothing to clear, so the
+        # payload must read as if the producer had never sent the field. Writing a
+        # blank here is what made the rf_* fields re-diff against NetBox's "" forever.
+        self.assertNotIn("tagged_vlans", out)           # forbidden -> dropped
         self.assertEqual(out["untagged_vlan"], 900)     # allowed for access -> kept
         self.assertEqual(list(dropped), ["tagged_vlans"])
 
@@ -153,8 +165,8 @@ class NormalizeChangesetTests(SimpleTestCase):
         """The reversed policy is registry-wide: dcim.interface "type" behaves the same."""
         entity = {"type": "1000base-t", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
         out, dropped = self._drop("dcim.interface", {}, entity)
-        self.assertIsNone(out["rf_channel"])
-        self.assertIsNone(out["rf_role"])
+        self.assertNotIn("rf_channel", out)
+        self.assertNotIn("rf_role", out)
         self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
 
     def test_shared_policy_keeps_rf_fields_on_a_wireless_type(self):
@@ -168,7 +180,7 @@ class NormalizeChangesetTests(SimpleTestCase):
         """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
         entity = {"qinq_role": "svlan", "qinq_svlan": 7}
         out, dropped = self._drop("ipam.vlan", {}, entity)
-        self.assertIsNone(out["qinq_svlan"])
+        self.assertNotIn("qinq_svlan", out)
         self.assertEqual(list(dropped), ["qinq_svlan"])
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
@@ -227,6 +239,139 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertNotIn("rf_channel", out)
 
 
+    # --- a driver value must be SUBMITTED to win (N3) -------------------------
+
+    def test_create_omitting_the_driver_field_keeps_its_dependent_fields(self):
+        """A create that simply omits mode keeps the VLANs NetBox would have stored."""
+        # The policy is that a SUBMITTED driver value wins over the fields it forbids.
+        # With no submitted driver value there is nothing to win, so producer data is
+        # left alone: mode absent must not read as mode "" and drop both VLAN fields.
+        entity = {"name": "vmeth0", "untagged_vlan": 601, "tagged_vlans": [602]}
+        out, dropped = self._drop("virtualization.vminterface", {}, entity)
+        self.assertEqual(out["untagged_vlan"], 601)
+        self.assertEqual(out["tagged_vlans"], [602])
+        self.assertEqual(dropped, {})
+
+    def test_explicitly_submitted_empty_driver_value_does_win(self):
+        """An explicitly submitted empty mode IS a submitted value, and forbids the VLANs."""
+        entity = {"name": "vmeth0", "mode": "", "untagged_vlan": 601, "tagged_vlans": [602]}
+        out, dropped = self._drop("virtualization.vminterface", {}, entity)
+        self.assertNotIn("untagged_vlan", out)
+        self.assertNotIn("tagged_vlans", out)
+        self.assertEqual(sorted(dropped), ["tagged_vlans", "untagged_vlan"])
+        # the reason must not claim a value that was never submitted
+        self.assertIn("empty", dropped["tagged_vlans"])
+        self.assertNotIn("''", dropped["tagged_vlans"])
+
+    def test_explicitly_submitted_null_driver_value_does_win(self):
+        """A submitted null mode is submitted too, and reads as no 802.1Q."""
+        out, dropped = self._drop("dcim.interface", {}, {"mode": None, "tagged_vlans": [602]})
+        self.assertNotIn("tagged_vlans", out)
+        self.assertEqual(list(dropped), ["tagged_vlans"])
+
+    def test_stored_driver_value_never_drops_submitted_data(self):
+        """A driver value that was only STORED does not drop submitted data."""
+        # The stored mode forbids tagged_vlans, but the producer submitted no mode, so
+        # there is no submitted driver value to win and the explicit list stands (NetBox
+        # judges it, exactly as it does on develop).
+        out, dropped = self._drop(
+            "dcim.interface", {"mode": "access", "tagged_vlans": [101]}, {"tagged_vlans": [102]},
+        )
+        self.assertEqual(out["tagged_vlans"], [102])
+        self.assertEqual(dropped, {})
+
+    def test_non_string_driver_value_fails_open_in_both_phases(self):
+        """A driver value that is not a string is not one we can reason about."""
+        # A malformed payload must not turn into a TypeError on an unhashable rule key.
+        out, dropped = self._drop(
+            "dcim.interface",
+            {"mode": "tagged", "tagged_vlans": [101]},
+            {"mode": {"vid": 5}, "tagged_vlans": [102]},
+        )
+        self.assertEqual(out["tagged_vlans"], [102])
+        self.assertEqual(dropped, {})
+
+    # --- the clear must converge against what NetBox actually stores (N1) -----
+
+    def test_submitted_forbidden_field_is_removed_not_blanked(self):
+        """A dropped field leaves the payload entirely; no blank is invented for it."""
+        out, dropped = self._drop("dcim.interface", {}, {"type": "1000base-t", "rf_role": "ap"})
+        self.assertNotIn("rf_role", out)
+        self.assertEqual(list(dropped), ["rf_role"])
+
+    def test_type_rf_clear_converges_against_the_blank_string_netbox_stores(self):
+        """The type/rf_* clear plans nothing once NetBox has stored '' for the rf fields."""
+        # rf_channel/rf_role are CharFields with null=False: NetBox coerces the submitted
+        # null to ''. Re-injecting None every round diffed '' vs None and emitted a
+        # spurious UPDATE on every ingest cycle forever.
+        payload = {"type": "1000base-t", "rf_role": "ap", "rf_channel": "2.4g-1-2412-22"}
+        stored = {"type": "ieee802.11ac", "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+                  "rf_channel_frequency": 2412, "rf_channel_width": 22}
+        round1, dropped = self._drop("dcim.interface", dict(stored), dict(payload))
+        self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
+        self.assertIsNone(round1["rf_role"])                            # stale value cleared
+        self.assertNotEqual(shallow_compare_dict(stored, round1), {})    # round 1 is a real change
+
+        stored2 = {"type": "1000base-t", "rf_role": "", "rf_channel": "",
+                   "rf_channel_frequency": None, "rf_channel_width": None}
+        round2, dropped2 = self._drop("dcim.interface", dict(stored2), dict(payload))
+        self.assertEqual(sorted(dropped2), ["rf_channel", "rf_role"])    # still reported
+        self.assertNotIn("rf_role", round2)                             # but nothing written
+        self.assertEqual(shallow_compare_dict(stored2, round2), {})      # -> empty plan
+
+    # --- every (driver value, dependent field) pair in the registry -----------
+
+    def _pair_sentinel(self, dependent):
+        """A non-empty submitted value for a dependent field (only truthiness matters)."""
+        return ["x"] if dependent == "tagged_vlans" else "x"
+
+    def _assert_pair_converges(self, object_type, driver_field, driver_value, dependent):
+        """Assert one (driver value, dependent field) pair drops, clears once, then converges."""
+        sentinel = self._pair_sentinel(dependent)
+        submitted = {driver_field: driver_value, dependent: sentinel}
+
+        # 1. a submitted driver value drops the field it forbids, and writes no blank
+        out, dropped = self._drop(object_type, {}, dict(submitted))
+        self.assertNotIn(dependent, out)
+        self.assertIn(dependent, dropped)
+
+        # 2. with no submitted driver value, submitted data survives untouched
+        out, dropped = self._drop(object_type, {}, {dependent: sentinel})
+        self.assertEqual(out[dependent], sentinel)
+        self.assertEqual(dropped, {})
+
+        # 3. a non-empty STORED value is cleared exactly once...
+        stored = {driver_field: driver_value, dependent: sentinel}
+        round1, _ = self._drop(object_type, dict(stored), dict(submitted))
+        self.assertNotEqual(shallow_compare_dict(stored, round1), {})
+
+        # ...and whichever empty representation NetBox then stores, the next round
+        # plans nothing at all for the field.
+        for netbox_stored in ("", None, [], (), {}):
+            with self.subTest(netbox_stored=netbox_stored):
+                stored2 = {driver_field: driver_value, dependent: netbox_stored}
+                round2, _ = self._drop(object_type, dict(stored2), dict(submitted))
+                self.assertNotIn(dependent, round2)
+                self.assertEqual(shallow_compare_dict(stored2, round2), {})
+
+    def test_every_registered_driver_value_dependent_pair_converges(self):
+        """Every (driver value, dependent field) pair in every rule map converges."""
+        # Exhaustive over the registry, including all ~100 non-wireless interface types
+        # in _INTERFACE_TYPE_RF_RULES, so a new rule cannot be added without meeting it.
+        pairs = 0
+        for object_type, rules in _DRIVER_FIELD_RULES.items():
+            for driver_field, value_map in rules.items():
+                for driver_value, dependents in value_map.items():
+                    for dependent in dependents:
+                        with self.subTest(object_type=object_type, driver_field=driver_field,
+                                          driver_value=driver_value, dependent=dependent):
+                            self._assert_pair_converges(
+                                object_type, driver_field, driver_value, dependent,
+                            )
+                        pairs += 1
+        self.assertGreater(pairs, 100)  # the map is generated; guard against an empty sweep
+
+
 class InterfaceModeClearE2ETests(APITestCase):
     """End-to-end: seed an existing interface, ingest a mode change, assert clear."""
 
@@ -262,6 +407,58 @@ class InterfaceModeClearE2ETests(APITestCase):
         cs = r1.json().get("change_set", {})
         r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
         return r1, r2
+
+    def _plan(self, payload):
+        """Generate a diff for a payload and return its change set."""
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs):
+        """Apply a change set and assert it landed without errors."""
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"), r.content)
+        return r
+
+    def _converge(self, payload, label, max_applies=2, quiet_rounds=4):
+        """
+        Apply a payload until its plan is empty, then assert it stays empty.
+
+        Returns the number of applies it took. An empty plan is the strongest
+        available statement of convergence: the change set carries no changes at
+        all, so re-ingest performs no write and logs no object change.
+        """
+        applies = 0
+        for _ in range(max_applies + 1):
+            cs = self._plan(payload)
+            if not cs.get("changes", []):
+                break
+            self._apply(cs)
+            applies += 1
+        else:
+            self.fail(f"{label} did not converge within {max_applies} applies")
+        self.assertLessEqual(applies, max_applies, f"{label} needed {applies} applies")
+        for quiet in range(1, quiet_rounds + 1):
+            self.assertEqual(
+                self._plan(payload).get("changes", []), [],
+                f"{label} re-planned on quiet round {quiet}",
+            )
+        return applies
+
+    def _iface_payload(self, **fields):
+        """Build a dcim.interface generate-diff payload for this test's device."""
+        entity = {"device": self._device()}
+        entity.update(fields)
+        return {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": entity}}
+
+    def _vm_payload(self, **fields):
+        """Build a virtualization.vminterface generate-diff payload."""
+        entity = {"virtual_machine": {"name": "obs3607-vm",
+                                      "cluster": {"name": "obs3607-cl", "type": {"name": "obs3607-ct"}}}}
+        entity.update(fields)
+        return {"timestamp": 1, "object_type": "virtualization.vminterface",
+                "entity": {"vm_interface": entity}}
 
     def test_tagged_to_access_clears_tagged_vlans_and_is_idempotent(self):
         """E2E: tagged -> access clears tagged_vlans, keeps untagged_vlan, and re-diffs as NOOP."""
@@ -585,3 +782,221 @@ class InterfaceModeClearE2ETests(APITestCase):
         cvlan.refresh_from_db()
         self.assertEqual(cvlan.qinq_role, "svlan")
         self.assertIsNone(cvlan.qinq_svlan)
+
+    # --- N1: the type/rf_* clear converges instead of writing every cycle -----
+
+    def test_type_change_rf_clear_converges_and_stops_writing(self):
+        """A non-wireless type reported with rf_* fields clears once, then plans nothing."""
+        # An interface exists as ieee802.11ac with rf_role/rf_channel set; the producer
+        # now reports it as 1000base-t while STILL reporting the rf fields. Round 1 must
+        # clear the stale values; every round after it must plan nothing. Blanking the
+        # submitted value instead of dropping it made rounds 2+ diff the injected None
+        # against the "" NetBox stores and emit a spurious UPDATE forever.
+        _, a1 = self._diff_apply({
+            "name": "Wl1", "type": "ieee802.11ac", "device": self._device(),
+            "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+        })
+        self.assertEqual(a1.status_code, 200)
+        iface = Interface.objects.get(name="Wl1")
+        self.assertEqual(iface.rf_role, "ap")
+        self.assertIsNotNone(iface.rf_channel_frequency)  # derived by Interface.save()
+
+        payload = self._iface_payload(
+            name="Wl1", type="1000base-t", rf_role="ap", rf_channel="2.4g-1-2412-22",
+        )
+        cs = self._plan(payload)
+        self.assertTrue([c for c in cs["changes"] if c["object_type"] == "dcim.interface"])
+        self.assertEqual(
+            sorted(cs.get("warnings", {}).get("dcim.interface", {})), ["rf_channel", "rf_role"],
+        )
+        self._apply(cs)
+        iface.refresh_from_db()
+        self.assertEqual(iface.type, "1000base-t")
+        self.assertEqual(iface.rf_role, "")        # what NetBox stores for these CharFields
+        self.assertEqual(iface.rf_channel, "")
+        self.assertIsNone(iface.rf_channel_frequency)
+        self.assertIsNone(iface.rf_channel_width)
+        last_updated = iface.last_updated
+
+        for quiet in range(1, 6):
+            cs = self._plan(payload)
+            self.assertEqual(cs.get("changes", []), [], f"re-planned on quiet round {quiet}")
+            # still reported by the producer, still dropped, never written again
+            self.assertEqual(
+                sorted(cs.get("warnings", {}).get("dcim.interface", {})),
+                ["rf_channel", "rf_role"],
+            )
+        iface.refresh_from_db()
+        self.assertEqual(iface.last_updated, last_updated)  # no write after round 1
+
+    # --- N3: a create that omits the driver field keeps its data --------------
+
+    def test_vminterface_create_without_mode_keeps_the_vlans_netbox_stores(self):
+        """A vminterface create omitting mode keeps its tagged VLANs, exactly as NetBox does."""
+        # NetBox nulls untagged_vlan itself in BaseInterface.save() but KEEPS tagged_vlans
+        # on a create (_state.adding is True), and the vminterface serializer validates
+        # neither. Nothing may be dropped here: no mode was submitted, so no driver value
+        # won anything, and the payload contradicted nothing.
+        payload = self._vm_payload(
+            name="vmeth0",
+            untagged_vlan={"vid": 3601, "name": "v3601"},
+            tagged_vlans=[{"vid": 3602, "name": "v3602"}],
+        )
+        cs = self._plan(payload)
+        self.assertNotIn("virtualization.vminterface", cs.get("warnings", {}))
+        self._apply(cs)
+
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth0")
+        self.assertFalse(vmi.mode)
+        self.assertIsNone(vmi.untagged_vlan)                                # NetBox's own save()
+        self.assertEqual([v.vid for v in vmi.tagged_vlans.all()], [3602])   # kept, not dropped
+
+    def test_modeless_untagged_vlan_replans_exactly_as_on_develop(self):
+        """A mode-less interface still reporting an untagged VLAN re-plans, as on develop."""
+        # Documented residual, NOT introduced by the driver-field policy: NetBox nulls
+        # untagged_vlan on EVERY save of a mode-less interface, so a producer that keeps
+        # reporting one keeps planning an update. Closing it would mean dropping submitted
+        # data with no submitted driver value to justify it, which is exactly the loss this
+        # scoping exists to prevent, so develop's behaviour is kept and pinned here.
+        payload = self._vm_payload(name="vmeth1", untagged_vlan={"vid": 3611, "name": "v3611"})
+        self._apply(self._plan(payload))
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth1")
+        self.assertIsNone(vmi.untagged_vlan)
+        vm_changes = [c for c in self._plan(payload).get("changes", [])
+                      if c["object_type"] == "virtualization.vminterface"]
+        self.assertTrue(vm_changes)  # re-plans; the policy deliberately does not silence it
+
+    # --- N2: a dropped match criterion must be dropped BEFORE matching --------
+
+    def test_vlan_qinq_role_create_applies_and_converges(self):
+        """A VLAN naming a service role with an svlan applies once, then plans nothing."""
+        # qinq_svlan is an ipam.vlan MATCH criterion (unique_qinq_svlan_vid, and the
+        # "qinq_svlan IS NULL" condition on the logical vid criteria). Dropping it after
+        # the existing-object lookup left the entity unmatchable, so it re-planned a
+        # CREATE and duplicated the row on every ingest. The policy runs before matching.
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 3971, "name": "n2-cvlan", "qinq_role": "svlan",
+            "qinq_svlan": {"vid": 3970, "name": "n2-svlan"},
+        }}}
+        cs = self._plan(payload)
+        self.assertIn("qinq_svlan", cs.get("warnings", {}).get("ipam.vlan", {}))
+        for change in cs["changes"]:
+            self.assertNotIn("qinq_svlan", change.get("data", {}))
+            self.assertNotIn("qinq_svlan", change.get("new_refs", []))
+        self._apply(cs)
+
+        from ipam.models import VLAN
+        vlan = VLAN.objects.get(vid=3971)
+        self.assertEqual(vlan.qinq_role, "svlan")
+        self.assertIsNone(vlan.qinq_svlan)
+
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+        self.assertEqual(VLAN.objects.filter(vid=3971).count(), 1)  # no duplicate rows
+
+    def test_vlan_customer_role_keeps_its_service_vlan_and_converges(self):
+        """qinq_role 'cvlan' permits qinq_svlan: it is kept, applied and converges."""
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 3973, "name": "n2-cust", "qinq_role": "cvlan",
+            "qinq_svlan": {"vid": 3972, "name": "n2-svc"},
+        }}}
+        cs = self._plan(payload)
+        self.assertNotIn("ipam.vlan", cs.get("warnings", {}))
+        self._apply(cs)
+        from ipam.models import VLAN
+        vlan = VLAN.objects.get(vid=3973)
+        self.assertEqual(vlan.qinq_svlan.vid, 3972)   # allowed -> kept verbatim
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- the whole mode rule map, end to end, over four quiet rounds ----------
+
+    def test_interface_mode_matrix_applies_and_converges(self):
+        """Every mode in the rule map applies with all three VLAN fields submitted, then converges."""
+        modes = list(_DRIVER_FIELD_RULES["dcim.interface"]["mode"])
+        self.assertEqual(len(modes), 5)
+        for i, mode in enumerate(modes):
+            with self.subTest(mode=mode):
+                payload = self._iface_payload(
+                    name=f"EthM{i}", type="1000base-t", mode=mode,
+                    untagged_vlan={"vid": 3700 + i, "name": f"u{i}"},
+                    tagged_vlans=[{"vid": 3710 + i, "name": f"t{i}"}],
+                    qinq_svlan={"vid": 3720 + i, "name": f"s{i}"},
+                )
+                self._converge(payload, f"dcim.interface mode {mode!r}")
+                iface = Interface.objects.get(name=f"EthM{i}")
+                forbidden = _DRIVER_FIELD_RULES["dcim.interface"]["mode"][mode]
+                if "tagged_vlans" in forbidden:
+                    self.assertEqual(iface.tagged_vlans.count(), 0)
+                else:
+                    self.assertEqual([v.vid for v in iface.tagged_vlans.all()], [3710 + i])
+                if "untagged_vlan" in forbidden:
+                    self.assertIsNone(iface.untagged_vlan)
+                else:
+                    self.assertEqual(iface.untagged_vlan.vid, 3700 + i)
+                if "qinq_svlan" in forbidden:
+                    self.assertIsNone(iface.qinq_svlan)
+                else:
+                    self.assertEqual(iface.qinq_svlan.vid, 3720 + i)
+
+    def test_vminterface_mode_matrix_applies_and_converges(self):
+        """Every mode in the rule map converges for vminterface too, where no serializer polices it."""
+        modes = list(_DRIVER_FIELD_RULES["virtualization.vminterface"]["mode"])
+        for i, mode in enumerate(modes):
+            with self.subTest(mode=mode):
+                payload = self._vm_payload(
+                    name=f"vmethM{i}", mode=mode,
+                    untagged_vlan={"vid": 3730 + i, "name": f"vu{i}"},
+                    tagged_vlans=[{"vid": 3740 + i, "name": f"vt{i}"}],
+                    qinq_svlan={"vid": 3750 + i, "name": f"vs{i}"},
+                )
+                self._converge(payload, f"virtualization.vminterface mode {mode!r}")
+                from virtualization.models import VMInterface
+                vmi = VMInterface.objects.get(name=f"vmethM{i}")
+                forbidden = _DRIVER_FIELD_RULES["virtualization.vminterface"]["mode"][mode]
+                if "tagged_vlans" in forbidden:
+                    self.assertEqual(vmi.tagged_vlans.count(), 0)
+                if "qinq_svlan" in forbidden:
+                    self.assertIsNone(vmi.qinq_svlan)
+
+    def test_interface_type_rf_matrix_applies_and_converges(self):
+        """Representative non-wireless types with all four rf_* fields submitted converge."""
+        # The type rule map is generated as the complement of the wireless allow-set, so
+        # every non-wireless value shares one code path; the exhaustive sweep over all of
+        # them is the unit test above. These are the shapes a producer actually sends.
+        for i, iface_type in enumerate(("1000base-t", "virtual", "lag")):
+            with self.subTest(type=iface_type):
+                payload = self._iface_payload(
+                    name=f"EthT{i}", type=iface_type, rf_role="ap",
+                    rf_channel="2.4g-1-2412-22", rf_channel_frequency=2412, rf_channel_width=22,
+                )
+                self._converge(payload, f"dcim.interface type {iface_type!r}")
+                iface = Interface.objects.get(name=f"EthT{i}")
+                self.assertEqual(iface.type, iface_type)
+                # Measured: a field the payload never carries lands as NULL, while a
+                # field submitted as null lands as '' (see the update case above) — the
+                # SAME CharField, two empty representations. No single blank a planner
+                # could write matches both, which is why the drop removes the field.
+                self.assertFalse(iface.rf_role)
+                self.assertFalse(iface.rf_channel)
+                self.assertIsNone(iface.rf_channel_frequency)
+                self.assertIsNone(iface.rf_channel_width)
+
+    def test_wireless_type_keeps_all_four_rf_fields_and_converges(self):
+        """A wireless type permits the rf fields: they are kept, applied and converge."""
+        payload = self._iface_payload(
+            name="EthW", type="ieee802.11ac", rf_role="ap", rf_channel="2.4g-1-2412-22",
+        )
+        cs = self._plan(payload)
+        self.assertNotIn("dcim.interface", cs.get("warnings", {}))
+        self._apply(cs)
+        iface = Interface.objects.get(name="EthW")
+        self.assertEqual(iface.rf_role, "ap")
+        self.assertEqual(iface.rf_channel, "2.4g-1-2412-22")
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_interface_mode_vlan_reconcile.py
@@ -9,7 +9,11 @@ from utilities.testing import APITestCase
 
 from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
 from netbox_diode_plugin.api.differ import normalize_changeset
-from netbox_diode_plugin.api.field_policy import _DRIVER_FIELD_RULES, submitted_driver_field_drops
+from netbox_diode_plugin.api.field_policy import (
+    _DRIVER_FIELD_RULES,
+    match_participating_fields,
+    submitted_driver_field_drops,
+)
 from netbox_diode_plugin.plugin_config import get_diode_user
 
 
@@ -176,12 +180,30 @@ class NormalizeChangesetTests(SimpleTestCase):
         self.assertEqual(out["rf_channel"], "2.4g-1-2412-22")
         self.assertEqual(dropped, {})
 
-    def test_shared_policy_applies_to_vlan_qinq_role(self):
-        """The reversed policy is registry-wide: ipam.vlan "qinq_role" behaves the same."""
+    def test_a_match_participating_field_is_never_dropped(self):
+        """ipam.vlan qinq_svlan is a match criterion, so the policy leaves it alone."""
+        # The reversal is NOT registry-wide. qinq_svlan is read by four ipam.vlan
+        # matchers, so dropping it changes which row the payload identifies: measured,
+        # it adopted and renamed an unrelated VLAN sharing the vid, or inserted a
+        # duplicate and converged onto it. NetBox's own 400 stands instead.
+        self.assertIn("qinq_svlan", match_participating_fields("ipam.vlan"))
         entity = {"qinq_role": "svlan", "qinq_svlan": 7}
         out, dropped = self._drop("ipam.vlan", {}, entity)
-        self.assertNotIn("qinq_svlan", out)
-        self.assertEqual(list(dropped), ["qinq_svlan"])
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+
+    def test_the_interface_policy_fields_are_not_match_criteria(self):
+        """The fields the policy does drop are not how any matcher identifies a row."""
+        # This is what makes the motivating cases safe to drop, and it is asserted
+        # rather than assumed: if a future matcher starts reading one of them, the
+        # gate above will silently start exempting it and this test says so first.
+        for object_type in ("dcim.interface", "virtualization.vminterface"):
+            matched = match_participating_fields(object_type)
+            for value_map in _DRIVER_FIELD_RULES[object_type].values():
+                for dependents in value_map.values():
+                    for dependent in dependents:
+                        with self.subTest(object_type=object_type, dependent=dependent):
+                            self.assertNotIn(dependent, matched)
 
     def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
         """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
@@ -329,6 +351,20 @@ class NormalizeChangesetTests(SimpleTestCase):
         """Assert one (driver value, dependent field) pair drops, clears once, then converges."""
         sentinel = self._pair_sentinel(dependent)
         submitted = {driver_field: driver_value, dependent: sentinel}
+
+        if dependent in match_participating_fields(object_type):
+            # Exempt: the field identifies the row, so phase 1 must not touch it and
+            # there is nothing for us to converge -- NetBox rejects the payload, which
+            # is develop's behaviour and the safe one. Phase 2 must still clear a stale
+            # STORED value the payload no longer carries.
+            out, dropped = self._drop(object_type, {}, dict(submitted))
+            self.assertEqual(out[dependent], sentinel)
+            self.assertEqual(dropped, {})
+            stored = {driver_field: driver_value, dependent: sentinel}
+            cleared, _ = self._drop(object_type, dict(stored), {driver_field: driver_value})
+            self.assertIn(dependent, cleared)
+            self.assertFalse(cleared[dependent])
+            return
 
         # 1. a submitted driver value drops the field it forbids, and writes no blank
         out, dropped = self._drop(object_type, {}, dict(submitted))
@@ -870,32 +906,34 @@ class InterfaceModeClearE2ETests(APITestCase):
 
     # --- N2: a dropped match criterion must be dropped BEFORE matching --------
 
-    def test_vlan_qinq_role_create_applies_and_converges(self):
-        """A VLAN naming a service role with an svlan applies once, then plans nothing."""
-        # qinq_svlan is an ipam.vlan MATCH criterion (unique_qinq_svlan_vid, and the
-        # "qinq_svlan IS NULL" condition on the logical vid criteria). Dropping it after
-        # the existing-object lookup left the entity unmatchable, so it re-planned a
-        # CREATE and duplicated the row on every ingest. The policy runs before matching.
+    def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
+        """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""
+        # The regression this pins: dropping qinq_svlan before matching made the entity
+        # satisfy logical_vlan_vid_no_group_or_svlan_or_site ("vid where group IS NULL
+        # AND qinq_svlan IS NULL AND site IS NULL"), i.e. vid alone -- so it adopted
+        # whatever VLAN held that vid and renamed it. Measured: a seeded VLAN was
+        # silently renamed and re-roled where develop wrote nothing at all.
+        from ipam.models import VLAN
+        seeded = VLAN.objects.create(
+            vid=4091, name="lq-someone-elses-vlan", description="OWNED BY ANOTHER SOURCE",
+        )
         payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
-            "vid": 3971, "name": "n2-cvlan", "qinq_role": "svlan",
-            "qinq_svlan": {"vid": 3970, "name": "n2-svlan"},
+            "vid": 4091, "name": "lq-brand-new-svlan", "qinq_role": "svlan",
+            "qinq_svlan": {"vid": 4090, "name": "lq-parent"},
         }}}
         cs = self._plan(payload)
-        self.assertIn("qinq_svlan", cs.get("warnings", {}).get("ipam.vlan", {}))
-        for change in cs["changes"]:
-            self.assertNotIn("qinq_svlan", change.get("data", {}))
-            self.assertNotIn("qinq_svlan", change.get("new_refs", []))
-        self._apply(cs)
+        # nothing is dropped and nothing is warned about: the field identifies the row
+        self.assertNotIn("ipam.vlan", cs.get("warnings", {}))
 
-        from ipam.models import VLAN
-        vlan = VLAN.objects.get(vid=3971)
-        self.assertEqual(vlan.qinq_role, "svlan")
-        self.assertIsNone(vlan.qinq_svlan)
+        # NetBox rejects the contradiction, which is exactly develop's answer
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertNotEqual(r.status_code, 200, r.content)
 
-        for quiet in range(1, 5):
-            self.assertEqual(self._plan(payload).get("changes", []), [],
-                             f"re-planned on quiet round {quiet}")
-        self.assertEqual(VLAN.objects.filter(vid=3971).count(), 1)  # no duplicate rows
+        seeded.refresh_from_db()
+        self.assertEqual(seeded.name, "lq-someone-elses-vlan")
+        self.assertEqual(seeded.description, "OWNED BY ANOTHER SOURCE")
+        self.assertFalse(seeded.qinq_role)  # '' or None; both mean 'not a Q-in-Q VLAN'
+        self.assertEqual(VLAN.objects.filter(vid=4091).count(), 1)  # and no duplicate
 
     def test_vlan_customer_role_keeps_its_service_vlan_and_converges(self):
         """qinq_role 'cvlan' permits qinq_svlan: it is kept, applied and converges."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_updates_cases.json
@@ -2175,7 +2175,10 @@
         "lookup": {"name": "WirelessGigabitEthernet1/0/1"},
         "create_expect": {
             "name": "WirelessGigabitEthernet1/0/1",
-            "label": "Core Link 1"
+            "label": "Core Link 1",
+            "mode": "access",
+            "untagged_vlan.vid": 900,
+            "tagged_vlans.all": []
         },
         "create": {
             "interface": {
@@ -2305,6 +2308,10 @@
                         "status": "active",
                         "description": "Primary VDC"
                     }
+                ],
+                "tagged_vlans": [
+                    {"vid": 101, "name": "Voice VLAN", "status": "active"},
+                    {"vid": 102, "name": "Data VLAN", "status": "active"}
                 ]
             }    
         },
@@ -2436,11 +2443,18 @@
                         "status": "active",
                         "description": "Primary VDC"
                     }
+                ],
+                "tagged_vlans": [
+                    {"vid": 101, "name": "Voice VLAN", "status": "active"},
+                    {"vid": 102, "name": "Data VLAN", "status": "active"}
                 ]
             }    
         },
         "update_expect": {
-            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"]
+            "tags.all.__by_name": ["Tag 1", "Tag 2", "Tag 3"],
+            "mode": "access",
+            "untagged_vlan.vid": 900,
+            "tagged_vlans.all": []
         }
     },
     {


### PR DESCRIPTION
## The failure

A `dcim.interface` payload naming `mode: "access"` **and** `tagged_vlans` is
self-contradictory, and NetBox rejects the whole entity rather than the surplus field:
`400 {"tagged_vlans": ["Interface mode does not support tagged vlans"]}`
(`dcim/api/serializers_/device_components.py:315`). Found ingesting a 94-entity corpus:
`WirelessGigabitEthernet1/0/1`, mode `access`, type `other-wireless`, with
`untagged_vlan`, `tagged_vlans` and a `vlan_translation_policy`. On develop it 400s on all
six ingest rounds and the row never exists.

## The policy

**A driver value the producer SUBMITTED wins over the dependent fields it forbids** — on
creates too, and even when the producer submitted the forbidden field explicitly. The rule
registry is unchanged (`dcim.interface` mode and type, `virtualization.vminterface` mode,
`ipam.vlan` qinq_role) and moves to a new `api/field_policy.py`, shared by two phases:

- **Phase 1** — transformer, before any fingerprinting: a submitted driver value forbids a
  submitted field → the field is **removed**, and the removal reported through the change
  set's existing `warnings` key.
- **Phase 2** — differ, after matching: develop's stale clear, unchanged (it clears a
  non-empty **stored** value the driver value forbids). `differ.py` is otherwise
  byte-identical to develop.

Three scoping decisions, each measured:

1. **The driver field must be explicitly present.** With no submitted driver value there is
   nothing to win. A `vminterface` create that omits `mode` keeps `tagged_vlans=[602]` —
   what develop stores, because `BaseInterface.save()` nulls `untagged_vlan` but keeps
   tagged VLANs while `_state.adding`.
2. **Removed, not blanked.** Measured: `rf_role` stores `''` when submitted as null but
   `NULL` when absent — one column, two empty values, so no blank matches both and a
   mismatch re-diffs forever. Deleting the key leaves clearing to phase 2's stored-value
   guard, which converges.
3. **Never drop a field a matcher reads.** This is the invariant, not a per-type
   exception, and it is the one that took three attempts to get right. A matcher is how the
   plugin decides *which row* a payload means, so removing a field it reads changes what
   gets matched, not just what gets written. Measured on `ipam.vlan.qinq_svlan`, which four
   matchers read (`unique_qinq_svlan_vid` and `..._name` via their fields;
   `logical_vlan_vid_no_group_or_svlan_or_site` and `logical_vlan_in_site` via a
   `qinq_svlan IS NULL` condition): dropping it **before** the lookup made a contradictory
   payload satisfy the vid-only criterion, so it adopted and renamed a pre-existing VLAN
   that merely shared the vid — where develop wrote nothing — or inserted a duplicate and
   converged onto it, which no re-ingest check can see. Dropping it **after** the lookup
   left the entity unmatchable and re-planned a CREATE forever. Neither placement is safe,
   because the problem is that an identity field is dropped at all. So a match-participating
   field is never dropped and NetBox's own error stands.

   `dcim.interface` and `virtualization.vminterface` cost nothing: no matcher reads `mode`,
   `type`, `tagged_vlans`, `untagged_vlan`, `qinq_svlan` or the rf fields on either — they
   match on device/VM plus name. That zero is asserted rather than assumed, so a future
   matcher that starts reading one of them fails a test instead of silently widening the
   exemption.

## What it costs

Submitted data is dropped, visibly: `{"tagged_vlans": ["Dropped: submitted mode 'access'
does not support this field."]}`. One measured payload loses data NetBox would have kept: a
`virtualization.vminterface` **create** whose submitted mode forbids tagged VLANs (develop
stores `[2701]`). That serializer alone does no mode/VLAN validation, and
`BaseInterface.save()` clears them on every later save anyway. Pinned by its own test.

## Convergence, measured on v4.5.5 (six rounds each)

| payload | applies | rounds after |
| --- | --- | --- |
| corpus interface #39, verbatim | 1 (200) | 5 × empty plan |
| `dcim.interface` mode access / tagged / tagged-all / q-in-q | 1 | 5 × empty |
| `dcim.interface` mode `""` | 2 | 4 × empty |
| `dcim.interface` type non-wireless + 4 rf fields, update and create | 1 | 5 × empty |
| `virtualization.vminterface` mode, all 5 values | 1 (`""`: 2) | 5 × empty (4) |
| `ipam.vlan` qinq_role cvlan (permitted, nothing dropped) | 1 | 5 × empty, 1 row |

The extra apply for mode `""` is develop's create path stripping an explicitly empty value.
A unit sweep asserts the same drop / clear-once / then-nothing shape for **every** (driver
value, dependent field) pair in the registry — 786 on v4.5.5.

## Residual, measured identical on develop

- A `vminterface` reporting an `untagged_vlan` with **no** mode re-plans an update every
  round: NetBox nulls that column on every save. Silencing it means dropping data with no
  submitted driver value, which is what (1) exists to prevent.
- An explicitly blank `qinq_role` creates the row, then 400s `This field may not be blank.`
  every round — reproduced on develop with no dependent field involved.
- A driver value that is only **stored** drops nothing: stored mode `access` plus submitted
  `tagged_vlans` still 400s.

## Tests

Byte-identical across the three version directories. Suites green: **v4.4.10 451, v4.5.5
472, v4.6.0 534**, against develop baselines of 422/443/505 measured in the same harness.
Host `ruff` clean. Every behavioural change was reverted individually and named a failing
test; disabling the match-criterion gate alone fails four, including the end-to-end one that
pins a seeded VLAN keeping its name, description and role.

## Why this is worth reviewing carefully

Two earlier shapes of this change passed full suites and were still wrong, both in the same
direction — they converted a loud `400` into a silent success that wrote the wrong thing:

* applying the policy to a submitted field with no submitted driver value dropped VLANs
  NetBox would have stored;
* dropping a match-criterion field retargeted the entity onto an unrelated row.

Both were caught by adversarial verification rather than by the suite, which is why the
scoping decisions above are stated as measurements and why the gate in (3) is asserted by a
test rather than trusted. The motivating payload is also, as far as I could establish, not
one any producer emits today — it was found in a hand-written corpus fixture. The reason to
take the change anyway is (1) and (2): it fixes `access ↔ tagged` transitions and two
`vminterface` idempotency loops that do not converge on develop today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
