### PR TITLE
chore(codeowners): add Paul and Samiur, drop Micah and Luke

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jajeffries @leoparente @ltucker @mfiedorowicz @MicahParks @davidlanouette
+* @jajeffries @leoparente @mfiedorowicz @paulstuart @samiura @davidlanouette


### PR DESCRIPTION
Refreshes `.github/CODEOWNERS`.

```diff
-* @jajeffries @leoparente @ltucker @mfiedorowicz @MicahParks @davidlanouette
+* @jajeffries @leoparente @mfiedorowicz @paulstuart @samiura @davidlanouette
```

**Added:** `@paulstuart` (Paul Stuart), `@samiura` (Samiur Arif)
**Removed:** `@MicahParks` (Micah Parks), `@ltucker` (Luke Tucker)

All four handles were verified against the GitHub API rather than guessed, since a
handle that doesn't resolve makes the whole rule silently inert. Both additions are
already owners on `netboxlabs/orb-agent`, and the ordering follows that file — new
names before `@davidlanouette`, which stays last.

Worth a check from someone who knows the org: CODEOWNERS entries only take effect for
users with write access to this repo, so if either new owner isn't yet a collaborator
here, GitHub will accept the file and quietly skip them on review assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
