### PR TITLE
feat: NetBox 4.7.x support

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       matrix:
         python: [ "3.10" ]

--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Default NetBox version used for coverage reporting
-  DEFAULT_NETBOX_VERSION: "v4.6.0"
+  DEFAULT_NETBOX_VERSION: "v4.6.10"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python: [ "3.10" ]
-        netbox: [ "v4.7.0-beta2", "v4.6.0", "v4.5.5", "v4.4.10" ]
+        netbox: [ "v4.7.0-beta2", "v4.6.10", "v4.5.5", "v4.4.10" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python: [ "3.10" ]
-        netbox: [ "v4.7.0-beta2", "v4.6.10", "v4.5.5", "v4.4.10" ]
+        netbox: [ "v4.7.0", "v4.6.10", "v4.5.5", "v4.4.10" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python: [ "3.10" ]
-        netbox: [ "v4.6.0", "v4.5.5", "v4.4.10" ]
+        netbox: [ "v4.7.0-beta2", "v4.6.0", "v4.5.5", "v4.4.10" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ at [https://netboxlabs.com/blog/introducing-diode-streamlining-data-ingestion-in
 |    >= 4.4.10    |     1.7.0      |
 |    >= 4.5.0     |     1.7.0      |
 |    >= 4.6.0     |     1.12.0     |
+|    >= 4.7.0     |     1.17.0     |
 
 ## Installation
 

--- a/docker/v4.7.x/Dockerfile
+++ b/docker/v4.7.x/Dockerfile
@@ -1,4 +1,4 @@
-ARG NETBOX_VERSION=v4.7.0-beta2
+ARG NETBOX_VERSION=v4.7.0-5.1.0
 FROM netboxcommunity/netbox:${NETBOX_VERSION}
 
 COPY common/netbox/configuration/ /etc/netbox/config/

--- a/docker/v4.7.x/Dockerfile
+++ b/docker/v4.7.x/Dockerfile
@@ -1,0 +1,14 @@
+ARG NETBOX_VERSION=v4.7.0-beta2
+FROM netboxcommunity/netbox:${NETBOX_VERSION}
+
+COPY common/netbox/configuration/ /etc/netbox/config/
+RUN chmod 755 /etc/netbox/config/* && \
+    chown netbox:root /etc/netbox/config/*
+
+COPY common/netbox/local_settings.py /opt/netbox/netbox/netbox/local_settings.py
+RUN chmod 755 /opt/netbox/netbox/netbox/local_settings.py && \
+    chown netbox:root /opt/netbox/netbox/netbox/local_settings.py
+
+COPY v4.7.x/requirements-diode-netbox-plugin.txt /opt/netbox/
+ENV VIRTUAL_ENV=/opt/netbox/venv
+RUN /usr/local/bin/uv pip install -r /opt/netbox/requirements-diode-netbox-plugin.txt

--- a/docker/v4.7.x/docker-compose.override.yaml
+++ b/docker/v4.7.x/docker-compose.override.yaml
@@ -1,0 +1,5 @@
+services:
+  netbox:
+    volumes:
+      - ./netbox/launch-netbox.sh:/opt/netbox/launch-netbox.sh:z,ro
+      - ./netbox/granian.py:/opt/netbox/netbox/netbox/granian.py:z,ro

--- a/docker/v4.7.x/requirements-diode-netbox-plugin.txt
+++ b/docker/v4.7.x/requirements-diode-netbox-plugin.txt
@@ -4,5 +4,5 @@ coverage==7.6.0
 grpcio==1.76.0
 protobuf==5.29.6
 pytest==9.0.3
-netboxlabs-netbox-branching==1.2.0b1
+netboxlabs-netbox-branching==1.2.0
 granian[reload]

--- a/docker/v4.7.x/requirements-diode-netbox-plugin.txt
+++ b/docker/v4.7.x/requirements-diode-netbox-plugin.txt
@@ -1,0 +1,8 @@
+Brotli==1.2.0
+certifi==2024.7.4
+coverage==7.6.0
+grpcio==1.76.0
+protobuf==5.29.6
+pytest==9.0.3
+netboxlabs-netbox-branching==1.2.0b1
+granian[reload]

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -116,5 +116,17 @@ class NetBoxDiodePluginConfig(PluginConfig):
         "apply_deadlock_max_retries": 2,
     }
 
+    def ready(self):
+        """Connect the service-user permission provisioning to post_migrate."""
+        super().ready()
+        from django.db.models.signals import post_migrate
+
+        from .provisioning import provision_diode_permissions
+        post_migrate.connect(
+            provision_diode_permissions,
+            sender=self,
+            dispatch_uid="netbox_diode_plugin.provision_diode_permissions",
+        )
+
 
 config = NetBoxDiodePluginConfig

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -117,15 +117,34 @@ class NetBoxDiodePluginConfig(PluginConfig):
     }
 
     def ready(self):
-        """Connect the service-user permission provisioning to post_migrate."""
+        """Connect the service-user permission provisioning signals."""
         super().ready()
-        from django.db.models.signals import post_migrate
+        from django.contrib.contenttypes.models import ContentType
+        from django.db.models.signals import post_migrate, post_save
 
-        from .provisioning import provision_diode_permissions
+        from .provisioning import (
+            extend_view_permission_for_new_type,
+            provision_diode_permissions,
+        )
         post_migrate.connect(
             provision_diode_permissions,
             sender=self,
             dispatch_uid="netbox_diode_plugin.provision_diode_permissions",
+        )
+        # ContentType rows (and thus ObjectTypes) are created lazily on
+        # first reference; keep the view grant complete as they appear.
+        # ObjectType is a proxy of ContentType and Django signals fire with
+        # the class the save went through, so connect both senders.
+        from core.models import ObjectType
+        post_save.connect(
+            extend_view_permission_for_new_type,
+            sender=ContentType,
+            dispatch_uid="netbox_diode_plugin.extend_view_permission_ct",
+        )
+        post_save.connect(
+            extend_view_permission_for_new_type,
+            sender=ObjectType,
+            dispatch_uid="netbox_diode_plugin.extend_view_permission_ot",
         )
 
 

--- a/netbox_diode_plugin/__init__.py
+++ b/netbox_diode_plugin/__init__.py
@@ -16,7 +16,7 @@ class NetBoxDiodePluginConfig(PluginConfig):
     version = version_semver()
     base_url = "diode"
     min_version = "4.4.10"
-    max_version = "4.6.99"
+    max_version = "4.7.99"
     middleware = [
         "netbox_diode_plugin.api.profile.DiodeProfileMiddleware",
     ]

--- a/netbox_diode_plugin/api/compat.py
+++ b/netbox_diode_plugin/api/compat.py
@@ -104,7 +104,8 @@ def _migrate_contact_group_down(data: dict):
 
 @diode_migration(min_version="4.7.0-beta1", max_version=None, object_type="ipam.service")
 def _migrate_service_port_mappings(data: dict):
-    """Synthesizes port_mappings from legacy protocol/ports.
+    """
+    Synthesizes port_mappings from legacy protocol/ports.
 
     NetBox 4.7 replaced Service.protocol/ports with the unified
     port_mappings field ("tcp/80"-style strings); the legacy fields are

--- a/netbox_diode_plugin/api/compat.py
+++ b/netbox_diode_plugin/api/compat.py
@@ -101,3 +101,19 @@ def _migrate_contact_group_down(data: dict):
     groups = data.pop("groups", None)
     if groups and len(groups) == 1:
         data["group"] = groups[0]
+
+@diode_migration(min_version="4.7.0-beta1", max_version=None, object_type="ipam.service")
+def _migrate_service_port_mappings(data: dict):
+    """Synthesizes port_mappings from legacy protocol/ports.
+
+    NetBox 4.7 replaced Service.protocol/ports with the unified
+    port_mappings field ("tcp/80"-style strings); the legacy fields are
+    no longer model-backed, so a payload carrying only them would fail
+    with "At least one port mapping is required".
+    """
+    protocol = data.pop("protocol", None)
+    ports = data.pop("ports", None)
+    if data.get("port_mappings"):
+        return  # producer already speaks port_mappings
+    if protocol and ports:
+        data["port_mappings"] = [f"{protocol}/{port}" for port in ports]

--- a/netbox_diode_plugin/api/compat.py
+++ b/netbox_diode_plugin/api/compat.py
@@ -118,3 +118,27 @@ def _migrate_service_port_mappings(data: dict):
         return  # producer already speaks port_mappings
     if protocol and ports:
         data["port_mappings"] = [f"{protocol}/{port}" for port in ports]
+
+def _flat_mac_to_primary_mac_address(data: dict):
+    """
+    Rewrites the flat mac_address value into the modeled primary MAC form.
+
+    NetBox 4.7 added mac_address as a writable serializer shortcut with no
+    backing model column, so it cannot pass the plugin's diffable-field
+    gate. The plugin has always modeled this as a nested MACAddress via
+    primary_mac_address, which diffs and applies cleanly on every
+    supported NetBox version - so translate rather than reject.
+    """
+    mac = data.pop("mac_address", None)
+    if mac and data.get("primary_mac_address") is None:
+        data["primary_mac_address"] = {"mac_address": mac}
+
+@diode_migration(min_version="4.2.0", max_version=None, object_type="dcim.interface")
+def _migrate_interface_mac_address(data: dict):
+    """Translates dcim.interface's flat mac_address shortcut."""
+    _flat_mac_to_primary_mac_address(data)
+
+@diode_migration(min_version="4.2.0", max_version=None, object_type="virtualization.vminterface")
+def _migrate_vminterface_mac_address(data: dict):
+    """Translates virtualization.vminterface's flat mac_address shortcut."""
+    _flat_mac_to_primary_mac_address(data)

--- a/netbox_diode_plugin/api/counter_buffer.py
+++ b/netbox_diode_plugin/api/counter_buffer.py
@@ -63,11 +63,20 @@ _previous_update_counter = counters.update_counter
 
 
 @wraps(_previous_update_counter)
-def _buffered_update_counter(model, pk, counter_name, value):
-    """Record the delta while a buffer is active; otherwise delegate upstream."""
+def _buffered_update_counter(model, pk, counter_name, value, using=None, **kwargs):
+    """Record the delta while a buffer is active; otherwise delegate upstream.
+
+    NetBox 4.7 passes ``using`` through the counter signal handlers; older
+    versions do not accept it, so it is forwarded only when set. A delta
+    bound for a non-default database is never buffered - the flush writes
+    via the default alias, so buffering it would apply the delta to the
+    wrong database.
+    """
+    if using is not None:
+        kwargs["using"] = using
     buffer = _apply_counter_buffer.get()
-    if buffer is None:
-        return _previous_update_counter(model, pk, counter_name, value)
+    if buffer is None or using not in (None, "default"):
+        return _previous_update_counter(model, pk, counter_name, value, **kwargs)
 
     # Bypass wins: no update, and nothing buffered to apply later either.
     if _bypass_active.get():

--- a/netbox_diode_plugin/api/counter_buffer.py
+++ b/netbox_diode_plugin/api/counter_buffer.py
@@ -64,7 +64,8 @@ _previous_update_counter = counters.update_counter
 
 @wraps(_previous_update_counter)
 def _buffered_update_counter(model, pk, counter_name, value, using=None, **kwargs):
-    """Record the delta while a buffer is active; otherwise delegate upstream.
+    """
+    Record the delta while a buffer is active; otherwise delegate upstream.
 
     NetBox 4.7 passes ``using`` through the counter signal handlers; older
     versions do not accept it, so it is forwarded only when set. A delta

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -1186,15 +1186,28 @@ class ObjectMatchCriteria:
     model_class: type[models.Model] | None = None
     name: str | None = None
 
+    # True for constraints declared with nulls_distinct=False (NetBox 4.7
+    # collapses e.g. Device's tenant-null partial constraint into one such
+    # constraint): NULL participates in uniqueness, so an absent/None field
+    # matches via IS NULL instead of disqualifying the matcher.
+    nulls_not_distinct: bool = False
+
     min_version: str | None = None
     max_version: str | None = None
 
     def __hash__(self):
         """Hash the object match criteria."""
-        return hash((self.fields, self.expressions, self.condition, self.model_class.__name__, self.name))
+        return hash((
+            self.fields, self.expressions, self.condition,
+            self.model_class.__name__, self.name, self.nulls_not_distinct,
+        ))
 
     def has_required_fields(self, data) -> bool:
         """Returns True if the data given contains a value for all fields referenced by the constraint."""
+        if self.nulls_not_distinct:
+            # absent fields are treated as NULL, which is a matchable value;
+            # the all-None guards below still refuse fully-null lookups.
+            return True
         return all(field in data for field in self._get_refs())
 
     @cache
@@ -1248,7 +1261,7 @@ class ObjectMatchCriteria:
         insensitive = self._get_insensitive_refs()
         values = []
         for field in sorted_fields:
-            value = data[field]
+            value = data.get(field) if self.nulls_not_distinct else data[field]
             if isinstance(value, dict):
                 logger.warning(f"unexpected value type for fingerprinting: {value}")
                 return None
@@ -1323,6 +1336,10 @@ class ObjectMatchCriteria:
         for field_name in self.fields:
             field = self.model_class._meta.get_field(field_name)
             if field_name not in data:
+                if self.nulls_not_distinct:
+                    # absent field participates as NULL (IS NULL lookup)
+                    lookup_kwargs[field.name] = None
+                    continue
                 return None  # cannot match, missing field data
             lookup_value = data.get(field_name)
             if isinstance(lookup_value, UnresolvedReference):
@@ -1344,6 +1361,10 @@ class ObjectMatchCriteria:
         if refs and all(data.get(r) is None for r in refs):
             return None
 
+        if self.nulls_not_distinct:
+            # absent fields participate as NULL under nulls_distinct=False
+            data = {**dict.fromkeys(refs), **data}
+
         data = self._prepare_data(data)
 
         replacements = {
@@ -1356,7 +1377,17 @@ class ObjectMatchCriteria:
             if hasattr(expr, "get_expression_for_validation"):
                 expr = expr.get_expression_for_validation()
 
-            refs = [F(ref) for ref in _get_refs(expr)]
+            expr_refs = _get_refs(expr)
+            if self.nulls_not_distinct and any(data.get(r) is None for r in expr_refs):
+                # NULL participates in uniqueness: match via IS NULL. Only
+                # expressible for a plain single-field reference; a composite
+                # expression over a NULL value cannot be matched.
+                if len(expr_refs) == 1:
+                    filters.append(Q(**{f"{next(iter(expr_refs))}__isnull": True}))
+                    continue
+                return None
+
+            refs = [F(ref) for ref in expr_refs]
             for ref in refs:
                 if ref not in replacements:
                     return None  # cannot match, missing field data
@@ -1941,7 +1972,12 @@ def _get_custom_field_matchers(model_class) -> tuple:
     """Get matchers for unique custom fields (cached)."""
     if not hasattr(model_class, "get_custom_fields"):
         return ()
-    unique_custom_fields = CustomField.objects.get_for_model(model_class).filter(unique=True)
+    # NetBox 4.7 changed CustomField.objects.get_for_model() to return a
+    # materialized list rather than a QuerySet, so filter by iteration
+    # (works on both).
+    unique_custom_fields = [
+        cf for cf in CustomField.objects.get_for_model(model_class) if cf.unique
+    ]
     if not unique_custom_fields:
         return ()
     return tuple(
@@ -2019,6 +2055,7 @@ def _get_model_matchers(model_class) -> list[ObjectMatchCriteria]:
                     fields=tuple(constraint.fields),
                     condition=constraint.condition,
                     name=constraint.name,
+                    nulls_not_distinct=constraint.nulls_distinct is False,
                 )
             )
         elif len(constraint.expressions) > 0:
@@ -2028,6 +2065,7 @@ def _get_model_matchers(model_class) -> list[ObjectMatchCriteria]:
                     expressions=tuple(constraint.expressions),
                     condition=constraint.condition,
                     name=constraint.name,
+                    nulls_not_distinct=constraint.nulls_distinct is False,
                 )
             )
         else:

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -1377,31 +1377,35 @@ class ObjectMatchCriteria:
             if hasattr(expr, "get_expression_for_validation"):
                 expr = expr.get_expression_for_validation()
 
-            expr_refs = _get_refs(expr)
-            if self.nulls_not_distinct and any(data.get(r) is None for r in expr_refs):
-                # NULL participates in uniqueness: match via IS NULL. Only
-                # expressible for a plain single-field reference; a composite
-                # expression over a NULL value cannot be matched.
-                if len(expr_refs) == 1:
-                    filters.append(Q(**{f"{next(iter(expr_refs))}__isnull": True}))
-                    continue
-                return None
-
-            refs = [F(ref) for ref in expr_refs]
-            for ref in refs:
-                if ref not in replacements:
-                    return None  # cannot match, missing field data
-                if isinstance(replacements[ref], UnresolvedReference):
-                    return None  # cannot match, missing field data
-
-            rhs = expr.replace_expressions(replacements)
-            condition = Exact(expr, rhs)
-            filters.append(condition)
+            expr_filter = self._build_expression_filter(expr, data, replacements)
+            if expr_filter is None:
+                return None  # cannot match
+            filters.append(expr_filter)
 
         qs = self.model_class.objects.filter(*filters)
         if self.condition:
             qs = qs.filter(self.condition)
         return qs
+
+    def _build_expression_filter(self, expr, data, replacements):
+        """Builds the filter for one constraint expression, or None if unmatchable."""
+        expr_refs = _get_refs(expr)
+        if self.nulls_not_distinct and any(data.get(r) is None for r in expr_refs):
+            # NULL participates in uniqueness: match via IS NULL. Only
+            # expressible for a plain single-field reference; a composite
+            # expression over a NULL value cannot be matched.
+            if len(expr_refs) == 1:
+                return Q(**{f"{next(iter(expr_refs))}__isnull": True})
+            return None
+
+        for ref in (F(r) for r in expr_refs):
+            if ref not in replacements:
+                return None  # cannot match, missing field data
+            if isinstance(replacements[ref], UnresolvedReference):
+                return None  # cannot match, missing field data
+
+        rhs = expr.replace_expressions(replacements)
+        return Exact(expr, rhs)
 
     def _prepare_data(self, data: dict) -> dict:
         prepared = {}

--- a/netbox_diode_plugin/api/plugin_utils.py
+++ b/netbox_diode_plugin/api/plugin_utils.py
@@ -1,8 +1,8 @@
 """Diode plugin helpers."""
 
 # Generated code. DO NOT EDIT.
-# Source: NetBox v4.7.0-beta1
-# Timestamp: 2026-08-18 14:37:00Z
+# Source: NetBox v4.7.0-beta2
+# Timestamp: 2026-08-28 12:13:46Z
 
 from dataclasses import dataclass
 import datetime

--- a/netbox_diode_plugin/api/plugin_utils.py
+++ b/netbox_diode_plugin/api/plugin_utils.py
@@ -1,8 +1,8 @@
 """Diode plugin helpers."""
 
 # Generated code. DO NOT EDIT.
-# Source: NetBox v4.7.0-beta2
-# Timestamp: 2026-08-28 12:13:46Z
+# Source: NetBox v4.7.0
+# Timestamp: 2026-09-02 20:52:39Z
 
 from dataclasses import dataclass
 import datetime

--- a/netbox_diode_plugin/api/plugin_utils.py
+++ b/netbox_diode_plugin/api/plugin_utils.py
@@ -1,8 +1,8 @@
 """Diode plugin helpers."""
 
 # Generated code. DO NOT EDIT.
-# Source: NetBox v4.6.0
-# Timestamp: 2026-07-08 14:57:56Z
+# Source: NetBox v4.7.0-beta1
+# Timestamp: 2026-08-18 14:37:00Z
 
 from dataclasses import dataclass
 import datetime
@@ -365,6 +365,21 @@ _JSON_REF_INFO = {
             is_generic=True,
         ),
         "user": RefInfo(object_type="users.user", field_name="object", is_generic=True),
+        "cooling_feed": RefInfo(
+            object_type="dcim.coolingfeed", field_name="object", is_generic=True
+        ),
+        "cooling_intake": RefInfo(
+            object_type="dcim.coolingintake", field_name="object", is_generic=True
+        ),
+        "cooling_outflow": RefInfo(
+            object_type="dcim.coolingoutflow", field_name="object", is_generic=True
+        ),
+        "cooling_source": RefInfo(
+            object_type="dcim.coolingsource", field_name="object", is_generic=True
+        ),
+        "module_bay_type": RefInfo(
+            object_type="dcim.modulebaytype", field_name="object", is_generic=True
+        ),
     },
     "circuits.circuit": {
         "assignments": RefInfo(
@@ -496,6 +511,39 @@ _JSON_REF_INFO = {
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
+    "dcim.coolingfeed": {
+        "cooling_source": RefInfo(
+            object_type="dcim.coolingsource", field_name="cooling_source"
+        ),
+        "owner": RefInfo(object_type="users.owner", field_name="owner"),
+        "rack": RefInfo(object_type="dcim.rack", field_name="rack"),
+        "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
+        "tenant": RefInfo(object_type="tenancy.tenant", field_name="tenant"),
+    },
+    "dcim.coolingintake": {
+        "cooling_outflow": RefInfo(
+            object_type="dcim.coolingoutflow", field_name="cooling_outflow"
+        ),
+        "device": RefInfo(object_type="dcim.device", field_name="device"),
+        "module": RefInfo(object_type="dcim.module", field_name="module"),
+        "owner": RefInfo(object_type="users.owner", field_name="owner"),
+        "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
+    },
+    "dcim.coolingoutflow": {
+        "cooling_intake": RefInfo(
+            object_type="dcim.coolingintake", field_name="cooling_intake"
+        ),
+        "device": RefInfo(object_type="dcim.device", field_name="device"),
+        "module": RefInfo(object_type="dcim.module", field_name="module"),
+        "owner": RefInfo(object_type="users.owner", field_name="owner"),
+        "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
+    },
+    "dcim.coolingsource": {
+        "location": RefInfo(object_type="dcim.location", field_name="location"),
+        "owner": RefInfo(object_type="users.owner", field_name="owner"),
+        "site": RefInfo(object_type="dcim.site", field_name="site"),
+        "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
+    },
     "dcim.device": {
         "cluster": RefInfo(object_type="virtualization.cluster", field_name="cluster"),
         "device_type": RefInfo(object_type="dcim.devicetype", field_name="device_type"),
@@ -596,6 +644,12 @@ _JSON_REF_INFO = {
         "component_rear_port": RefInfo(
             object_type="dcim.rearport", field_name="component", is_generic=True
         ),
+        "component_cooling_intake": RefInfo(
+            object_type="dcim.coolingintake", field_name="component", is_generic=True
+        ),
+        "component_cooling_outflow": RefInfo(
+            object_type="dcim.coolingoutflow", field_name="component", is_generic=True
+        ),
         "device": RefInfo(object_type="dcim.device", field_name="device"),
         "manufacturer": RefInfo(
             object_type="dcim.manufacturer", field_name="manufacturer"
@@ -645,12 +699,29 @@ _JSON_REF_INFO = {
             object_type="dcim.module", field_name="installed_module"
         ),
         "module": RefInfo(object_type="dcim.module", field_name="module"),
+        "module_bay_types": RefInfo(
+            object_type="dcim.modulebaytype",
+            field_name="module_bay_types",
+            is_many=True,
+        ),
+        "owner": RefInfo(object_type="users.owner", field_name="owner"),
+        "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
+    },
+    "dcim.modulebaytype": {
+        "manufacturer": RefInfo(
+            object_type="dcim.manufacturer", field_name="manufacturer"
+        ),
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
     "dcim.moduletype": {
         "manufacturer": RefInfo(
             object_type="dcim.manufacturer", field_name="manufacturer"
+        ),
+        "module_bay_types": RefInfo(
+            object_type="dcim.modulebaytype",
+            field_name="module_bay_types",
+            is_many=True,
         ),
         "owner": RefInfo(object_type="users.owner", field_name="owner"),
         "profile": RefInfo(object_type="dcim.moduletypeprofile", field_name="profile"),
@@ -1173,6 +1244,31 @@ _JSON_REF_INFO = {
         "assigned_object_user": RefInfo(
             object_type="users.user", field_name="assigned_object", is_generic=True
         ),
+        "assigned_object_cooling_feed": RefInfo(
+            object_type="dcim.coolingfeed",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_cooling_intake": RefInfo(
+            object_type="dcim.coolingintake",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_cooling_outflow": RefInfo(
+            object_type="dcim.coolingoutflow",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_cooling_source": RefInfo(
+            object_type="dcim.coolingsource",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_module_bay_type": RefInfo(
+            object_type="dcim.modulebaytype",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
         "created_by": RefInfo(object_type="users.user", field_name="created_by"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
@@ -1546,6 +1642,21 @@ _JSON_REF_INFO = {
         ),
         "interface_user": RefInfo(
             object_type="users.user", field_name="interface", is_generic=True
+        ),
+        "interface_cooling_feed": RefInfo(
+            object_type="dcim.coolingfeed", field_name="interface", is_generic=True
+        ),
+        "interface_cooling_intake": RefInfo(
+            object_type="dcim.coolingintake", field_name="interface", is_generic=True
+        ),
+        "interface_cooling_outflow": RefInfo(
+            object_type="dcim.coolingoutflow", field_name="interface", is_generic=True
+        ),
+        "interface_cooling_source": RefInfo(
+            object_type="dcim.coolingsource", field_name="interface", is_generic=True
+        ),
+        "interface_module_bay_type": RefInfo(
+            object_type="dcim.modulebaytype", field_name="interface", is_generic=True
         ),
     },
     "ipam.ipaddress": {
@@ -2023,6 +2134,21 @@ _JSON_REF_INFO = {
         ),
         "object_user": RefInfo(
             object_type="users.user", field_name="object", is_generic=True
+        ),
+        "object_cooling_feed": RefInfo(
+            object_type="dcim.coolingfeed", field_name="object", is_generic=True
+        ),
+        "object_cooling_intake": RefInfo(
+            object_type="dcim.coolingintake", field_name="object", is_generic=True
+        ),
+        "object_cooling_outflow": RefInfo(
+            object_type="dcim.coolingoutflow", field_name="object", is_generic=True
+        ),
+        "object_cooling_source": RefInfo(
+            object_type="dcim.coolingsource", field_name="object", is_generic=True
+        ),
+        "object_module_bay_type": RefInfo(
+            object_type="dcim.modulebaytype", field_name="object", is_generic=True
         ),
         "role": RefInfo(object_type="tenancy.contactrole", field_name="role"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
@@ -2572,6 +2698,31 @@ _JSON_REF_INFO = {
         "assigned_object_user": RefInfo(
             object_type="users.user", field_name="assigned_object", is_generic=True
         ),
+        "assigned_object_cooling_feed": RefInfo(
+            object_type="dcim.coolingfeed",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_cooling_intake": RefInfo(
+            object_type="dcim.coolingintake",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_cooling_outflow": RefInfo(
+            object_type="dcim.coolingoutflow",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_cooling_source": RefInfo(
+            object_type="dcim.coolingsource",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
+        "assigned_object_module_bay_type": RefInfo(
+            object_type="dcim.modulebaytype",
+            field_name="assigned_object",
+            is_generic=True,
+        ),
         "l2vpn": RefInfo(object_type="vpn.l2vpn", field_name="l2vpn"),
         "tags": RefInfo(object_type="extras.tag", field_name="tags", is_many=True),
     },
@@ -2952,6 +3103,21 @@ _JSON_REF_INFO = {
         "termination_user": RefInfo(
             object_type="users.user", field_name="termination", is_generic=True
         ),
+        "termination_cooling_feed": RefInfo(
+            object_type="dcim.coolingfeed", field_name="termination", is_generic=True
+        ),
+        "termination_cooling_intake": RefInfo(
+            object_type="dcim.coolingintake", field_name="termination", is_generic=True
+        ),
+        "termination_cooling_outflow": RefInfo(
+            object_type="dcim.coolingoutflow", field_name="termination", is_generic=True
+        ),
+        "termination_cooling_source": RefInfo(
+            object_type="dcim.coolingsource", field_name="termination", is_generic=True
+        ),
+        "termination_module_bay_type": RefInfo(
+            object_type="dcim.modulebaytype", field_name="termination", is_generic=True
+        ),
         "tunnel": RefInfo(object_type="vpn.tunnel", field_name="tunnel"),
     },
     "wireless.wirelesslan": {
@@ -3017,6 +3183,10 @@ _GENERIC_OBJECT_VARIANTS: dict[str, str] = {
     "object_contact_assignment": "tenancy.contactassignment",
     "object_contact_group": "tenancy.contactgroup",
     "object_contact_role": "tenancy.contactrole",
+    "object_cooling_feed": "dcim.coolingfeed",
+    "object_cooling_intake": "dcim.coolingintake",
+    "object_cooling_outflow": "dcim.coolingoutflow",
+    "object_cooling_source": "dcim.coolingsource",
     "object_custom_field": "extras.customfield",
     "object_custom_field_choice_set": "extras.customfieldchoiceset",
     "object_custom_link": "extras.customlink",
@@ -3045,6 +3215,7 @@ _GENERIC_OBJECT_VARIANTS: dict[str, str] = {
     "object_manufacturer": "dcim.manufacturer",
     "object_module": "dcim.module",
     "object_module_bay": "dcim.modulebay",
+    "object_module_bay_type": "dcim.modulebaytype",
     "object_module_type": "dcim.moduletype",
     "object_module_type_profile": "dcim.moduletypeprofile",
     "object_owner": "users.owner",
@@ -3290,12 +3461,80 @@ _LEGAL_FIELDS = {
             "type",
         ]
     ),
+    "dcim.coolingfeed": frozenset(
+        [
+            "comments",
+            "cooling_capacity",
+            "cooling_source",
+            "custom_fields",
+            "description",
+            "max_flow",
+            "max_flow_unit",
+            "name",
+            "owner",
+            "rack",
+            "status",
+            "tags",
+            "tenant",
+        ]
+    ),
+    "dcim.coolingintake": frozenset(
+        [
+            "cooling_outflow",
+            "custom_fields",
+            "description",
+            "device",
+            "diameter",
+            "diameter_unit",
+            "label",
+            "max_flow",
+            "max_flow_unit",
+            "module",
+            "name",
+            "owner",
+            "tags",
+            "type",
+        ]
+    ),
+    "dcim.coolingoutflow": frozenset(
+        [
+            "cooling_intake",
+            "custom_fields",
+            "description",
+            "device",
+            "diameter",
+            "diameter_unit",
+            "label",
+            "module",
+            "name",
+            "owner",
+            "tags",
+            "type",
+        ]
+    ),
+    "dcim.coolingsource": frozenset(
+        [
+            "comments",
+            "cooling_capacity",
+            "custom_fields",
+            "description",
+            "fluid_type",
+            "location",
+            "name",
+            "owner",
+            "site",
+            "status",
+            "tags",
+            "type",
+        ]
+    ),
     "dcim.device": frozenset(
         [
             "airflow",
             "asset_tag",
             "cluster",
             "comments",
+            "cooling_method",
             "custom_fields",
             "description",
             "device_type",
@@ -3353,9 +3592,11 @@ _LEGAL_FIELDS = {
         [
             "airflow",
             "comments",
+            "cooling_method",
             "custom_fields",
             "default_platform",
             "description",
+            "end_of_life",
             "exclude_from_utilization",
             "is_full_depth",
             "manufacturer",
@@ -3391,6 +3632,8 @@ _LEGAL_FIELDS = {
     "dcim.interface": frozenset(
         [
             "bridge",
+            "channel_id",
+            "channels",
             "custom_fields",
             "description",
             "device",
@@ -3398,6 +3641,7 @@ _LEGAL_FIELDS = {
             "enabled",
             "label",
             "lag",
+            "mac_address",
             "mark_connected",
             "mgmt_only",
             "mode",
@@ -3517,9 +3761,23 @@ _LEGAL_FIELDS = {
             "installed_module",
             "label",
             "module",
+            "module_bay_types",
             "name",
             "owner",
             "position",
+            "tags",
+        ]
+    ),
+    "dcim.modulebaytype": frozenset(
+        [
+            "color",
+            "comments",
+            "custom_fields",
+            "description",
+            "manufacturer",
+            "name",
+            "owner",
+            "slug",
             "tags",
         ]
     ),
@@ -3528,10 +3786,13 @@ _LEGAL_FIELDS = {
             "airflow",
             "attributes",
             "comments",
+            "cooling_method",
             "custom_fields",
             "description",
+            "end_of_life",
             "manufacturer",
             "model",
+            "module_bay_types",
             "owner",
             "part_number",
             "profile",
@@ -3628,6 +3889,8 @@ _LEGAL_FIELDS = {
             "airflow",
             "asset_tag",
             "comments",
+            "cooling_capability",
+            "cooling_capacity",
             "custom_fields",
             "desc_units",
             "description",
@@ -3689,6 +3952,8 @@ _LEGAL_FIELDS = {
     "dcim.racktype": frozenset(
         [
             "comments",
+            "cooling_capability",
+            "cooling_capacity",
             "custom_fields",
             "desc_units",
             "description",
@@ -3812,6 +4077,7 @@ _LEGAL_FIELDS = {
             "is_cloneable",
             "label",
             "name",
+            "nulls_first",
             "object_types",
             "owner",
             "related_object_filter",
@@ -4019,6 +4285,7 @@ _LEGAL_FIELDS = {
             "owner",
             "parent_object_id",
             "parent_object_type",
+            "port_mappings",
             "ports",
             "protocol",
             "tags",
@@ -4227,6 +4494,7 @@ _LEGAL_FIELDS = {
             "custom_fields",
             "description",
             "enabled",
+            "mac_address",
             "mode",
             "mtu",
             "name",
@@ -4533,6 +4801,20 @@ _FORMAT_TRANSFORMATIONS = {
     "dcim.consoleserverport": {
         "speed": int_from_int64string,
     },
+    "dcim.coolingfeed": {
+        "cooling_capacity": transform_float_to_decimal,
+        "max_flow": transform_float_to_decimal,
+    },
+    "dcim.coolingintake": {
+        "diameter": transform_float_to_decimal,
+        "max_flow": transform_float_to_decimal,
+    },
+    "dcim.coolingoutflow": {
+        "diameter": transform_float_to_decimal,
+    },
+    "dcim.coolingsource": {
+        "cooling_capacity": transform_float_to_decimal,
+    },
     "dcim.device": {
         "latitude": transform_float_to_decimal,
         "longitude": transform_float_to_decimal,
@@ -4541,6 +4823,7 @@ _FORMAT_TRANSFORMATIONS = {
         "vc_priority": int_from_int64string,
     },
     "dcim.devicetype": {
+        "end_of_life": transform_timestamp_to_date_only,
         "u_height": transform_float_to_decimal,
         "weight": transform_float_to_decimal,
     },
@@ -4549,6 +4832,8 @@ _FORMAT_TRANSFORMATIONS = {
         "rear_port_position": int_from_int64string,
     },
     "dcim.interface": {
+        "channel_id": int_from_int64string,
+        "channels": int_from_int64string,
         "mtu": int_from_int64string,
         "rf_channel_frequency": transform_float_to_decimal,
         "rf_channel_width": transform_float_to_decimal,
@@ -4557,6 +4842,7 @@ _FORMAT_TRANSFORMATIONS = {
     },
     "dcim.moduletype": {
         "attributes": parse_json,
+        "end_of_life": transform_timestamp_to_date_only,
         "weight": transform_float_to_decimal,
     },
     "dcim.moduletypeprofile": {
@@ -4572,6 +4858,7 @@ _FORMAT_TRANSFORMATIONS = {
         "maximum_draw": int_from_int64string,
     },
     "dcim.rack": {
+        "cooling_capacity": transform_float_to_decimal,
         "max_weight": int_from_int64string,
         "mounting_depth": int_from_int64string,
         "outer_depth": int_from_int64string,
@@ -4586,6 +4873,7 @@ _FORMAT_TRANSFORMATIONS = {
         "units": for_all(int_from_int64string, False, False),
     },
     "dcim.racktype": {
+        "cooling_capacity": transform_float_to_decimal,
         "max_weight": int_from_int64string,
         "mounting_depth": int_from_int64string,
         "outer_depth": int_from_int64string,

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -87,29 +87,30 @@ def _read_secret(secret_file: str, default: str | None = None) -> str | None:
 
 def get_diode_user():
     """
-    Returns the Diode user.
+    Returns the Diode service user.
 
-    The service user is a superuser: Diode's apply path is authorized by
-    the plugin's own token-scope layer, and its writes already operate
-    outside NetBox's object-permission model. NetBox 4.7 additionally
-    scopes attribute-based related-object resolution in serializers to the
-    requesting user's view permissions (utilities.api
-    get_related_object_by_attrs), which restrict() bypasses for active
-    superusers - without this, every name-based reference in an applied
-    change set would fail as "related object not found". Existing rows
-    from older plugin versions are upgraded lazily.
+    The user is deliberately NOT a superuser (revoked for cause in
+    migration 0005_revoke_superuser_status). The permissions NetBox 4.7
+    requires of it - view for attribute-based related-object resolution
+    and dcim.add_macaddress for interface MAC writes - are provisioned as
+    explicit ObjectPermissions on post_migrate (see provisioning.py).
+
+    The account is created with an unusable password (older plugin
+    versions left a raw empty string, which Django treats as usable;
+    that is corrected lazily). Deactivating the user or disabling its
+    ObjectPermissions in the NetBox UI is respected as an operator kill
+    switch and never undone here.
     """
     diode_username = get_plugin_config("netbox_diode_plugin", "diode_username")
 
     try:
         diode_user = User.objects.get(username=diode_username)
     except User.DoesNotExist:
-        diode_user = User.objects.create(username=diode_username, is_active=True, is_superuser=True)
+        diode_user = User.objects.create(username=diode_username, is_active=True)
 
-    if not diode_user.is_superuser or not diode_user.is_active:
-        diode_user.is_superuser = True
-        diode_user.is_active = True
-        diode_user.save(update_fields=["is_superuser", "is_active"])
+    if diode_user.password == "":
+        diode_user.set_unusable_password()
+        diode_user.save(update_fields=["password"])
 
     return diode_user
 

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -86,13 +86,29 @@ def _read_secret(secret_file: str, default: str | None = None) -> str | None:
             return f.readline().strip()
 
 def get_diode_user():
-    """Returns the Diode user."""
+    """Returns the Diode user.
+
+    The service user is a superuser: Diode's apply path is authorized by
+    the plugin's own token-scope layer, and its writes already operate
+    outside NetBox's object-permission model. NetBox 4.7 additionally
+    scopes attribute-based related-object resolution in serializers to the
+    requesting user's view permissions (utilities.api
+    get_related_object_by_attrs), which restrict() bypasses for active
+    superusers - without this, every name-based reference in an applied
+    change set would fail as "related object not found". Existing rows
+    from older plugin versions are upgraded lazily.
+    """
     diode_username = get_plugin_config("netbox_diode_plugin", "diode_username")
 
     try:
         diode_user = User.objects.get(username=diode_username)
     except User.DoesNotExist:
-        diode_user = User.objects.create(username=diode_username, is_active=True)
+        diode_user = User.objects.create(username=diode_username, is_active=True, is_superuser=True)
+
+    if not diode_user.is_superuser or not diode_user.is_active:
+        diode_user.is_superuser = True
+        diode_user.is_active = True
+        diode_user.save(update_fields=["is_superuser", "is_active"])
 
     return diode_user
 

--- a/netbox_diode_plugin/plugin_config.py
+++ b/netbox_diode_plugin/plugin_config.py
@@ -86,7 +86,8 @@ def _read_secret(secret_file: str, default: str | None = None) -> str | None:
             return f.readline().strip()
 
 def get_diode_user():
-    """Returns the Diode user.
+    """
+    Returns the Diode user.
 
     The service user is a superuser: Diode's apply path is authorized by
     the plugin's own token-scope layer, and its writes already operate

--- a/netbox_diode_plugin/provisioning.py
+++ b/netbox_diode_plugin/provisioning.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""
+Provision the Diode service user's NetBox object permissions.
+
+NetBox 4.7 consults the requesting user's permissions in two places on
+the plugin's apply path:
+
+- attribute-based related-object resolution during serializer
+  validation restricts lookups to objects the user may view
+  (``utilities.api.get_related_object_by_attrs`` -> ``restrict(user,
+  'view')``, NetBox #21988);
+- creating/updating an interface's primary MAC address requires
+  ``dcim.add_macaddress`` (``MACAddressShortcutMixin``).
+
+The service user is deliberately NOT a superuser (that was revoked for
+cause in migration 0005_revoke_superuser_status); instead these two
+explicit, auditable ObjectPermissions are provisioned and re-synced on
+every ``manage.py migrate`` via post_migrate, so new object types picked
+up by a NetBox upgrade are covered by the same command that installs
+them.
+
+The view grant spans all object types with no constraints: NetBox's
+``restrict()`` short-circuits an unconstrained grant and returns the
+queryset unmodified, and the plugin's matcher/differ already read
+through unrestricted model managers, so this matches the plugin's
+existing read posture exactly - without superuser's write, user
+management, or script-execution reach.
+
+Operator kill switches are respected: deactivating the service user or
+disabling either ObjectPermission in the NetBox UI is never undone here
+(sync only touches enabled permissions' object-type sets).
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+VIEW_PERMISSION_NAME = "Diode ingestion: view for reference resolution"
+MACADDRESS_PERMISSION_NAME = "Diode ingestion: MAC address create"
+
+
+def provision_diode_permissions(sender=None, **kwargs):  # noqa: ARG001
+    """Create/refresh the service user's ObjectPermissions (post_migrate receiver)."""
+    # Deferred imports: models are not loadable at module import time.
+    from core.models import ObjectType
+    from users.models import ObjectPermission
+
+    from .plugin_config import get_diode_user
+
+    diode_user = get_diode_user()
+
+    view_permission, created = ObjectPermission.objects.get_or_create(
+        name=VIEW_PERMISSION_NAME,
+        defaults={"actions": ["view"], "constraints": None},
+    )
+    if created:
+        logger.info("Created ObjectPermission %r for the Diode service user", VIEW_PERMISSION_NAME)
+    if view_permission.enabled:
+        view_permission.object_types.set(ObjectType.objects.all())
+    else:
+        logger.warning(
+            "ObjectPermission %r is disabled; attribute-based reference "
+            "resolution will fail until it is re-enabled", VIEW_PERMISSION_NAME
+        )
+    view_permission.users.add(diode_user)
+
+    mac_permission, created = ObjectPermission.objects.get_or_create(
+        name=MACADDRESS_PERMISSION_NAME,
+        defaults={"actions": ["add"], "constraints": None},
+    )
+    if created:
+        logger.info("Created ObjectPermission %r for the Diode service user", MACADDRESS_PERMISSION_NAME)
+    if mac_permission.enabled:
+        mac_permission.object_types.set(
+            ObjectType.objects.filter(app_label="dcim", model="macaddress")
+        )
+    mac_permission.users.add(diode_user)

--- a/netbox_diode_plugin/provisioning.py
+++ b/netbox_diode_plugin/provisioning.py
@@ -40,6 +40,28 @@ VIEW_PERMISSION_NAME = "Diode ingestion: view for reference resolution"
 MACADDRESS_PERMISSION_NAME = "Diode ingestion: MAC address create"
 
 
+def extend_view_permission_for_new_type(sender, instance, created, **kwargs):  # noqa: ARG001
+    """
+    Add a lazily-created content type to the view grant (post_save receiver).
+
+    ObjectType rows are created on first reference, not only during
+    migrate, so a post_migrate-only sync leaves late-born types outside
+    the grant and their name-based references failing as 'related object
+    not found'. Observed live: 5 of 170 types missing within hours of
+    provisioning.
+    """
+    if not created:
+        return
+    from users.models import ObjectPermission
+
+    try:
+        view_permission = ObjectPermission.objects.get(name=VIEW_PERMISSION_NAME)
+    except ObjectPermission.DoesNotExist:
+        return  # not provisioned yet; post_migrate will pick everything up
+    if view_permission.enabled:
+        view_permission.object_types.add(instance)
+
+
 def provision_diode_permissions(sender=None, **kwargs):  # noqa: ARG001
     """Create/refresh the service user's ObjectPermissions (post_migrate receiver)."""
     # Deferred imports: models are not loadable at module import time.

--- a/netbox_diode_plugin/provisioning.py
+++ b/netbox_diode_plugin/provisioning.py
@@ -72,6 +72,19 @@ def provision_diode_permissions(sender=None, **kwargs):  # noqa: ARG001
 
     diode_user = get_diode_user()
 
+    # The service user is resolved purely by the configured diode_username
+    # (long-standing design). If that name collides with a human or
+    # SSO-managed account, the grants below would attach to it - warn
+    # loudly so the collision is visible; refusing it outright is a
+    # behavioral redesign tracked separately.
+    if diode_user.has_usable_password() or diode_user.is_superuser:
+        logger.warning(
+            "The configured diode_username resolves to an account with a "
+            "usable password and/or superuser status; if this is not the "
+            "plugin-managed service account, choose a dedicated username "
+            "before the ingestion permissions below attach to it."
+        )
+
     view_permission, created = ObjectPermission.objects.get_or_create(
         name=VIEW_PERMISSION_NAME,
         defaults={"actions": ["view"], "constraints": None},

--- a/netbox_diode_plugin/provisioning.py
+++ b/netbox_diode_plugin/provisioning.py
@@ -55,13 +55,13 @@ def provision_diode_permissions(sender=None, **kwargs):  # noqa: ARG001
         defaults={"actions": ["view"], "constraints": None},
     )
     if created:
-        logger.info("Created ObjectPermission %r for the Diode service user", VIEW_PERMISSION_NAME)
+        logger.info("Created the Diode ingestion view ObjectPermission")
     if view_permission.enabled:
         view_permission.object_types.set(ObjectType.objects.all())
     else:
         logger.warning(
-            "ObjectPermission %r is disabled; attribute-based reference "
-            "resolution will fail until it is re-enabled", VIEW_PERMISSION_NAME
+            "The Diode ingestion view ObjectPermission is disabled; "
+            "attribute-based reference resolution will fail until it is re-enabled"
         )
     view_permission.users.add(diode_user)
 
@@ -70,7 +70,7 @@ def provision_diode_permissions(sender=None, **kwargs):  # noqa: ARG001
         defaults={"actions": ["add"], "constraints": None},
     )
     if created:
-        logger.info("Created ObjectPermission %r for the Diode service user", MACADDRESS_PERMISSION_NAME)
+        logger.info("Created the Diode ingestion MAC-address-create ObjectPermission")
     if mac_permission.enabled:
         mac_permission.object_types.set(
             ObjectType.objects.filter(app_label="dcim", model="macaddress")

--- a/netbox_diode_plugin/tests/v4.7.x/tests/__init__.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin."""

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_api_apply_change_set.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_api_apply_change_set.py
@@ -1,0 +1,1136 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Rack, Site
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from ipam.models import ASN, RIR, IPAddress, Prefix
+from netaddr import IPNetwork
+from rest_framework import status
+from utilities.testing import APITestCase
+from virtualization.models import Cluster, ClusterType, VirtualMachine
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+User = get_user_model()
+
+def _get_error(response, object_name, field):
+    return response.json().get("errors", {}).get(object_name, {}).get(field, [])
+
+class BaseApplyChangeSet(APITestCase):
+    """Base ApplyChangeSet test case."""
+
+    def setUp(self):
+        """Set up test."""
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+        rir = RIR.objects.create(name="RFC 6996", is_private=True)
+        self.asns = [ASN(asn=65000 + i, rir=rir) for i in range(8)]
+        ASN.objects.bulk_create(self.asns)
+
+        self.sites = (
+            Site(
+                id=10,
+                name="Site 1",
+                slug="site-1",
+                facility="Alpha",
+                description="First test site",
+                physical_address="123 Fake St Lincoln NE 68588",
+                shipping_address="123 Fake St Lincoln NE 68588",
+                comments="Lorem ipsum etcetera",
+            ),
+            Site(
+                id=20,
+                name="Site 2",
+                slug="site-2",
+                facility="Bravo",
+                description="Second test site",
+                physical_address="725 Cyrus Valleys Suite 761 Douglasfort NE 57761",
+                shipping_address="725 Cyrus Valleys Suite 761 Douglasfort NE 57761",
+                comments="Lorem ipsum etcetera",
+            ),
+        )
+        Site.objects.bulk_create(self.sites)
+
+        self.racks = (
+            Rack(name="Rack 1", site=self.sites[0]),
+            Rack(name="Rack 2", site=self.sites[1]),
+        )
+        Rack.objects.bulk_create(self.racks)
+
+        manufacturer = Manufacturer.objects.create(
+            name="Manufacturer 1", slug="manufacturer-1"
+        )
+
+        self.device_types = (
+            DeviceType(
+                manufacturer=manufacturer, model="Device Type 1", slug="device-type-1"
+            ),
+            DeviceType(
+                manufacturer=manufacturer,
+                model="Device Type 2",
+                slug="device-type-2",
+                u_height=2,
+            ),
+        )
+        DeviceType.objects.bulk_create(self.device_types)
+
+        # bulk create is wierd due to mptt
+        self.roles = [
+            DeviceRole.objects.create(name="Device Role 1", slug="device-role-1", color="ff0000"),
+            DeviceRole.objects.create(name="Device Role 2", slug="device-role-2", color="00ff00"),
+        ]
+
+        cluster_type = ClusterType.objects.create(
+            name="Cluster Type 1", slug="cluster-type-1"
+        )
+
+        self.cluster_types = (cluster_type,)
+
+        site_content_type = ContentType.objects.get_for_model(Site)
+
+        self.clusters = (
+            Cluster(name="Cluster 1", type=cluster_type, scope_type=site_content_type, scope_id=self.sites[0].id),
+            Cluster(name="Cluster 2", type=cluster_type, scope_type=site_content_type, scope_id=self.sites[0].id),
+        )
+        Cluster.objects.bulk_create(self.clusters)
+
+        self.devices = (
+            Device(
+                id=10,
+                device_type=self.device_types[0],
+                role=self.roles[0],
+                name="Device 1",
+                site=self.sites[0],
+                rack=self.racks[0],
+                cluster=self.clusters[0],
+                local_context_data={"A": 1},
+            ),
+            Device(
+                id=20,
+                device_type=self.device_types[0],
+                role=self.roles[0],
+                name="Device 2",
+                site=self.sites[0],
+                rack=self.racks[0],
+                cluster=self.clusters[0],
+                local_context_data={"B": 2},
+            ),
+        )
+        Device.objects.bulk_create(self.devices)
+
+        self.interfaces = (
+            Interface(name="Interface 1", device=self.devices[0], type="1000baset"),
+            Interface(name="Interface 2", device=self.devices[0], type="1000baset"),
+            Interface(name="Interface 3", device=self.devices[0], type="1000baset"),
+            Interface(name="Interface 4", device=self.devices[0], type="1000baset"),
+            Interface(name="Interface 5", device=self.devices[0], type="1000baset"),
+        )
+        Interface.objects.bulk_create(self.interfaces)
+
+        self.ip_addresses = (
+            IPAddress(
+                address=IPNetwork("10.0.0.1/24"), assigned_object=self.interfaces[0]
+            ),
+            IPAddress(
+                address=IPNetwork("192.0.2.1/24"), assigned_object=self.interfaces[1]
+            ),
+        )
+        IPAddress.objects.bulk_create(self.ip_addresses)
+
+        self.virtual_machines = (
+            VirtualMachine(name="Virtual Machine 1"),
+            VirtualMachine(name="Virtual Machine 2"),
+        )
+        VirtualMachine.objects.bulk_create(self.virtual_machines)
+
+        self.url = "/netbox/api/plugins/diode/apply-change-set/"
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url,
+            data=payload,
+            format="json",
+            **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+
+class ApplyChangeSetTestCase(BaseApplyChangeSet):
+    """ApplyChangeSet test cases."""
+
+    @staticmethod
+    def get_change_id(payload, index):
+        """Get change_id from payload."""
+        return payload.get("changes")[index].get("change_id")
+
+    def test_change_type_create_return_200(self):
+        """Test create change_type with successful."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.interface",
+                    "object_id": None,
+                    "ref_id": "2",
+                    "data": {
+                        "name": "Interface 1",
+                        "device": self.devices[1].pk,
+                        "type": "other",
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "ipam.ipaddress",
+                    "object_id": None,
+                    "ref_id": "3",
+                    "data": {
+                        "address": "192.163.2.1/24",
+                        "assigned_object_type": "dcim.interface",
+                        "assigned_object_id": self.interfaces[2].pk
+                    },
+                },
+            ],
+        }
+
+        _ = self.send_request(payload)
+
+    def test_change_type_update_return_200(self):
+        """Test update change_type with successful."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+            ],
+        }
+
+        _ = self.client.post(
+            self.url, payload, format="json", **self.authorization_header
+        )
+
+        site_updated = Site.objects.get(id=20)
+
+        self.assertEqual(site_updated.name, "Site A")
+
+    def test_change_type_create_with_error_return_400(self):
+        """Test create change_type with wrong payload."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+        site_created = Site.objects.filter(name="Site A")
+
+        self.assertIn(
+            'Expected a list of items but got type "int".',
+            _get_error(response, "dcim.site", "asns"),
+        )
+        self.assertFalse(site_created.exists())
+
+    def test_change_type_update_with_error_return_400(self):
+        """Test update change_type with wrong payload."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        site_updated = Site.objects.get(id=20)
+        self.assertIn(
+            'Expected a list of items but got type "int".',
+            _get_error(response, "dcim.site", "asns")
+        )
+        self.assertEqual(site_updated.name, "Site 2")
+
+    def test_change_type_create_with_multiples_objects_return_200(self):
+        """Test create change type with two objects."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site Z",
+                        "slug": "site-z",
+                        "facility": "Omega",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "2",
+                    "data": {
+                        "device_type": self.device_types[1].pk,
+                        "role": self.roles[1].pk,
+                        "name": "Test Device 500",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+            ],
+        }
+
+        _ = self.send_request(payload)
+
+    def test_change_type_update_with_multiples_objects_return_200(self):
+        """Test update change type with two objects."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": 10,
+                    "data": {
+                        "device_type": self.device_types[1].pk,
+                        "role": self.roles[1].pk,
+                        "name": "Test Device 3",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+            ],
+        }
+
+        _ = self.send_request(payload)
+
+        site_updated = Site.objects.get(id=20)
+        device_updated = Device.objects.get(id=10)
+
+        self.assertEqual(site_updated.name, "Site A")
+        self.assertEqual(device_updated.name, "Test Device 3")
+
+    def test_change_type_create_and_update_with_error_in_one_object_return_400(self):
+        """Test create and update change type with one object with error."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site Z",
+                        "slug": "site-z",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": 10,
+                    "data": {
+                        "device_type": 3,
+                        "role": self.roles[1].pk,
+                        "name": "Test Device 4",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        site_created = Site.objects.filter(name="Site Z")
+        device_created = Device.objects.filter(name="Test Device 4")
+
+        self.assertIn(
+            "Related object not found using the provided numeric ID: 3",
+            _get_error(response, "dcim.device", "device_type"),
+        )
+        self.assertFalse(site_created.exists())
+        self.assertFalse(device_created.exists())
+
+    def test_multiples_create_type_error_in_two_objects_return_400(self):
+        """Test create with error in two objects."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site Z",
+                        "slug": "site-z",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": [self.asns[0].pk, self.asns[1].pk],
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "2",
+                    "data": {
+                        "device_type": 3,
+                        "role": self.roles[1].pk,
+                        "name": "Test Device 4",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "3",
+                    "data": {
+                        "device_type": 100,
+                        "role": 10,
+                        "name": "Test Device 40",
+                        "site": self.sites[1].pk,
+                        "rack": self.racks[1].pk,
+                        "cluster": self.clusters[1].pk,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        site_created = Site.objects.filter(name="Site Z")
+        device_created = Device.objects.filter(name="Test Device 4")
+
+        self.assertIn(
+            "Related object not found using the provided numeric ID: 3",
+            _get_error(response, "dcim.device", "device_type"),
+        )
+
+        self.assertFalse(site_created.exists())
+        self.assertFalse(device_created.exists())
+
+    def test_change_type_update_with_object_id_not_exist_return_400(self):
+        """Test update object with nonexistent object_id."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 30,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.client.post(
+            self.url, payload, format="json", **self.authorization_header
+        )
+
+        site_updated = Site.objects.get(id=20)
+
+        self.assertIn(
+            "dcim.site with id 30 does not exist",
+            _get_error(response, "dcim.site", "object_id"),
+        )
+        self.assertEqual(site_updated.name, "Site 2")
+
+    def test_change_set_id_field_not_provided_return_400(self):
+        """Test update object with change_set_id incorrect."""
+        payload = {
+            "id": None,
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        self.assertIsNone(response.json().get("errors", {}).get("change_id", None))
+        self.assertIn(
+            "Change set ID is required",
+            _get_error(response, "changeset", "id"),
+        )
+
+    def test_change_type_field_not_provided_return_400(
+        self,
+    ):
+        """Test update object with change_type incorrect."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": 20,
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                        "asns": 1,
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn(
+            "Unsupported change type ''",
+            _get_error(response, "dcim.site", "change_type"),
+        )
+
+    def test_change_set_id_field_and_change_set_not_provided_return_400(self):
+        """Test update object with change_set_id and change_set incorrect."""
+        payload = {
+            "id": "",
+            "changes": [],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn(
+            "Change set ID is required",
+            _get_error(response, "changeset", "id"),
+        )
+
+    def test_change_type_and_object_type_provided_return_400(
+        self,
+    ):
+        """Test change_type and object_type incorrect."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": None,
+                    "object_version": None,
+                    "object_type": "",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Site A",
+                        "slug": "site-a",
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "2",
+                    "data": {
+                        "name": "Site Z",
+                        "slug": "site-z",
+                        "facility": "Betha",
+                        "description": "",
+                        "physical_address": "123 Fake St Lincoln NE 68588",
+                        "shipping_address": "123 Fake St Lincoln NE 68588",
+                        "comments": "Lorem ipsum etcetera",
+                    },
+                },
+            ],
+        }
+
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn(
+            "Unsupported change type 'None'",
+            _get_error(response, "__all__", "change_type"),
+        )
+
+    def test_create_ip_address_return_200(self):
+        """Test create ip_address with successful."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "ipam.ipaddress",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "address": "192.161.3.1/24",
+                        "assigned_object_id": self.interfaces[3].pk,
+                        "assigned_object_type": "dcim.interface",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload)
+
+    def test_add_primary_ip_address_to_device(self):
+        """Add primary ip address to device."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": self.devices[0].pk,
+                    "data": {
+                        "name": self.devices[0].name,
+                        "site": {"name": self.sites[0].name},
+                        "primary_ip4": self.ip_addresses[0].pk
+                    },
+                },
+            ],
+        }
+
+        _ = self.send_request(payload)
+        device_updated = Device.objects.get(id=10)
+
+        self.assertEqual(device_updated.name, self.devices[0].name)
+        self.assertEqual(device_updated.primary_ip4, self.ip_addresses[0])
+
+    def test_create_prefix_with_site_stored_as_scope(self):
+        """Test create prefix with site stored as scope."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "ipam.prefix",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "prefix": "192.168.0.0/24",
+                        "scope_id": self.sites[0].pk,
+                        "scope_type": "dcim.site",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload)
+        self.assertEqual(Prefix.objects.get(prefix="192.168.0.0/24").scope, self.sites[0])
+
+    def test_create_prefix_with_unknown_site_fails(self):
+        """Test create prefix with unknown site fails."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "ipam.prefix",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "prefix": "192.168.0.0/24",
+                        "scope_id": 99,
+                        "scope_type": "dcim.site",
+                    },
+                },
+            ],
+        }
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+        print(response.json())
+        self.assertIn(
+            'Related object not found using the provided value: 99.',
+            _get_error(response, "ipam.prefix", "scope_id"),
+        )
+        self.assertFalse(Prefix.objects.filter(prefix="192.168.0.0/24").exists())
+
+    def test_create_virtualization_cluster_with_site_stored_as_scope(self):
+        """Test create cluster with site stored as scope."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "virtualization.cluster",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "Cluster 3",
+                        "type": {
+                            "name": self.cluster_types[0].name,
+                        },
+                        "scope_id": self.sites[0].pk,
+                        "scope_type": "dcim.site",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload)
+        self.assertEqual(Cluster.objects.get(name="Cluster 3").scope, self.sites[0])
+
+    def test_create_virtualmachine_with_cluster_site_stored_as_scope(self):
+        """Test create virtualmachine with cluster site stored as scope."""
+        payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "update",
+                    "object_version": None,
+                    "object_type": "virtualization.cluster",
+                    "object_id": self.clusters[0].pk,
+                    "data": {
+                        "scope_id": self.sites[0].pk,
+                        "scope_type": "dcim.site",
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "virtualization.virtualmachine",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": "VM foobar",
+                        "site": self.sites[0].pk,
+                        "cluster": self.clusters[0].pk
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload)
+        self.assertEqual(VirtualMachine.objects.get(name="VM foobar", site_id=self.sites[0].id).cluster.scope, self.sites[0])
+
+    def test_apply_two_changes_that_create_the_same_object_return_200(self):
+        """Test apply two changes that create the same object return 200."""
+        site_name = uuid.uuid4()
+        payload1 = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": f"Site {site_name}",
+                        "slug": f"site-{site_name}",
+                        "comments": "comment 1",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload1)
+
+        payload2 = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": f"Site {site_name}",
+                        "slug": f"site-{site_name}",
+                        "comments": "comment 1",
+                    },
+                },
+            ],
+        }
+        _ = self.send_request(payload2)
+
+    def test_module_bay_from_template_no_duplicate(self):
+        """Test that module bays created from templates are reused and updated, not duplicated."""
+        from dcim.models import Module, ModuleBay, ModuleBayTemplate, ModuleType
+
+        # Create a device type with a module bay template
+        device_type = DeviceType.objects.create(
+            manufacturer=Manufacturer.objects.first(),
+            model="Device with Module Bay Template",
+            slug="device-with-module-bay-template",
+        )
+
+        # Create module bay template
+        ModuleBayTemplate.objects.create(
+            device_type=device_type,
+            name="Tray",
+        )
+
+        # Create module type
+        module_type = ModuleType.objects.create(
+            manufacturer=Manufacturer.objects.first(),
+            model="Test Module Type",
+        )
+
+        # Step 1: Create a device - this will auto-create module bay "Tray" from template
+        device_payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "device-1",
+                    "data": {
+                        "name": "Test Device with Module Bay",
+                        "device_type": device_type.id,
+                        "role": self.roles[0].id,
+                        "site": self.sites[0].id,
+                    },
+                },
+            ],
+        }
+        self.send_request(device_payload)
+
+        # Verify device was created
+        device = Device.objects.get(name="Test Device with Module Bay")
+
+        # Verify module bay was auto-created from template
+        module_bays_before = ModuleBay.objects.filter(device=device, name="Tray")
+        self.assertEqual(module_bays_before.count(), 1)
+        module_bay = module_bays_before.first()
+        self.assertIsNone(module_bay.module)  # No module installed yet
+        self.assertEqual(module_bay.description, "")  # Template has no description
+
+        # Step 2: Create a module with the module bay - should reuse existing bay and update it
+        module_payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.modulebay",
+                    "object_id": None,
+                    "ref_id": "modulebay-1",
+                    "data": {
+                        "name": "Tray",
+                        "device": device.id,
+                        "description": "Ingested module bay",
+                    },
+                },
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.module",
+                    "object_id": None,
+                    "ref_id": "module-1",
+                    "new_refs": ["module_bay"],
+                    "data": {
+                        "device": device.id,
+                        "module_bay": "modulebay-1",
+                        "module_type": module_type.id,
+                        "description": "Ingested module",
+                    },
+                },
+            ],
+        }
+        self.send_request(module_payload)
+
+        # Verify NO duplicate module bays were created
+        module_bays_after = ModuleBay.objects.filter(device=device, name="Tray")
+        self.assertEqual(
+            module_bays_after.count(),
+            1,
+            "Module bay should be reused, not duplicated"
+        )
+
+        # Verify the module bay was updated with the description
+        module_bay.refresh_from_db()
+        self.assertEqual(
+            module_bay.description,
+            "Ingested module bay",
+            "Module bay should be updated with ingested data"
+        )
+
+        # Verify module was created successfully
+        modules = Module.objects.filter(device=device, module_bay=module_bay)
+        self.assertEqual(modules.count(), 1)
+        module = modules.first()
+        self.assertEqual(module.module_type, module_type)
+        self.assertEqual(module.description, "Ingested module")
+
+    def test_interface_from_template_no_duplicate(self):
+        """Test that interfaces created from templates are reused and updated, not duplicated."""
+        from dcim.models import InterfaceTemplate
+
+        # Create a device type with an interface template
+        device_type = DeviceType.objects.create(
+            manufacturer=Manufacturer.objects.first(),
+            model="Device with Interface Template",
+            slug="device-with-interface-template",
+        )
+
+        # Create interface template
+        InterfaceTemplate.objects.create(
+            device_type=device_type,
+            name="eth0",
+            type="1000base-t",
+        )
+
+        # Step 1: Create a device - this will auto-create interface "eth0" from template
+        device_payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.device",
+                    "object_id": None,
+                    "ref_id": "device-1",
+                    "data": {
+                        "name": "Test Device with Interface",
+                        "device_type": device_type.id,
+                        "role": self.roles[0].id,
+                        "site": self.sites[0].id,
+                    },
+                },
+            ],
+        }
+        self.send_request(device_payload)
+
+        # Verify device was created
+        device = Device.objects.get(name="Test Device with Interface")
+
+        # Verify interface was auto-created from template
+        interfaces_before = Interface.objects.filter(device=device, name="eth0")
+        self.assertEqual(interfaces_before.count(), 1)
+        interface = interfaces_before.first()
+        self.assertEqual(interface.description, "")  # Template has no description
+
+        # Step 2: Try to create the same interface with additional data - should reuse and update
+        interface_payload = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.interface",
+                    "object_id": None,
+                    "ref_id": "interface-1",
+                    "data": {
+                        "name": "eth0",
+                        "device": device.id,
+                        "type": "1000base-t",
+                        "description": "Ingested interface",
+                        "enabled": True,
+                    },
+                },
+            ],
+        }
+        self.send_request(interface_payload)
+
+        # Verify NO duplicate interfaces were created
+        interfaces_after = Interface.objects.filter(device=device, name="eth0")
+        self.assertEqual(
+            interfaces_after.count(),
+            1,
+            "Interface should be reused, not duplicated"
+        )
+
+        # Verify the interface was updated with the description
+        interface.refresh_from_db()
+        self.assertEqual(
+            interface.description,
+            "Ingested interface",
+            "Interface should be updated with ingested data"
+        )
+        self.assertTrue(interface.enabled)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_api_bulk_apply.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_api_bulk_apply.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkApply Tests."""
+
+import uuid
+
+from dcim.models import Site
+from rest_framework import status
+
+from .test_api_apply_change_set import BaseApplyChangeSet
+
+
+class BulkApplyTestCase(BaseApplyChangeSet):
+    """BulkApply test cases."""
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.batch_url = "/netbox/api/plugins/diode/bulk-apply/"
+        # BaseApplyChangeSet creates fixtures with hardcoded ids (Site id=10, id=20)
+        # via bulk_create, which does not advance the Postgres PK sequence.
+        # Auto-allocating CREATE INSERTs in this test class would otherwise
+        # collide with those fixture ids once the sequence catches up.
+        from django.db import connection
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT setval(pg_get_serial_sequence('dcim_site', 'id'), 10000, false)"
+            )
+
+    def _changeset_create_site(self, name, slug):
+        return {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.site",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {
+                        "name": name,
+                        "slug": slug,
+                        "facility": "Alpha",
+                        "description": "",
+                        "physical_address": "1 Fake St",
+                        "shipping_address": "1 Fake St",
+                        "comments": "",
+                        "asns": [self.asns[0].pk],
+                    },
+                },
+            ],
+        }
+
+    def _changeset_create_site_bad(self, name, slug):
+        cs = self._changeset_create_site(name, slug)
+        # asns must be a list — pass an int to trigger DRF ValidationError
+        cs["changes"][0]["data"]["asns"] = 1
+        return cs
+
+    def _post_batch(self, payload, status_code=status.HTTP_200_OK):
+        response = self.client.post(
+            self.batch_url,
+            data=payload,
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_batch_three_changesets_all_created(self):
+        """All three changesets in a batch create successfully."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Batch Site A", "batch-site-a"),
+                self._changeset_create_site("Batch Site B", "batch-site-b"),
+                self._changeset_create_site("Batch Site C", "batch-site-c"),
+            ],
+        }
+
+        response = self._post_batch(payload)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        for r in results:
+            self.assertIsNone(r.get("errors"))
+
+        for slug in ("batch-site-a", "batch-site-b", "batch-site-c"):
+            self.assertTrue(Site.objects.filter(slug=slug).exists())
+
+    def test_batch_savepoint_isolation_bad_middle(self):
+        """A bad changeset in the middle does not roll back the others."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Iso Site A", "iso-site-a"),
+                self._changeset_create_site_bad("Iso Site B", "iso-site-b"),
+                self._changeset_create_site("Iso Site C", "iso-site-c"),
+            ],
+        }
+
+        response = self._post_batch(payload, status_code=status.HTTP_207_MULTI_STATUS)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertIsNotNone(results[1].get("errors"))
+        self.assertIsNone(results[2].get("errors"))
+
+        self.assertTrue(Site.objects.filter(slug="iso-site-a").exists())
+        self.assertFalse(Site.objects.filter(slug="iso-site-b").exists())
+        self.assertTrue(Site.objects.filter(slug="iso-site-c").exists())
+
+    def test_batch_single_changeset_matches_old_endpoint(self):
+        """A 1-element batch produces the same effect as the per-changeset endpoint."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Single Site", "single-site"),
+            ],
+        }
+
+        response = self._post_batch(payload)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertTrue(Site.objects.filter(slug="single-site").exists())
+
+    def test_batch_empty_returns_400(self):
+        """Empty change_sets list returns 400."""
+        self._post_batch({"change_sets": []}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_missing_change_sets_returns_400(self):
+        """Missing change_sets key returns 400."""
+        self._post_batch({}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_batch_change_sets_not_a_list_returns_400(self):
+        """change_sets not a list returns 400."""
+        self._post_batch(
+            {"change_sets": {"not": "a list"}},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def test_change_type_from_dict_normalises_and_round_trips(self):
+        """from_dict normalises change_type to enum; to_dict round-trips back to string."""
+        from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeType
+
+        change = Change.from_dict({
+            "change_type": "create",
+            "object_type": "dcim.site",
+            "data": {"name": "x", "slug": "x"},
+        })
+        self.assertEqual(change.change_type, ChangeType.CREATE)
+
+        cs = ChangeSet.from_dict({
+            "id": str(uuid.uuid4()),
+            "changes": [{"change_type": "update", "object_type": "dcim.site"}],
+        })
+        self.assertEqual(cs.changes[0].change_type, ChangeType.UPDATE)
+        self.assertEqual(cs.changes[0].to_dict()["change_type"], "update")
+
+        bad = Change.from_dict({"change_type": "delete", "object_type": "dcim.site"})
+        self.assertEqual(bad.change_type, "delete")
+
+    def test_change_set_from_dict_carries_branch_and_warnings(self):
+        """ChangeSet.from_dict picks up branch and warnings, and to_dict round-trips them."""
+        from netbox_diode_plugin.api.common import ChangeSet
+
+        cs = ChangeSet.from_dict({
+            "id": str(uuid.uuid4()),
+            "changes": [],
+            "branch": {"id": "abc", "name": "feature/x"},
+            "warnings": {"some_warning": ["foo"]},
+        })
+        self.assertEqual(cs.branch, {"id": "abc", "name": "feature/x"})
+        self.assertEqual(cs.warnings, {"some_warning": ["foo"]})
+        d = cs.to_dict()
+        self.assertEqual(d["branch"], {"id": "abc", "name": "feature/x"})
+        self.assertEqual(d["warnings"], {"some_warning": ["foo"]})
+
+        cs_empty = ChangeSet.from_dict({"id": str(uuid.uuid4()), "changes": []})
+        self.assertIsNone(cs_empty.branch)
+        self.assertIsNone(cs_empty.warnings)
+
+    def test_batch_malformed_per_entry_yields_207(self):
+        """A batch entry with non-list ``changes`` yields a per-item error, not a 500."""
+        payload = {
+            "change_sets": [
+                self._changeset_create_site("Batch OK", "batch-ok"),
+                {"id": str(uuid.uuid4()), "changes": "not-a-list"},
+            ],
+        }
+        response = self._post_batch(payload, status_code=status.HTTP_207_MULTI_STATUS)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 2)
+        self.assertIsNone(results[0].get("errors"))
+        self.assertIsNotNone(results[1].get("errors"))
+        self.assertTrue(Site.objects.filter(slug="batch-ok").exists())
+

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_api_bulk_plan.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_api_bulk_plan.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkPlan API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Site
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BulkPlanTestCase(APITestCase):
+    """BulkPlan endpoint test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Existing Site",
+            slug="existing-site",
+            comments="original comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, expected_status=status.HTTP_200_OK):
+        """Post the payload and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    def test_single_entity_create(self):
+        """Test bulk plan with a single new entity."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "New Site", "slug": "new-site"}},
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_type"], "create")
+        self.assertEqual(changes[0]["object_type"], "dcim.site")
+
+    def test_single_entity_update(self):
+        """Test bulk plan with a single existing entity that has changes."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "updated comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["change_type"], "update")
+        self.assertEqual(changes[0]["object_id"], self.site.pk)
+
+    def test_single_entity_no_changes(self):
+        """Test bulk plan with an entity that matches NetBox exactly — empty changes."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        cs = r.get("change_set", {})
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 0)
+
+    def test_multiple_entities_mixed(self):
+        """Test bulk plan with multiple entities — one create, one update, one no-change."""
+        payload = {
+            "entities": [
+                {
+                    "id": "create-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Brand New Site", "slug": "brand-new-site"}},
+                },
+                {
+                    "id": "update-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "changed",
+                        }
+                    },
+                },
+                {
+                    "id": "noop-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 3)
+
+        ids = {r["id"]: r for r in results}
+
+        create_r = ids["create-1"]
+        self.assertIsNone(create_r.get("errors"))
+        self.assertEqual(len(create_r["change_set"]["changes"]), 1)
+        self.assertEqual(create_r["change_set"]["changes"][0]["change_type"], "create")
+
+        update_r = ids["update-1"]
+        self.assertIsNone(update_r.get("errors"))
+        self.assertEqual(len(update_r["change_set"]["changes"]), 1)
+        self.assertEqual(update_r["change_set"]["changes"][0]["change_type"], "update")
+
+        noop_r = ids["noop-1"]
+        self.assertEqual(len(noop_r["change_set"]["changes"]), 0)
+
+    def test_entity_with_missing_entity_field(self):
+        """Test that a missing entity field returns per-entity error without failing the batch."""
+        payload = {
+            "entities": [
+                {
+                    "id": "good-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Good Site", "slug": "good-site"}},
+                },
+                {
+                    "id": "bad-1",
+                    "object_type": "dcim.site",
+                    "entity": None,
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 2)
+
+        ids = {r["id"]: r for r in results}
+
+        good = ids["good-1"]
+        self.assertIsNone(good.get("errors"))
+        self.assertIsNotNone(good.get("change_set"))
+
+        bad = ids["bad-1"]
+        self.assertIsNotNone(bad.get("errors"))
+        self.assertIn("entity", bad["errors"].get("request", {}))
+
+    def test_entity_with_missing_object_type(self):
+        """Test that a missing object_type returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "entity": {"site": {"name": "Some Site", "slug": "some-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+        self.assertIn("object_type", results[0]["errors"].get("request", {}))
+
+    def test_entity_with_unsupported_object_type(self):
+        """Test that an unsupported object_type returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+        self.assertIn("object_type", results[0]["errors"].get("request", {}))
+
+    def test_entity_with_invalid_object_type_format(self):
+        """Test that an invalid object_type format returns per-entity error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "nodotshere",
+                    "entity": {"nodotshere": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].get("errors"))
+
+    def test_empty_entities_list(self):
+        """Test that an empty entities list returns 400."""
+        payload = {"entities": []}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_entities_field(self):
+        """Test that a missing entities field returns 400."""
+        payload = {"something_else": "value"}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_entities_not_a_list(self):
+        """Test that entities as a non-list returns 400."""
+        payload = {"entities": "not a list"}
+        self.send_request(payload, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_id_correlation(self):
+        """Test that returned results preserve the entity IDs for correlation."""
+        payload = {
+            "entities": [
+                {
+                    "id": "aaa-111",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site A", "slug": "site-a"}},
+                },
+                {
+                    "id": "bbb-222",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site B", "slug": "site-b"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["id"], "aaa-111")
+        self.assertEqual(results[1]["id"], "bbb-222")
+
+    def test_entity_without_id(self):
+        """Test that an entity without an id field gets null id in the result."""
+        payload = {
+            "entities": [
+                {
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "No ID Site", "slug": "no-id-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["id"])
+        self.assertIsNone(results[0].get("errors"))

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_api_bulk_plan_apply.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_api_bulk_plan_apply.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - BulkPlanApply API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+from uuid import uuid4
+
+from dcim.models import Device, MACAddress, Site, VirtualChassis
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BulkPlanApplyTestCase(APITestCase):
+    """BulkPlanApply endpoint test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(
+            name="Existing Site",
+            slug="existing-site",
+            comments="original comments",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, expected_status=status.HTTP_200_OK):
+        """Post the payload and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    # --- Happy path: plan + apply both succeed ---
+
+    def test_single_entity_create_applies(self):
+        """Plan creates a new site and apply persists it to NetBox."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "New Site", "slug": "new-site"}},
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+
+        r = results[0]
+        self.assertEqual(r["id"], "entity-1")
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertIsNotNone(cs)
+        self.assertEqual(len(cs["changes"]), 1)
+        self.assertEqual(cs["changes"][0]["change_type"], "create")
+        # Site should exist after apply.
+        self.assertTrue(Site.objects.filter(slug="new-site").exists())
+
+    def test_single_entity_update_applies(self):
+        """Plan updates an existing site and apply persists the change."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "updated comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        r = results[0]
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertEqual(cs["changes"][0]["change_type"], "update")
+        self.site.refresh_from_db()
+        self.assertEqual(self.site.comments, "updated comments")
+
+    def test_single_entity_no_changes_skips_apply(self):
+        """Entity matching NetBox exactly produces empty change_set; apply is skipped."""
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {
+                        "site": {
+                            "name": "Existing Site",
+                            "slug": "existing-site",
+                            "comments": "original comments",
+                        }
+                    },
+                }
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        r = results[0]
+        self.assertIsNone(r.get("errors"))
+        cs = r.get("change_set")
+        self.assertEqual(len(cs["changes"]), 0)
+
+    # --- Plan failures short-circuit apply ---
+
+    def test_plan_failure_missing_entity_field(self):
+        """Missing entity field returns plan error per-entity; batch returns 207."""
+        payload = {
+            "entities": [
+                {
+                    "id": "good-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Good Site", "slug": "good-site"}},
+                },
+                {
+                    "id": "bad-1",
+                    "object_type": "dcim.site",
+                    "entity": None,
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        results = response.json().get("results", [])
+        ids = {r["id"]: r for r in results}
+
+        good = ids["good-1"]
+        self.assertIsNone(good.get("errors"))
+        self.assertIsNotNone(good.get("change_set"))
+        self.assertTrue(Site.objects.filter(slug="good-site").exists())
+
+        bad = ids["bad-1"]
+        self.assertIsNone(bad.get("change_set"))
+        self.assertIsNotNone(bad.get("errors"))
+        self.assertIn("plan", bad["errors"])
+        self.assertNotIn("apply", bad["errors"])
+
+    def test_plan_failure_unsupported_object_type(self):
+        """Unsupported object_type returns plan error, apply is skipped."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIsNone(r.get("change_set"))
+        self.assertIn("plan", r["errors"])
+        self.assertIn("object_type", r["errors"]["plan"].get("request", {}))
+
+    def test_plan_failure_invalid_object_type_format(self):
+        """Invalid object_type format returns plan error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "object_type": "nodotshere",
+                    "entity": {"nodotshere": {"name": "test"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIsNone(r.get("change_set"))
+        self.assertIn("plan", r["errors"])
+
+    def test_plan_failure_missing_object_type(self):
+        """Missing object_type returns plan error."""
+        payload = {
+            "entities": [
+                {
+                    "id": "bad-1",
+                    "entity": {"site": {"name": "Site", "slug": "site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+        r = response.json()["results"][0]
+        self.assertIn("plan", r["errors"])
+
+    # --- Apply failures: change_set still returned, apply error reported ---
+
+    def test_apply_failure_returns_change_set_and_apply_error(self):
+        """When _apply_one_changeset returns errors, the change_set is still in the response."""
+        from netbox_diode_plugin.api.common import ChangeSetResult
+
+        payload = {
+            "entities": [
+                {
+                    "id": "entity-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Apply Fail Site", "slug": "apply-fail-site"}},
+                }
+            ]
+        }
+
+        with mock.patch(
+            "netbox_diode_plugin.api.views._apply_one_changeset",
+            return_value=ChangeSetResult(
+                id="cs-id",
+                errors={"dcim.site": {"slug": ["already exists"]}},
+            ),
+        ):
+            response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+
+        r = response.json()["results"][0]
+        self.assertIsNotNone(r.get("change_set"))
+        self.assertIsNotNone(r.get("errors"))
+        self.assertNotIn("plan", r["errors"])
+        self.assertIn("apply", r["errors"])
+        self.assertIn("dcim.site", r["errors"]["apply"])
+
+    def test_mixed_batch_plan_ok_plan_fail_apply_fail(self):
+        """Mixed batch: one ok, one plan-fail, one apply-fail. Order preserved, 207 returned."""
+        from netbox_diode_plugin.api.common import ChangeSetResult
+
+        payload = {
+            "entities": [
+                {
+                    "id": "ok-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "OK Site", "slug": "ok-site"}},
+                },
+                {
+                    "id": "plan-fail-1",
+                    "object_type": "fake.model",
+                    "entity": {"model": {"name": "fake"}},
+                },
+                {
+                    "id": "apply-fail-1",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Apply Fail", "slug": "apply-fail"}},
+                },
+            ]
+        }
+
+        # Only fail the third entity's apply. The first uses the real applier.
+        original_apply = None
+        call_count = {"n": 0}
+
+        def fake_apply(change_set, request):
+            call_count["n"] += 1
+            # First call (ok-1) — delegate to real applier.
+            # Second call would be for apply-fail-1 (plan-fail-1 short-circuits).
+            if call_count["n"] == 1:
+                return original_apply(change_set, request)
+            return ChangeSetResult(
+                id=change_set.id,
+                errors={"dcim.site": {"slug": ["already exists"]}},
+            )
+
+        # Capture the real _apply_one_changeset for the first call to delegate to.
+        from netbox_diode_plugin.api import views as views_module
+        original_apply = views_module._apply_one_changeset
+
+        with mock.patch.object(views_module, "_apply_one_changeset", side_effect=fake_apply):
+            response = self.send_request(payload, expected_status=status.HTTP_207_MULTI_STATUS)
+
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 3)
+        ids = [r["id"] for r in results]
+        self.assertEqual(ids, ["ok-1", "plan-fail-1", "apply-fail-1"])
+
+        ok = results[0]
+        self.assertIsNone(ok.get("errors"))
+        self.assertIsNotNone(ok.get("change_set"))
+
+        plan_fail = results[1]
+        self.assertIsNone(plan_fail.get("change_set"))
+        self.assertIn("plan", plan_fail["errors"])
+
+        apply_fail = results[2]
+        self.assertIsNotNone(apply_fail.get("change_set"))
+        self.assertIn("apply", apply_fail["errors"])
+
+    # --- Envelope validation ---
+
+    def test_empty_entities_list(self):
+        """Empty entities list returns 400."""
+        self.send_request({"entities": []}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_entities_field(self):
+        """Missing entities field returns 400."""
+        self.send_request({"something_else": "value"}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_entities_not_a_list(self):
+        """Non-list entities returns 400."""
+        self.send_request({"entities": "not a list"}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    # --- ID correlation ---
+
+    def test_id_correlation_preserved(self):
+        """Result IDs match input IDs in order."""
+        payload = {
+            "entities": [
+                {
+                    "id": "aaa-111",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site A", "slug": "site-a"}},
+                },
+                {
+                    "id": "bbb-222",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "Site B", "slug": "site-b"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual([r["id"] for r in results], ["aaa-111", "bbb-222"])
+
+    def test_entity_without_id(self):
+        """Entity without an id field gets null id in result."""
+        payload = {
+            "entities": [
+                {
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": "No ID Site", "slug": "no-id-site"}},
+                },
+            ]
+        }
+
+        response = self.send_request(payload)
+        results = response.json().get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0]["id"])
+        self.assertIsNone(results[0].get("errors"))
+
+    # --- Auth/permissions ---
+
+    def test_unauthenticated_request_returns_403(self):
+        """Missing token returns 403 (DiodeOAuth2Authentication has no authenticate_header)."""
+        response = self.client.post(self.url, data={"entities": []}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # --- Cross-request plan race must not produce duplicate MACAddress ---
+
+    def test_concurrent_plans_dedupe_macaddress_via_pre_save_match(self):
+        """
+        Two requests planning the same MAC must apply to a single row.
+
+        Two reconciler workers planning equivalent change_sets for the same
+        interface + MAC each see no existing MAC row and each plan a CREATE.
+        Two sequential ``/bulk-plan/`` calls model this exactly: each request
+        has its own request-scoped obj_cache, so plan B cannot see plan A's
+        pending CREATE.
+
+        NetBox has no DB-level unique constraint on
+        (mac_address, assigned_object_type, assigned_object_id), so the
+        applier dedupes by routing dcim.macaddress through the find-first
+        CREATE path (matcher.requires_pre_save_match). Apply B's CREATE
+        therefore matches the row apply A just committed instead of
+        inserting a second one.
+        """
+        suffix = uuid4().hex[:8]
+        mac = "00:00:00:00:00:42"
+
+        plan_payload = {
+            "entities": [
+                {
+                    "id": f"race-{suffix}",
+                    "object_type": "dcim.interface",
+                    "entity": {
+                        "interface": {
+                            "name": f"eth0-{suffix}",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": f"dev-{suffix}",
+                                "role": {"name": f"role-{suffix}"},
+                                "site": {"name": f"site-{suffix}"},
+                                "device_type": {
+                                    "manufacturer": {"name": f"mfr-{suffix}"},
+                                    "model": f"dt-{suffix}",
+                                },
+                            },
+                            "primary_mac_address": {"mac_address": mac},
+                        },
+                    },
+                }
+            ]
+        }
+
+        plan_url = "/netbox/api/plugins/diode/bulk-plan/"
+        apply_url = "/netbox/api/plugins/diode/bulk-apply/"
+
+        plan_a = self.client.post(
+            plan_url, data=plan_payload, format="json", **self.authorization_header
+        )
+        plan_b = self.client.post(
+            plan_url, data=plan_payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(plan_a.status_code, status.HTTP_200_OK, plan_a.json())
+        self.assertEqual(plan_b.status_code, status.HTTP_200_OK, plan_b.json())
+
+        result_a = plan_a.json()["results"][0]
+        result_b = plan_b.json()["results"][0]
+        self.assertIsNone(result_a.get("errors"), result_a)
+        self.assertIsNone(result_b.get("errors"), result_b)
+        cs_a = result_a.get("change_set")
+        cs_b = result_b.get("change_set")
+        self.assertIsNotNone(cs_a, result_a)
+        self.assertIsNotNone(cs_b, result_b)
+
+        def mac_creates(change_set):
+            return [
+                c for c in change_set["changes"]
+                if c["object_type"] == "dcim.macaddress" and c["change_type"] == "create"
+            ]
+
+        self.assertEqual(len(mac_creates(cs_a)), 1, cs_a)
+        self.assertEqual(len(mac_creates(cs_b)), 1, cs_b)
+
+        apply_a = self.client.post(
+            apply_url,
+            data={"change_sets": [cs_a]},
+            format="json",
+            **self.authorization_header,
+        )
+        apply_b = self.client.post(
+            apply_url,
+            data={"change_sets": [cs_b]},
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(apply_a.status_code, status.HTTP_200_OK, apply_a.json())
+        self.assertEqual(apply_b.status_code, status.HTTP_200_OK, apply_b.json())
+
+        macs = MACAddress.objects.filter(mac_address=mac)
+        self.assertEqual(
+            macs.count(),
+            1,
+            f"expected exactly one MAC row after dedup, got {macs.count()}: "
+            f"{list(macs.values('pk', 'mac_address', 'assigned_object_id'))}",
+        )
+
+    def test_concurrent_plans_dedupe_virtualchassis_via_pre_save_match(self):
+        """
+        Two members planned before either apply must land in ONE chassis.
+
+        This is the only thing routing dcim.virtualchassis through the
+        find-first CREATE path buys, and it had no test. Two reconciler workers
+        each plan a member device carrying virtual_chassis: {"name": X} at a
+        moment when no chassis named X exists. Neither planner can match
+        anything -- there is no row yet, so VirtualChassisNameMatcher correctly
+        returns None -- so BOTH plans contain a masterless
+        create dcim.virtualchassis. Two sequential /bulk-plan/ calls model this
+        exactly: each request has its own request-scoped obj cache, so plan B
+        cannot see plan A's pending CREATE.
+
+        Nothing else catches the duplicate. VirtualChassis.name carries no
+        unique constraint, so apply B's INSERT succeeds and
+        _create_or_find_instance's IntegrityError fallback never runs; the
+        adoption pass declines a masterless payload outright
+        (_try_adopt_masterless_virtualchassis returns None when master is
+        None). The result would be a SPLIT CHASSIS: two rows of the same name,
+        one member each, one of them orphaned from the master the next ingest
+        binds.
+
+        Scope, precisely: this covers concurrent PLAN with sequential APPLY.
+        Two applies genuinely interleaved inside find_existing_object still
+        insert two rows -- pre-save matching is a lookup, not a lock.
+        """
+        suffix = uuid4().hex[:8]
+        vc_name = f"stack-{suffix}"
+        common = {
+            "site": {"name": f"site-{suffix}"},
+            "role": {"name": f"role-{suffix}"},
+            "device_type": {
+                "manufacturer": {"name": f"mfr-{suffix}"},
+                "model": f"dt-{suffix}",
+            },
+        }
+
+        def member_entity(device_name, position):
+            return {
+                "entities": [{
+                    "id": f"{device_name}",
+                    "object_type": "dcim.device",
+                    "entity": {"device": {
+                        "name": device_name,
+                        "vc_position": position,
+                        "virtual_chassis": {"name": vc_name},
+                        **common,
+                    }},
+                }]
+            }
+
+        plan_url = "/netbox/api/plugins/diode/bulk-plan/"
+        apply_url = "/netbox/api/plugins/diode/bulk-apply/"
+
+        change_sets = []
+        for device_name, position in ((f"sw1-{suffix}", 1), (f"sw2-{suffix}", 2)):
+            r = self.client.post(
+                plan_url,
+                data=member_entity(device_name, position),
+                format="json",
+                **self.authorization_header,
+            )
+            self.assertEqual(r.status_code, status.HTTP_200_OK, r.json())
+            result = r.json()["results"][0]
+            self.assertIsNone(result.get("errors"), result)
+            cs = result.get("change_set")
+            self.assertIsNotNone(cs, result)
+            vc_creates = [
+                c for c in cs["changes"]
+                if c["object_type"] == "dcim.virtualchassis" and c["change_type"] == "create"
+            ]
+            self.assertEqual(len(vc_creates), 1, cs)
+            self.assertIsNone(vc_creates[0]["data"].get("master"), vc_creates[0])
+            change_sets.append(cs)
+
+        # Both plans exist before either is applied -- that is the race.
+        for cs in change_sets:
+            r = self.client.post(
+                apply_url,
+                data={"change_sets": [cs]},
+                format="json",
+                **self.authorization_header,
+            )
+            self.assertEqual(r.status_code, status.HTTP_200_OK, r.json())
+
+        vcs = VirtualChassis.objects.filter(name=vc_name)
+        self.assertEqual(
+            vcs.count(), 1,
+            f"expected one chassis after dedup, got {list(vcs.values('pk', 'name'))}",
+        )
+        vc = vcs.first()
+        members = Device.objects.filter(virtual_chassis=vc).order_by("vc_position")
+        self.assertEqual(
+            [d.name for d in members], [f"sw1-{suffix}", f"sw2-{suffix}"],
+        )
+        self.assertEqual(vc.member_count, 2)
+
+    def test_a_stale_bulk_plan_does_not_write_the_chassis_it_matches(self):
+        """
+        The bulk endpoints reach the same applier, and the same stale plan.
+
+        /bulk-plan-apply/ cannot produce this shape by itself -- it plans and
+        applies in one call, so a chassis that exists is matched at PLAN time
+        and the plan is an UPDATE naming it by id. The stale plan needs the
+        pair: /bulk-plan/ while the chassis is absent, then /bulk-apply/ after
+        it has appeared, which is how a reconciler batches work and is exactly
+        the window the pre-save match exists to survive.
+
+        Asserted: the converged row is bound (one row, member joined, no
+        orphan) and none of its own fields are written by the plan.
+        """
+        suffix = uuid4().hex[:8]
+        vc_name = f"stack-{suffix}"
+        common = {
+            "site": {"name": f"site-{suffix}"},
+            "role": {"name": f"role-{suffix}"},
+            "device_type": {
+                "manufacturer": {"name": f"mfr-{suffix}"},
+                "model": f"dt-{suffix}",
+            },
+        }
+        plan = self.client.post(
+            "/netbox/api/plugins/diode/bulk-plan/",
+            data={"entities": [{
+                "id": f"sw1-{suffix}",
+                "object_type": "dcim.device",
+                "entity": {"device": {
+                    "name": f"sw1-{suffix}",
+                    "vc_position": 4,
+                    "virtual_chassis": {
+                        # No domain: the point of this test is the bind-only
+                        # contract on a row this payload cannot tell apart from
+                        # its own. Asserting a domain the row does not carry
+                        # identifies a DIFFERENT chassis and correctly gets its
+                        # own row, which would not exercise the bind at all.
+                        "name": vc_name,
+                        "description": "FROM-A",
+                    },
+                    **common,
+                }},
+            }]},
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(plan.status_code, status.HTTP_200_OK, plan.json())
+        result = plan.json()["results"][0]
+        self.assertIsNone(result.get("errors"), result)
+        change_set = result["change_set"]
+        vc_creates = [c for c in change_set["changes"]
+                      if c["object_type"] == "dcim.virtualchassis"
+                      and c["change_type"] == "create"]
+        self.assertEqual(len(vc_creates), 1, change_set)
+
+        # ...and only now does a chassis of that name appear.
+        vc = VirtualChassis.objects.create(
+            name=vc_name, description="OWNED-BY-B", domain="dom-b"
+        )
+        before = (vc.name, vc.description, vc.domain, vc.master_id, vc.last_updated)
+
+        applied = self.client.post(
+            "/netbox/api/plugins/diode/bulk-apply/",
+            data={"change_sets": [change_set]},
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(applied.status_code, status.HTTP_200_OK, applied.json())
+
+        rows = VirtualChassis.objects.filter(name=vc_name)
+        self.assertEqual(rows.count(), 1, list(rows.values("pk", "description", "master_id")))
+        fresh = rows.first()
+        self.assertEqual(
+            (fresh.name, fresh.description, fresh.domain, fresh.master_id, fresh.last_updated),
+            before,
+            "a stale bulk plan wrote the chassis it merely matched",
+        )
+        self.assertEqual(
+            Device.objects.get(name=f"sw1-{suffix}").virtual_chassis_id, fresh.pk
+        )
+        self.assertEqual(fresh.member_count, fresh.members.count())
+
+    def test_insufficient_scope_returns_403(self):
+        """Token with only read scope cannot call bulk-plan-apply (requires write)."""
+        read_only_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read"],
+            token_data={"scope": "netbox:read"},
+        )
+        with mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=read_only_user
+        ):
+            response = self.client.post(
+                self.url,
+                data={"entities": [{"id": "x", "object_type": "dcim.site",
+                                    "entity": {"site": {"name": "x", "slug": "x"}}}]},
+                format="json",
+                **self.authorization_header,
+            )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_api_diff_and_apply.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_api_diff_and_apply.py
@@ -1,0 +1,2182 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+import copy
+import datetime
+import decimal
+import logging
+from types import SimpleNamespace
+from unittest import mock
+from uuid import uuid4
+
+import netaddr
+from circuits.models import Circuit, Provider
+from core.models import ObjectType
+from dcim.models import Device, DeviceRole, DeviceType, FrontPort, Interface, Manufacturer, ModuleBay, RearPort, Site
+from extras.models import CustomField
+from extras.models.customfields import CustomFieldChoiceSet, CustomFieldChoiceSetBaseChoices, CustomFieldTypeChoices
+from ipam.models import ASN, VRF, IPAddress, VLANGroup, VLANTranslationPolicy
+from rest_framework import status
+from users.models import Owner, OwnerGroup
+from utilities.testing import APITestCase
+from virtualization.models import Cluster, VMInterface
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+def _get_error(response, object_name, field):
+    return response.json().get("errors", {}).get(object_name, {}).get(field, [])
+
+class GenerateDiffAndApplyTestCase(APITestCase):
+    """GenerateDiff -> ApplyChangeSet test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+        self.object_type = ObjectType.objects.get_for_model(Site)
+
+        self.uuid_field = CustomField.objects.create(
+            name='myuuid',
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            required=False,
+            unique=True,
+        )
+        self.uuid_field.object_types.set([self.object_type])
+        self.uuid_field.save()
+
+        self.json_field = CustomField.objects.create(
+            name='some_json',
+            type=CustomFieldTypeChoices.TYPE_JSON,
+            required=False,
+            unique=False,
+        )
+        self.json_field.object_types.set([self.object_type])
+        self.json_field.save()
+
+        self.datetime_field = CustomField.objects.create(
+            name='mydatetime',
+            type=CustomFieldTypeChoices.TYPE_DATETIME,
+            required=False,
+            unique=False,
+        )
+        self.datetime_field.object_types.set([self.object_type])
+        self.datetime_field.save()
+
+        self.date_field = CustomField.objects.create(
+            name='mydate',
+            type=CustomFieldTypeChoices.TYPE_DATE,
+            required=False,
+            unique=False,
+        )
+        self.date_field.object_types.set([self.object_type])
+        self.date_field.save()
+
+        self.decimal_field = CustomField.objects.create(
+            name='mydecimal',
+            type=CustomFieldTypeChoices.TYPE_DECIMAL,
+            required=False,
+            unique=False,
+        )
+        self.decimal_field.object_types.set([self.object_type])
+        self.decimal_field.save()
+
+        self.long_text_field = CustomField.objects.create(
+            name='my_long_text',
+            type=CustomFieldTypeChoices.TYPE_LONGTEXT,
+            required=False,
+            unique=False,
+        )
+        self.long_text_field.object_types.set([self.object_type])
+        self.long_text_field.save()
+
+        choices = CustomFieldChoiceSet.objects.create(
+            name='my_choices',
+            base_choices=CustomFieldChoiceSetBaseChoices.IATA,
+        )
+        self.selection_field = CustomField.objects.create(
+            name='my_selection',
+            type=CustomFieldTypeChoices.TYPE_SELECT,
+            required=False,
+            unique=False,
+            choice_set=choices,
+        )
+        self.selection_field.object_types.set([self.object_type])
+        self.selection_field.save()
+
+        self.multiple_selection_field = CustomField.objects.create(
+            name='my_multiple_selection',
+            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
+            required=False,
+            unique=False,
+            choice_set=choices,
+        )
+        self.multiple_selection_field.object_types.set([self.object_type])
+        self.multiple_selection_field.save()
+
+        self.object_field = CustomField.objects.create(
+            name='my_object',
+            type=CustomFieldTypeChoices.TYPE_OBJECT,
+            required=False,
+            unique=False,
+            related_object_type=self.object_type,
+        )
+        self.object_field.object_types.set([self.object_type])
+        self.object_field.save()
+
+        self.multiple_objects_field = CustomField.objects.create(
+            name='my_multiple_objects',
+            type=CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            required=False,
+            unique=False,
+            related_object_type=self.object_type,
+        )
+        self.multiple_objects_field.object_types.set([self.object_type])
+        self.multiple_objects_field.save()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def test_generate_diff_and_apply_create_interface_with_tags(self):
+        """Test generate diff and apply create interface with tags."""
+        interface_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.interface",
+            "entity": {
+                "interface": {
+                    "name": f"Interface {interface_uuid}",
+                    "mtu": "1500",
+                    "mode": "access",
+                    "tags": [
+                        {"name": "tag 1"}
+                    ],
+                    "type": "1000base-t",
+                    "device": {
+                        "name": f"Device {uuid4()}",
+                        "device_type": {
+                            "model": f"Device Type {uuid4()}",
+                            "manufacturer": {
+                                "name": f"Manufacturer {uuid4()}"
+                            }
+                        },
+                        "role": {
+                            "name": f"Role {uuid4()}"
+                        },
+                        "site": {
+                            "name": f"Site {uuid4()}"
+                        }
+                    },
+                    "enabled": True,
+                    "description": "Physical interface"
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_interface = Interface.objects.get(name=f"Interface {interface_uuid}")
+        self.assertEqual(new_interface.tags.count(), 1)
+        self.assertEqual(new_interface.tags.first().name, "tag 1")
+
+
+    def test_generate_diff_and_apply_create_and_update_device_role(self):
+        """Test generate diff and apply create and update device role."""
+        device_uuid = str(uuid4())
+        role_1_uuid = str(uuid4())
+        role_2_uuid = str(uuid4())
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "device_type": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {role_1_uuid}"
+                    },
+                    "site": {
+                        "name": f"Site {site_uuid}"
+                    }
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(new_device.site.name, f"Site {site_uuid}")
+        self.assertEqual(new_device.role.name, f"Role {role_1_uuid}")
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "deviceType": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {role_2_uuid}"
+                    },
+                    "site": {
+                        "name": f"Site {site_uuid}"
+                    }
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.site.name, f"Site {site_uuid}")
+        self.assertEqual(device.role.name, f"Role {role_2_uuid}")
+
+
+    def test_generate_diff_and_apply_create_site_autoslug(self):
+        """Test generate diff and apply create site."""
+        """Test generate diff create site."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.slug, f"site-{site_uuid}")
+
+    def test_generate_diff_and_apply_tags_merged(self):
+        """Test generate diff and apply merges tags."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "tags": [
+                        {"name": "tag 1"},
+                        {"name": "tag 2"},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.tags.count(), 2)
+        tag_names = [tag.name for tag in new_site.tags.all()]
+        self.assertIn("tag 1", tag_names)
+        self.assertIn("tag 2", tag_names)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "tags": [
+                        {"name": "tag 3"},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.tags.count(), 3)
+        tag_names = [tag.name for tag in new_site.tags.all()]
+        self.assertIn("tag 1", tag_names)
+        self.assertIn("tag 2", tag_names)
+        self.assertIn("tag 3", tag_names)
+
+    def test_generate_diff_and_apply_refs_not_merged(self):
+        """Test generate diff and apply does not merge reference lists."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "asns": [
+                        {"asn": "1", "rir": {"name": "RIR 1"}},
+                        {"asn": "2", "rir": {"name": "RIR 1"}},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.asns.count(), 2)
+        asns = [asn.asn for asn in new_site.asns.all()]
+        self.assertIn(1, asns)
+        self.assertIn(2, asns)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "asns": [
+                        {"asn": "3", "rir": {"name": "RIR 1"}},
+                    ],
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.asns.count(), 1)
+        asns = [asn.asn for asn in new_site.asns.all()]
+        self.assertNotIn(1, asns)
+        self.assertNotIn(2, asns)
+        self.assertIn(3, asns)
+
+
+    def test_generate_diff_and_apply_create_interface_with_primay_mac_address(self):
+        """Test generate diff and apply create interface with primary mac address."""
+        interface_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.interface",
+            "entity": {
+                "interface": {
+                    "name": f"Interface {interface_uuid}",
+                    "type": "1000base-t",
+                    "device": {
+                        "name": f"Device {uuid4()}",
+                        "role": {
+                            "Name": f"Role {uuid4()}",
+                        },
+                        "site": {
+                            "Name": f"Site {uuid4()}",
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "Name": f"Manufacturer {uuid4()}",
+                            },
+                            "model": f"Device Type {uuid4()}",
+                        },
+                    },
+                    "primary_mac_address": {
+                        "mac_address": "00:00:00:00:00:01",
+                    },
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_interface = Interface.objects.get(name=f"Interface {interface_uuid}")
+        self.assertEqual(new_interface.primary_mac_address.mac_address, "00:00:00:00:00:01")
+
+    def test_generate_diff_and_apply_create_device_with_primary_ip4_camel_case(self):
+        """Test generate diff and apply create device with primary ip4 (camel case)."""
+        device_uuid = str(uuid4())
+        interface_uuid = str(uuid4())
+        addr = "192.168.1.1"
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ipAddress": {
+                    "address": addr,
+                    "assignedObjectInterface": {
+                        "name": f"Interface {interface_uuid}",
+                        "type": "1000base-t",
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "role": {
+                                "name": f"Role {uuid4()}",
+                            },
+                            "site": {
+                                "name": f"Site {uuid4()}",
+                            },
+                            "deviceType": {
+                                "manufacturer": {
+                                    "name": f"Manufacturer {uuid4()}",
+                                },
+                                "model": f"Device Type {uuid4()}",
+                            },
+                            "primaryIp4": {
+                                "address": addr,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_ipaddress = IPAddress.objects.get(address=addr)
+        self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.primary_ip4.pk, new_ipaddress.pk)
+
+    def test_generate_diff_and_apply_create_device_with_primary_ip4(self):
+        """Test generate diff and apply create device with primary ip4."""
+        device_uuid = str(uuid4())
+        interface_uuid = str(uuid4())
+        addr = "192.168.1.1"
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": addr,
+                    "assigned_object_interface": {
+                        "name": f"Interface {interface_uuid}",
+                        "type": "1000base-t",
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "role": {
+                                "name": f"Role {uuid4()}",
+                            },
+                            "site": {
+                                "name": f"Site {uuid4()}",
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": f"Manufacturer {uuid4()}",
+                                },
+                                "model": f"Device Type {uuid4()}",
+                            },
+                            "primary_ip4": {
+                                "address": addr,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_ipaddress = IPAddress.objects.get(address=addr)
+        self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.primary_ip4.pk, new_ipaddress.pk)
+
+    def _create_device_with_interface(self, suffix, address=None):
+        """Create a site/role/type/device/interface graph, optionally with an IP."""
+        site = Site.objects.create(name=f"Site {suffix}", slug=f"site-{suffix}")
+        manufacturer = Manufacturer.objects.create(
+            name=f"Manufacturer {suffix}", slug=f"manufacturer-{suffix}"
+        )
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model=f"Device Type {suffix}",
+            slug=f"device-type-{suffix}",
+        )
+        role = DeviceRole.objects.create(
+            name=f"Role {suffix}", slug=f"role-{suffix}", color="ff0000"
+        )
+        device = Device.objects.create(
+            name=f"Device {suffix}", device_type=device_type, role=role, site=site
+        )
+        interface = Interface.objects.create(
+            device=device, name="GigabitEthernet1", type="1000base-t"
+        )
+        ip = IPAddress.objects.create(address=address) if address else None
+        return device, interface, ip
+
+    def _device_primary_ip4_payload(self, device, interface, address):
+        """Device-discovery style payload: IP assigned to an interface of a device whose primary_ip4 is that IP."""
+        return {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": address,
+                    "assigned_object_interface": {
+                        "name": interface.name,
+                        "type": interface.type,
+                        "device": {
+                            "name": device.name,
+                            "role": {"name": device.role.name},
+                            "site": {"name": device.site.name},
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": device.device_type.manufacturer.name
+                                },
+                                "model": device.device_type.model,
+                            },
+                            "primary_ip4": {"address": address},
+                        },
+                    },
+                },
+            },
+        }
+
+    def test_apply_device_primary_ip4_with_preexisting_unassigned_ip(self):
+        """Apply primary_ip4 when the IP exists unassigned and is only assigned to an interface later in the change set."""
+        addr = "10.0.1.123/24"
+        # poisoned state: a prior network-discovery ingest created the IP
+        # without an interface assignment; the device and interface exist too
+        device, interface, ip = self._create_device_with_interface(str(uuid4()), address=addr)
+
+        payload = self._device_primary_ip4_payload(device, interface, addr)
+        self.diff_and_apply(payload)
+
+        ip.refresh_from_db()
+        device.refresh_from_db()
+        self.assertEqual(ip.assigned_object, interface)
+        self.assertEqual(device.primary_ip4_id, ip.pk)
+
+    def test_rediff_converged_device_primary_ip4_is_noop(self):
+        """A converged device with primary_ip4 re-diffs to an empty change set."""
+        addr = "10.0.2.45/24"
+        device, interface, ip = self._create_device_with_interface(str(uuid4()), address=addr)
+        ip.assigned_object = interface
+        ip.save()
+        device.primary_ip4 = ip
+        device.save()
+
+        payload = self._device_primary_ip4_payload(device, interface, addr)
+        response = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+
+    def test_generate_diff_and_apply_create_device_with_primary_ip6(self):
+        """Test generate diff and apply create device with primary ip6."""
+        device_uuid = str(uuid4())
+        interface_uuid = str(uuid4())
+        addr = "2001:db8::1"
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": addr,
+                    "assigned_object_interface": {
+                        "name": f"Interface {interface_uuid}",
+                        "type": "1000base-t",
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "role": {
+                                "name": f"Role {uuid4()}",
+                            },
+                            "site": {
+                                "name": f"Site {uuid4()}",
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": f"Manufacturer {uuid4()}",
+                                },
+                                "model": f"Device Type {uuid4()}",
+                            },
+                            "primary_ip6": {
+                                "address": addr,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_ipaddress = IPAddress.objects.get(address=addr)
+        self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.primary_ip6.pk, new_ipaddress.pk)
+
+    def test_generate_diff_and_apply_create_device_with_oob_ip(self):
+        """Test generate diff and apply create device with oob ip."""
+        device_uuid = str(uuid4())
+        interface_uuid = str(uuid4())
+        addr = "192.168.1.1/24"
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": addr,
+                    "assigned_object_interface": {
+                        "name": f"Interface {interface_uuid}",
+                        "type": "1000base-t",
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "role": {
+                                "name": f"Role {uuid4()}",
+                            },
+                            "site": {
+                                "name": f"Site {uuid4()}",
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": f"Manufacturer {uuid4()}",
+                                },
+                                "model": f"Device Type {uuid4()}",
+                            },
+                            "oob_ip": {
+                                "address": addr,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_ipaddress = IPAddress.objects.get(address=addr)
+        self.assertEqual(new_ipaddress.assigned_object.name, f"Interface {interface_uuid}")
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.oob_ip.pk, new_ipaddress.pk)
+
+    def test_generate_diff_and_apply_create_and_update_site_with_custom_field(self):
+        """Test generate diff and apply create and update site with custom field."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "A New Custom Site",
+                    "slug": "a-new-custom-site",
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": site_uuid,
+                        },
+                        "mydecimal": {
+                            "decimal": 1234.567,
+                        },
+                        "some_json": {
+                            "json": '{"some_key": 9876543210}',
+                        },
+                        "my_long_text": {
+                            "long_text": "This is a long text",
+                        },
+                        "my_selection": {
+                            "selection": "LAX",
+                        },
+                        "my_multiple_selection": {
+                            "multiple_selection": ["JFK", "LAX"],
+                        },
+                        "my_object": {
+                            "object": {
+                                "site": {
+                                    "name": "Custom Object Site Ref 1",
+                                }
+                            },
+                        },
+                        "my_multiple_objects": {
+                            "multiple_objects": [
+                                {
+                                    "site": {
+                                        "name": "Custom Object Site Ref 2",
+                                    }
+                                },
+                                {
+                                    "site": {
+                                        "name": "Custom Object Site Ref 3",
+                                    }
+                                },
+                            ],
+                        },
+                    },
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name="A New Custom Site")
+        self.assertEqual(new_site.custom_field_data[self.uuid_field.name], site_uuid)
+        self.assertEqual(new_site.custom_field_data[self.json_field.name], {"some_key": 9876543210})
+        self.assertEqual(new_site.custom_field_data[self.decimal_field.name], 1234.567)
+        self.assertEqual(new_site.custom_field_data[self.long_text_field.name], "This is a long text")
+        self.assertEqual(new_site.custom_field_data[self.selection_field.name], "LAX")
+        self.assertEqual(new_site.custom_field_data[self.multiple_selection_field.name], ["JFK", "LAX"])
+
+        siteRef1 = Site.objects.get(name="Custom Object Site Ref 1")
+        self.assertIsNotNone(siteRef1)
+        self.assertEqual(new_site.custom_field_data[self.object_field.name], siteRef1.pk)
+        siteRef2 = Site.objects.get(name="Custom Object Site Ref 2")
+        self.assertIsNotNone(siteRef2)
+        self.assertEqual(new_site.custom_field_data[self.multiple_objects_field.name][0], siteRef2.pk)
+        siteRef3 = Site.objects.get(name="Custom Object Site Ref 3")
+        self.assertIsNotNone(siteRef3)
+        self.assertEqual(new_site.custom_field_data[self.multiple_objects_field.name][1], siteRef3.pk)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "comments": "An updated comment",
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": site_uuid,
+                        },
+                        "some_json": {
+                            "json": '{"some_key": 1234567890}',
+                        },
+                        "mydatetime": {
+                            "datetime": "2026-01-01T09:00:00Z",
+                        },
+                        "mydate": {
+                            "date": "2026-01-01T00:00:00Z",
+                        },
+                    },
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name="A New Custom Site")
+        self.assertEqual(new_site.cf[self.uuid_field.name], site_uuid)
+        self.assertEqual(new_site.cf[self.json_field.name], {"some_key": 1234567890})
+        self.assertEqual(new_site.cf[self.datetime_field.name], datetime.datetime(2026, 1, 1, 9, 0, 0, tzinfo=datetime.timezone.utc))
+        self.assertEqual(new_site.cf[self.date_field.name], datetime.date(2026, 1, 1))
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": site_uuid,
+                        },
+                        "mydatetime": {
+                            "datetime": "2026-01-01T10:00:00Z",
+                        },
+                        "mydate": {
+                            "date": "2026-01-02T00:00:00Z",
+                        },
+                        "my_multiple_objects": {
+                            "multiple_objects": [
+                                {
+                                    "site": {
+                                        "name": "Custom Object Site Ref 2",
+                                    }
+                                },
+                                {
+                                    "site": {
+                                        "name": "Custom Object Site Ref 4",
+                                    }
+                                },
+                            ],
+                        },
+
+                    },
+                },
+            }
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name="A New Custom Site")
+        self.assertEqual(new_site.cf[self.uuid_field.name], site_uuid)
+        self.assertEqual(new_site.cf[self.json_field.name], {"some_key": 1234567890})
+        self.assertEqual(new_site.cf[self.datetime_field.name], datetime.datetime(2026, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc))
+        self.assertEqual(new_site.cf[self.date_field.name], datetime.date(2026, 1, 2))
+
+        self.assertEqual(len(new_site.custom_field_data[self.multiple_objects_field.name]), 2)
+        siteRef2 = Site.objects.get(name="Custom Object Site Ref 2")
+        self.assertIsNotNone(siteRef2)
+        self.assertEqual(new_site.custom_field_data[self.multiple_objects_field.name][0], siteRef2.pk)
+        siteRef4 = Site.objects.get(name="Custom Object Site Ref 4")
+        self.assertIsNotNone(siteRef3)
+        self.assertEqual(new_site.custom_field_data[self.multiple_objects_field.name][1], siteRef4.pk)
+
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": site_uuid,
+                        },
+                        "mydatetime": {
+                            "datetime": "2026-01-01T10:00:00Z",
+                        },
+                        "mydate": {
+                            "date": "2026-01-02T00:00:00Z",
+                        },
+                    },
+                },
+            }
+        }
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+    def test_generate_diff_and_apply_circuit_with_install_date(self):
+        """Test generate diff and apply circuit with date."""
+        circuit_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "circuits.circuit",
+            "entity": {
+                "circuit": {
+                    "cid": f"Circuit {circuit_uuid}",
+                    "install_date": "2026-01-01T00:00:00Z",
+                    "provider": {
+                        "name": f"Provider {uuid4()}",
+                    },
+                    "type": {
+                        "name": f"Ciruit Type {uuid4()}",
+                    },
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_circuit = Circuit.objects.get(cid=f"Circuit {circuit_uuid}")
+        self.assertEqual(new_circuit.install_date, datetime.date(2026, 1, 1))
+
+    def test_generate_diff_and_apply_site_with_lat_lon(self):
+        """Test generate diff and apply site with lat and lon."""
+        site_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "latitude":  23.456,
+                    "longitude": 78.910,
+                },
+            },
+        }
+
+        _, response = self.diff_and_apply(payload)
+        new_site = Site.objects.get(name=f"Site {site_uuid}")
+        self.assertEqual(new_site.latitude, decimal.Decimal("23.456"))
+        self.assertEqual(new_site.longitude, decimal.Decimal("78.910"))
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": f"Site {site_uuid}",
+                    "latitude":  23.456,
+                    "longitude": 78.910,
+                },
+            },
+        }
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+    def test_generate_diff_and_apply_wrong_type_date(self):
+        """Test generate diff and apply wrong type date."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Site Generate Diff 1",
+                    "slug": "site-generate-diff-1",
+                    "custom_fields": {
+                        "mydate": {
+                            "date": 12,
+                        },
+                    },
+                },
+            }
+        }
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+
+        diff = response1.json().get("change_set", {})
+
+        response2 = self.client.post(
+            self.apply_url, data=diff, format="json", **self.authorization_header
+        )
+        self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_generate_diff_and_apply_vlan_group_with_vid_ranges(self):
+        """Test generate diff and apply vlan group vid ranges."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vlangroup",
+            "entity": {
+                "vlan_group": {
+                    "name": "VLAN Group 1",
+                    "vid_ranges": [1,5,10,15],
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_vlan_group = VLANGroup.objects.get(name="VLAN Group 1")
+        self.assertEqual(new_vlan_group.vid_ranges[0].lower, 1)
+        self.assertEqual(new_vlan_group.vid_ranges[0].upper, 6)
+        self.assertEqual(new_vlan_group.vid_ranges[1].lower, 10)
+        self.assertEqual(new_vlan_group.vid_ranges[1].upper, 16)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vlangroup",
+            "entity": {
+                "vlan_group": {
+                    "name": "VLAN Group 1",
+                    "vid_ranges": [3,9,12,20],
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_vlan_group = VLANGroup.objects.get(name="VLAN Group 1")
+        self.assertEqual(new_vlan_group.vid_ranges[0].lower, 3)
+        self.assertEqual(new_vlan_group.vid_ranges[0].upper, 10)
+        self.assertEqual(new_vlan_group.vid_ranges[1].lower, 12)
+        self.assertEqual(new_vlan_group.vid_ranges[1].upper, 21)
+
+    def test_generate_diff_and_apply_vrf_no_rd_dedup(self):
+        """Re-ingesting an RD-less VRF resolves to the existing row (empty diff on second pass)."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {
+                "vrf": {
+                    "name": "VRF-A",
+                },
+            },
+        }
+        self.diff_and_apply(payload)
+        # Second diff must be a no-op — proves the matcher resolved to the existing VRF.
+        response = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+        vrfs = VRF.objects.filter(name="VRF-A")
+        self.assertEqual(vrfs.count(), 1)
+        self.assertIsNone(vrfs.first().rd)
+
+    def test_generate_diff_and_apply_vrf_no_rd_does_not_match_rd_vrf(self):
+        """An RD-less ingest must not collapse into an existing RD'd VRF with the same name."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-B", "rd": "65000:1"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-B"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-B").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual(vrfs[0].rd, "65000:1")
+        self.assertIsNone(vrfs[1].rd)
+
+    def test_generate_diff_and_apply_vrf_rd_after_no_rd_does_not_collapse(self):
+        """An RD'd ingest after a no-RD ingest with the same name should create a new VRF."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-C"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-C", "rd": "65000:2"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-C").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertIsNone(vrfs[0].rd)
+        self.assertEqual(vrfs[1].rd, "65000:2")
+
+    def test_generate_diff_and_apply_vrf_no_rd_update(self):
+        """Repeat no-RD ingest with a different field value should update the same VRF, not duplicate."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-D", "description": "first"}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-D", "description": "second"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-D")
+        self.assertEqual(vrfs.count(), 1)
+        self.assertEqual(vrfs.first().description, "second")
+
+    def test_generate_diff_and_apply_vrf_no_rd_within_tenant_dedup(self):
+        """Re-ingesting an RD-less VRF within the same tenant resolves to the existing row."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
+        })
+        # Second diff must be a no-op — proves logical_vrf_name_within_tenant matched.
+        response = self.client.post(self.diff_url, data={
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-E", "tenant": {"name": "Tenant E"}}},
+        }, format="json", **self.authorization_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("change_set", {}).get("changes", []), [])
+        self.assertEqual(VRF.objects.filter(name="VRF-E").count(), 1)
+
+    def test_generate_diff_and_apply_vrf_no_rd_no_cross_tenant_collapse(self):
+        """Two RD-less VRFs with the same name in different tenants must remain distinct."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-F", "tenant": {"name": "Tenant F1"}}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-F", "tenant": {"name": "Tenant F2"}}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-F").select_related("tenant").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual({v.tenant.name for v in vrfs}, {"Tenant F1", "Tenant F2"})
+
+    def test_generate_diff_and_apply_vrf_no_rd_no_tenant_does_not_match_tenant_vrf(self):
+        """A no-tenant RD-less ingest must not collapse into a same-name VRF that has a tenant."""
+        self.diff_and_apply({
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-G", "tenant": {"name": "Tenant G"}}},
+        })
+        self.diff_and_apply({
+            "timestamp": 2,
+            "object_type": "ipam.vrf",
+            "entity": {"vrf": {"name": "VRF-G"}},
+        })
+        vrfs = VRF.objects.filter(name="VRF-G").order_by("pk")
+        self.assertEqual(vrfs.count(), 2)
+        self.assertEqual(vrfs[0].tenant.name, "Tenant G")
+        self.assertIsNone(vrfs[1].tenant)
+
+    def test_generate_diff_and_apply_ip_address_with_assigned_object_interface(self):
+        """Test ip."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                    "assigned_object_interface": {
+                        "device": {
+                            "name": "Device ABC",
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Manufacturer ABC"
+                                },
+                                "model": "Device Type ABC"
+                            },
+                            "role": {
+                                "name": "Role ABC"
+                            },
+                            "platform": {
+                            "name": "Platform ABC",
+                            "manufacturer": {
+                                "name": "Manufacturer ABC"
+                            }
+                            },
+                            "site": {
+                                "name": "Site ABC"
+                            }
+                        },
+                        "name": "Interface ABC",
+                        "type": "1000base-t",
+                        "mode": "access"
+                    },
+                    "description": "IP Address description",
+                    "comments": "Lorem ipsum dolor sit amet",
+                    "tags": [
+                        {
+                            "name": "tag 1"
+                        },
+                        {
+                            "name": "tag 2"
+                        }
+                    ]
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_generate_diff_update_ip_address(self):
+        """Test generate diff update ip address."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/32",
+                    "status": "deprecated",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        self.assertEqual(diff.get("changes", []), [])
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "active",
+                    "role": "secondary",
+                }
+            }
+        }
+
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116")
+        self.assertEqual(ip.status, "active")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/24",
+                    "status": "deprecated",
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116/24")
+        self.assertEqual(ip.role, "secondary")
+        self.assertEqual(ip.status, "deprecated")
+        self.assertEqual(ip.address, netaddr.IPNetwork("254.198.174.0/24"))
+
+        vrf_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116/24",
+                    "status": "active",
+                    "vrf": {
+                        "name": f"VRF {vrf_uuid}"
+                    }
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116/24", vrf__name=f"VRF {vrf_uuid}")
+        self.assertEqual(ip.vrf.name, f"VRF {vrf_uuid}")
+        self.assertEqual(ip.status, "active")
+
+        ip2 = IPAddress.objects.get(address="254.198.174.116/24", vrf__isnull=True)
+        self.assertEqual(ip2.vrf, None)
+        self.assertEqual(ip2.status, "deprecated")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.ipaddress",
+            "entity": {
+                "ip_address": {
+                    "address": "254.198.174.116",
+                    "status": "dhcp",
+                    "vrf": {
+                        "name": f"VRF {vrf_uuid}"
+                    }
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+        ip = IPAddress.objects.get(address="254.198.174.116", vrf__name=f"VRF {vrf_uuid}")
+        self.assertEqual(ip.status, "dhcp")
+
+        ip2 = IPAddress.objects.get(address="254.198.174.116/24", vrf__isnull=True)
+        self.assertEqual(ip2.vrf, None)
+        self.assertEqual(ip2.status, "deprecated")
+
+    def test_generate_diff_and_apply_complex_vminterface(self):
+        """Test generate diff and apply and update a complex vm interface."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "virtualization.vminterface",
+            "entity": {
+                "vm_interface": {
+                    "virtual_machine": {
+                        "name": "Virtual Machine 15e00bdf-4294-41df-a450-ffcfec6c7f2b",
+                        "status": "active",
+                        "site": {
+                            "name": "Site 10"
+                        },
+                        "cluster": {
+                            "name": "Cluster 10",
+                            "type": {
+                                "name": "Cluster type 10"
+                            },
+                            "group": {
+                                "name": "Cluster group 10"
+                            },
+                            "status": "active",
+                            "scope_site": {
+                                "name": "Site 10"
+                            }
+                        },
+                        "role": {
+                            "name": "Role 10"
+                        },
+                        "platform": {
+                            "name": "Platform 10",
+                            "manufacturer": {
+                            "name": "Manufacturer 10"
+                            }
+                        },
+                        "vcpus": 1.0,
+                        "memory": "4096",
+                        "disk": "100",
+                        "description": "Virtual Machine A description",
+                        "comments": "Lorem ipsum dolor sit amet",
+                        "tags": [
+                            {
+                            "name": "tag 1"
+                            }
+                        ]
+                    },
+                    "name": "Interface 47e8a593-8b74-4e94-9a8e-c02113f0bf88",
+                    "enabled": False,
+                    "mtu": "1500",
+                    "primary_mac_address": {
+                        "mac_address": "00:00:00:00:00:00"
+                    },
+                    "description": "Interface A description",
+                    "tags": [
+                        {
+                            "name": "tag 1"
+                        }
+                    ]
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+
+        payload2 = copy.deepcopy(payload)
+        payload2['entity']['vm_interface']["mtu"] = "2000"
+        payload2['entity']['vm_interface']["primary_mac_address"] = {
+            "mac_address": "00:00:00:00:00:01"
+        }
+        _ = self.diff_and_apply(payload2)
+        vm_interface = VMInterface.objects.get(name="Interface 47e8a593-8b74-4e94-9a8e-c02113f0bf88")
+        self.assertEqual(vm_interface.mtu, 2000)
+        self.assertEqual(vm_interface.primary_mac_address.mac_address, "00:00:00:00:00:01")
+
+    def test_generate_diff_and_apply_dedupe_devicetype(self):
+        """Test generate diff and apply dedupe devicetype in wireless link."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "wireless.wirelesslink",
+            "entity": {
+                "wireless_link": {
+                    "interface_a": {
+                        "device": {
+                            "name": "Device 1",
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "role": {"name": "Device Role 1"},
+                            "site": {"name": "Site 1"}
+                        },
+                        "name": "Radio0/1",
+                        "type": "ieee802.11ac",
+                        "enabled": True
+                    },
+                    "interface_b": {
+                        "device": {
+                            "name": "Device 2",
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "role": {"name": "Device Role 1"},
+                            "site": {"name": "Site 1"}
+                        },
+                        "name": "Radio0/1",
+                        "type": "ieee802.11ac",
+                        "enabled": True
+                    },
+                    "ssid": "P2P-Link-1",
+                    "status": "connected",
+                    "tenant": {"name": "Tenant 1"},
+                    "auth_type": "wpa-personal",
+                    "auth_cipher": "aes",
+                    "auth_psk": "P2PLinkKey123!",
+                    "distance": 1.5,
+                    "distance_unit": "km",
+                    "description": "Point-to-point wireless backhaul link",
+                    "comments": "Building A to Building B wireless bridge",
+                    "tags": [
+                        {
+                            "name": "Tag 1"
+                        },
+                        {
+                            "name": "Tag 2"
+                        }
+                    ]
+                }
+            }
+        }
+
+        _ = self.diff_and_apply(payload)
+
+    def test_generate_diff_and_apply_provider_with_accounts(self):
+        """Test generate diff and apply provider with accounts."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "circuits.provider",
+            "entity": {
+                "provider": {
+                    "name": "Level 3 Communications",
+                    "slug": "level3",
+                    "description": "Global Tier 1 Internet Service Provider",
+                    "comments": "Primary transit provider for data center connectivity",
+                    "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}],
+                    "accounts": [
+                        {
+                            "provider": {"name": "Level 3 Communications"},
+                            "name": "East Coast Account",
+                            "account": "L3-12345",
+                            "description": "East Coast regional services account",
+                            "comments": "Managed through regional NOC"
+                        },
+                        {
+                            "provider": {"name": "Level 3 Communications"},
+                            "name": "West Coast Account",
+                            "account": "L3-67890",
+                            "description": "West Coast regional services account",
+                            "comments": "Managed through regional NOC"
+                        }
+                    ],
+                    "asns": [
+                        {
+                            "asn": "3356",
+                            "rir": {"name": "ARIN"},
+                            "tenant": {"name": "Tenant 1"},
+                            "description": "Level 3 Global ASN",
+                            "comments": "Primary transit ASN"
+                        }
+                    ]
+                }
+            }
+        }
+
+        _ = self.diff_and_apply(payload)
+        provider = Provider.objects.get(name="Level 3 Communications")
+        self.assertEqual(provider.accounts.count(), 2)
+        self.assertEqual(provider.asns.count(), 1)
+
+    def test_generate_diff_and_apply_module_bay_with_module(self):
+        """Test generate diff and apply module bay with a module installed (non-circular)."""
+        # First create the module bay
+        bay_payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "dcim.modulebay",
+            "entity": {
+                "module_bay": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "name": "Module Bay 1",
+                    "label": "STACK-1",
+                    "position": "Rear",
+                    "description": "Primary stacking module bay",
+                    "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+                }
+            }
+        }
+        _ = self.diff_and_apply(bay_payload)
+        module_bay = ModuleBay.objects.get(name="Module Bay 1")
+        self.assertEqual(module_bay.device.name, "Device 1")
+
+        # Then install a module into that bay (non-circular — module references
+        # the same bay it's installed in, no sub-bays that reference back)
+        module_payload = {
+            "timestamp": "2025-04-16T02:58:21.564615Z",
+            "object_type": "dcim.module",
+            "entity": {
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module_type": {
+                        "manufacturer": {"name": "Cisco"},
+                        "model": "C2960S-STACK"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        }
+                    }
+                }
+            }
+        }
+        _ = self.diff_and_apply(module_payload)
+        from dcim.models import Module
+        module = Module.objects.get(module_bay__name="Module Bay 1")
+        self.assertEqual(module.device.name, "Device 1")
+        self.assertEqual(module.module_type.manufacturer.name, "Cisco")
+        self.assertEqual(module.module_type.model, "C2960S-STACK")
+        self.assertEqual(module.module_bay.name, "Module Bay 1")
+
+    def test_generate_diff_and_apply_module_bay_circular_ref_fails(self):
+        """Test generate diff and apply module bay."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "dcim.modulebay",
+            "entity":     {
+                "module_bay": {
+                    "name": "Module Bay 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {"name": "Device Role 1"},
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "site": {"name": "Site 1"}
+                    },
+                    "module": {
+                        "asset_tag": "1234567890",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {"name": "Device Role 1"},
+                            "device_type": {
+                                "manufacturer": {"name": "Cisco"},
+                                "model": "C2960S"
+                            },
+                            "site": {"name": "Site 1"}
+                        },
+                        "module_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S-STACK"
+                        },
+                        "module_bay": {
+                            "name": "Module Bay 1",
+                            "device": {
+                                "name": "Device 1",
+                                "role": {"name": "Device Role 1"},
+                                "device_type": {
+                                    "manufacturer": {"name": "Cisco"},
+                                    "model": "C2960S"
+                                },
+                                "site": {"name": "Site 1"}
+                            },
+                            "module": {
+                                "asset_tag": "1234567890",
+                            }
+                        }
+                    },
+                    "label": "STACK-2",
+                    "position": "Rear",
+                    "description": "Secondary stacking module bay",
+                    "tags": [{"name": "Tag 1"}, {"name": "Tag 2"}]
+                }
+            }
+        }
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+
+        response2 = self.client.post(
+            self.apply_url, data=diff, format="json", **self.authorization_header
+        )
+        self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn(
+            "A module bay cannot belong to a module installed within it.",
+            _get_error(response2, "dcim.modulebay", "__all__")
+        )
+
+    def test_generate_diff_and_apply_virtual_machine_with_primary_ip_4_ok(self):
+        """Test generate diff and apply virtual machine with primary ip 4 assigned."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "virtualization.virtualmachine",
+            "entity": {
+                "timestamp": "2025-04-16T13:45:02.045208Z",
+                "virtual_machine": {
+                    "name": "app-server-01",
+                    "status": "active",
+                    "site": {"name": "Site 1"},
+                    "cluster": {
+                        "name": "Cluster 1",
+                        "type": {"name": "Cluster Type 1"}
+                    },
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {"name": "Cisco"},
+                            "model": "C2960S"
+                        },
+                        "role": {"name": "Device Role 1"},
+                        "site": {"name": "Site 1"},
+                        "cluster": {
+                            "name": "Cluster 1",
+                            "type": {"name": "Cluster Type 1"}
+                        }
+                    },
+                    "serial": "VM-2023-001",
+                    "role": {"name": "Application Server"},
+                    "tenant": {"name": "Tenant 1"},
+                    "platform": {"name": "Ubuntu 22.04"},
+                    "primary_ip4": {
+                        "address": "192.168.2.10",
+                        "assigned_object_vm_interface": {
+                            "virtual_machine": {
+                                "name": "app-server-01",
+                                "cluster": {
+                                    "name": "Cluster 1",
+                                    "type": {"name": "Cluster Type 1"}
+                                },
+                                "tenant": {"name": "Tenant 1"},
+                            },
+                            "name": "eth0",
+                            "enabled": True,
+                            "mtu": "1500",
+                        }
+                    },
+                    "vcpus": 4.0,
+                    "memory": "214748364",
+                    "disk": "147483647",
+                    "description": "Primary application server instance",
+                    "comments": "Hosts critical business applications",
+                    "tags": [
+                        {
+                            "name": "Tag 1"
+                        },
+                        {
+                            "name": "Tag 2"
+                        }
+                    ]
+                }
+            }
+        }
+        _ = self.diff_and_apply(payload)
+
+    def test_generate_diff_and_apply_update_cluster_location(self):
+        """Test generate diff and apply update cluster location, same site."""
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "virtualization.cluster",
+            "entity":     {
+                "cluster": {
+                    "name": "Cluster A",
+                    "type": {"name": "Cluster Type 1"},
+                    "group": {"name": "Cluster Group 1"},
+                    "status": "active",
+                    "tenant": {"name": "Tenant 1"},
+                    "scope_site": {"name": "Site 1"},
+                    "description": "Cluster 1 Description",
+                    "comments": "Cluster 1 Comments",
+                    "tags": [{"name": "Tag 1"}]
+                }
+            },
+        }
+        _ = self.diff_and_apply(payload)
+
+        cluster = Cluster.objects.get(name="Cluster A")
+        self.assertEqual(cluster.scope.name, "Site 1")
+
+        payload = {
+            "timestamp": "2025-04-16T02:58:20.564615Z",
+            "object_type": "virtualization.cluster",
+            "entity":     {
+                "cluster": {
+                    "name": "Cluster A",
+                    "type": {"name": "Cluster Type 1"},
+                    "group": {"name": "Cluster Group 1"},
+                    "status": "active",
+                    "tenant": {"name": "Tenant 1"},
+                    "scope_location": {"name": "Location 1", "site": {"name": "Site 1"}},
+                    "description": "Cluster 1 Description",
+                    "comments": "Cluster 1 Comments",
+                    "tags": [{"name": "Tag 1"}]
+                }
+            },
+        }
+        _ = self.diff_and_apply(payload)
+        cluster = Cluster.objects.get(name="Cluster A")
+        self.assertEqual(cluster.scope.name, "Location 1")
+
+    def test_generate_diff_and_apply_create_and_update_owner(self):
+        """Test generate diff and apply create and update owner (NetBox 4.5.0)."""
+        owner_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "users.owner",
+            "entity": {
+                "owner": {
+                    "name": f"Owner {owner_uuid}",
+                    "group": {
+                        "name": f"Owner Group {group_uuid}",
+                    },
+                    "description": "Primary network owner",
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_owner = Owner.objects.get(name=f"Owner {owner_uuid}")
+        self.assertEqual(new_owner.description, "Primary network owner")
+        self.assertEqual(new_owner.group.name, f"Owner Group {group_uuid}")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "users.owner",
+            "entity": {
+                "owner": {
+                    "name": f"Owner {owner_uuid}",
+                    "group": {
+                        "name": f"Owner Group {group_uuid}",
+                    },
+                    "description": "Updated network owner",
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        updated_owner = Owner.objects.get(name=f"Owner {owner_uuid}")
+        self.assertEqual(updated_owner.description, "Updated network owner")
+
+    def test_generate_diff_and_apply_create_and_update_ownergroup(self):
+        """Test generate diff and apply create and update ownergroup (NetBox 4.5.0)."""
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "users.ownergroup",
+            "entity": {
+                "owner_group": {
+                    "name": f"Owner Group {group_uuid}",
+                    "description": "Network operations team",
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_group = OwnerGroup.objects.get(name=f"Owner Group {group_uuid}")
+        self.assertEqual(new_group.description, "Network operations team")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "users.ownergroup",
+            "entity": {
+                "owner_group": {
+                    "name": f"Owner Group {group_uuid}",
+                    "description": "Updated network operations team",
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        updated_group = OwnerGroup.objects.get(name=f"Owner Group {group_uuid}")
+        self.assertEqual(updated_group.description, "Updated network operations team")
+
+    def test_generate_diff_and_apply_create_device_with_owner(self):
+        """Test generate diff and apply create device with owner field (NetBox 4.5.0)."""
+        device_uuid = str(uuid4())
+        owner_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "device_type": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {uuid4()}"
+                    },
+                    "site": {
+                        "name": f"Site {uuid4()}"
+                    },
+                    "owner": {
+                        "name": f"Owner {owner_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(new_device.owner.name, f"Owner {owner_uuid}")
+
+    def test_generate_diff_and_apply_create_circuit_with_owner(self):
+        """Test generate diff and apply create circuit with owner field (NetBox 4.5.0)."""
+        circuit_uuid = str(uuid4())
+        owner_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "circuits.circuit",
+            "entity": {
+                "circuit": {
+                    "cid": f"Circuit {circuit_uuid}",
+                    "provider": {
+                        "name": f"Provider {uuid4()}",
+                    },
+                    "type": {
+                        "name": f"Circuit Type {uuid4()}",
+                    },
+                    "owner": {
+                        "name": f"Owner {owner_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                },
+            },
+        }
+        _, response = self.diff_and_apply(payload)
+        new_circuit = Circuit.objects.get(cid=f"Circuit {circuit_uuid}")
+        self.assertEqual(new_circuit.owner.name, f"Owner {owner_uuid}")
+
+    def test_generate_diff_and_apply_update_device_owner(self):
+        """Test generate diff and apply update device owner (NetBox 4.5.0)."""
+        device_uuid = str(uuid4())
+        site_uuid = str(uuid4())
+        owner1_uuid = str(uuid4())
+        owner2_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+
+        # Create device with initial owner
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "device_type": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {uuid4()}"
+                    },
+                    "site": {
+                        "name": f"Site {site_uuid}"
+                    },
+                    "owner": {
+                        "name": f"Owner {owner1_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.owner.name, f"Owner {owner1_uuid}")
+
+        # Update device to different owner
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": f"Device {device_uuid}",
+                    "device_type": {
+                        "model": f"Device Type {uuid4()}",
+                        "manufacturer": {
+                            "name": f"Manufacturer {uuid4()}"
+                        }
+                    },
+                    "role": {
+                        "name": f"Role {uuid4()}"
+                    },
+                    "site": {
+                        "name": f"Site {site_uuid}"
+                    },
+                    "owner": {
+                        "name": f"Owner {owner2_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                },
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        device = Device.objects.get(name=f"Device {device_uuid}")
+        self.assertEqual(device.owner.name, f"Owner {owner2_uuid}")
+
+    def test_generate_diff_and_apply_create_frontport_with_positions(self):
+        """Test generate diff and apply create frontport with positions field (NetBox 4.5.0)."""
+        device_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.frontport",
+            "entity": {
+                "front_port": {
+                    "device": {
+                        "name": f"Device {device_uuid}",
+                        "device_type": {
+                            "manufacturer": {"name": f"Manufacturer {uuid4()}"},
+                            "model": f"Device Type {uuid4()}"
+                        },
+                        "role": {"name": f"Role {uuid4()}"},
+                        "site": {"name": f"Site {uuid4()}"}
+                    },
+                    "name": f"Front Port {uuid4()}",
+                    "type": "8p8c",
+                    "rear_port": {
+                        "device": {
+                            "name": f"Device {device_uuid}",
+                            "device_type": {
+                                "manufacturer": {"name": f"Manufacturer {uuid4()}"},
+                                "model": f"Device Type {uuid4()}"
+                            },
+                            "role": {"name": f"Role {uuid4()}"},
+                            "site": {"name": f"Site {uuid4()}"}
+                        },
+                        "name": f"Rear Port {uuid4()}",
+                        "type": "8p8c",
+                        "positions": "2"
+                    },
+                    "rear_port_position": "1",
+                    "description": "Front port with positions"
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_generate_diff_and_apply_create_rearport(self):
+        """Test generate diff and apply create rearport (NetBox 4.5.0)."""
+        device_uuid = str(uuid4())
+        rearport_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.rearport",
+            "entity": {
+                "rear_port": {
+                    "device": {
+                        "name": f"Device {device_uuid}",
+                        "device_type": {
+                            "manufacturer": {"name": f"Manufacturer {uuid4()}"},
+                            "model": f"Device Type {uuid4()}"
+                        },
+                        "role": {"name": f"Role {uuid4()}"},
+                        "site": {"name": f"Site {uuid4()}"}
+                    },
+                    "name": f"Rear Port {rearport_uuid}",
+                    "type": "8p8c",
+                    "positions": "4",
+                    "description": "Rear port with multiple positions"
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_rearport = RearPort.objects.get(name=f"Rear Port {rearport_uuid}")
+        self.assertEqual(new_rearport.positions, 4)
+        self.assertEqual(new_rearport.type, "8p8c")
+
+    def test_generate_diff_and_apply_create_asn_with_sites(self):
+        """Test generate diff and apply create ASN with sites field (NetBox 4.5.0)."""
+        site1_uuid = str(uuid4())
+        site2_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.asn",
+            "entity": {
+                "asn": {
+                    "asn": "65001",
+                    "rir": {"name": f"RIR {uuid4()}"},
+                    "description": "ASN with multiple sites",
+                    "sites": [
+                        {"name": f"Site {site1_uuid}"},
+                        {"name": f"Site {site2_uuid}"}
+                    ]
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_asn = ASN.objects.get(asn=65001)
+        self.assertEqual(new_asn.sites.count(), 2)
+        site_names = [site.name for site in new_asn.sites.all()]
+        self.assertIn(f"Site {site1_uuid}", site_names)
+        self.assertIn(f"Site {site2_uuid}", site_names)
+
+    def test_generate_diff_and_apply_create_vlan_translation_policy(self):
+        """Test generate diff and apply create VLAN translation policy (NetBox 4.5.0)."""
+        policy_uuid = str(uuid4())
+        owner_uuid = str(uuid4())
+        group_uuid = str(uuid4())
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vlantranslationpolicy",
+            "entity": {
+                "vlan_translation_policy": {
+                    "name": f"VLAN Translation Policy {policy_uuid}",
+                    "description": "Policy for VLAN translation",
+                    "owner": {
+                        "name": f"Owner {owner_uuid}",
+                        "group": {
+                            "name": f"Owner Group {group_uuid}",
+                        },
+                    },
+                }
+            }
+        }
+        _, response = self.diff_and_apply(payload)
+        new_policy = VLANTranslationPolicy.objects.get(name=f"VLAN Translation Policy {policy_uuid}")
+        self.assertEqual(new_policy.description, "Policy for VLAN translation")
+        self.assertEqual(new_policy.owner.name, f"Owner {owner_uuid}")
+
+    def test_multiobject_cf_rediff_noop(self):
+        """
+        Test that re-diffing a device with multiobject custom field produces no changes.
+
+        INT-219: multiobject custom field values are order-insensitive (sets),
+        but the differ was comparing them as ordered lists. This caused phantom
+        changesets on every re-diff because the "before" IDs (from queryset,
+        ordered by name) didn't match the "desired" IDs (sorted numerically).
+        """
+        device_cf = CustomField.objects.create(
+            name='int219_multi_sites',
+            type=CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            required=False,
+            related_object_type=ObjectType.objects.get_for_model(Site),
+        )
+        device_object_type = ObjectType.objects.get_for_model(Device)
+        device_cf.object_types.set([device_object_type])
+        device_cf.save()
+
+        # Pre-create "Gamma" so it gets a LOWER ID than Alpha and Beta.
+        # When diff+apply later creates Alpha and Beta, they get higher IDs.
+        # This ensures name-alphabetical order (Alpha, Beta, Gamma) differs
+        # from numeric ID order (Gamma, Alpha, Beta) — which triggers the bug.
+        Site.objects.create(name="INT219-Site-Gamma", slug="int219-site-gamma")
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "INT219-Test-Device",
+                    "role": {"name": "INT219-Role"},
+                    "site": {"name": "INT219-Site-Primary"},
+                    "device_type": {
+                        "model": "INT219-Model",
+                        "manufacturer": {"name": "INT219-Manufacturer"},
+                    },
+                    "serial": "INT219-SERIAL-001",
+                    "custom_fields": {
+                        "int219_multi_sites": {
+                            "multiple_objects": [
+                                {"site": {"name": "INT219-Site-Alpha"}},
+                                {"site": {"name": "INT219-Site-Beta"}},
+                                {"site": {"name": "INT219-Site-Gamma"}},
+                            ],
+                        },
+                    },
+                },
+            },
+        }
+
+        # First diff+apply: creates the device, Alpha, Beta (Gamma already exists)
+        self.diff_and_apply(payload)
+        device = Device.objects.get(name="INT219-Test-Device")
+        self.assertIsNotNone(device)
+        self.assertEqual(len(device.custom_field_data['int219_multi_sites']), 3)
+
+        # Verify IDs are NOT in alphabetical-name order (precondition for the bug)
+        alpha = Site.objects.get(name="INT219-Site-Alpha")
+        beta = Site.objects.get(name="INT219-Site-Beta")
+        gamma = Site.objects.get(name="INT219-Site-Gamma")
+        name_order_ids = [alpha.pk, beta.pk, gamma.pk]
+        numeric_order_ids = sorted(name_order_ids)
+        self.assertNotEqual(
+            name_order_ids, numeric_order_ids,
+            "Test precondition failed: IDs happen to match name order. "
+            "Pre-creating Gamma should have given it a lower ID than Alpha/Beta."
+        )
+
+        # Step 2: Re-diff with the exact same payload.
+        # Before the fix, this produces a false "update" changeset because
+        # cf.serialize() returns IDs in queryset name-order [alpha, beta, gamma]
+        # but the transformer sorts resolved IDs numerically [gamma, alpha, beta].
+        response = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+
+        # The re-diff should produce NO changes — the data hasn't changed.
+        self.assertEqual(
+            changes, [],
+            f"Expected no changes on re-diff, but got: {changes}"
+        )
+
+    def test_all_digit_name_object_cf_resolves_new_ref(self):
+        """
+        A CF whose name is all digits must resolve a new object ref, not 500.
+
+        NetBox permits all-digit custom field names (validator ^[a-z0-9_]+$).
+        The apply-time new_refs path for such a CF is "custom_fields.<digits>";
+        the ref-resolution path helpers must not coerce that dict key to a list
+        index (which would KeyError on the string-keyed custom_fields dict and,
+        because the KeyError arg is an int, bypass the unresolved-ref handler
+        and surface as a 500).
+        """
+        cf = CustomField.objects.create(
+            name='12345',
+            type=CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            required=False,
+            related_object_type=ObjectType.objects.get_for_model(Site),
+        )
+        cf.object_types.set([ObjectType.objects.get_for_model(Device)])
+        cf.save()
+
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "DigitCF-Device",
+                    "role": {"name": "DigitCF-Role"},
+                    "site": {"name": "DigitCF-Site-Primary"},
+                    "device_type": {
+                        "model": "DigitCF-Model",
+                        "manufacturer": {"name": "DigitCF-Manufacturer"},
+                    },
+                    # References a site that does not exist yet -> the CF ref is
+                    # unresolved and must be resolved at apply via new_refs.
+                    "custom_fields": {
+                        "12345": {
+                            "multiple_objects": [
+                                {"site": {"name": "DigitCF-Site-New"}},
+                            ],
+                        },
+                    },
+                },
+            },
+        }
+
+        # apply must succeed (diff_and_apply asserts 200 on both calls)
+        self.diff_and_apply(payload)
+        device = Device.objects.get(name="DigitCF-Device")
+        new_site = Site.objects.get(name="DigitCF-Site-New")
+        self.assertEqual(device.custom_field_data['12345'], [new_site.pk])
+
+    def diff_and_apply(self, payload):
+        """Diff and apply the payload."""
+        response1 = self.client.post(
+            self.diff_url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        diff = response1.json().get("change_set", {})
+        response2 = self.client.post(
+            self.apply_url, data=diff, format="json", **self.authorization_header
+        )
+        self.assertEqual(response2.status_code, status.HTTP_200_OK, response2.content)
+        return (response1, response2)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_api_generate_diff.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_api_generate_diff.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+import logging
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest import mock
+from uuid import uuid4
+
+from core.models import ObjectType
+from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, RackType, Site
+from extras.models import CustomField
+from extras.models.customfields import CustomFieldTypeChoices
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+def _get_error(response, object_name, field):
+    return response.json().get("errors", {}).get(object_name, {}).get(field, [])
+
+
+class GenerateDiffTestCase(APITestCase):
+    """GenerateDiff test cases."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/generate-diff/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+        self.object_type = ObjectType.objects.get_for_model(Site)
+
+        self.uuid_field = CustomField.objects.create(
+            name='myuuid',
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            required=False,
+            unique=True,
+        )
+        self.uuid_field.object_types.set([self.object_type])
+        self.uuid_field.save()
+
+        self.json_field = CustomField.objects.create(
+            name='some_json',
+            type=CustomFieldTypeChoices.TYPE_JSON,
+            required=False,
+            unique=False,
+        )
+        self.json_field.object_types.set([self.object_type])
+        self.json_field.save()
+
+        self.site_uuid = str(uuid4())
+        self.site = Site.objects.create(
+            name="Site Generate Diff 1",
+            slug="site-generate-diff-1",
+            facility="Alpha",
+            description="First test site",
+            physical_address="123 Fake St Lincoln NE 68588",
+            shipping_address="123 Fake St Lincoln NE 68588",
+            comments="Lorem ipsum etcetera",
+        )
+        self.site.custom_field_data[self.uuid_field.name] = self.site_uuid
+        self.site.custom_field_data[self.json_field.name] = {
+            "some_key": "some_value",
+        }
+        self.site.save()
+
+        self.manufacturer = Manufacturer.objects.create(
+            name="Manufacturer 1",
+        )
+        self.manufacturer.save()
+        self.rack_type = RackType.objects.create(
+            model="Rack Type 1",
+            slug="rack-type-1",
+            manufacturer=self.manufacturer,
+        )
+        self.rack_type.save()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def test_generate_diff_create_site(self):
+        """Test generate diff create site."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "A New Site",
+                    "slug": "a-new-site",
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.site")
+        self.assertEqual(change.get("change_type"), "create")
+        self.assertEqual(change.get("object_id"), None)
+        self.assertIsNotNone(change.get("ref_id"))
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("name"), "A New Site")
+        self.assertEqual(data.get("slug"), "a-new-site")
+
+    def test_generate_diff_create_site_with_custom_field(self):
+        """Test generate diff create site with custom field."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "A New Site",
+                    "slug": "a-new-site",
+                    "custom_fields": {
+                        "some_json": {
+                            "json": '{"some_key": 1234567890}',
+                        },
+                    },
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.site")
+        self.assertEqual(change.get("change_type"), "create")
+        self.assertEqual(change.get("object_id"), None)
+        self.assertIsNotNone(change.get("ref_id"))
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("name"), "A New Site")
+        self.assertEqual(data.get("slug"), "a-new-site")
+        self.assertEqual(data.get("custom_fields", {}).get("some_json", {}).get("some_key"), 1234567890)
+
+    def test_generate_diff_update_site(self):
+        """Test generate diff update site."""
+        """Test generate diff create site."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    "name": "Site Generate Diff 1",
+                    "slug": "site-generate-diff-1",
+                    "comments": "An updated comment",
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.site")
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+        self.assertEqual(change.get("ref_id"), None)
+        self.assertEqual(change.get("data").get("name"), "Site Generate Diff 1")
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("name"), "Site Generate Diff 1")
+        self.assertEqual(data.get("slug"), "site-generate-diff-1")
+        self.assertEqual(data.get("comments"), "An updated comment")
+
+    def test_match_site_by_custom_field(self):
+        """Test match site by custom field."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.site",
+            "entity": {
+                "site": {
+                    # here name and slug are not present in the payload
+                    # but we expect to match the existing site by the
+                    # unique custom field myuuid
+                    "comments": "A custom comment",
+                    "custom_fields": {
+                        "myuuid": {
+                            "text": self.site_uuid,
+                        },
+                    },
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.site")
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.site.id)
+        self.assertEqual(change.get("ref_id"), None)
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("comments"), "A custom comment")
+        self.assertEqual(data.get("custom_fields", {}).get("myuuid"), self.site_uuid)
+
+        before = change.get("before", {})
+        self.assertEqual(before.get("name"), "Site Generate Diff 1")
+        self.assertEqual(before.get("slug"), "site-generate-diff-1")
+
+    def test_generate_diff_update_rack_type_autoslug(self):
+        """Test generate diff update rack type autoslug."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.racktype",
+            "entity": {
+                "rack_type": {
+                    "model": "Rack Type 1",
+                    "form_factor": "wall-frame",
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.racktype")
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.rack_type.id)
+        self.assertEqual(change.get("ref_id"), None)
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("model"), "Rack Type 1")
+        self.assertEqual(data.get("slug"), None) # slug is not set, use prior slug
+        self.assertEqual(data.get("form_factor"), "wall-frame")
+
+        before = change.get("before", {})
+        self.assertEqual(before.get("model"), "Rack Type 1")
+        # correct slug is present in before data
+        self.assertEqual(before.get("slug"), "rack-type-1")
+
+    def test_generate_diff_update_rack_type_camel_case(self):
+        """Test generate diff update rack type with came cased protoJSON."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.racktype",
+            "entity": {
+                "rackType": {
+                    "slug": "rack-type-1",
+                    "model": "Rack Type 1",
+                    "formFactor": "wall-frame",
+                },
+            }
+        }
+
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 1)
+        change = changes[0]
+        self.assertEqual(change.get("object_type"), "dcim.racktype")
+        self.assertEqual(change.get("change_type"), "update")
+        self.assertEqual(change.get("object_id"), self.rack_type.id)
+        self.assertEqual(change.get("ref_id"), None)
+
+        data = change.get("data", {})
+        self.assertEqual(data.get("model"), "Rack Type 1")
+        self.assertEqual(data.get("form_factor"), "wall-frame")
+
+        before = change.get("before", {})
+        self.assertEqual(before.get("model"), "Rack Type 1")
+
+    def test_merge_states_failed(self):
+        """Test merge states failed."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vrf",
+            "entity": {
+                "vrf": {
+                    "name": "Customer-A-VRF",
+                    "rd": "65000:100",
+                    "tenant": {"name": "Tenant 1"},
+                    "enforce_unique": True,
+                    "description": "Isolated routing domain for Customer A",
+                    "comments": "Used for customer's private network services",
+                    "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                    ],
+                    "import_targets": [
+                        {
+                            "name": "65000:100",
+                            "description": "Primary import route target"
+                        },
+                        {
+                            "name": "65000:101",
+                            "description": "Backup import route target"
+                        }
+                    ],
+                    "export_targets": [
+                        {
+                            "name": "65000:100",
+                            "description": "Primary export route target"
+                        }
+                    ]
+                }
+            }
+        }
+
+        response = self.send_request(payload, status.HTTP_400_BAD_REQUEST)
+        logger.error(response.json())
+        errs = _get_error(response, "ipam.vrf", "__all__")
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertTrue(err.startswith("Conflicting values for 'description' merging duplicate ipam.routetarget"))
+
+    def test_vlangroup_error(self):
+        """Test vlangroup error."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "ipam.vlangroup",
+            "entity": {
+                "vlan_group": {
+                    "name": "Data Center Core",
+                    "slug": "dc-core",
+                    "scope_site": {
+                        "name": "Data Center West",
+                        "slug": "dc-west",
+                        "status": "active"
+                    },
+                    "description": "Core network VLANs for data center infrastructure",
+                    "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                    ]
+                }
+            }
+        }
+        _ = self.send_request(payload)
+
+    def test_generate_diff_dedupe_different_object_types(self):
+        """Test generate diff dedupe different object types with same values."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "Cat8000V",
+                    "role": {"name": "undefined"},
+                    "site": {"name": "undefined"},
+                    "serial": "9OBXJHNNU5V",
+                    "status": "active",
+                    "platform": {"name": "ios", "manufacturer": {"name": "undefined"}},
+                    "device_type": {"model": "C8000V", "manufacturer": {"name": "undefined"}}
+                },
+            },
+        }
+        response = self.send_request(payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cs = response.json().get("change_set", {})
+        self.assertIsNotNone(cs.get("id"))
+        changes = cs.get("changes", [])
+        self.assertEqual(len(changes), 6)
+        by_object_type = defaultdict(int)
+        for change in changes:
+            by_object_type[change.get("object_type")] += 1
+
+        self.assertEqual(by_object_type["dcim.device"], 1)
+        self.assertEqual(by_object_type["dcim.manufacturer"], 1)
+        self.assertEqual(by_object_type["dcim.platform"], 1)
+        self.assertEqual(by_object_type["dcim.devicetype"], 1)
+        self.assertEqual(by_object_type["dcim.site"], 1)
+        self.assertEqual(by_object_type["dcim.devicerole"], 1)
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+
+class PKBasedMatchingTestCase(APITestCase):
+    """Test PK-based matching via metadata.source_match.netbox_id."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.url = "/netbox/api/plugins/diode/generate-diff/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        self.site = Site.objects.create(name="PK Test Site", slug="pk-test-site")
+        manufacturer = Manufacturer.objects.create(name="PK Test Manufacturer", slug="pk-test-manufacturer")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="PK Test Type", slug="pk-test-type"
+        )
+        self.role = DeviceRole.objects.create(name="PK Test Role", slug="pk-test-role", color="ff0000")
+        self.device = Device.objects.create(
+            name="PK Test Device",
+            device_type=device_type,
+            role=self.role,
+            site=self.site,
+            serial="ORIG-SERIAL",
+        )
+        self.interface = Interface.objects.create(
+            device=self.device,
+            name="eth0",
+            type="virtual",
+        )
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def send_request(self, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            self.url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    def test_pk_match_noop(self):
+        """PK match with identical data produces no changes."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "PK Test Device",
+                    "serial": "ORIG-SERIAL",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": self.device.pk},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        # all changes should be noop since data matches
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertTrue(len(device_changes) <= 1)
+        if device_changes:
+            self.assertEqual(device_changes[0]["change_type"], "noop")
+
+    def test_pk_match_update(self):
+        """PK match with changed attribute produces update changeset."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "PK Test Device",
+                    "serial": "NEW-SERIAL",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": self.device.pk},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertEqual(len(device_changes), 1)
+        change = device_changes[0]
+        self.assertEqual(change["change_type"], "update")
+        self.assertEqual(change["object_id"], self.device.pk)
+        self.assertEqual(change["data"]["serial"], "NEW-SERIAL")
+
+    def test_pk_match_ignores_name(self):
+        """PK match finds the device even when the name is different — produces update, not create."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "Completely Different Name",
+                    "serial": "ORIG-SERIAL",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": self.device.pk},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertEqual(len(device_changes), 1)
+        change = device_changes[0]
+        self.assertEqual(change["change_type"], "update")
+        self.assertEqual(change["object_id"], self.device.pk)
+        # name change should be in the diff
+        self.assertEqual(change["data"]["name"], "Completely Different Name")
+
+    def test_pk_not_found_raises_error(self):
+        """PK that doesn't exist returns an error, not a create."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "Ghost Device",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": 999999},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload, status_code=status.HTTP_400_BAD_REQUEST)
+        errors = response.json().get("errors", {})
+        self.assertTrue(len(errors) > 0)
+
+    def test_no_metadata_uses_normal_matching(self):
+        """Without metadata, normal constraint-based matching applies."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "PK Test Device",
+                    "serial": "CHANGED-SERIAL",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertEqual(len(device_changes), 1)
+        change = device_changes[0]
+        # should still match by name+site and produce an update
+        self.assertEqual(change["change_type"], "update")
+        self.assertEqual(change["object_id"], self.device.pk)
+
+    def test_pk_match_device_via_nested_interface(self):
+        """Interface ingested with parent device carrying netbox_id — device matched by PK, interface by name."""
+        payload = {
+            "object_type": "dcim.interface",
+            "entity": {
+                "interface": {
+                    "name": "eth0",
+                    "type": "virtual",
+                    "mtu": 9000,
+                    "device": {
+                        "name": "Irrelevant Name",
+                        "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                        "role": {"name": "PK Test Role"},
+                        "site": {"name": "PK Test Site"},
+                        "metadata": {
+                            "source_match": {"netbox_id": self.device.pk},
+                        },
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        interface_changes = [c for c in changes if c["object_type"] == "dcim.interface"]
+        # device should be matched by PK (name differs so it's an update)
+        self.assertEqual(len(device_changes), 1)
+        self.assertEqual(device_changes[0]["change_type"], "update")
+        self.assertEqual(device_changes[0]["object_id"], self.device.pk)
+        # interface should be matched by name within the PK-resolved device
+        self.assertEqual(len(interface_changes), 1)
+        self.assertEqual(interface_changes[0]["change_type"], "update")
+        self.assertEqual(interface_changes[0]["object_id"], self.interface.pk)
+
+    def test_invalid_netbox_id_falls_through(self):
+        """Invalid (non-numeric) netbox_id is ignored with a warning, falls through to normal matching."""
+        payload = {
+            "object_type": "dcim.device",
+            "entity": {
+                "device": {
+                    "name": "PK Test Device",
+                    "serial": "CHANGED-FOR-INVALID-PK-TEST",
+                    "device_type": {"model": "PK Test Type", "manufacturer": {"name": "PK Test Manufacturer"}},
+                    "role": {"name": "PK Test Role"},
+                    "site": {"name": "PK Test Site"},
+                    "metadata": {
+                        "source_match": {"netbox_id": "not-a-number"},
+                    },
+                },
+            },
+        }
+        response = self.send_request(payload)
+        cs = response.json().get("change_set", {})
+        changes = cs.get("changes", [])
+        device_changes = [c for c in changes if c["object_type"] == "dcim.device"]
+        self.assertEqual(len(device_changes), 1)
+        # should fall through to normal matching and find the device by name
+        self.assertEqual(device_changes[0]["change_type"], "update")
+        self.assertEqual(device_changes[0]["object_id"], self.device.pk)
+        # warning should be present
+        warnings = cs.get("warnings", {})
+        self.assertIn("metadata", warnings.get("dcim.device", {}))

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_api_get_default_branch.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_api_get_default_branch.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - GetDefaultBranch API Tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.models import Setting
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class GetDefaultBranchViewTestCase(APITestCase):
+    """Test cases for GetDefaultBranchView."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.url = "/netbox/api/plugins/diode/default-branch/"
+
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def test_get_default_branch_unauthenticated(self):
+        """Test that unauthenticated requests are rejected."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_default_branch_without_read_scope(self):
+        """Test that requests without netbox:read scope are rejected."""
+        # Mock user with only write scope
+        user_without_read = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:write"],
+            token_data={"scope": "netbox:write"}
+        )
+
+        with mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=user_without_read
+        ):
+            response = self.client.get(self.url, **self.authorization_header)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_default_branch_no_branching_plugin(self):
+        """Test response when branching plugin is not installed."""
+        # Create a setting without branch
+        Setting.objects.create(diode_target="grpc://localhost:8080/diode")
+
+        # Mock Branch as None (simulating plugin not installed)
+        with mock.patch('netbox_diode_plugin.api.views.Branch', None):
+            response = self.client.get(self.url, **self.authorization_header)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("branch", response.json())
+            self.assertIsNone(response.json()["branch"])
+
+    def test_get_default_branch_no_settings(self):
+        """Test response when no settings exist."""
+        # Ensure no settings exist
+        Setting.objects.all().delete()
+
+        response = self.client.get(self.url, **self.authorization_header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("branch", response.json())
+        self.assertIsNone(response.json()["branch"])
+
+    def test_get_default_branch_settings_without_branch(self):
+        """Test response when settings exist but branch is not set."""
+        # Create a setting without branch
+        Setting.objects.create(diode_target="grpc://localhost:8080/diode", branch_id=None)
+
+        response = self.client.get(self.url, **self.authorization_header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("branch", response.json())
+        self.assertIsNone(response.json()["branch"])
+
+    def test_get_default_branch_with_branching_plugin_and_branch_set(self):
+        """Test response when branching plugin is installed and branch is set."""
+        # Create a mock Branch object
+        mock_branch = mock.Mock()
+        mock_branch.schema_id = "branch-123"
+        mock_branch.name = "main"
+        mock_branch.id = 1
+
+        # Create a setting with branch_id
+        Setting.objects.create(
+            diode_target="grpc://localhost:8080/diode",
+            branch_id=1
+        )
+
+        # Mock the Branch model and query
+        mock_branch_model = mock.Mock()
+        mock_branch_model.objects.get.return_value = mock_branch
+
+        with mock.patch('netbox_diode_plugin.api.views.Branch', mock_branch_model):
+            with mock.patch.object(Setting, 'branch', new_callable=mock.PropertyMock) as mock_branch_property:
+                mock_branch_property.return_value = mock_branch
+
+                response = self.client.get(self.url, **self.authorization_header)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertIn("branch", response.json())
+                self.assertIsNotNone(response.json()["branch"])
+                self.assertEqual(response.json()["branch"]["id"], "branch-123")
+                self.assertEqual(response.json()["branch"]["name"], "main")
+
+    def test_get_default_branch_exception_handling(self):
+        """Test that exceptions during branch retrieval are handled gracefully."""
+        # Create a setting with branch_id
+        Setting.objects.create(
+            diode_target="grpc://localhost:8080/diode",
+            branch_id=1
+        )
+
+        # Mock Branch model to exist but raise exception on query
+        mock_branch_model = mock.Mock()
+
+        with mock.patch('netbox_diode_plugin.api.views.Branch', mock_branch_model):
+            with mock.patch.object(Setting, 'branch', new_callable=mock.PropertyMock) as mock_branch_property:
+                # Simulate an exception when accessing the branch property
+                mock_branch_property.side_effect = Exception("Database error")
+
+                response = self.client.get(self.url, **self.authorization_header)
+
+                # Should return 200 with null branch due to exception handling
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertIn("branch", response.json())
+                self.assertIsNone(response.json()["branch"])
+
+    def test_get_default_branch_with_valid_authentication(self):
+        """Test that authenticated requests with proper scope are successful."""
+        response = self.client.get(self.url, **self.authorization_header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("branch", response.json())
+        # Response structure is correct even if branch is None
+        self.assertIsInstance(response.json(), dict)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_applier_cable.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_applier_cable.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Cable apply integration tests."""
+
+from dcim.models import (
+    Cable,
+    CableTermination,
+    Device,
+    DeviceRole,
+    DeviceType,
+    Interface,
+    Manufacturer,
+    Site,
+)
+from django.test import TestCase
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeSetException, ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
+
+
+class CableApplyTestCase(TestCase):
+    """A cable CREATE materializes two CableTermination rows via CableSerializer."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test fixtures."""
+        mfr = Manufacturer.objects.create(name="MFR-Cable", slug="mfr-cable")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="DT-Cable", slug="dt-cable")
+        role = DeviceRole.objects.create(name="Role-Cable", slug="role-cable")
+        site = Site.objects.create(name="Site-Cable", slug="site-cable")
+        dev_a = Device.objects.create(name="Cable Device A", device_type=dt, role=role, site=site)
+        dev_b = Device.objects.create(name="Cable Device B", device_type=dt, role=role, site=site)
+        dev_c = Device.objects.create(name="Cable Device C", device_type=dt, role=role, site=site)
+        cls.iface_a = Interface.objects.create(device=dev_a, name="Cable Iface A", type="1000base-t")
+        cls.iface_b = Interface.objects.create(device=dev_b, name="Cable Iface B", type="1000base-t")
+        cls.iface_c = Interface.objects.create(device=dev_c, name="Cable Iface C", type="1000base-t")
+
+    def _cable_change(self, a_pk, b_pk, label="Cable 1"):
+        return Change(
+            change_type=ChangeType.CREATE,
+            object_type="dcim.cable",
+            ref_id="new_object:dcim.cable:c1",
+            data={
+                "status": "connected",
+                "label": label,
+                "a_terminations": [{"object_type": "dcim.interface", "object_id": a_pk}],
+                "b_terminations": [{"object_type": "dcim.interface", "object_id": b_pk}],
+            },
+            new_refs=[],
+        )
+
+    def test_cable_create_materializes_two_terminations(self):
+        """Cable create materializes two terminations."""
+        cs = ChangeSet(id="cs-cable-1", changes=[self._cable_change(self.iface_a.pk, self.iface_b.pk)])
+        apply_changeset(cs, request=None)
+
+        cable = Cable.objects.get(label="Cable 1")
+        terms = CableTermination.objects.filter(cable=cable)
+        self.assertEqual(terms.count(), 2)
+        term_ids = {(t.cable_end, t.termination_id) for t in terms}
+        self.assertIn(("A", self.iface_a.pk), term_ids)
+        self.assertIn(("B", self.iface_b.pk), term_ids)
+
+    def test_already_cabled_interface_fails_change_with_clean_error(self):
+        """Already cabled interface fails change with clean error."""
+        # First cable connects A<->B. A second, distinct-termination-set cable
+        # that reuses interface A (now already cabled) cannot be matched by
+        # CableTerminationSetMatcher (different termination set: A<->C vs A<->B),
+        # so it falls through to CableSerializer.is_valid()/Cable.clean(), which
+        # rejects it because interface A already has a cable connection.
+        cs1 = ChangeSet(id="cs-cable-a", changes=[self._cable_change(self.iface_a.pk, self.iface_b.pk)])
+        apply_changeset(cs1, request=None)
+
+        cs2 = ChangeSet(id="cs-cable-b", changes=[self._cable_change(self.iface_a.pk, self.iface_c.pk, label="Cable 2")])
+        with self.assertRaises(ChangeSetException) as ctx:
+            apply_changeset(cs2, request=None)
+        msg = str(ctx.exception).lower()
+        self.assertTrue(
+            any(s in msg for s in ("already", "cabled", "connect", "duplicate termination")),
+            f"expected a cable-conflict clean() message, got: {ctx.exception}",
+        )
+        self.assertFalse(Cable.objects.filter(label="Cable 2").exists())
+
+
+class CableMultiObjectUpdateTestCase(TestCase):
+    """
+    UPDATE of a multi-object end with mixed new/existing terminations resolves.
+
+    Regression for the new_refs/resort desync: `_generate_changeset` computed
+    index paths (``a_terminations.0.object_id``) via
+    ``cleanup_unresolved_references`` BEFORE ``_partially_merge`` re-sorted the
+    termination lists for stable comparison. On an end mixing an
+    already-resolved pk (int, sorts first — digits precede ``new_object:``)
+    with a still-unresolved new-object ref, the sort moved entries after the
+    paths were fixed: the path landed on the int (skipped) while the
+    unresolved ref at its new index was never resolved, reaching
+    CableSerializer as a string and failing the whole update. Goes through the
+    REAL ``generate_changeset`` -> ``apply_changeset`` path with the cable
+    matched via ``metadata.source_match.netbox_id``.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up an existing cabled pair; a third interface is created by ingest."""
+        mfr = Manufacturer.objects.create(name="MFR-MultiTerm", slug="mfr-multiterm")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="DT-MultiTerm", slug="dt-multiterm")
+        cls.role = DeviceRole.objects.create(name="Role-MultiTerm", slug="role-multiterm")
+        cls.site = Site.objects.create(name="Site-MultiTerm", slug="site-multiterm")
+        cls.dev_a = Device.objects.create(name="MultiTerm Device A", device_type=cls.dt, role=cls.role, site=cls.site)
+        cls.dev_b = Device.objects.create(name="MultiTerm Device B", device_type=cls.dt, role=cls.role, site=cls.site)
+        cls.iface_a0 = Interface.objects.create(device=cls.dev_a, name="mt-eth0", type="1000base-t")
+        cls.iface_b0 = Interface.objects.create(device=cls.dev_b, name="mt-eth1", type="1000base-t")
+
+    def _iface_payload(self, device, name):
+        return {
+            "object_interface": {
+                "name": name,
+                "type": "1000base-t",
+                "device": {
+                    "name": device.name,
+                    "device_type": {
+                        "manufacturer": {"name": "MFR-MultiTerm"},
+                        "model": "DT-MultiTerm",
+                    },
+                    "role": {"name": "Role-MultiTerm"},
+                    "site": {"name": "Site-MultiTerm"},
+                },
+            }
+        }
+
+    def test_add_new_termination_to_existing_cable_resolves(self):
+        """Adding a NEW interface to an existing cable's end resolves + applies."""
+        # existing cable A:[mt-eth0] <-> B:[mt-eth1]
+        cs = ChangeSet(
+            id="cs-mt-seed",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id="new_object:dcim.cable:seed",
+                    data={
+                        "status": "connected",
+                        "label": "MT Cable",
+                        "a_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_a0.pk}],
+                        "b_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_b0.pk}],
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(cs, request=None)
+        cable = Cable.objects.get(label="MT Cable")
+
+        # UPDATE via netbox_id: end A gains a NEW (not-yet-existing) interface.
+        # The new termination is listed FIRST so its pre-sort index (0) differs
+        # from its post-sort index (ints sort before "new_object:" strings) --
+        # the exact desync scenario.
+        entity = {
+            "status": "connected",
+            "label": "MT Cable",
+            "a_terminations": [
+                self._iface_payload(self.dev_a, "mt-eth2-new"),
+                self._iface_payload(self.dev_a, "mt-eth0"),
+            ],
+            "b_terminations": [self._iface_payload(self.dev_b, "mt-eth1")],
+            "metadata": {"source_match": {"netbox_id": cable.pk}},
+        }
+        result = generate_changeset(entity, "dcim.cable")
+        self.assertIsNotNone(result.change_set)
+        # must not raise (pre-fix: the unresolved new-object ref reached the
+        # serializer as a string and failed the update)
+        apply_changeset(result.change_set, request=None)
+
+        new_iface = Interface.objects.get(device=self.dev_a, name="mt-eth2-new")
+        terms = CableTermination.objects.filter(cable=cable)
+        self.assertEqual(terms.count(), 3)
+        term_ids = {(t.cable_end, t.termination_id) for t in terms}
+        self.assertIn(("A", self.iface_a0.pk), term_ids)
+        self.assertIn(("A", new_iface.pk), term_ids)
+        self.assertIn(("B", self.iface_b0.pk), term_ids)
+
+
+class CableEndSwapNoopTestCase(TestCase):
+    """
+    Re-ingesting the same cable with A/B ends swapped is a NOOP.
+
+    Cable identity is A/B-insensitive; without end alignment in the differ,
+    alternating feeds that flip endpoint order keep generating UPDATEs that
+    only toggle cable_end instead of converging.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed a cabled interface pair."""
+        mfr = Manufacturer.objects.create(name="MFR-Swap", slug="mfr-swap")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="DT-Swap", slug="dt-swap")
+        cls.role = DeviceRole.objects.create(name="Role-Swap", slug="role-swap")
+        cls.site = Site.objects.create(name="Site-Swap", slug="site-swap")
+        cls.dev_a = Device.objects.create(name="Swap Device A", device_type=cls.dt, role=cls.role, site=cls.site)
+        cls.dev_b = Device.objects.create(name="Swap Device B", device_type=cls.dt, role=cls.role, site=cls.site)
+        cls.iface_a = Interface.objects.create(device=cls.dev_a, name="sw-eth0", type="1000base-t")
+        cls.iface_b = Interface.objects.create(device=cls.dev_b, name="sw-eth1", type="1000base-t")
+
+    def _iface(self, device, name):
+        return {
+            "object_interface": {
+                "name": name,
+                "type": "1000base-t",
+                "device": {
+                    "name": device.name,
+                    "device_type": {"manufacturer": {"name": "MFR-Swap"}, "model": "DT-Swap"},
+                    "role": {"name": "Role-Swap"},
+                    "site": {"name": "Site-Swap"},
+                },
+            }
+        }
+
+    def test_swapped_ends_rediff_is_noop(self):
+        """Swapped-end re-ingest matches the cable and produces no changes."""
+        cs = ChangeSet(
+            id="cs-swap-seed",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id="new_object:dcim.cable:swap",
+                    data={
+                        "status": "connected",
+                        "a_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_a.pk}],
+                        "b_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_b.pk}],
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(cs, request=None)
+
+        # same cable, ends flipped
+        entity = {
+            "status": "connected",
+            "a_terminations": [self._iface(self.dev_b, "sw-eth1")],
+            "b_terminations": [self._iface(self.dev_a, "sw-eth0")],
+        }
+        result = generate_changeset(entity, "dcim.cable")
+        self.assertEqual(result.change_set.changes, [])
+
+    def test_stale_swapped_create_preserves_cable_ends(self):
+        """
+        A stale CREATE for an existing cable must not toggle cable_end.
+
+        Applying a CREATE change (as if planned before the cable existed) whose
+        ends are swapped relative to the existing cable hits the applier
+        pre-save-match path (dcim.cable in _REQUIRES_PRE_SAVE_MATCH). The match
+        is by A/B-insensitive set, so terminations must be left intact — only
+        attributes update — otherwise cable_end flips and alternating stale
+        creates toggle the physical assignment forever.
+        """
+        seed = ChangeSet(
+            id="cs-stale-seed",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id="new_object:dcim.cable:stale-seed",
+                    data={
+                        "status": "connected",
+                        "label": "Stale Cable",
+                        "a_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_a.pk}],
+                        "b_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_b.pk}],
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(seed, request=None)
+        cable = Cable.objects.get(label="Stale Cable")
+        ends_before = {(t.termination_id, t.cable_end) for t in CableTermination.objects.filter(cable=cable)}
+        self.assertEqual(ends_before, {(self.iface_a.pk, "A"), (self.iface_b.pk, "B")})
+
+        # stale CREATE for the SAME cable, ends swapped + a changed attribute
+        stale = ChangeSet(
+            id="cs-stale-swap",
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id="new_object:dcim.cable:stale-swap",
+                    data={
+                        "status": "connected",
+                        "label": "Stale Cable Relabeled",
+                        "a_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_b.pk}],
+                        "b_terminations": [{"object_type": "dcim.interface", "object_id": self.iface_a.pk}],
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(stale, request=None)
+
+        # still exactly one cable, ends UNCHANGED (no cable_end toggle)
+        self.assertEqual(Cable.objects.filter(label__startswith="Stale Cable").count(), 1)
+        cable.refresh_from_db()
+        ends_after = {(t.termination_id, t.cable_end) for t in CableTermination.objects.filter(cable=cable)}
+        self.assertEqual(ends_after, ends_before)
+        # non-termination attributes still update through the pre-save-match path
+        self.assertEqual(cable.label, "Stale Cable Relabeled")
+
+
+class CablePartitionTestCase(TestCase):
+    """
+    Pre-save-match strip is A/B-grouping aware, not a blanket drop.
+
+    The set matcher finds a cable by its A/B-insensitive termination set, so a
+    stale CREATE for the same set matches it. Stripping terminations is correct
+    only when the submitted grouping equals the existing one up to a whole-end
+    swap; a genuine repartition (same set, different grouping) must be applied,
+    consistent with the differ UPDATE path — not silently dropped.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed a device with three interfaces for multi-termination cables."""
+        mfr = Manufacturer.objects.create(name="MFR-Part", slug="mfr-part")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="DT-Part", slug="dt-part")
+        role = DeviceRole.objects.create(name="Role-Part", slug="role-part")
+        site = Site.objects.create(name="Site-Part", slug="site-part")
+        cls.dev_a = Device.objects.create(name="Part Device A", device_type=dt, role=role, site=site)
+        cls.dev_b = Device.objects.create(name="Part Device B", device_type=dt, role=role, site=site)
+        cls.if1 = Interface.objects.create(device=cls.dev_a, name="p-eth0", type="1000base-t")
+        cls.if2 = Interface.objects.create(device=cls.dev_a, name="p-eth1", type="1000base-t")
+        cls.if3 = Interface.objects.create(device=cls.dev_b, name="p-eth2", type="1000base-t")
+
+    def _terms(self, *ifaces):
+        return [{"object_type": "dcim.interface", "object_id": i.pk} for i in ifaces]
+
+    def _seed(self, label, a_ifaces, b_ifaces):
+        cable = Cable(a_terminations=list(a_ifaces), b_terminations=list(b_ifaces))
+        cable.label = label
+        cable.status = "connected"
+        cable.save()
+        return cable
+
+    def _apply_create(self, cs_id, label, a_ifaces, b_ifaces):
+        cs = ChangeSet(
+            id=cs_id,
+            changes=[
+                Change(
+                    change_type=ChangeType.CREATE,
+                    object_type="dcim.cable",
+                    ref_id=f"new_object:dcim.cable:{cs_id}",
+                    data={
+                        "status": "connected",
+                        "label": label,
+                        "a_terminations": self._terms(*a_ifaces),
+                        "b_terminations": self._terms(*b_ifaces),
+                    },
+                    new_refs=[],
+                )
+            ],
+        )
+        apply_changeset(cs, request=None)
+
+    def _grouping(self, cable):
+        cable.refresh_from_db()
+        return {(t.termination_id, t.cable_end) for t in CableTermination.objects.filter(cable=cable)}
+
+    def test_genuine_repartition_is_applied(self):
+        """A:[if1,if2]/B:[if3] re-fed as A:[if1]/B:[if2,if3] moves if2 A->B."""
+        cable = self._seed("Repart", [self.if1, self.if2], [self.if3])
+        self.assertEqual(
+            self._grouping(cable),
+            {(self.if1.pk, "A"), (self.if2.pk, "A"), (self.if3.pk, "B")},
+        )
+        # stale CREATE with the same set but if2 moved to end B (+ relabel)
+        self._apply_create("cs-repart", "Repart-Relabeled", [self.if1], [self.if2, self.if3])
+        self.assertEqual(Cable.objects.filter(label__startswith="Repart").count(), 1)
+        self.assertEqual(
+            self._grouping(cable),
+            {(self.if1.pk, "A"), (self.if2.pk, "B"), (self.if3.pk, "B")},
+        )
+        cable.refresh_from_db()
+        self.assertEqual(cable.label, "Repart-Relabeled")
+
+    def test_whole_end_swap_stays_noop(self):
+        """A whole-end swap of a multi-termination cable does not toggle cable_end."""
+        cable = self._seed("Swap", [self.if1, self.if2], [self.if3])
+        before = self._grouping(cable)
+        # swap ends: A<->B (same grouping, opposite labels)
+        self._apply_create("cs-swap", "Swap", [self.if3], [self.if1, self.if2])
+        self.assertEqual(self._grouping(cable), before)
+
+    def test_within_end_reorder_stays_noop(self):
+        """Reordering terminations within an end changes nothing (same grouping)."""
+        cable = self._seed("Reorder", [self.if1, self.if2], [self.if3])
+        before = self._grouping(cable)
+        self._apply_create("cs-reorder", "Reorder", [self.if2, self.if1], [self.if3])
+        self.assertEqual(self._grouping(cable), before)
+
+
+class ApplierKeyErrorScopeTestCase(TestCase):
+    """Only missing new_object references become clean per-entity errors."""
+
+    def _change(self, data, new_refs):
+        return Change(
+            change_type=ChangeType.CREATE,
+            object_type="dcim.cable",
+            ref_id="new_object:dcim.cable:k1",
+            data=data,
+            new_refs=new_refs,
+        )
+
+    def test_dangling_new_object_ref_is_clean_error(self):
+        """A missing new_object ref surfaces as ChangeSetException, not a 500."""
+        cs = ChangeSet(
+            id="cs-keyerr-1",
+            changes=[self._change({"status": "connected", "label": "new_object:dcim.interface:missing"}, ["label"])],
+        )
+        with self.assertRaises(ChangeSetException):
+            apply_changeset(cs, request=None)
+
+    def test_unrelated_keyerror_propagates(self):
+        """A KeyError with a non-reference key is a real bug and propagates."""
+        cs = ChangeSet(
+            id="cs-keyerr-2",
+            changes=[self._change({"status": "connected", "label": "not-a-ref"}, ["label"])],
+        )
+        with self.assertRaises(KeyError):
+            apply_changeset(cs, request=None)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_applier_paths.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_applier_paths.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Applier path-helper tests."""
+
+from django.test import SimpleTestCase, TestCase
+
+from netbox_diode_plugin.api.applier import _get_path, _pre_apply, _set_path
+from netbox_diode_plugin.api.common import Change, ChangeType
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+class PathHelperListIndexTestCase(SimpleTestCase):
+    """_get_path / _set_path must treat all-digit segments as list indices."""
+
+    def test_get_path_into_list_of_dicts(self):
+        """Get path into list of dicts."""
+        data = {
+            "a_terminations": [
+                {"object_type": "dcim.interface", "object_id": "new_object:dcim.interface:u0"},
+                {"object_type": "dcim.interface", "object_id": "new_object:dcim.interface:u1"},
+            ],
+        }
+        self.assertEqual(_get_path(data, "a_terminations.0.object_id"), "new_object:dcim.interface:u0")
+        self.assertEqual(_get_path(data, "a_terminations.1.object_id"), "new_object:dcim.interface:u1")
+
+    def test_set_path_into_list_of_dicts(self):
+        """Set path into list of dicts."""
+        data = {
+            "b_terminations": [
+                {"object_type": "dcim.interface", "object_id": "new_object:dcim.interface:u9"},
+            ],
+        }
+        _set_path(data, "b_terminations.0.object_id", 123)
+        self.assertEqual(data["b_terminations"][0]["object_id"], 123)
+        self.assertEqual(data["b_terminations"][0]["object_type"], "dcim.interface")
+
+    def test_string_keys_still_work(self):
+        """String keys still work."""
+        data = {"name": {"nested": "x"}}
+        self.assertEqual(_get_path(data, "name.nested"), "x")
+        _set_path(data, "name.nested", "y")
+        self.assertEqual(data["name"]["nested"], "y")
+
+
+class _FakeInstance:
+    def __init__(self, pk):
+        self.pk = pk
+
+
+class PreApplyTerminationResolutionTestCase(TestCase):
+    """_pre_apply resolves termination object_id refs to {object_type, object_id: pk}."""
+
+    def test_termination_refs_resolve_to_pk_dict_shape(self):
+        """Termination refs resolve to pk dict shape."""
+        ref_a = "new_object:dcim.interface:ua"
+        ref_b = "new_object:dcim.interface:ub"
+        change = Change(
+            change_type=ChangeType.CREATE,
+            object_type="dcim.cable",
+            ref_id="new_object:dcim.cable:uc",
+            data={
+                "status": "connected",
+                "a_terminations": [{"object_type": "dcim.interface", "object_id": ref_a}],
+                "b_terminations": [{"object_type": "dcim.interface", "object_id": ref_b}],
+            },
+            new_refs=["a_terminations.0.object_id", "b_terminations.0.object_id"],
+        )
+        created = {ref_a: _FakeInstance(101), ref_b: _FakeInstance(202)}
+
+        model_class = get_object_type_model("dcim.cable")
+        data = _pre_apply(model_class, change, created)
+
+        self.assertEqual(data["a_terminations"], [{"object_type": "dcim.interface", "object_id": 101}])
+        self.assertEqual(data["b_terminations"], [{"object_type": "dcim.interface", "object_id": 202}])
+        self.assertIn("a_terminations", data)
+        self.assertIn("b_terminations", data)
+
+    def test_original_change_data_not_mutated(self):
+        """A retried apply (e.g. after deadlock) must see the original string refs again."""
+        ref_a = "new_object:dcim.interface:ua"
+        change = Change(
+            change_type=ChangeType.CREATE,
+            object_type="dcim.cable",
+            ref_id="new_object:dcim.cable:uc",
+            data={
+                "status": "connected",
+                "a_terminations": [{"object_type": "dcim.interface", "object_id": ref_a}],
+            },
+            new_refs=["a_terminations.0.object_id"],
+        )
+        created = {ref_a: _FakeInstance(101)}
+        model_class = get_object_type_model("dcim.cable")
+
+        _pre_apply(model_class, change, created)
+
+        self.assertEqual(change.data["a_terminations"][0]["object_id"], ref_a)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_authentication.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_authentication.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Authentication Tests."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.test import APIRequestFactory
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class DiodeOAuth2AuthenticationTestCase(TestCase):
+    """Test cases for DiodeOAuth2Authentication."""
+
+    def setUp(self):
+        """Set up test case."""
+        self.auth = DiodeOAuth2Authentication()
+        self.factory = APIRequestFactory()
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+        self.valid_token = "valid_oauth_token"
+        self.invalid_token = "invalid_oauth_token"
+        self.token_without_scope = "token_without_scope"
+        self.token_with_scope = "token_with_scope"
+
+        # Mock the cache
+        self.cache_patcher = mock.patch.object(cache, 'get')
+        self.cache_get_mock = self.cache_patcher.start()
+        self.cache_set_patcher = mock.patch.object(cache, 'set')
+        self.cache_set_mock = self.cache_set_patcher.start()
+
+        # Mock requests.post for token introspection
+        self.requests_patcher = mock.patch('requests.post')
+        self.requests_mock = self.requests_patcher.start()
+        self.requests_mock.return_value.raise_for_status = mock.Mock()
+
+        # Mock get_diode_auth_introspect_url
+        self.introspect_url_patcher = mock.patch(
+            'netbox_diode_plugin.plugin_config.get_diode_auth_introspect_url',
+            return_value='http://test-introspect-url'
+        )
+        self.introspect_url_patcher.start()
+
+        self.required_audience_patcher = mock.patch(
+            'netbox_diode_plugin.api.authentication.get_required_token_audience',
+            return_value=[]
+        )
+        self.required_audience_mock = self.required_audience_patcher.start()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.cache_patcher.stop()
+        self.cache_set_patcher.stop()
+        self.requests_patcher.stop()
+        self.introspect_url_patcher.stop()
+        self.required_audience_patcher.stop()
+
+    def test_authenticate_no_auth_header(self):
+        """Test authentication with no Authorization header."""
+        request = self.factory.get('/')
+        result = self.auth.authenticate(request)
+        self.assertIsNone(result)
+
+    def test_authenticate_invalid_auth_header_format(self):
+        """Test authentication with invalid Authorization header format."""
+        request = self.factory.get('/', HTTP_AUTHORIZATION='InvalidFormat')
+        result = self.auth.authenticate(request)
+        self.assertIsNone(result)
+
+    def test_authenticate_cached_token(self):
+        """Test authentication with cached token."""
+        self.cache_get_mock.return_value = self.diode_user
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.valid_token}')
+
+        user, _ = self.auth.authenticate(request)
+        self.assertEqual(user, self.diode_user.user)
+        self.cache_get_mock.assert_called_once()
+
+    def test_authenticate_invalid_token(self):
+        """Test authentication with invalid token."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {'active': False}
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.invalid_token}')
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_authenticate_token_with_required_scope(self):
+        """Test authentication with token having required scope."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write',
+            'exp': 1000,
+            'iat': 500
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.token_with_scope}')
+
+        user, _ = self.auth.authenticate(request)
+        self.assertEqual(user, self.diode_user.user)
+        self.cache_set_mock.assert_called_once()
+
+    def test_authenticate_token_with_required_audience(self):
+        """Test authentication with token having required audience."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write',
+            'exp': 1000,
+            'iat': 500
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.token_with_scope}')
+
+        self.cache_get_mock.return_value = None
+        self.required_audience_mock.return_value = ['netbox']
+        try:
+            # should fail if the token does not have the required audience
+            with self.assertRaises(AuthenticationFailed):
+                self.auth.authenticate(request)
+            self.required_audience_mock.assert_called_once()
+            self.cache_set_mock.assert_not_called()
+
+            # should succeed if the token has the required audience
+            self.requests_mock.return_value.json.return_value = {
+                'active': True,
+                'aud': ['netbox', 'api', 'other'],
+                'scope': 'netbox:read netbox:write',
+                'exp': 1000,
+                'iat': 500
+            }
+
+            user, _ = self.auth.authenticate(request)
+            self.assertEqual(user, self.diode_user.user)
+            self.cache_set_mock.assert_called_once()
+        finally:
+            self.required_audience_patcher.return_value = []
+
+    def test_authenticate_token_introspection_failure(self):
+        """Test authentication when token introspection fails."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.side_effect = Exception("Introspection failed")
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.valid_token}')
+
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    def test_authenticate_token_with_default_expiry(self):
+        """Test authentication with token having no expiry information."""
+        self.cache_get_mock.return_value = None
+        self.requests_mock.return_value.json.return_value = {
+            'active': True,
+            'scope': 'netbox:read netbox:write'
+        }
+
+        request = self.factory.get('/', HTTP_AUTHORIZATION=f'Bearer {self.token_with_scope}')
+
+        user, _ = self.auth.authenticate(request)
+        self.assertEqual(user, self.diode_user.user)
+
+        self.cache_set_mock.assert_called_once()
+
+        # Get the actual call arguments
+        call_args = self.cache_set_mock.call_args
+        if not call_args:
+            self.fail("Cache set was not called with any arguments")
+
+        # The cache key should start with 'diode:oauth2:introspect:'
+        cache_key = call_args.args[0]
+        self.assertTrue(cache_key.startswith('diode:oauth2:introspect:'))
+
+        # The cached value should be the diode user
+        self.assertEqual(call_args.args[1].user, self.diode_user.user)
+        self.assertEqual(call_args.args[1].token_scopes, self.diode_user.token_scopes)
+
+        # The timeout should be 300 (default)
+        self.assertEqual(call_args.kwargs['timeout'], 300)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_cable_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_cable_matcher.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for CableTerminationSetMatcher and dcim.cable pre-save routing."""
+
+from dcim.models import Cable, Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
+from django.test import TestCase
+
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.matcher import (
+    CableTerminationSetMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+    get_model_matchers,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+class RequiresPreSaveMatchTestCase(TestCase):
+    """Tests for requires_pre_save_match on dcim.cable."""
+
+    def test_dcim_cable_requires_pre_save_match(self):
+        """Dcim cable requires pre save match."""
+        # Cable has no DB unique constraint; uniqueness lives on CableTermination,
+        # so the applier must look up an existing cable before CREATE (spec 5.3, contract H).
+        self.assertTrue(requires_pre_save_match("dcim.cable"))
+
+
+class CableTerminationSetMatcherFingerprintTestCase(TestCase):
+    """Tests for CableTerminationSetMatcher.fingerprint."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.matcher = CableTerminationSetMatcher(
+            model_class=get_object_type_model("dcim.cable"),
+            name="logical_cable_termination_set",
+        )
+
+    def _data(self, a, b):
+        return {
+            "a_terminations": [{"object_type": t, "object_id": i} for t, i in a],
+            "b_terminations": [{"object_type": t, "object_id": i} for t, i in b],
+        }
+
+    def test_has_required_fields_both_ends_nonempty(self):
+        """Has required fields both ends nonempty."""
+        self.assertTrue(self.matcher.has_required_fields(
+            self._data([("dcim.interface", 1)], [("dcim.interface", 2)])))
+
+    def test_has_required_fields_missing_end(self):
+        """Has required fields missing end."""
+        self.assertFalse(self.matcher.has_required_fields(
+            {"a_terminations": [{"object_type": "dcim.interface", "object_id": 1}]}))
+
+    def test_has_required_fields_empty_list(self):
+        """Has required fields empty list."""
+        self.assertFalse(self.matcher.has_required_fields(
+            {"a_terminations": [], "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}]}))
+
+    def test_fingerprint_equal_under_ab_swap(self):
+        """Fingerprint equal under ab swap."""
+        fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
+        fp2 = self.matcher.fingerprint(self._data([("dcim.interface", 2)], [("dcim.interface", 1)]))
+        self.assertIsNotNone(fp1)
+        self.assertEqual(fp1, fp2)
+
+    def test_fingerprint_equal_under_within_end_reorder(self):
+        """Fingerprint equal under within end reorder."""
+        fp1 = self.matcher.fingerprint(self._data(
+            [("dcim.interface", 1), ("dcim.interface", 3)], [("dcim.interface", 2)]))
+        fp2 = self.matcher.fingerprint(self._data(
+            [("dcim.interface", 3), ("dcim.interface", 1)], [("dcim.interface", 2)]))
+        self.assertEqual(fp1, fp2)
+
+    def test_fingerprint_differs_for_different_set(self):
+        """Fingerprint differs for different set."""
+        fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
+        fp2 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 9)]))
+        self.assertNotEqual(fp1, fp2)
+
+    def test_fingerprint_distinguishes_object_type(self):
+        """Fingerprint distinguishes object type."""
+        fp1 = self.matcher.fingerprint(self._data([("dcim.interface", 1)], [("dcim.interface", 2)]))
+        fp2 = self.matcher.fingerprint(self._data([("dcim.frontport", 1)], [("dcim.interface", 2)]))
+        self.assertNotEqual(fp1, fp2)
+
+    def test_fingerprint_none_when_not_matchable(self):
+        """Fingerprint none when not matchable."""
+        self.assertIsNone(self.matcher.fingerprint({"a_terminations": []}))
+
+
+class FindObjCacheKeyCableTestCase(TestCase):
+    """Tests for _find_obj_cache_key with dcim.cable."""
+
+    def test_find_obj_cache_key_none_for_cable(self):
+        """Find obj cache key none for cable."""
+        data = {
+            "status": "connected",
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": 1}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}],
+        }
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.cable"))
+
+
+class CableTerminationSetMatcherRegistrationTestCase(TestCase):
+    """
+    dcim.cable must resolve to a non-empty matcher list including the set matcher.
+
+    Regression for: CableTerminationSetMatcher was defined but never wired into
+    _LOGICAL_MATCHERS, so get_model_matchers("dcim.cable") returned [] and the
+    matcher's build_queryset/fingerprint logic never ran for real cable ingestion.
+    """
+
+    def test_get_model_matchers_returns_cable_termination_set_matcher(self):
+        """Get model matchers returns cable termination set matcher."""
+        model_class = get_object_type_model("dcim.cable")
+        matchers = get_model_matchers(model_class)
+        self.assertTrue(
+            any(isinstance(m, CableTerminationSetMatcher) for m in matchers),
+            "CableTerminationSetMatcher is not registered for dcim.cable "
+            "(get_model_matchers returned no such matcher)",
+        )
+
+
+class FindExistingObjectCableDbTestCase(TestCase):
+    """
+    DB-backed regression: two distinct cables must not cross-resolve.
+
+    Exercises find_existing_object end-to-end (registration + build_queryset)
+    against real Cable/CableTermination rows, per brief Step 8.
+    """
+
+    def setUp(self):
+        """Set up test fixtures."""
+        manufacturer = Manufacturer.objects.create(name="CableTestMfr", slug="cable-test-mfr")
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model="CableTestModel", slug="cable-test-model")
+        device_role = DeviceRole.objects.create(name="CableTestRole", slug="cable-test-role", color="ff0000")
+        site = Site.objects.create(name="CableTestSite", slug="cable-test-site")
+
+        self.device1 = Device.objects.create(
+            name="CableTestDevice1", device_type=device_type, role=device_role, site=site,
+        )
+        self.device2 = Device.objects.create(
+            name="CableTestDevice2", device_type=device_type, role=device_role, site=site,
+        )
+        self.device3 = Device.objects.create(
+            name="CableTestDevice3", device_type=device_type, role=device_role, site=site,
+        )
+        self.device4 = Device.objects.create(
+            name="CableTestDevice4", device_type=device_type, role=device_role, site=site,
+        )
+
+        # A termination (interface) can belong to at most one cable, so each
+        # cable in this fixture uses its own dedicated pair of interfaces.
+        self.if1 = Interface.objects.create(device=self.device1, name="eth0", type="1000base-t")
+        self.if2 = Interface.objects.create(device=self.device2, name="eth0", type="1000base-t")
+        self.if3 = Interface.objects.create(device=self.device3, name="eth0", type="1000base-t")
+        self.if4 = Interface.objects.create(device=self.device4, name="eth0", type="1000base-t")
+
+        self.cable_12 = Cable.objects.create(status="connected")
+        self.cable_12.a_terminations = [self.if1]
+        self.cable_12.b_terminations = [self.if2]
+        self.cable_12.save()
+
+        self.cable_34 = Cable.objects.create(status="connected")
+        self.cable_34.a_terminations = [self.if3]
+        self.cable_34.b_terminations = [self.if4]
+        self.cable_34.save()
+
+    def _data(self, a_if, b_if):
+        return {
+            "status": "connected",
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": a_if.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": b_if.pk}],
+        }
+
+    def test_finds_correct_cable_for_its_own_termination_set(self):
+        """Finds correct cable for its own termination set."""
+        result = find_existing_object(self._data(self.if1, self.if2), "dcim.cable")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, self.cable_12.pk)
+
+    def test_does_not_cross_resolve_distinct_cable(self):
+        """Does not cross resolve distinct cable."""
+        result_34 = find_existing_object(self._data(self.if3, self.if4), "dcim.cable")
+        self.assertIsNotNone(result_34)
+        self.assertEqual(result_34.pk, self.cable_34.pk)
+        self.assertNotEqual(result_34.pk, self.cable_12.pk)
+
+    def test_ab_swap_still_resolves_same_cable(self):
+        """Ab swap still resolves same cable."""
+        # A/B order is insignificant for identity (spec 5.3 contract).
+        result = find_existing_object(self._data(self.if2, self.if1), "dcim.cable")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, self.cable_12.pk)
+
+    def test_no_match_for_nonexistent_termination_set(self):
+        """No match for nonexistent termination set."""
+        result = find_existing_object(self._data(self.if1, self.if3), "dcim.cable")
+        self.assertIsNone(result)
+
+
+class CableTerminationSetMatcherQuerysetTestCase(TestCase):
+    """Tests for CableTerminationSetMatcher.build_queryset."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set Up Test Data."""
+        site = Site.objects.create(name="S1", slug="s1")
+        mfr = Manufacturer.objects.create(name="M1", slug="m1")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="DT1", slug="dt1")
+        role = DeviceRole.objects.create(name="R1", slug="r1")
+        dev = Device.objects.create(name="D1", site=site, device_type=dt, role=role)
+        cls.if1 = Interface.objects.create(device=dev, name="eth0", type="1000base-t")
+        cls.if2 = Interface.objects.create(device=dev, name="eth1", type="1000base-t")
+        cls.if3 = Interface.objects.create(device=dev, name="eth2", type="1000base-t")
+        cls.cable = Cable(a_terminations=[cls.if1], b_terminations=[cls.if2])
+        cls.cable.save()
+        cls.matcher = CableTerminationSetMatcher(
+            model_class=get_object_type_model("dcim.cable"),
+            name="logical_cable_termination_set",
+        )
+
+    def _data(self, *pairs):
+        terms = [{"object_type": t, "object_id": i} for t, i in pairs]
+        return {"a_terminations": terms[:1], "b_terminations": terms[1:]}
+
+    def test_exact_set_matches(self):
+        """Exact set matches."""
+        data = self._data(("dcim.interface", self.if1.pk), ("dcim.interface", self.if2.pk))
+        qs = self.matcher.build_queryset(data)
+        self.assertIsNotNone(qs)
+        self.assertEqual(list(qs.values_list("pk", flat=True)), [self.cable.pk])
+
+    def test_exact_set_matches_under_ab_swap(self):
+        """Exact set matches under ab swap."""
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if2.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+        }
+        self.assertEqual(
+            list(self.matcher.build_queryset(data).values_list("pk", flat=True)),
+            [self.cable.pk],
+        )
+
+    def test_empty_end_returns_none(self):
+        """Empty end returns none."""
+        qs = self.matcher.build_queryset(
+            {"a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+             "b_terminations": []}
+        )
+        self.assertIsNone(qs)  # has_required_fields False for empty b
+
+    def test_superset_rejected(self):
+        """Superset rejected."""
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+            "b_terminations": [
+                {"object_type": "dcim.interface", "object_id": self.if2.pk},
+                {"object_type": "dcim.interface", "object_id": self.if3.pk},
+            ],
+        }
+        self.assertEqual(list(self.matcher.build_queryset(data)), [])
+
+    def test_partial_overlap_rejected(self):
+        """Partial overlap rejected."""
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if3.pk}],
+        }
+        self.assertEqual(list(self.matcher.build_queryset(data)), [])
+
+    def test_unresolved_returns_none(self):
+        """Unresolved returns none."""
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface",
+                                "object_id": UnresolvedReference("dcim.interface", "u-1")}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if2.pk}],
+        }
+        self.assertIsNone(self.matcher.build_queryset(data))
+
+    def test_duplicate_pair_returns_none(self):
+        """
+        A:[if1] B:[if1] must not false-match the if1<->if2 cable.
+
+        The same object on both ends is an invalid cable (unique termination
+        constraint). Without dedup, len(pairs)==2 and both existence filters
+        are satisfied by the single if1 row of cable if1<->if2, matching it.
+        build_queryset must return None so the serializer rejects the payload.
+        """
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+        }
+        self.assertIsNone(self.matcher.build_queryset(data))
+
+    def test_multi_termination_per_end_exact_match(self):
+        """
+        A cable with 2 terminations on one end matches its exact 3-set.
+
+        Proves successive build_queryset filters create separate joins (one
+        CableTermination row per requested pair), not a single-alias AND that
+        would make multi-termination matching impossible. Uses fresh
+        interfaces: a termination may only belong to one cable.
+        """
+        dev = self.if1.device
+        m1 = Interface.objects.create(device=dev, name="m0", type="1000base-t")
+        m2 = Interface.objects.create(device=dev, name="m1", type="1000base-t")
+        m3 = Interface.objects.create(device=dev, name="m2", type="1000base-t")
+        multi = Cable(a_terminations=[m1, m2], b_terminations=[m3])
+        multi.save()
+        data = {
+            "a_terminations": [
+                {"object_type": "dcim.interface", "object_id": m1.pk},
+                {"object_type": "dcim.interface", "object_id": m2.pk},
+            ],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": m3.pk}],
+        }
+        qs = self.matcher.build_queryset(data)
+        self.assertEqual(list(qs.values_list("pk", flat=True)), [multi.pk])
+
+    def test_multi_termination_superset_rejected(self):
+        """A 2-per-end request must NOT match a cable missing one of them."""
+        dev = self.if1.device
+        m1 = Interface.objects.create(device=dev, name="n0", type="1000base-t")
+        m2 = Interface.objects.create(device=dev, name="n1", type="1000base-t")
+        m3 = Interface.objects.create(device=dev, name="n2", type="1000base-t")
+        # cable only has {m1, m2}; request adds a third (m3)
+        Cable(a_terminations=[m1], b_terminations=[m2]).save()
+        data = {
+            "a_terminations": [
+                {"object_type": "dcim.interface", "object_id": m1.pk},
+                {"object_type": "dcim.interface", "object_id": m3.pk},
+            ],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": m2.pk}],
+        }
+        self.assertEqual(list(self.matcher.build_queryset(data)), [])
+
+    def test_find_existing_object_matches_via_matcher(self):
+        """Find existing object matches via matcher."""
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": self.if1.pk}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": self.if2.pk}],
+        }
+        found = find_existing_object(data, "dcim.cable")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.pk, self.cable.pk)
+
+
+class CableFingerprintsNoCrashTestCase(TestCase):
+    """Regression: cable fingerprinting must not crash on edge-case input."""
+
+    def test_fingerprints_no_crash_on_termination_dicts(self):
+        """Fingerprints no crash on termination dicts."""
+        # regression: list-of-dict terminations must not raise
+        # "unhashable type: 'dict'" in _fingerprint_all.
+        from netbox_diode_plugin.api.matcher import fingerprints
+        data = {
+            "a_terminations": [{"object_type": "dcim.interface", "object_id": 1}],
+            "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}],
+        }
+        fps = fingerprints(data, "dcim.cable")  # must not raise
+        self.assertIsInstance(fps, list)
+        self.assertGreaterEqual(len(fps), 1)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_change_log_buffer.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_change_log_buffer.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - buffered_change_logging tests."""
+
+import logging
+from types import SimpleNamespace
+from unittest import mock
+from uuid import uuid4
+
+from core.models import ObjectChange
+from dcim.models import Site
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from extras.models import Tag
+from ipam.models import ASN, RIR
+from netbox.config import get_config
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api import change_log_buffer, views
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+class BufferedChangeLoggingApplyTestCase(APITestCase):
+    """End-to-end behaviour of `buffered_change_logging` via `/bulk-plan-apply/`."""
+
+    def setUp(self):
+        """Auth + clean ObjectChange table for predictable counts."""
+        self.url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            "_introspect_token",
+            return_value=self.diode_user,
+        )
+        self.introspect_patcher.start()
+
+        ObjectChange.objects.all().delete()
+
+    def tearDown(self):
+        """Stop the auth patcher."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def _make_payload(self, suffix):
+        """Build a single-entity bulk-plan-apply payload that creates a fresh Site."""
+        return {
+            "entities": [
+                {
+                    "id": f"entity-{suffix}",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": f"Site {suffix}", "slug": f"site-{suffix}"}},
+                }
+            ]
+        }
+
+    def _site_change_count(self):
+        """Return the number of ObjectChange rows whose changed_object is a Site."""
+        return ObjectChange.objects.filter(
+            changed_object_type__app_label="dcim",
+            changed_object_type__model="site",
+        ).count()
+
+    # --- Setting OFF: buffer is a pass-through, upstream writes synchronously ---
+
+    def test_setting_false_writes_objectchange_synchronously(self):
+        """With the setting off (default), the apply writes ObjectChange synchronously via upstream."""
+        response = self.client.post(
+            self.url,
+            data=self._make_payload(uuid4().hex[:8]),
+            format="json",
+            **self.authorization_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        # Upstream synchronous path -> row already in DB at request return.
+        self.assertEqual(self._site_change_count(), 1)
+
+    # --- Setting ON: buffer collects + flushes one bulk_create at commit ---
+
+    def test_setting_true_flushes_objectchange_on_commit(self):
+        """With the setting on, the buffered ObjectChange is written by the on_commit flush."""
+        suffix = uuid4().hex[:8]
+        # Django's TestCase wraps each test in a transaction that is
+        # rolled back at end-of-test, which means `transaction.on_commit`
+        # callbacks normally never fire. `captureOnCommitCallbacks` runs
+        # them explicitly on context exit so we can assert the flush.
+        with mock.patch.object(change_log_buffer, "get_plugin_config", return_value=True), \
+             self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url, data=self._make_payload(suffix), format="json", **self.authorization_header
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        # Apply transaction committed -> on_commit fired -> exactly one row.
+        self.assertEqual(self._site_change_count(), 1)
+        oc = ObjectChange.objects.get(
+            changed_object_type__app_label="dcim", changed_object_type__model="site"
+        )
+        self.assertEqual(oc.action, "create")
+        self.assertEqual(oc.object_repr, f"Site {suffix}")
+
+    # --- Rollback: no flush on apply failure ---
+
+    def test_rollback_does_not_flush(self):
+        """If apply_changeset raises, transaction.on_commit never fires and nothing is written."""
+        suffix = uuid4().hex[:8]
+
+        def failing_apply(change_set, request):
+            Site.objects.create(name=f"Doomed {suffix}", slug=f"doomed-{suffix}")
+            raise RuntimeError("forced rollback")
+
+        with mock.patch.object(change_log_buffer, "get_plugin_config", return_value=True), \
+             mock.patch.object(views, "apply_changeset", side_effect=failing_apply), \
+             mock.patch.object(change_log_buffer, "_flush_objectchanges") as mock_flush, \
+             self.captureOnCommitCallbacks(execute=True):
+            self.client.post(
+                self.url, data=self._make_payload(suffix), format="json", **self.authorization_header
+            )
+
+        # Outer atomic rolled back the Site; the append on_commit was discarded.
+        self.assertFalse(Site.objects.filter(slug=f"doomed-{suffix}").exists())
+        # Flush still runs at request end but the batch is empty.
+        if mock_flush.called:
+            self.assertEqual(list(mock_flush.call_args.args[0]), [])
+
+    # --- Bypass wins when both flags are enabled ---
+
+    def test_bypass_takes_precedence_over_buffer_when_both_active(self):
+        """When apply_bypass_change_logging is active, the buffer never collects and nothing is written."""
+        suffix = uuid4().hex[:8]
+
+        bypass_token = change_log_buffer._bypass_active.set(True)
+        try:
+            with mock.patch.object(change_log_buffer, "get_plugin_config", return_value=True), \
+                 self.captureOnCommitCallbacks(execute=True):
+                response = self.client.post(
+                    self.url, data=self._make_payload(suffix), format="json", **self.authorization_header
+                )
+        finally:
+            change_log_buffer._bypass_active.reset(bypass_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        # Site was created (apply itself wasn't bypassed), but no ObjectChange.
+        self.assertTrue(Site.objects.filter(slug=f"site-{suffix}").exists())
+        self.assertEqual(self._site_change_count(), 0)
+
+    # --- Request-level batching: many entities -> one consolidated flush ---
+
+    def test_multi_entity_request_flushes_one_batch(self):
+        """3 entities in one request -> ONE flush carrying all 3 entities' rows."""
+        suffix = uuid4().hex[:8]
+        payload = {
+            "entities": [
+                {
+                    "id": f"entity-{i}-{suffix}",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": f"Site {i} {suffix}", "slug": f"site-{i}-{suffix}"}},
+                }
+                for i in range(3)
+            ]
+        }
+
+        with mock.patch.object(change_log_buffer, "get_plugin_config", return_value=True), \
+             mock.patch.object(
+                 change_log_buffer, "_flush_objectchanges",
+                 side_effect=change_log_buffer._flush_objectchanges,
+             ) as spy_flush, \
+             self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url, data=payload, format="json", **self.authorization_header
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        # Single flush for the whole request, not one per entity.
+        spy_flush.assert_called_once()
+        flushed = list(spy_flush.call_args.args[0])
+        self.assertEqual(len(flushed), 3)
+        reprs = {oc.object_repr for oc in flushed}
+        self.assertEqual(reprs, {f"Site 0 {suffix}", f"Site 1 {suffix}", f"Site 2 {suffix}"})
+        self.assertEqual(self._site_change_count(), 3)
+
+    def test_failed_entity_excluded_from_batch(self):
+        """When one entity fails, its rows are dropped from the consolidated flush."""
+        suffix = uuid4().hex[:8]
+        good_slug = f"good-{suffix}"
+        bad_slug = f"bad-{suffix}"
+        payload = {
+            "entities": [
+                {
+                    "id": f"good-{suffix}",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": f"Good {suffix}", "slug": good_slug}},
+                },
+                {
+                    "id": f"bad-{suffix}",
+                    "object_type": "dcim.site",
+                    "entity": {"site": {"name": f"Bad {suffix}", "slug": bad_slug}},
+                },
+            ]
+        }
+
+        original_apply = views.apply_changeset
+        call_count = {"n": 0}
+
+        def selective_failing_apply(change_set, request):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return original_apply(change_set, request)
+            Site.objects.create(name=f"Bad inner {suffix}", slug=bad_slug)
+            raise RuntimeError("forced rollback for second entity")
+
+        with mock.patch.object(change_log_buffer, "get_plugin_config", return_value=True), \
+             mock.patch.object(views, "apply_changeset", side_effect=selective_failing_apply), \
+             mock.patch.object(
+                 change_log_buffer, "_flush_objectchanges",
+                 side_effect=change_log_buffer._flush_objectchanges,
+             ) as spy_flush, \
+             self.captureOnCommitCallbacks(execute=True):
+            self.client.post(
+                self.url, data=payload, format="json", **self.authorization_header
+            )
+
+        # Good entity made it through; bad entity rolled back.
+        self.assertTrue(Site.objects.filter(slug=good_slug).exists())
+        self.assertFalse(Site.objects.filter(slug=bad_slug).exists())
+        # Flush happens but only contains the good row.
+        spy_flush.assert_called_once()
+        flushed = list(spy_flush.call_args.args[0])
+        self.assertEqual(len(flushed), 1)
+        self.assertEqual(flushed[0].object_repr, f"Good {suffix}")
+
+
+class FastSerializeTestCase(TestCase):
+    """`_fast_serialize_object` parity and the buffer-active gate."""
+
+    def setUp(self):
+        """Create a Site with an m2m relation (asns) and a tag."""
+        ObjectChange.objects.all().delete()
+        self.site = Site.objects.create(name="Parity site", slug=f"parity-{uuid4().hex[:8]}")
+        self.site.tags.add(
+            Tag.objects.create(name="alpha", slug="alpha"),
+            Tag.objects.create(name="beta", slug="beta"),
+        )
+        rir = RIR.objects.create(name="Test RIR", slug=f"rir-{uuid4().hex[:8]}")
+        self.asn = ASN.objects.create(asn=65001, rir=rir)
+        self.site.asns.add(self.asn)
+
+    def test_fast_serialize_omits_m2m_and_placeholders_tags(self):
+        """Fast output equals upstream minus m2m, with tags left as an empty placeholder."""
+        vanilla = change_log_buffer._original_serialize_object(self.site, exclude=[])
+        fast = change_log_buffer._fast_serialize_object(self.site, exclude=[])
+
+        # `asns` is the only serialisable m2m on Site; the fast path drops it.
+        m2m_names = {f.name for f in Site._meta.local_many_to_many if f.serialize}
+        self.assertIn("asns", m2m_names)
+        self.assertNotIn("asns", fast)
+        # Tags are a placeholder, resolved in bulk at flush, not per-save.
+        self.assertEqual(fast["tags"], [])
+
+        # Every other field matches upstream exactly.
+        expected = {k: v for k, v in vanilla.items() if k not in m2m_names and k != "tags"}
+        actual = {k: v for k, v in fast.items() if k != "tags"}
+        self.assertEqual(actual, expected)
+
+    def test_full_parity_after_enrichment(self):
+        """Fast serialize + m2m + tag enrichment reproduces the upstream serializer output."""
+        vanilla = change_log_buffer._original_serialize_object(self.site, exclude=[])
+        row = ObjectChange(
+            changed_object_type_id=ContentType.objects.get_for_model(Site).id,
+            changed_object_id=self.site.pk,
+            action="create",
+            postchange_data=change_log_buffer._fast_serialize_object(self.site, exclude=[]),
+        )
+        change_log_buffer._enrich_m2m([row])
+        change_log_buffer._enrich_tags([row])
+
+        # m2m ordering: enrichment sorts, upstream uses queryset order;
+        # compare membership for the relation, then the rest exactly.
+        self.assertEqual(set(row.postchange_data.pop("asns")), set(vanilla.pop("asns")))
+        self.assertEqual(row.postchange_data, vanilla)
+
+    def test_serialize_object_gate_is_inactive_without_buffer(self):
+        """With no buffer active, serialize_object delegates to the upstream implementation."""
+        # Identical output to the captured original means the gate did not
+        # engage the fast path.
+        self.assertEqual(
+            self.site.serialize_object(),
+            change_log_buffer._original_serialize_object(self.site),
+        )
+
+    def test_serialize_object_gate_engages_fast_path_with_buffer(self):
+        """With a buffer active, serialize_object routes through the fast path (no m2m)."""
+        token = change_log_buffer._apply_change_buffer.set({})
+        try:
+            gated = self.site.serialize_object()
+        finally:
+            change_log_buffer._apply_change_buffer.reset(token)
+        self.assertNotIn("asns", gated)
+
+
+class EnrichM2MTestCase(TestCase):
+    """`_enrich_m2m` re-adds m2m relations to buffered rows in bulk."""
+
+    def setUp(self):
+        """Two Sites, each with distinct ASNs, to exercise per-object grouping."""
+        ObjectChange.objects.all().delete()
+        rir = RIR.objects.create(name="Enrich RIR", slug=f"erir-{uuid4().hex[:8]}")
+        self.asn1 = ASN.objects.create(asn=65010, rir=rir)
+        self.asn2 = ASN.objects.create(asn=65011, rir=rir)
+        self.site_a = Site.objects.create(name="Enrich A", slug=f"enrich-a-{uuid4().hex[:8]}")
+        self.site_b = Site.objects.create(name="Enrich B", slug=f"enrich-b-{uuid4().hex[:8]}")
+        self.site_a.asns.add(self.asn1, self.asn2)
+        self.site_b.asns.add(self.asn1)
+        self.ct_id = ContentType.objects.get_for_model(Site).id
+
+    def _row(self, site):
+        return ObjectChange(
+            changed_object_type_id=self.ct_id,
+            changed_object_id=site.pk,
+            action="create",
+            postchange_data=change_log_buffer._fast_serialize_object(site, exclude=[]),
+        )
+
+    def test_enrich_populates_m2m_per_object(self):
+        """Each row's postchange_data gets its own object's relation, sorted."""
+        rows = [self._row(self.site_a), self._row(self.site_b)]
+        change_log_buffer._enrich_m2m(rows)
+
+        self.assertEqual(rows[0].postchange_data["asns"], sorted([self.asn1.pk, self.asn2.pk]))
+        self.assertEqual(rows[1].postchange_data["asns"], [self.asn1.pk])
+
+    def test_enriched_membership_matches_upstream(self):
+        """After enrichment, m2m membership matches what the upstream serializer records."""
+        vanilla = change_log_buffer._original_serialize_object(self.site_a, exclude=[])
+        row = self._row(self.site_a)
+        change_log_buffer._enrich_m2m([row])
+        self.assertEqual(set(row.postchange_data["asns"]), set(vanilla["asns"]))
+
+    def test_enrich_is_bulk_one_query_per_relation(self):
+        """Resolving N objects' relations costs one query per relation, not one per object."""
+        rows = [self._row(self.site_a), self._row(self.site_b)]
+        # Site has a single serialisable m2m (asns) -> exactly one query.
+        with self.assertNumQueries(1):
+            change_log_buffer._enrich_m2m(rows)
+
+
+class EnrichTagsTestCase(TestCase):
+    """`_enrich_tags` fills the tag placeholder left by the fast serializer in bulk."""
+
+    def setUp(self):
+        """Two Sites with overlapping tags to exercise per-object grouping."""
+        ObjectChange.objects.all().delete()
+        self.red = Tag.objects.create(name="red", slug="red")
+        self.blue = Tag.objects.create(name="blue", slug="blue")
+        self.site_a = Site.objects.create(name="Tag A", slug=f"tag-a-{uuid4().hex[:8]}")
+        self.site_b = Site.objects.create(name="Tag B", slug=f"tag-b-{uuid4().hex[:8]}")
+        self.site_a.tags.add(self.red, self.blue)
+        self.site_b.tags.add(self.red)
+        self.ct_id = ContentType.objects.get_for_model(Site).id
+
+    def _row(self, site):
+        return ObjectChange(
+            changed_object_type_id=self.ct_id,
+            changed_object_id=site.pk,
+            action="create",
+            postchange_data=change_log_buffer._fast_serialize_object(site, exclude=[]),
+        )
+
+    def test_enrich_fills_tags_per_object_sorted(self):
+        """Each row gets its own object's tag names, sorted."""
+        rows = [self._row(self.site_a), self._row(self.site_b)]
+        change_log_buffer._enrich_tags(rows)
+        self.assertEqual(rows[0].postchange_data["tags"], ["blue", "red"])
+        self.assertEqual(rows[1].postchange_data["tags"], ["red"])
+
+    def test_enrich_tags_one_query_per_content_type(self):
+        """N taggable objects of one model cost a single tag query, not one per object."""
+        rows = [self._row(self.site_a), self._row(self.site_b)]
+        with self.assertNumQueries(1):
+            change_log_buffer._enrich_tags(rows)
+
+    def test_enrich_tags_empty_for_untagged_object(self):
+        """A taggable object with no tags keeps the empty placeholder."""
+        site_c = Site.objects.create(name="Tag C", slug=f"tag-c-{uuid4().hex[:8]}")
+        row = self._row(site_c)
+        change_log_buffer._enrich_tags([row])
+        self.assertEqual(row.postchange_data["tags"], [])
+
+    def test_enrich_tags_skips_rows_without_placeholder(self):
+        """Rows whose postchange_data has no `tags` key (non-taggable shape) are not given one."""
+        row = ObjectChange(
+            changed_object_type_id=self.ct_id,
+            changed_object_id=self.site_a.pk,
+            action="create",
+            postchange_data={"name": "no-tags-key"},
+        )
+        change_log_buffer._enrich_tags([row])
+        self.assertNotIn("tags", row.postchange_data)
+
+
+class SnapshotForApplyTestCase(TestCase):
+    """`snapshot_for_apply` captures prechange consistent with the buffered postchange."""
+
+    def setUp(self):
+        """A Site with an m2m relation (asns) and a tag."""
+        ObjectChange.objects.all().delete()
+        self.site = Site.objects.create(name="Snap site", slug=f"snap-{uuid4().hex[:8]}")
+        self.site.tags.add(Tag.objects.create(name="green", slug="green"))
+        rir = RIR.objects.create(name="Snap RIR", slug=f"srir-{uuid4().hex[:8]}")
+        self.asn = ASN.objects.create(asn=65100, rir=rir)
+        self.site.asns.add(self.asn)
+        self.ct_id = ContentType.objects.get_for_model(Site).id
+        self._exclude = ["last_updated"] if get_config().CHANGELOG_SKIP_EMPTY_CHANGES else []
+
+    def _snapshot_with_buffer(self):
+        token = change_log_buffer._apply_change_buffer.set({})
+        try:
+            change_log_buffer.snapshot_for_apply(self.site)
+        finally:
+            change_log_buffer._apply_change_buffer.reset(token)
+        return self.site._prechange_snapshot
+
+    def test_buffer_active_captures_sorted_m2m_and_tags(self):
+        """With the buffer active, prechange records m2m + tags resolved now, sorted."""
+        snap = self._snapshot_with_buffer()
+        self.assertEqual(snap["asns"], [self.asn.pk])
+        self.assertEqual(snap["tags"], ["green"])
+
+    def test_prechange_matches_postchange_for_unchanged_object(self):
+        """Prechange and postchange are identical for an unmodified object (no spurious diff)."""
+        prechange = self._snapshot_with_buffer()
+
+        # Build postchange exactly as the buffered flush would.
+        row = ObjectChange(
+            changed_object_type_id=self.ct_id,
+            changed_object_id=self.site.pk,
+            action="update",
+            postchange_data=change_log_buffer._fast_serialize_object(self.site, exclude=self._exclude),
+        )
+        change_log_buffer._enrich_m2m([row])
+        change_log_buffer._enrich_tags([row])
+
+        self.assertEqual(prechange, row.postchange_data)
+
+    def test_buffer_inactive_delegates_to_netbox_snapshot(self):
+        """With no buffer, prechange comes from NetBox's own snapshot (full serializer)."""
+        if hasattr(self.site, "_prechange_snapshot"):
+            del self.site._prechange_snapshot
+        change_log_buffer.snapshot_for_apply(self.site)
+        self.assertTrue(hasattr(self.site, "_prechange_snapshot"))
+        # The full serializer includes the m2m relation directly.
+        self.assertIn("asns", self.site._prechange_snapshot)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_changeset_validate_alias.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_changeset_validate_alias.py
@@ -1,0 +1,31 @@
+"""Unit tests for ChangeSet.validate with serializer-aliased wire fields."""
+from django.test import TestCase
+
+from netbox_diode_plugin.api.common import NON_FIELD_ERRORS, Change, ChangeSet, ChangeType
+
+
+class ValidateAliasedFieldsTests(TestCase):
+    """validate() must map wire names to model attributes and never crash."""
+
+    def _changeset(self, object_type, data):
+        return ChangeSet(changes=[
+            Change(change_type=ChangeType.CREATE, object_type=object_type, ref_id="1", data=data)
+        ])
+
+    def test_aliased_wire_field_validates_cleanly(self):
+        """'attributes' must be renamed to attribute_data before model(**data)."""
+        cs = self._changeset(
+            "dcim.moduletype",
+            {"model": "mt-alias", "manufacturer": 1, "attributes": {"ram": 64}},
+        )
+        self.assertIsNone(cs.validate())
+
+    def test_unexpected_kwarg_becomes_error_not_crash(self):
+        """A non-model key must surface as a validation error, not a TypeError."""
+        cs = self._changeset(
+            "dcim.module",
+            {"device": 1, "module_bay": 1, "module_type": 1, "adopt_components": True},
+        )
+        errors = cs.validate()
+        self.assertIsNotNone(errors)
+        self.assertIn("adopt_components", str(errors["dcim.module"][NON_FIELD_ERRORS]))

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_counter_buffer.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_counter_buffer.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - buffered_counter_updates tests."""
+
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import (
+    ConsolePortTemplate,
+    Device,
+    DeviceRole,
+    DeviceType,
+    Interface,
+    InterfaceTemplate,
+    Manufacturer,
+    Site,
+)
+from django.db import connection, transaction
+from django.db.models import When
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api import counter_buffer
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.counter_buffer import (
+    _flush_counter_deltas,
+    buffered_counter_updates,
+)
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+def _enabled():
+    """Turn the `apply_buffer_counter_updates` gate on for the duration of a block."""
+    return mock.patch.object(counter_buffer, "get_plugin_config", return_value=True)
+
+
+class BufferedCounterUpdatesTestCase(TestCase):
+    """Behaviour of the `buffered_counter_updates` context manager over real ORM writes."""
+
+    def setUp(self):
+        """Two DeviceTypes sharing a manufacturer - cheap parents with several counters each."""
+        mfr = Manufacturer.objects.create(name="bcu-mfr", slug="bcu-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="bcu-dt", slug="bcu-dt")
+        self.other_dt = DeviceType.objects.create(
+            manufacturer=mfr, model="bcu-dt2", slug="bcu-dt2"
+        )
+
+    def _stored(self, device_type=None, field="interface_template_count"):
+        """Read a counter column straight from the DB, bypassing any in-memory instance."""
+        dt = device_type or self.dt
+        return DeviceType.objects.filter(pk=dt.pk).values_list(field, flat=True)[0]
+
+    def _add_interface_templates(self, count, device_type=None):
+        """Create `count` InterfaceTemplates, each of which increments the parent's counter."""
+        dt = device_type or self.dt
+        return [
+            InterfaceTemplate.objects.create(
+                device_type=dt, name=f"eth{i}-{uuid.uuid4().hex[:6]}", type="1000base-t"
+            )
+            for i in range(count)
+        ]
+
+    @staticmethod
+    def _counter_updates(captured):
+        """Return the UPDATE statements captured against the DeviceType table."""
+        return [
+            q["sql"]
+            for q in captured.captured_queries
+            if q["sql"].lstrip().upper().startswith("UPDATE")
+            and "dcim_devicetype" in q["sql"]
+        ]
+
+    # --- Setting OFF: pass-through, upstream updates synchronously ---
+
+    def test_setting_false_updates_counter_synchronously(self):
+        """With the setting off (default), each child write updates the counter immediately."""
+        with buffered_counter_updates():
+            self._add_interface_templates(2)
+            # No buffer: upstream's per-write UPDATE has already landed.
+            self.assertEqual(self._stored(), 2)
+        self.assertEqual(self._stored(), 2)
+
+    def test_setting_false_issues_one_update_per_child(self):
+        """The unbuffered path is exactly what it was before: one statement per child write."""
+        with CaptureQueriesContext(connection) as captured:
+            with buffered_counter_updates():
+                self._add_interface_templates(3)
+        self.assertEqual(len(self._counter_updates(captured)), 3)
+
+    # --- Setting ON: deltas accumulate, flush lands at context exit ---
+
+    def test_deltas_are_withheld_until_the_flush(self):
+        """Inside the context the parent row is untouched; on exit the total is applied."""
+        with _enabled(), buffered_counter_updates():
+            self._add_interface_templates(3)
+            # The whole point: the parent row has not been locked yet.
+            self.assertEqual(self._stored(), 0)
+        self.assertEqual(self._stored(), 3)
+
+    def test_deltas_coalesce_into_one_statement(self):
+        """N children of one parent collapse to a single UPDATE carrying +N."""
+        with CaptureQueriesContext(connection) as captured:
+            with _enabled(), buffered_counter_updates():
+                self._add_interface_templates(5)
+
+        self.assertEqual(len(self._counter_updates(captured)), 1)
+        self.assertEqual(self._stored(), 5)
+
+    def test_net_zero_delta_issues_no_statement(self):
+        """A child created and deleted in the same apply nets to zero and is never written."""
+        with CaptureQueriesContext(connection) as captured:
+            with _enabled(), buffered_counter_updates():
+                created = self._add_interface_templates(1)
+                created[0].delete()
+
+        self.assertEqual(self._counter_updates(captured), [])
+        self.assertEqual(self._stored(), 0)
+
+    def test_delete_decrements(self):
+        """post_delete deltas are buffered and flushed the same way as post_save ones."""
+        templates = self._add_interface_templates(3)
+        self.assertEqual(self._stored(), 3)
+
+        with _enabled(), buffered_counter_updates():
+            templates[0].delete()
+            templates[1].delete()
+            self.assertEqual(self._stored(), 3)
+        self.assertEqual(self._stored(), 1)
+
+    def test_reparent_splits_delta_across_both_parents(self):
+        """Moving a child buffers -1 on the old parent and +1 on the new one."""
+        template = self._add_interface_templates(1)[0]
+        self.assertEqual(self._stored(), 1)
+
+        with _enabled(), buffered_counter_updates():
+            template.device_type = self.other_dt
+            template.save()
+            self.assertEqual(self._stored(), 1)
+            self.assertEqual(self._stored(self.other_dt), 0)
+
+        self.assertEqual(self._stored(), 0)
+        self.assertEqual(self._stored(self.other_dt), 1)
+
+    def test_distinct_deltas_share_one_statement(self):
+        """Two parents with different deltas are carried by one CASE expression, not two UPDATEs."""
+        with CaptureQueriesContext(connection) as captured:
+            with _enabled(), buffered_counter_updates():
+                self._add_interface_templates(1)
+                self._add_interface_templates(3, device_type=self.other_dt)
+
+        self.assertEqual(len(self._counter_updates(captured)), 1)
+        self.assertEqual(self._stored(), 1)
+        self.assertEqual(self._stored(self.other_dt), 3)
+
+    def test_separate_counters_get_one_statement_each(self):
+        """Grouping is per (model, counter field): two counters on one model, two statements."""
+        with CaptureQueriesContext(connection) as captured:
+            with _enabled(), buffered_counter_updates():
+                self._add_interface_templates(2)
+                ConsolePortTemplate.objects.create(device_type=self.dt, name="con0")
+
+        self.assertEqual(len(self._counter_updates(captured)), 2)
+        self.assertEqual(self._stored(), 2)
+        self.assertEqual(self._stored(field="console_port_template_count"), 1)
+
+    # --- The safety property: the flush is inside the transaction ---
+
+    def test_flush_is_not_deferred_to_on_commit(self):
+        """
+        The deltas must land pre-commit, not via `transaction.on_commit`.
+
+        Deferring to on_commit would put the counter write outside the
+        transaction that justified it, so a crash between COMMIT and the
+        callback would silently lose the increment. `captureOnCommitCallbacks`
+        holds every registered callback back; the counter must already be
+        correct without any of them running.
+        """
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            with _enabled(), buffered_counter_updates():
+                self._add_interface_templates(2)
+            self.assertEqual(self._stored(), 2)
+
+        self.assertEqual(callbacks, [])
+
+    def test_rollback_discards_deltas(self):
+        """A failed apply rolls the flush back with the writes that produced it."""
+        with self.assertRaises(RuntimeError):
+            with transaction.atomic():
+                with _enabled(), buffered_counter_updates():
+                    self._add_interface_templates(2)
+                    raise RuntimeError("forced rollback")
+
+        self.assertEqual(self._stored(), 0)
+        self.assertEqual(InterfaceTemplate.objects.filter(device_type=self.dt).count(), 0)
+
+    def test_flush_failure_rolls_back_the_apply(self):
+        """If the flush itself raises, the exception reaches the enclosing atomic block."""
+        with self.assertRaises(RuntimeError):
+            with transaction.atomic():
+                with mock.patch.object(
+                    counter_buffer,
+                    "_flush_counter_deltas",
+                    side_effect=RuntimeError("deadlock"),
+                ):
+                    with _enabled(), buffered_counter_updates():
+                        self._add_interface_templates(1)
+
+        self.assertEqual(self._stored(), 0)
+        self.assertEqual(InterfaceTemplate.objects.filter(device_type=self.dt).count(), 0)
+
+    # --- Interaction with the bypass ---
+
+    def test_bypass_takes_precedence_when_both_active(self):
+        """With apply_bypass_counter_updates active nothing is written or buffered."""
+        token = counter_buffer._bypass_active.set(True)
+        try:
+            with CaptureQueriesContext(connection) as captured:
+                with _enabled(), buffered_counter_updates():
+                    self._add_interface_templates(2)
+        finally:
+            counter_buffer._bypass_active.reset(token)
+
+        self.assertEqual(self._counter_updates(captured), [])
+        self.assertEqual(self._stored(), 0)
+        # The children themselves were still created; only the counter is skipped.
+        self.assertEqual(InterfaceTemplate.objects.filter(device_type=self.dt).count(), 2)
+
+    # --- Nothing outside an apply is affected ---
+
+    def test_writes_outside_the_context_are_unbuffered(self):
+        """With no buffer active the wrapper delegates, so ordinary NetBox writes are unchanged."""
+        with _enabled():
+            self._add_interface_templates(2)
+        self.assertEqual(self._stored(), 2)
+
+    def test_buffer_does_not_leak_past_the_context(self):
+        """The contextvar is reset on exit, so a later write is synchronous again."""
+        with _enabled(), buffered_counter_updates():
+            self._add_interface_templates(1)
+
+        self.assertIsNone(counter_buffer._apply_counter_buffer.get())
+        with _enabled():
+            self._add_interface_templates(1)
+        self.assertEqual(self._stored(), 2)
+
+
+class FlushCounterDeltasTestCase(TestCase):
+    """`_flush_counter_deltas` statement shape: per-row deltas, sorted, chunked."""
+
+    def setUp(self):
+        """Three DeviceTypes to carry independent per-row deltas."""
+        mfr = Manufacturer.objects.create(name="fcd-mfr", slug="fcd-mfr")
+        self.dts = [
+            DeviceType.objects.create(manufacturer=mfr, model=f"fcd-dt{i}", slug=f"fcd-dt{i}")
+            for i in range(3)
+        ]
+
+    def _stored(self, dt):
+        """Read the interface_template_count column straight from the DB."""
+        return DeviceType.objects.filter(pk=dt.pk).values_list(
+            "interface_template_count", flat=True
+        )[0]
+
+    def test_per_row_deltas_are_applied_independently(self):
+        """One statement carries a different delta for each row via its CASE expression."""
+        a, b, c = self.dts
+        DeviceType.objects.filter(pk=c.pk).update(interface_template_count=10)
+
+        buffer = {
+            (DeviceType, "interface_template_count"): {a.pk: 1, b.pk: 4, c.pk: -3},
+        }
+        with CaptureQueriesContext(connection) as captured:
+            _flush_counter_deltas(buffer)
+
+        updates = [q for q in captured.captured_queries if "UPDATE" in q["sql"].upper()]
+        self.assertEqual(len(updates), 1)
+        self.assertEqual(self._stored(a), 1)
+        self.assertEqual(self._stored(b), 4)
+        self.assertEqual(self._stored(c), 7)
+
+    def test_deltas_are_relative_not_absolute(self):
+        """The CASE uses `F(counter) + delta`, so a concurrent baseline is preserved."""
+        a = self.dts[0]
+        DeviceType.objects.filter(pk=a.pk).update(interface_template_count=100)
+
+        _flush_counter_deltas({(DeviceType, "interface_template_count"): {a.pk: 5}})
+        self.assertEqual(self._stored(a), 105)
+
+    @staticmethod
+    def _when_spy():
+        """Patch `When` with a pass-through spy so the emitted pk order can be read back."""
+        return mock.patch.object(counter_buffer, "When", side_effect=When)
+
+    def test_primary_keys_are_sorted_within_a_statement(self):
+        """
+        Consistent lock ordering is the reason batching is safe.
+
+        Two workers flushing the same parent rows must approach them in the
+        same order or they deadlock each other, so the pks are emitted
+        ascending regardless of the order they were buffered in.
+        """
+        a, b, c = self.dts
+        shuffled = {c.pk: 1, a.pk: 1, b.pk: 1}
+
+        with self._when_spy() as spy:
+            _flush_counter_deltas({(DeviceType, "interface_template_count"): shuffled})
+
+        emitted = [call.kwargs["pk"] for call in spy.call_args_list]
+        self.assertEqual(emitted, sorted([a.pk, b.pk, c.pk]))
+
+    def test_counter_groups_are_emitted_in_a_stable_order(self):
+        """Groups are ordered by (model label, counter name) so workers agree across counters."""
+        a = self.dts[0]
+        buffer = {
+            (DeviceType, "interface_template_count"): {a.pk: 1},
+            (DeviceType, "console_port_template_count"): {a.pk: 1},
+        }
+        with CaptureQueriesContext(connection) as captured:
+            _flush_counter_deltas(buffer)
+
+        updates = [
+            q["sql"] for q in captured.captured_queries if "UPDATE" in q["sql"].upper()
+        ]
+        self.assertEqual(len(updates), 2)
+        # Alphabetical by counter name: console_port before interface_template.
+        self.assertIn("console_port_template_count", updates[0])
+        self.assertIn("interface_template_count", updates[1])
+
+    def test_large_batches_are_chunked_in_sorted_order(self):
+        """
+        Chunking bounds the CASE expression without disturbing the global pk order.
+
+        Splitting into several statements is only safe because the chunks are
+        contiguous ascending slices: workers still walk the rows in one
+        direction, which is the property that keeps the batched flush from
+        deadlocking against itself.
+        """
+        pks = list(range(1, 2501))
+        buffer = {(DeviceType, "interface_template_count"): dict.fromkeys(reversed(pks), 1)}
+
+        with self._when_spy() as spy, CaptureQueriesContext(connection) as captured:
+            _flush_counter_deltas(buffer)
+
+        updates = [q["sql"] for q in captured.captured_queries if "UPDATE" in q["sql"].upper()]
+        self.assertEqual(len(updates), 3)
+        self.assertEqual([call.kwargs["pk"] for call in spy.call_args_list], pks)
+
+    def test_chunk_size_bounds_each_statement(self):
+        """The chunk boundary is what splits the statements, not anything incidental."""
+        a, b, c = self.dts
+        buffer = {(DeviceType, "interface_template_count"): {a.pk: 1, b.pk: 1, c.pk: 1}}
+
+        with mock.patch.object(counter_buffer, "_CHUNK_SIZE", 2), \
+             CaptureQueriesContext(connection) as captured:
+            _flush_counter_deltas(buffer)
+
+        updates = [q for q in captured.captured_queries if "UPDATE" in q["sql"].upper()]
+        self.assertEqual(len(updates), 2)
+        self.assertEqual(self._stored(a), 1)
+        self.assertEqual(self._stored(b), 1)
+        self.assertEqual(self._stored(c), 1)
+
+    def test_zero_delta_rows_are_skipped(self):
+        """Rows whose deltas cancelled out are dropped before the statement is built."""
+        a, b = self.dts[0], self.dts[1]
+        with CaptureQueriesContext(connection) as captured:
+            _flush_counter_deltas(
+                {(DeviceType, "interface_template_count"): {a.pk: 0, b.pk: 0}}
+            )
+        self.assertEqual(
+            [q for q in captured.captured_queries if "UPDATE" in q["sql"].upper()], []
+        )
+
+    def test_missing_row_is_a_no_op(self):
+        """A parent deleted earlier in the transaction simply matches nothing."""
+        a = self.dts[0]
+        missing_pk = max(dt.pk for dt in self.dts) + 10_000
+        _flush_counter_deltas(
+            {(DeviceType, "interface_template_count"): {a.pk: 2, missing_pk: 5}}
+        )
+        self.assertEqual(self._stored(a), 2)
+
+
+class BufferedCounterUpdatesApplyTestCase(APITestCase):
+    """End-to-end: the buffer is wired into the `/bulk-plan-apply/` apply path."""
+
+    def setUp(self):
+        """
+        Auth plus a Device to hang interfaces off.
+
+        `Device.interface_count` is the counter the buffer exists for -- the
+        hot parent row in the contention this feature addresses -- and it is
+        present across every NetBox version the plugin supports, unlike the
+        DeviceType counters, which vary.
+        """
+        super().setUp()
+        self.url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        patcher = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.site = Site.objects.create(name="bcu-site", slug="bcu-site")
+        mfr = Manufacturer.objects.create(name="bcu-api-mfr", slug="bcu-api-mfr")
+        self.dt = DeviceType.objects.create(
+            manufacturer=mfr, model="bcu-api-dt", slug="bcu-api-dt"
+        )
+        self.role = DeviceRole.objects.create(name="bcu-role", slug="bcu-role")
+        self.device = Device.objects.create(
+            name="bcu-device", site=self.site, device_type=self.dt, role=self.role
+        )
+
+    def _payload(self, names):
+        """Build a bulk-plan-apply payload creating one Interface per name."""
+        return {
+            "entities": [
+                {
+                    "id": f"entity-{name}",
+                    "object_type": "dcim.interface",
+                    "entity": {
+                        "interface": {
+                            "name": name,
+                            "type": "1000base-t",
+                            "device": {
+                                "name": "bcu-device",
+                                "site": {"name": "bcu-site"},
+                                "role": {"name": "bcu-role"},
+                                "device_type": {
+                                    "manufacturer": {"name": "bcu-api-mfr"},
+                                    "model": "bcu-api-dt",
+                                },
+                            },
+                        }
+                    },
+                }
+                for name in names
+            ]
+        }
+
+    def _interface_count(self):
+        """Read Device.interface_count straight from the DB."""
+        return Device.objects.filter(pk=self.device.pk).values_list(
+            "interface_count", flat=True
+        )[0]
+
+    def test_apply_keeps_the_counter_exact_with_the_buffer_on(self):
+        """Three interfaces applied with the buffer on leave interface_count at 3."""
+        suffix = uuid.uuid4().hex[:6]
+        names = [f"eth-{suffix}-{i}" for i in range(3)]
+
+        with _enabled():
+            response = self.client.post(
+                self.url, data=self._payload(names), format="json", **self.auth
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertEqual(Interface.objects.filter(name__in=names).count(), 3)
+        self.assertEqual(self._interface_count(), 3)
+
+    def test_buffered_and_unbuffered_applies_agree(self):
+        """The buffer is a performance change only: the counter lands where it would have."""
+        suffix = uuid.uuid4().hex[:6]
+
+        unbuffered = [f"eth-off-{suffix}-{i}" for i in range(2)]
+        response = self.client.post(
+            self.url, data=self._payload(unbuffered), format="json", **self.auth
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        baseline = self._interface_count()
+
+        buffered = [f"eth-on-{suffix}-{i}" for i in range(2)]
+        with _enabled():
+            response = self.client.post(
+                self.url, data=self._payload(buffered), format="json", **self.auth
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        self.assertEqual(baseline, 2)
+        self.assertEqual(self._interface_count(), 4)
+        self.assertEqual(
+            self._interface_count(), Interface.objects.filter(device=self.device).count()
+        )

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_deferred_update_branch.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_deferred_update_branch.py
@@ -1,0 +1,466 @@
+"""The applier's deferred (ref_id) UPDATE branch: what it re-reads, and what that costs."""
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from core.models import ObjectChange
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Interface,
+    InterfaceTemplate,
+    Manufacturer,
+    Site,
+    VirtualChassis,
+)
+from django.test import TestCase
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.applier import (
+    _carry_forward_relation_cache,
+    _instance_for_deferred_update,
+)
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class CarryForwardRelationCacheTests(TestCase):
+    """
+    The deferred UPDATE re-reads its row; re-reading must not re-fetch its FKs.
+
+    _apply_change's ref_id UPDATE branch replaced the CREATE's in-memory
+    instance with a fresh read of the row, because the counter machinery
+    decides from the instance's change tracker and a stale instance makes it
+    double-count (test_virtualchassis_ingest covers that end of it). What the
+    row's own columns must be fresh for, the rows its FKs point AT do not: a
+    fresh load starts with an empty _state.fields_cache, so every forward FK
+    the serializer's validators or the model's own save() touch is fetched
+    again.
+
+    That cost lands on far more than VirtualChassis. transformer's
+    _IS_CIRCULAR_REFERENCE routes thirteen (type, field) shapes over seven
+    types through this branch, including dcim.interface.primary_mac_address --
+    every mac-bearing interface in an ingest. Measured on a 48-interface
+    /bulk-plan-apply/, per deferred update, and stated as three separate
+    numbers because the first draft of this branch conflated them: the re-read
+    ITSELF costs +3 (2758 -> 2902 over 48, 79 -> 82 on one); the changelog
+    snapshot that first draft also took cost a further +4 and has since been
+    dropped; and carrying the relation cache forward gives back 2 of the 3
+    (2902 -> 2806, 82 -> 80), those two being full-row re-fetches of dcim_device
+    and dcim_site the CREATE's instance already had in hand. +7 was the whole
+    first draft, not the re-read. What ships is +1 per deferred update.
+    """
+
+    def setUp(self):
+        """Two devices in one site, and an interface on the first."""
+        self.site = Site.objects.create(name="dub-site", slug="dub-site")
+        mfr = Manufacturer.objects.create(name="dub-mfr", slug="dub-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="dub-dt", slug="dub-dt")
+        self.role = DeviceRole.objects.create(name="dub-role", slug="dub-role")
+        self.dev = Device.objects.create(
+            name="dub-sw1", site=self.site, device_type=self.dt, role=self.role
+        )
+        self.other = Device.objects.create(
+            name="dub-sw2", site=self.site, device_type=self.dt, role=self.role
+        )
+        self.iface = Interface.objects.create(
+            device=self.dev, name="eth0", type="1000base-t"
+        )
+
+    def _instance_with_loaded_relations(self):
+        """Stand in for the CREATE's instance: device, and device.site, attached."""
+        stale = Interface.objects.select_related("device__site").get(pk=self.iface.pk)
+        self.assertEqual(stale.device.site.pk, self.site.pk)
+        return stale
+
+    def test_a_fresh_read_alone_pays_for_the_relations_again(self):
+        """The cost being removed, measured on the same objects as the test below."""
+        fresh = Interface.objects.get(pk=self.iface.pk)
+        with self.assertNumQueries(2):
+            self.assertEqual(fresh.device.pk, self.dev.pk)
+            self.assertEqual(fresh.device.site.pk, self.site.pk)
+
+    def test_carried_forward_relations_cost_nothing(self):
+        """After the carry-forward the same two accesses are free."""
+        stale = self._instance_with_loaded_relations()
+        fresh = Interface.objects.get(pk=self.iface.pk)
+
+        _carry_forward_relation_cache(stale, fresh)
+
+        with self.assertNumQueries(0):
+            self.assertEqual(fresh.device.pk, self.dev.pk)
+            self.assertEqual(fresh.device.site.pk, self.site.pk)
+
+    def test_the_row_s_own_columns_still_come_from_the_database(self):
+        """
+        Only _state.fields_cache is carried, never a column and never the tracker.
+
+        The re-read exists so the change tracker starts from the row's real
+        state; a carry-forward that touched model attributes would undo the
+        thing it is decorating.
+        """
+        stale = self._instance_with_loaded_relations()
+        Interface.objects.filter(pk=self.iface.pk).update(description="written by a signal")
+        fresh = Interface.objects.get(pk=self.iface.pk)
+
+        _carry_forward_relation_cache(stale, fresh)
+
+        self.assertEqual(fresh.description, "written by a signal")
+        self.assertEqual(stale.description, "")
+
+    def test_an_fk_the_database_has_moved_is_not_paired_with_the_old_object(self):
+        """
+        A carried object must match the column, or it is not carried.
+
+        This is the one hazard the guard does cover, and the guard is a COLUMN
+        comparison: it cannot notice the target row's own contents changing
+        under the stale instance. See _carry_forward_relation_cache for the
+        known consumer of that -- ComponentModel.save's _site / _location /
+        _rack denormalisation, on the base of every device component, not
+        ModularComponentModel, which defines no save() of its own.
+        """
+        stale = self._instance_with_loaded_relations()
+        Interface.objects.filter(pk=self.iface.pk).update(device=self.other)
+        fresh = Interface.objects.get(pk=self.iface.pk)
+
+        _carry_forward_relation_cache(stale, fresh)
+
+        self.assertEqual(fresh.device_id, self.other.pk)
+        self.assertEqual(fresh.device.pk, self.other.pk)
+
+
+class DeferredUpdateRefTypeTests(APITestCase):
+    """
+    The re-read is a PK lookup, so it must only run for the ref's own type.
+
+    _apply_change's ref_id UPDATE branch replaced the CREATE's in-memory
+    instance with model_class.objects.get(pk=created[ref_id].pk). A pk only
+    identifies a row WITHIN a type: point a ref_id-only UPDATE at a CREATE of a
+    different object_type and that lookup lands on whatever row of the update's
+    OWN type happens to carry the other type's pk -- an uninvolved bystander,
+    which the payload is then written to. The parent commit wrote the payload
+    onto the (wrongly typed) object the ref actually named, so re-reading
+    unconditionally was a divergence from it in the destructive direction.
+
+    Nothing plannable gets here -- differ.diff_to_change takes ref_id from the
+    entity node's own id, so a create and its deferred update are one node and
+    one type -- which is exactly why this needs a hand-built changeset to pin.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode endpoints accept requests."""
+        super().setUp()
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+    def test_a_cross_type_ref_never_writes_a_bystander_row(self):
+        """
+        A Site planted at the new chassis's pk must come out untouched.
+
+        The plant is what makes the assertion meaningful: without a row at that
+        pk the lookup raises DoesNotExist and the changeset merely 400s, which
+        would pass whether the guard existed or not.
+        """
+        probe = VirtualChassis.objects.create(name="dur-probe")
+        bystander = Site.objects.create(
+            pk=probe.pk + 1, name="dur-bystander", slug="dur-bystander",
+            description="UNTOUCHED",
+        )
+
+        response = self.client.post(
+            self.apply_url,
+            data={
+                "id": str(uuid.uuid4()),
+                "changes": [
+                    {
+                        "change_id": str(uuid.uuid4()), "change_type": "create",
+                        "object_version": None, "object_type": "dcim.virtualchassis",
+                        "object_id": None, "ref_id": "1", "data": {"name": "dur-vc"},
+                    },
+                    {
+                        "change_id": str(uuid.uuid4()), "change_type": "update",
+                        "object_version": None, "object_type": "dcim.site",
+                        "object_id": None, "ref_id": "1",
+                        "data": {"description": "CROSSTYPE-WRITE"},
+                    },
+                ],
+            },
+            format="json", **self.auth,
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        created_vc = VirtualChassis.objects.get(name="dur-vc")
+        self.assertEqual(
+            created_vc.pk, bystander.pk,
+            "the pk collision this test depends on did not happen",
+        )
+        bystander.refresh_from_db()
+        self.assertEqual(
+            bystander.description, "UNTOUCHED",
+            "a cross-type ref_id wrote an uninvolved row",
+        )
+        # The other half of "byte-identical to the parent": the parent did not
+        # merely leave the bystander alone, it wrote the payload onto the object
+        # the ref actually names. Asserting only the negative would also pass on
+        # a version of this branch that quietly dropped the write.
+        self.assertEqual(
+            created_vc.description, "CROSSTYPE-WRITE",
+            "the ref's own object did not receive the deferred payload",
+        )
+
+
+class InstanceForDeferredUpdateTests(TestCase):
+    """
+    The helper directly, so the guard is pinned in both directions.
+
+    The end-to-end test above fails if the guard is removed. It does NOT fail
+    if the guard is inverted or widened into "never re-read", because the
+    cross-type path is then still correct -- what breaks is the counter fix the
+    re-read exists for, and that is asserted in test_virtualchassis_ingest, a
+    different file. These three assertions keep the whole contract in one
+    place: re-read for the ref's own type, hand back the instance untouched for
+    any other, and carry the stale instance's loaded relations across the
+    re-read.
+    """
+
+    def setUp(self):
+        """One device in one site, and an interface on it."""
+        self.site = Site.objects.create(name="ifdu-site", slug="ifdu-site")
+        mfr = Manufacturer.objects.create(name="ifdu-mfr", slug="ifdu-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="ifdu-dt", slug="ifdu-dt")
+        role = DeviceRole.objects.create(name="ifdu-role", slug="ifdu-role")
+        self.dev = Device.objects.create(
+            name="ifdu-sw1", site=self.site, device_type=dt, role=role
+        )
+
+    def test_same_type_is_read_back_from_the_database(self):
+        """The point of the branch: the returned row's columns come from the DB."""
+        vc = VirtualChassis.objects.create(name="ifdu-vc", description="PERSISTED")
+        vc.description = "IN MEMORY ONLY"
+
+        fresh = _instance_for_deferred_update(vc, VirtualChassis)
+
+        self.assertIsNot(fresh, vc)
+        self.assertEqual(fresh.description, "PERSISTED")
+
+    def test_a_cross_type_ref_is_handed_back_untouched(self):
+        """A pk from another type's sequence is not looked up as this type."""
+        vc = VirtualChassis.objects.create(name="ifdu-cross")
+
+        self.assertIs(_instance_for_deferred_update(vc, Site), vc)
+
+    def test_the_re_read_keeps_the_relations_the_stale_instance_had_loaded(self):
+        """The carry-forward is wired into the helper, not just available beside it."""
+        iface = Interface.objects.create(
+            device=self.dev, name="ifdu-eth0", type="1000base-t"
+        )
+        self.assertTrue(Interface._meta.get_field("device").is_cached(iface))
+
+        fresh = _instance_for_deferred_update(iface, Interface)
+
+        self.assertIsNot(fresh, iface)
+        self.assertTrue(
+            Interface._meta.get_field("device").is_cached(fresh),
+            "the re-read dropped a relation the CREATE's instance already had",
+        )
+
+
+    def test_the_re_read_keeps_the_prechange_snapshot_the_create_took(self):
+        """
+        The changelog record must survive the re-read, not only the relations.
+
+        snapshot_for_apply attaches _prechange_snapshot to the instance it is
+        given, and the CREATE path calls it whenever a CREATE resolves onto an
+        existing row. The parent commit's deferred UPDATE saved THAT instance,
+        so NetBox recorded prechange_data; a fresh read carries no such
+        attribute. DeferredUpdateChangelogTests measures what that costs
+        end-to-end -- this pins the mechanism.
+        """
+        vc = VirtualChassis.objects.create(name="ifdu-snap", description="BEFORE")
+        vc._prechange_snapshot = {"description": "BEFORE"}
+
+        fresh = _instance_for_deferred_update(vc, VirtualChassis)
+
+        self.assertIsNot(fresh, vc)
+        self.assertEqual(
+            getattr(fresh, "_prechange_snapshot", None), {"description": "BEFORE"},
+            "the re-read dropped the prechange snapshot the CREATE path took",
+        )
+
+    def test_no_snapshot_is_invented_when_the_create_took_none(self):
+        """A plain CREATE takes no snapshot, and the re-read must not add one."""
+        vc = VirtualChassis.objects.create(name="ifdu-nosnap")
+
+        fresh = _instance_for_deferred_update(vc, VirtualChassis)
+
+        self.assertFalse(hasattr(fresh, "_prechange_snapshot"))
+
+
+class DeferredUpdateChangelogTests(APITestCase):
+    """
+    What the deferred UPDATE records in the changelog, on a planned shape.
+
+    The re-read this branch added replaces the CREATE's instance, and the
+    CREATE's instance is where snapshot_for_apply left its prechange. Dropping
+    it changes the audit trail twice over: an update that persists something
+    records prechange_data null instead of the row's before-state, and (through
+    NetBox's ObjectChange.has_changes gate, which compares prechange with
+    postchange) an update that persists NOTHING goes from being dropped to
+    being recorded. Neither belongs in a counter fix, and both are measured
+    here rather than argued: without _carry_forward_prechange_snapshot the
+    first test sees prechange_data null and the second sees one row instead of
+    none, on v4.4, v4.5 and v4.6 alike.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection, and a device type with an eth0 template."""
+        super().setUp()
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.bulk_plan_apply_url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+        self.site = Site.objects.create(name="duc-site", slug="duc-site")
+        self.mfr = Manufacturer.objects.create(name="duc-mfr", slug="duc-mfr")
+        self.dt = DeviceType.objects.create(
+            manufacturer=self.mfr, model="duc-dt", slug="duc-dt"
+        )
+        self.role = DeviceRole.objects.create(name="duc-role", slug="duc-role")
+
+    def _interface_changes(self, iface):
+        """This interface's changelog rows, oldest first."""
+        return list(
+            ObjectChange.objects.filter(
+                changed_object_type__app_label="dcim",
+                changed_object_type__model="interface",
+                changed_object_id=iface.pk,
+            ).order_by("pk")
+        )
+
+    def test_a_planned_deferred_update_records_its_prechange(self):
+        """
+        The PR's own headline cost shape, and its changelog.
+
+        The device type carries an eth0 InterfaceTemplate, so the device CREATE
+        auto-creates eth0 within this same apply; the interface CREATE then
+        matches that row through the auto-created-component find-first path
+        (which snapshots), and primary_mac_address is deferred to a ref_id
+        UPDATE. Fully plan-reachable: generate-diff emits exactly this.
+        """
+        InterfaceTemplate.objects.create(
+            device_type=self.dt, name="eth0", type="1000base-t"
+        )
+        payload = {"entities": [{
+            "id": "duc-1",
+            "object_type": "dcim.interface",
+            "entity": {"interface": {
+                "name": "eth0",
+                "type": "1000base-t",
+                "description": "FROM-INGEST",
+                "device": {
+                    "name": "duc-sw1",
+                    "role": {"name": "duc-role"},
+                    "site": {"name": "duc-site"},
+                    "device_type": {
+                        "manufacturer": {"name": "duc-mfr"}, "model": "duc-dt",
+                    },
+                },
+                "primary_mac_address": {"mac_address": "00:00:00:00:00:34"},
+            }},
+        }]}
+
+        response = self.client.post(
+            self.bulk_plan_apply_url, data=payload, format="json", **self.auth
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        result = response.json()["results"][0]
+        self.assertIsNone(result.get("errors"), result)
+        # Pin the shape this test depends on: the interface's primary_mac_address
+        # really is a ref_id UPDATE, not an object_id one.
+        deferred = [c for c in result["change_set"]["changes"]
+                    if c["object_type"] == "dcim.interface"
+                    and c["change_type"] == "update"]
+        self.assertEqual(len(deferred), 1, result["change_set"])
+        self.assertIsNone(deferred[0]["object_id"], deferred[0])
+        self.assertIsNotNone(deferred[0]["ref_id"], deferred[0])
+
+        iface = Interface.objects.get(device__name="duc-sw1", name="eth0")
+        self.assertIsNotNone(iface.primary_mac_address_id)
+        last = self._interface_changes(iface)[-1]
+        self.assertEqual(last.action, "update", last)
+        self.assertIsNotNone(
+            last.prechange_data,
+            "the deferred update recorded no prechange_data at all",
+        )
+        self.assertEqual(
+            sorted(k for k in last.postchange_data
+                   if last.prechange_data.get(k) != last.postchange_data.get(k)),
+            ["description", "primary_mac_address"],
+            last.prechange_data,
+        )
+
+    def test_a_deferred_update_that_persists_nothing_records_nothing(self):
+        """
+        The has_changes gate: no write, no changelog row.
+
+        Both writes in this changeset store what is already stored, so the
+        prechange equals the postchange and NetBox drops the row. It can only
+        do that if the prechange is there to compare.
+        """
+        device = Device.objects.create(
+            name="duc-sw2", site=self.site, device_type=self.dt, role=self.role
+        )
+        iface = Interface.objects.create(
+            device=device, name="eth0", type="1000base-t",
+            description="SAME", label="SAMELABEL",
+        )
+
+        def change(change_type, data):
+            return {
+                "id": str(uuid.uuid4()), "change_type": change_type,
+                "object_type": "dcim.interface", "object_id": None,
+                "ref_id": "1", "data": data, "new_refs": [],
+            }
+
+        response = self.client.post(
+            self.apply_url,
+            data={"id": str(uuid.uuid4()), "changes": [
+                change("create", {
+                    "device": device.pk, "name": "eth0", "type": "1000base-t",
+                    "description": "SAME", "label": "SAMELABEL",
+                }),
+                change("update", {"label": "SAMELABEL"}),
+            ]},
+            format="json", **self.auth,
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertIsNone(response.json().get("errors"))
+        self.assertEqual(
+            Interface.objects.filter(device=device, name="eth0").count(), 1,
+            "the matched CREATE inserted a duplicate",
+        )
+        self.assertEqual(
+            self._interface_changes(iface), [],
+            "a changeset that stored nothing wrote a changelog row",
+        )

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_differ_prechange_alias.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_differ_prechange_alias.py
@@ -1,0 +1,28 @@
+"""Prechange extraction must read aliased fields through their model source."""
+from dcim.models import Manufacturer, ModuleType, ModuleTypeProfile
+from django.test import TestCase
+
+from netbox_diode_plugin.api.differ import prechange_data_from_instance
+
+
+class PrechangeAliasTests(TestCase):
+    """getattr must target attribute_data while keying the result 'attributes'."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed a module type whose property view differs from the raw JSON."""
+        mfr = Manufacturer.objects.create(name="alias-mfr", slug="alias-mfr")
+        profile = ModuleTypeProfile.objects.create(
+            name="alias-profile",
+            schema={"properties": {"ram": {"type": "integer", "title": "RAM (GB)"}}},
+        )
+        cls.mt = ModuleType.objects.create(
+            manufacturer=mfr, model="alias-mt", profile=profile,
+            attribute_data={"ram": 64},
+        )
+
+    def test_prechange_reads_raw_attribute_data(self):
+        """The wire key must carry the raw JSON, not the title-cased view."""
+        data = prechange_data_from_instance(self.mt)
+        self.assertEqual(data.get("attributes"), {"ram": 64})
+        self.assertNotIn("attribute_data", data)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_diode_clients.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_diode_clients.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Diode Clients API Tests."""
+
+from unittest import mock
+
+from django.test import TestCase
+
+from netbox_diode_plugin.diode.clients import ClientAPI, ClientAPIError
+
+
+class DiodeClientsTestCase(TestCase):
+    """Test cases for Diode Clients API."""
+
+    def test_create_client(self):
+        """Test creating a client."""
+        with mock.patch('requests.post') as mock_post:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = {
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "client_name": "test-client",
+                "scope": "test-scope"
+            }
+
+            created = client.create_client(
+                name="test-client",
+                scope="test-scope"
+            )
+
+            self.assertEqual(created, {
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "client_name": "test-client",
+                "scope": "test-scope"
+            })
+
+            mock_post.assert_called_once_with(
+                "http://test-diode-url/clients",
+                headers={
+                    "Authorization": "Bearer test-client-auth-token"
+            },
+            json={
+                "client_name": "test-client",
+                "scope": "test-scope"
+            }
+        )
+
+    def test_list_clients(self):
+        """Test listing clients."""
+        with mock.patch('requests.get') as mock_get:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = {
+                "data": [
+                    {
+                        "client_id": "test-client-id",
+                        "client_name": "test-client",
+                        "scope": "test-scope"
+                    }
+                ],
+                "next_page_token": "test-next-page-token",
+                "prev_page_token": "test-prev-page-token"
+            }
+
+            result = client.list_clients(page_size=100)
+
+            self.assertEqual(result["data"], [
+                {
+                    "client_id": "test-client-id",
+                    "client_name": "test-client",
+                    "scope": "test-scope"
+                }
+            ])
+
+            self.assertEqual(result["next_page_token"], "test-next-page-token")
+            self.assertEqual(result["prev_page_token"], "test-prev-page-token")
+
+            mock_get.assert_called_once_with(
+                "http://test-diode-url/clients",
+                headers={
+                    "Authorization": "Bearer test-client-auth-token"
+                },
+                params={
+                    "page_size": 100,
+                }
+            )
+
+    def test_get_client(self):
+        """Test getting a client."""
+        with mock.patch('requests.get') as mock_get:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = {
+                "client_id": "test-client-id",
+                "client_name": "test-client",
+                "scope": "test-scope"
+            }
+
+            result = client.get_client("test-client-id")
+
+            self.assertEqual(result, {
+                "client_id": "test-client-id",
+                "client_name": "test-client",
+                "scope": "test-scope"
+            })
+
+            mock_get.assert_called_once_with(
+                "http://test-diode-url/clients/test-client-id",
+                headers={
+                    "Authorization": "Bearer test-client-auth-token"
+                }
+            )
+
+    def test_get_client_raises_error_on_bad_id(self):
+        """Test getting a client raises an error on bad ID."""
+        client = ClientAPI(
+            base_url="http://test-diode-url",
+            client_id="test-client-id",
+            client_secret="test-client-secret"
+        )
+        with self.assertRaises(ValueError):
+            client.get_client("../bad/../client/id")
+
+    def test_delete_client(self):
+        """Test deleting a client."""
+        with mock.patch('requests.delete') as mock_delete:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_delete.return_value.status_code = 204
+            mock_delete.return_value.raise_for_status = mock.Mock()
+
+            client.delete_client("test-client-id")
+
+            mock_delete.assert_called_once_with(
+                "http://test-diode-url/clients/test-client-id",
+                headers={
+                    "Authorization": "Bearer test-client-auth-token"
+                }
+            )
+
+    def test_delete_client_raises_error_on_bad_id(self):
+        """Test deleting a client raises an error on bad ID."""
+        client = ClientAPI(
+            base_url="http://test-diode-url",
+            client_id="test-client-id",
+            client_secret="test-client-secret"
+        )
+        with self.assertRaises(ValueError):
+            client.delete_client("../bad/../client/id")
+
+    def test_authentication_retries(self):
+        """Test authentication retries."""
+        with mock.patch('requests.post') as mock_post:
+            client = ClientAPI(
+                base_url="http://test-diode-url",
+                client_id="test-client-id",
+                client_secret="test-client-secret"
+            )
+            client._client_auth_token = "test-client-auth-token"
+
+            mock_post.side_effect = [
+                ClientAPIError("Failed to create client", 401),
+                mock.Mock(status_code=200, json=lambda: {"access_token": "new-access-token"}),
+                mock.Mock(status_code=201, json=lambda: {
+                    "client_id": "test-client-id",
+                    "client_secret": "test-client-secret",
+                    "client_name": "test-client",
+                    "scope": "diode:read diode:write"
+                }),
+            ]
+
+            result = client.create_client("test-client", "diode:read diode:write")
+            self.assertEqual(result, {
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "client_name": "test-client",
+                "scope": "diode:read diode:write"
+            })
+
+            self.assertEqual(mock_post.call_count, 3)
+
+            mock_post.assert_has_calls([
+                mock.call("http://test-diode-url/clients",
+                    headers={
+                        "Authorization": "Bearer test-client-auth-token"
+                    },
+                    json={
+                        "client_name": "test-client",
+                        "scope": "diode:read diode:write",
+                    }
+                ),
+                mock.call("http://test-diode-url/token",
+                    data='grant_type=client_credentials&client_id=test-client-id&client_secret=test-client-secret&scope=diode%3Aread+diode%3Awrite',
+                    headers={'Content-Type': 'application/x-www-form-urlencoded'}
+                ),
+                mock.call("http://test-diode-url/clients",
+                    headers={
+                        "Authorization": "Bearer new-access-token"
+                    },
+                    json={
+                        "client_name": "test-client",
+                        "scope": "diode:read diode:write",
+                    }
+                ),
+            ])
+
+

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_forms.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_forms.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+from unittest import mock
+
+from django.test import TestCase
+
+from netbox_diode_plugin.forms import SettingsForm
+from netbox_diode_plugin.models import Setting
+
+
+class SettingsFormTestCase(TestCase):
+    """Test case for the SettingsForm."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.setting = Setting.objects.create(
+            diode_target="grpc://localhost:8080/diode"
+        )
+
+    def test_form_initialization_with_override_allowed(self):
+        """Test form initialization when override is allowed."""
+        with mock.patch(
+            "netbox_diode_plugin.forms.get_plugin_config"
+        ) as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = None
+            form = SettingsForm(instance=self.setting)
+            mock_get_plugin_config.assert_called_with(
+                "netbox_diode_plugin", "diode_target_override"
+            )
+            self.assertFalse(form.fields["diode_target"].disabled)
+            self.assertNotIn(
+                "This field is not allowed to be modified.",
+                form.fields["diode_target"].help_text,
+            )
+
+    def test_form_initialization_with_diode_target_override(self):
+        """Test form initialization when override is disallowed."""
+        with mock.patch(
+            "netbox_diode_plugin.forms.get_plugin_config"
+        ) as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
+            form = SettingsForm(instance=self.setting)
+            mock_get_plugin_config.assert_called_with(
+                "netbox_diode_plugin", "diode_target_override"
+            )
+            self.assertTrue(form.fields["diode_target"].disabled)
+            self.assertEqual(
+                "This field is not allowed to be modified.",
+                form.fields["diode_target"].help_text,
+            )

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_generate_matching_docs.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests for generate_matching_docs command."""
+
+import io
+import sys
+from unittest import mock
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db.models import Q
+from django.test import TestCase
+
+from netbox_diode_plugin.api.matcher import AutoSlugMatcher, ObjectMatchCriteria
+from netbox_diode_plugin.management.commands.generate_matching_docs import (
+    Command,
+    MatcherInfo,
+)
+
+
+class MatcherInfoTestCase(TestCase):
+    """Test case for MatcherInfo dataclass."""
+
+    def test_matcher_info_creation(self):
+        """Test creating MatcherInfo with all fields."""
+        info = MatcherInfo(
+            name="test_matcher",
+            fields=["field1", "field2"],
+            condition="field1 is NOT NULL",
+            description="Test matcher description",
+            matcher_type="ObjectMatchCriteria",
+            version_constraints="≥4.3.0"
+        )
+
+        self.assertEqual(info.name, "test_matcher")
+        self.assertEqual(info.fields, ["field1", "field2"])
+        self.assertEqual(info.condition, "field1 is NOT NULL")
+        self.assertEqual(info.description, "Test matcher description")
+        self.assertEqual(info.matcher_type, "ObjectMatchCriteria")
+        self.assertEqual(info.version_constraints, "≥4.3.0")
+
+    def test_matcher_info_defaults(self):
+        """Test creating MatcherInfo with default values."""
+        info = MatcherInfo(name="test_matcher")
+
+        self.assertEqual(info.name, "test_matcher")
+        self.assertIsNone(info.fields)
+        self.assertIsNone(info.condition)
+        self.assertIsNone(info.description)
+        self.assertEqual(info.matcher_type, "ObjectMatchCriteria")
+        self.assertIsNone(info.version_constraints)
+
+
+class GenerateMatchingDocsCommandTestCase(TestCase):
+    """Test case for the generate_matching_docs command."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.command = Command()
+        self.command.stdout = io.StringIO()
+        self.command.stderr = io.StringIO()
+
+    def test_add_arguments(self):
+        """Test that the command accepts the --output argument."""
+        from django.core.management import get_commands
+        from django.core.management.base import BaseCommand
+
+        # Verify the command is registered
+        commands = get_commands()
+        self.assertIn('generate_matching_docs', commands)
+
+    def test_extract_condition_description_none(self):
+        """Test extracting condition description from None."""
+        result = self.command.extract_condition_description(None)
+        self.assertEqual(result, "None")
+
+    def test_extract_condition_description_simple(self):
+        """Test extracting condition description from a simple condition."""
+        condition = Q(field1__isnull=True)
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NULL")
+
+    def test_extract_condition_description_complex(self):
+        """Test extracting condition description from a complex condition."""
+        condition = Q(field1__isnull=True) & Q(field2="value")
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NULL AND field2 = value")
+
+    def test_extract_condition_description_or(self):
+        """Test extracting condition description with OR connector."""
+        condition = Q(field1="value1") | Q(field2="value2")
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 = value1 OR field2 = value2")
+
+    def test_extract_condition_description_not_null(self):
+        """Test extracting condition description for NOT NULL."""
+        condition = Q(field1__isnull=False)
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NOT NULL")
+
+    def test_get_matcher_description_ip_address_global(self):
+        """Test getting matcher description for IP address global matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_address_global_no_vrf"
+        mock_matcher.ip_fields = ["address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP address address in global namespace (no VRF)")
+
+    def test_get_matcher_description_ip_address_vrf(self):
+        """Test getting matcher description for IP address VRF matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_address_within_vrf"
+        mock_matcher.ip_fields = ["address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP address address within VRF")
+
+    def test_get_matcher_description_ip_range(self):
+        """Test getting matcher description for IP range matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_range_start_end_within_vrf"
+        mock_matcher.ip_fields = ["start_address", "end_address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertEqual(result, "Matches IP range start_address, end_address within VRF context")
+
+    def test_get_matcher_description_standard_fields(self):
+        """Test getting matcher description for standard field-based matcher."""
+        matcher = ObjectMatchCriteria(
+            fields=["name", "site"],
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
+
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: name, site")
+
+    def test_get_matcher_description_with_condition(self):
+        """Test getting matcher description for matcher with condition."""
+        matcher = ObjectMatchCriteria(
+            fields=["name", "site"],
+            name="test_matcher",
+            model_class=None,
+            condition=Q(site__isnull=False)
+        )
+
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: name, site where site is NOT NULL")
+
+    def test_get_matcher_description_custom(self):
+        """Test getting matcher description for custom matcher."""
+        matcher = ObjectMatchCriteria(
+            fields=None,
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
+
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Custom matcher")
+
+    def test_get_version_constraints_none(self):
+        """Test getting version constraints when none are set."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = None
+        mock_matcher.max_version = None
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertIsNone(result)
+
+    def test_get_version_constraints_min_only(self):
+        """Test getting version constraints with only min_version."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "4.3.0"
+        mock_matcher.max_version = None
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥4.3.0")
+
+    def test_get_version_constraints_max_only(self):
+        """Test getting version constraints with only max_version."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = None
+        mock_matcher.max_version = "4.2.99"
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≤4.2.99")
+
+    def test_get_version_constraints_both(self):
+        """Test getting version constraints with both min and max."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "4.3.0"
+        mock_matcher.max_version = "4.3.99"
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥4.3.0 ≤4.3.99")
+
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs._LOGICAL_MATCHERS')
+    def test_analyze_logical_matchers(self, mock_logical_matchers):
+        """Test analyzing logical matchers."""
+        # Create mock matchers
+        mock_matcher1 = mock.MagicMock()
+        mock_matcher1.name = "test_matcher_1"
+        mock_matcher1.fields = ["name"]
+        mock_matcher1.condition = None
+        mock_matcher1.min_version = "4.3.0"
+        mock_matcher1.max_version = None
+
+        mock_matcher2 = mock.MagicMock()
+        mock_matcher2.name = "test_matcher_2"
+        mock_matcher2.fields = ["name", "site"]
+        mock_matcher2.condition = Q(site__isnull=False)
+        mock_matcher2.min_version = None
+        mock_matcher2.max_version = "4.2.99"
+
+        # Mock the matcher factory
+        mock_logical_matchers.items.return_value = [
+            ("dcim.site", lambda: [mock_matcher1, mock_matcher2])
+        ]
+
+        result = self.command.analyze_logical_matchers()
+
+        self.assertIn("dcim.site", result)
+        self.assertEqual(len(result["dcim.site"]), 2)
+
+        # Check first matcher
+        matcher1_info = result["dcim.site"][0]
+        self.assertEqual(matcher1_info.name, "test_matcher_1")
+        self.assertEqual(matcher1_info.fields, ["name"])
+        self.assertEqual(matcher1_info.condition, "None")
+        self.assertEqual(matcher1_info.version_constraints, "≥4.3.0")
+        self.assertEqual(matcher1_info.matcher_source, "logical")
+
+        # Check second matcher
+        matcher2_info = result["dcim.site"][1]
+        self.assertEqual(matcher2_info.name, "test_matcher_2")
+        self.assertEqual(matcher2_info.fields, ["name", "site"])
+        self.assertEqual(matcher2_info.condition, "site is NOT NULL")
+        self.assertEqual(matcher2_info.version_constraints, "≤4.2.99")
+        self.assertEqual(matcher2_info.matcher_source, "logical")
+
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs.extract_supported_models')
+    @mock.patch('netbox_diode_plugin.management.commands.generate_matching_docs.get_model_matchers')
+    def test_analyze_builtin_matchers(self, mock_get_model_matchers, mock_supported_models):
+        """Test analyzing builtin matchers."""
+        # Create mock model class
+        mock_model_class = mock.MagicMock()
+        mock_model_class.__name__ = "TestModel"
+
+        # Create mock builtin matchers
+        mock_unique_matcher = mock.MagicMock()
+        mock_unique_matcher.name = "unique_name"
+        mock_unique_matcher.fields = ["name"]
+        mock_unique_matcher.condition = None
+        mock_unique_matcher.min_version = None
+        mock_unique_matcher.max_version = None
+
+        mock_constraint_matcher = mock.MagicMock()
+        mock_constraint_matcher.name = "test_constraint"
+        mock_constraint_matcher.fields = ["field1", "field2"]
+        mock_constraint_matcher.condition = Q(field1__isnull=True)
+        mock_constraint_matcher.min_version = None
+        mock_constraint_matcher.max_version = None
+
+        # Mock logical matcher (should be skipped)
+        mock_logical_matcher = mock.MagicMock()
+        mock_logical_matcher.name = "logical_test"
+        mock_logical_matcher.fields = ["name"]
+        mock_logical_matcher.condition = None
+        mock_logical_matcher.min_version = None
+        mock_logical_matcher.max_version = None
+
+        # Mock the supported models and get_model_matchers
+        mock_supported_models.return_value = {
+            "dcim.site": {"model": mock_model_class}
+        }
+        mock_get_model_matchers.return_value = [
+            mock_unique_matcher,
+            mock_constraint_matcher,
+            mock_logical_matcher  # This should be skipped
+        ]
+
+        result = self.command.analyze_builtin_matchers()
+
+        self.assertIn("dcim.site", result)
+        self.assertEqual(len(result["dcim.site"]), 2)  # Should only include builtin matchers
+
+        # Check unique field matcher
+        unique_matcher_info = result["dcim.site"][0]
+        self.assertEqual(unique_matcher_info.name, "unique_name")
+        self.assertEqual(unique_matcher_info.fields, ["name"])
+        self.assertEqual(unique_matcher_info.matcher_source, "builtin")
+
+        # Check constraint matcher
+        constraint_matcher_info = result["dcim.site"][1]
+        self.assertEqual(constraint_matcher_info.name, "test_constraint")
+        self.assertEqual(constraint_matcher_info.fields, ["field1", "field2"])
+        self.assertEqual(constraint_matcher_info.matcher_source, "builtin")
+
+    def test_combine_matchers(self):
+        """Test combining logical and builtin matchers."""
+        # Create logical matchers
+        logical_matcher = MatcherInfo(
+            name="logical_test",
+            fields=["name"],
+            condition="N/A",
+            description="Logical matcher",
+            version_constraints="All versions",
+            matcher_source="logical"
+        )
+
+        # Create builtin matchers
+        builtin_matcher = MatcherInfo(
+            name="builtin_test",
+            fields=["name"],
+            condition="N/A",
+            description="Builtin matcher",
+            version_constraints="All versions",
+            matcher_source="builtin"
+        )
+
+        logical_docs = {
+            "dcim.site": [logical_matcher],
+            "dcim.device": [logical_matcher]
+        }
+
+        builtin_docs = {
+            "dcim.site": [builtin_matcher],
+            "ipam.prefix": [builtin_matcher]
+        }
+
+        result = self.command.combine_matchers(logical_docs, builtin_docs)
+
+        # Check that all object types are included
+        self.assertIn("dcim.site", result)
+        self.assertIn("dcim.device", result)
+        self.assertIn("ipam.prefix", result)
+
+        # Check that dcim.site has both logical and builtin matchers
+        site_matchers = result["dcim.site"]
+        self.assertEqual(len(site_matchers), 2)
+
+        # Check that logical matcher comes first (as it was added first)
+        self.assertEqual(site_matchers[0].name, "logical_test")
+        self.assertEqual(site_matchers[0].matcher_source, "logical")
+        self.assertEqual(site_matchers[1].name, "builtin_test")
+        self.assertEqual(site_matchers[1].matcher_source, "builtin")
+
+        # Check that other object types have correct matchers
+        self.assertEqual(len(result["dcim.device"]), 1)
+        self.assertEqual(result["dcim.device"][0].matcher_source, "logical")
+
+        self.assertEqual(len(result["ipam.prefix"]), 1)
+        self.assertEqual(result["ipam.prefix"][0].matcher_source, "builtin")
+
+    def test_get_matcher_description_builtin_types(self):
+        """Test getting matcher description for different builtin matcher types."""
+        # Test CustomFieldMatcher
+        mock_custom_field_matcher = mock.MagicMock()
+        mock_custom_field_matcher.custom_field = "test_field"
+        mock_custom_field_matcher.fields = None
+        mock_custom_field_matcher.ip_fields = None
+        mock_custom_field_matcher.vrf_field = None
+
+        result = self.command.get_matcher_description(mock_custom_field_matcher)
+        self.assertEqual(result, "Matches on unique custom field: test_field")
+
+    def test_get_matcher_description_autoslug(self):
+        """Test getting matcher description for AutoSlugMatcher."""
+        # Test AutoSlugMatcher
+        autoslug_matcher = AutoSlugMatcher(
+            name="test_autoslug",
+            model_class=None,
+            slug_field="slug"
+        )
+
+        result = self.command.get_matcher_description(autoslug_matcher)
+        self.assertEqual(result, "Matches on auto-generated slug field: slug")
+
+    def test_get_matcher_description_unique_field(self):
+        """Test getting matcher description for unique field matcher."""
+        # Test unique field matcher
+        mock_unique_matcher = mock.MagicMock()
+        mock_unique_matcher.name = "unique_name"
+        mock_unique_matcher.fields = ["name"]
+        mock_unique_matcher.ip_fields = None
+        mock_unique_matcher.vrf_field = None
+        mock_unique_matcher.custom_field = None
+        mock_unique_matcher.slug_field = None
+
+        result = self.command.get_matcher_description(mock_unique_matcher)
+        self.assertEqual(result, "Matches on unique field(s): name")
+
+    def test_get_matcher_description_unique_constraint(self):
+        """Test getting matcher description for unique constraint matcher."""
+        # Test unique constraint matcher
+        mock_constraint_matcher = mock.MagicMock()
+        mock_constraint_matcher.name = "test_constraint"
+        mock_constraint_matcher.fields = ["field1", "field2"]
+        mock_constraint_matcher.condition = None
+        mock_constraint_matcher.custom_field = None
+        mock_constraint_matcher.slug_field = None
+
+        result = self.command.get_matcher_description(mock_constraint_matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: field1, field2")
+
+    def test_generate_markdown_table_empty(self):
+        """Test generating markdown table with empty documentation."""
+        docs = {}
+        result = self.command.generate_markdown_table(docs)
+
+        expected_lines = [
+            "# NetBox Diode Plugin - Object Matching Criteria",
+            "",
+            "This document describes how the Diode NetBox Plugin matches existing objects when applying changes.",
+            ""
+        ]
+
+        for line in expected_lines:
+            self.assertIn(line, result)
+
+    def test_generate_markdown_table_with_matchers(self):
+        """Test generating markdown table with matchers."""
+        matcher_info1 = MatcherInfo(
+            name="test_matcher_1",
+            fields=["name"],
+            condition="N/A",
+            description="Test description 1",
+            version_constraints="All versions",
+            matcher_source="logical"
+        )
+
+        matcher_info2 = MatcherInfo(
+            name="test_matcher_2",
+            fields=["name", "site"],
+            condition="site is NOT NULL",
+            description="Test description 2",
+            version_constraints="≥4.3.0",
+            matcher_source="logical"
+        )
+
+        docs = {
+            "dcim.site": [matcher_info1, matcher_info2]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check header
+        self.assertIn("# NetBox Diode Plugin - Object Matching Criteria", result)
+        self.assertIn("## dcim.site", result)
+
+        # Check table header
+        self.assertIn("| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |", result)
+        self.assertIn("|--------------|---------------------|------|--------|-----------|-------------|---------------------|", result)
+
+        # Check table rows
+        self.assertIn("| test_matcher_1 | 1 | logical | name | N/A | Test description 1 | All versions |", result)
+        self.assertIn("| test_matcher_2 | 2 | logical | name, site | site is NOT NULL | Test description 2 | ≥4.3.0 |", result)
+
+    def test_generate_markdown_table_with_pipe_escaping(self):
+        """Test generating markdown table with pipe character escaping."""
+        matcher_info = MatcherInfo(
+            name="test|matcher",
+            fields=["field|1", "field|2"],
+            condition="field|1 is NOT NULL",
+            description="Test|description",
+            version_constraints="≥4.3.0|test",
+            matcher_source="logical"
+        )
+
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check that pipe characters are escaped
+        self.assertIn(
+            "| test\\|matcher | 1 | logical | field\\|1, field\\|2 | field\\|1 is NOT NULL | Test\\|description | ≥4.3.0\\|test |",
+            result,
+        )
+
+    def test_generate_markdown_table_no_matchers(self):
+        """Test generating markdown table for object type with no matchers."""
+        docs = {
+            "dcim.site": []
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        self.assertIn("## dcim.site", result)
+        self.assertIn("No specific matching criteria defined.", result)
+
+    def test_generate_markdown_table_sorted_object_types(self):
+        """Test that object types are sorted in the output."""
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=["name"],
+            condition="N/A",
+            description="Test description",
+            version_constraints="All versions"
+        )
+
+        docs = {
+            "dcim.device": [matcher_info],
+            "dcim.site": [matcher_info],
+            "ipam.prefix": [matcher_info]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check that sections appear in alphabetical order
+        site_index = result.find("## dcim.site")
+        device_index = result.find("## dcim.device")
+        prefix_index = result.find("## ipam.prefix")
+
+        self.assertLess(device_index, site_index)
+        self.assertLess(site_index, prefix_index)
+
+    def test_condition_extraction_with_none_Q_condition(self):
+        """Test edge cases in condition extraction."""
+        # Test with non-Q condition
+        condition = "simple_string_condition"
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "simple_string_condition")
+
+    def test_condition_extraction_with_Q_condition_with_no_children(self):
+        """Test with Q condition that has no children."""
+        condition = Q()
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "")
+
+    def test_condition_extraction_with_Q_condition_with_children(self):
+        """Test with complex nested condition."""
+        condition = Q(field1__isnull=True) & (Q(field2="value1") | Q(field2="value2"))
+        result = self.command.extract_condition_description(condition)
+        self.assertEqual(result, "field1 is NULL AND (OR: ('field2', 'value1'), ('field2', 'value2'))")
+
+    def test_matcher_description_edge_cases(self):
+        """Test edge cases in matcher description generation."""
+        # Test with matcher that has fields but no condition
+        matcher = ObjectMatchCriteria(
+            fields=["name"],
+            name="test_matcher",
+            model_class=None,
+            condition=None
+        )
+
+        result = self.command.get_matcher_description(matcher)
+        self.assertEqual(result, "Matches on unique constraint fields: name")
+
+        # Test with matcher that has condition but no fields
+        matcher = ObjectMatchCriteria(
+            fields=None,
+            name="test_matcher",
+            model_class=None,
+            condition=Q(field1__isnull=True)
+        )
+
+        with mock.patch.object(self.command, 'extract_condition_description') as mock_extract:
+            mock_extract.return_value = "field1 is NULL"
+            result = self.command.get_matcher_description(matcher)
+
+        self.assertEqual(result, "Custom matcher")
+
+    def test_version_constraints_edge_cases(self):
+        """Test edge cases in version constraints."""
+        # Test with empty string versions
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = ""
+        mock_matcher.max_version = ""
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, None)
+
+        # Test with whitespace versions
+        mock_matcher = mock.MagicMock()
+        mock_matcher.min_version = "  4.3.0  "
+        mock_matcher.max_version = "  4.3.99  "
+
+        result = self.command.get_version_constraints(mock_matcher)
+        self.assertEqual(result, "≥  4.3.0   ≤  4.3.99  ")
+
+    def test_markdown_table_with_empty_values(self):
+        """Test edge cases in markdown table generation."""
+        # Test with None values
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=None,
+            condition=None,
+            description=None,
+            version_constraints=None,
+            matcher_source="logical"
+        )
+
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check that None values are handled gracefully
+        self.assertIn("| test_matcher | 1 | logical |  | N/A | N/A | All versions |", result)
+
+    def test_markdown_table_with_empty_fields(self):
+        """Test with empty fields list."""
+        matcher_info = MatcherInfo(
+            name="test_matcher",
+            fields=[],
+            condition="N/A",
+            description="Test description",
+            version_constraints="All versions",
+            matcher_source="logical"
+        )
+
+        docs = {
+            "dcim.site": [matcher_info]
+        }
+
+        result = self.command.generate_markdown_table(docs)
+
+        # Check that empty fields list is handled
+        self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_harmonize_formats.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_harmonize_formats.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - harmonize_formats Tests."""
+
+import datetime
+import decimal
+
+from django.db.backends.postgresql.psycopg_any import DateRange, DateTimeTZRange, NumericRange
+from django.test import TestCase
+
+from netbox_diode_plugin.api.common import harmonize_formats
+
+
+class HarmonizeFormatsNumericRangeTestCase(TestCase):
+    """Test NumericRange normalization to inclusive [lower, upper] pairs."""
+
+    def test_half_open_range_from_postgres(self):
+        """A range read back from Postgres is canonicalized half-open."""
+        self.assertEqual(harmonize_formats(NumericRange(1, 4095, bounds="[)")), [1, 4094])
+
+    def test_inclusive_range_from_python(self):
+        """
+        An inclusive range keeps its upper bound.
+
+        This is the shape of NetBox's own model default for
+        ``ipam.VLANGroup.vid_ranges`` (``default_vid_ranges`` returns
+        ``NumericRange(1, 4094, bounds="[]")``). The transformer applies that
+        default whenever the caller omits the field, so treating it as half-open
+        made every VLAN group created through Diode permit only 1-4093 and
+        reject VID 4094 for the lifetime of the group.
+        """
+        self.assertEqual(harmonize_formats(NumericRange(1, 4094, bounds="[]")), [1, 4094])
+
+    def test_operator_narrowed_range_is_preserved_either_way(self):
+        """A deliberately narrowed range round-trips from both bound styles."""
+        self.assertEqual(harmonize_formats(NumericRange(1, 1001, bounds="[)")), [1, 1000])
+        self.assertEqual(harmonize_formats(NumericRange(1, 1000, bounds="[]")), [1, 1000])
+
+    def test_exclusive_lower_bound(self):
+        """An exclusive lower bound is advanced to the first included value."""
+        self.assertEqual(harmonize_formats(NumericRange(0, 4095, bounds="()")), [1, 4094])
+
+    def test_unbounded_ends_do_not_raise(self):
+        """An unbounded end stays None rather than raising on None arithmetic."""
+        self.assertEqual(harmonize_formats(NumericRange(None, 4095, bounds="[)")), [None, 4094])
+        self.assertEqual(harmonize_formats(NumericRange(1, None, bounds="[)")), [1, None])
+
+    def test_non_integer_ranges_do_not_raise(self):
+        """
+        Date, datetime and decimal ranges must not blow up on integer arithmetic.
+
+        ``NumericRange`` is an alias of psycopg's generic ``Range``, so every
+        range type matches the same branch. Shifting a bound by one is only
+        meaningful for discrete integers, so other bound types are passed
+        through. ``vid_ranges`` is NetBox's only range field today, so none of
+        these are reachable, but the branch should stay total.
+        """
+        self.assertEqual(
+            harmonize_formats(DateRange(datetime.date(2020, 1, 1), datetime.date(2020, 2, 1))),
+            [datetime.date(2020, 1, 1), datetime.date(2020, 2, 1)],
+        )
+        self.assertEqual(
+            harmonize_formats(
+                DateTimeTZRange(datetime.datetime(2020, 1, 1), datetime.datetime(2020, 2, 1)),
+            ),
+            [datetime.datetime(2020, 1, 1), datetime.datetime(2020, 2, 1)],
+        )
+        self.assertEqual(
+            harmonize_formats(NumericRange(decimal.Decimal("1.5"), decimal.Decimal("9.5"))),
+            [decimal.Decimal("1.5"), decimal.Decimal("9.5")],
+        )
+
+    def test_nested_in_list_and_dict(self):
+        """Ranges are normalized through the containers the transformer emits."""
+        self.assertEqual(
+            harmonize_formats({"vid_ranges": [NumericRange(1, 4094, bounds="[]")]}),
+            {"vid_ranges": [[1, 4094]]},
+        )

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_interface_mode_vlan_reconcile.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_interface_mode_vlan_reconcile.py
@@ -1,0 +1,1821 @@
+"""Unit tests for the driver-field policy (interface mode/type, VLAN qinq_role)."""
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Interface
+from django.test import SimpleTestCase, TestCase
+from rest_framework import serializers
+from utilities.data import shallow_compare_dict
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api import field_policy
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.differ import normalize_changeset
+from netbox_diode_plugin.api.field_policy import (
+    _DRIVER_FIELD_RULES,
+    apply_submitted_driver_field_policy,
+    match_participating_fields,
+    prune_orphaned_nodes,
+    referenced_uuids,
+    submitted_driver_field_drops,
+)
+from netbox_diode_plugin.api.transformer import (
+    _fingerprint_dedupe,
+    raise_unsettled_conflicts,
+)
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class NormalizeChangesetTests(SimpleTestCase):
+    """Pure-logic tests: no DB, operate on plain dicts."""
+
+    def _plan(self, object_type, prechange, entity):
+        """Run both policy phases in pipeline order and return (entity, dropped)."""
+        # Phase 1 runs in the transformer, before any fingerprinting; phase 2 runs
+        # in the differ once an existing row has been matched. Tests exercise them
+        # in that order so a unit result means the same thing an ingest would.
+        dropped = submitted_driver_field_drops(object_type, entity)
+        normalize_changeset(object_type, prechange, entity)
+        return entity, dropped
+
+    def _run(self, object_type, prechange, entity):
+        return self._plan(object_type, prechange, entity)[0]
+
+    def _drop(self, object_type, prechange, entity):
+        """Run both phases and return (entity, dropped-submitted-field map)."""
+        return self._plan(object_type, prechange, entity)
+
+    def test_tagged_to_access_clears_tagged_vlans_keeps_untagged(self):
+        """Mode tagged -> access clears tagged_vlans but leaves untagged_vlan untouched."""
+        prechange = {"mode": "tagged", "tagged_vlans": [101, 102], "untagged_vlan": 5}
+        entity = {"mode": "access"}  # only mode submitted
+        out = self._run("dcim.interface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])       # forbidden -> cleared
+        self.assertNotIn("untagged_vlan", out)           # allowed for access -> untouched
+
+    def test_tagged_to_empty_clears_tagged_and_untagged(self):
+        """Mode tagged -> empty (routed) clears both tagged_vlans and untagged_vlan."""
+        prechange = {"mode": "tagged", "tagged_vlans": [101], "untagged_vlan": 5}
+        entity = {"mode": ""}
+        out = self._run("dcim.interface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertIsNone(out["untagged_vlan"])
+
+    def test_qinq_to_access_clears_tagged_and_qinq_svlan(self):
+        """Mode q-in-q -> access clears tagged_vlans and qinq_svlan."""
+        prechange = {"mode": "q-in-q", "tagged_vlans": [101], "qinq_svlan": 9}
+        entity = {"mode": "access"}
+        out = self._run("dcim.interface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertIsNone(out["qinq_svlan"])
+
+    def test_explicit_forbidden_value_is_dropped_driver_wins(self):
+        """The submitted driver value wins: an explicit but forbidden value is dropped."""
+        # POLICY (reversed): a payload naming mode "access" AND naming tagged VLANs is
+        # self-contradictory. NetBox rejects the WHOLE entity for it, so the mode wins
+        # and the field it forbids is discarded — producer intent does NOT protect it.
+        prechange = {"mode": "tagged", "tagged_vlans": [101]}
+        entity = {"mode": "access", "tagged_vlans": [200]}
+        out, dropped = self._drop("dcim.interface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertIn("tagged_vlans", dropped)
+        self.assertIn("mode", dropped["tagged_vlans"])
+        self.assertIn("access", dropped["tagged_vlans"])
+
+    def test_explicit_allowed_value_is_respected(self):
+        """Producer intent survives for everything the driver value ALLOWS."""
+        # mode "tagged" permits tagged_vlans, so an explicit list is kept verbatim and
+        # is not reported as dropped. This is the half of producer intent that stands.
+        out, dropped = self._drop(
+            "dcim.interface",
+            {"mode": "access", "tagged_vlans": []},
+            {"mode": "tagged", "tagged_vlans": [200]},
+        )
+        self.assertEqual(out["tagged_vlans"], [200])
+        self.assertEqual(dropped, {})
+
+    def test_explicit_empty_forbidden_value_is_not_a_change(self):
+        """A submitted value that is already empty is left exactly as submitted."""
+        # Rewriting it would be pointless and could only manufacture a spurious
+        # change (e.g. [] -> None); nothing is reported as dropped either.
+        out, dropped = self._drop(
+            "dcim.interface", {}, {"mode": "access", "tagged_vlans": []}
+        )
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertEqual(dropped, {})
+
+    def test_no_clear_when_prechange_field_already_empty(self):
+        """Nothing is injected into entity when the prechange dependent field was already empty."""
+        prechange = {"mode": "tagged", "tagged_vlans": []}
+        entity = {"mode": "access"}
+        out = self._run("dcim.interface", prechange, entity)
+        self.assertNotIn("tagged_vlans", out)  # nothing stale -> nothing injected
+
+    def test_effective_mode_from_prechange_when_mode_not_submitted(self):
+        """Effective mode falls back to prechange when mode itself is not submitted."""
+        # mode already access in DB, some other field updated, stale tagged_vlans present
+        prechange = {"mode": "access", "tagged_vlans": [101], "description": "old"}
+        entity = {"description": "new"}
+        out = self._run("dcim.interface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])
+
+    def test_vminterface_covered(self):
+        """virtualization.vminterface is covered by the same normalization rules."""
+        prechange = {"mode": "tagged", "tagged_vlans": [101]}
+        entity = {"mode": "access"}
+        out = self._run("virtualization.vminterface", prechange, entity)
+        self.assertEqual(out["tagged_vlans"], [])
+
+    def test_unregistered_type_is_noop(self):
+        """Object types not in the registry are left untouched."""
+        prechange = {"mode": "tagged", "tagged_vlans": [101]}
+        entity = {"mode": "access"}
+        out = self._run("dcim.device", prechange, entity)
+        self.assertNotIn("tagged_vlans", out)
+
+    def test_create_drops_forbidden_submitted_value(self):
+        """A create is not exempt: mode "access" drops the tagged_vlans it forbids."""
+        # This is the corpus shape (interface "WirelessGigabitEthernet1/0/1"): a CREATE
+        # carrying mode "access" together with untagged_vlan AND tagged_vlans. Before
+        # the reversed policy this was a no-op and NetBox 400'd the whole entity.
+        entity = {
+            "mode": "access",
+            "untagged_vlan": 900,
+            "tagged_vlans": [101, 102],
+        }
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        # DROPPED, not blanked: with no stored row there is nothing to clear, so the
+        # payload must read as if the producer had never sent the field. Writing a
+        # blank here is what made the rf_* fields re-diff against NetBox's "" forever.
+        self.assertNotIn("tagged_vlans", out)           # forbidden -> dropped
+        self.assertEqual(out["untagged_vlan"], 900)     # allowed for access -> kept
+        self.assertEqual(list(dropped), ["tagged_vlans"])
+
+    def test_create_injects_nothing_when_field_not_submitted(self):
+        """A create with nothing forbidden submitted stays untouched (nothing injected)."""
+        entity = {"mode": "access"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertNotIn("tagged_vlans", out)  # no stored row, nothing to clear
+        self.assertNotIn("qinq_svlan", out)
+        self.assertEqual(dropped, {})
+
+    def test_create_unknown_mode_fails_open(self):
+        """An unrecognised driver value forbids nothing, on creates too."""
+        entity = {"mode": "future-mode", "tagged_vlans": [101]}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["tagged_vlans"], [101])
+        self.assertEqual(dropped, {})
+
+    def test_stale_clear_is_not_reported_as_dropped(self):
+        """Injecting a clear for a stale STORED value is not a drop of producer data."""
+        out, dropped = self._drop(
+            "dcim.interface", {"mode": "tagged", "tagged_vlans": [101]}, {"mode": "access"}
+        )
+        self.assertEqual(out["tagged_vlans"], [])
+        self.assertEqual(dropped, {})  # nothing was submitted, so nothing was discarded
+
+    def test_shared_policy_applies_to_interface_type_rf_fields(self):
+        """The reversed policy is registry-wide: dcim.interface "type" behaves the same."""
+        entity = {"type": "1000base-t", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertNotIn("rf_channel", out)
+        self.assertNotIn("rf_role", out)
+        self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
+
+    def test_shared_policy_keeps_rf_fields_on_a_wireless_type(self):
+        """A wireless type permits the rf fields, so an explicit create keeps them."""
+        entity = {"type": "ieee802.11ac", "rf_channel": "2.4g-1-2412-22", "rf_role": "ap"}
+        out, dropped = self._drop("dcim.interface", {}, entity)
+        self.assertEqual(out["rf_channel"], "2.4g-1-2412-22")
+        self.assertEqual(dropped, {})
+
+    def test_a_match_participating_field_is_never_dropped(self):
+        """ipam.vlan qinq_svlan is a match criterion, so the policy leaves it alone."""
+        # The reversal is NOT registry-wide. qinq_svlan is read by four ipam.vlan
+        # matchers, so dropping it changes which row the payload identifies: measured,
+        # it adopted and renamed an unrelated VLAN sharing the vid, or inserted a
+        # duplicate and converged onto it. NetBox's own 400 stands instead.
+        self.assertIn("qinq_svlan", match_participating_fields("ipam.vlan"))
+        entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+        out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+
+    def test_the_interface_policy_fields_are_not_match_criteria(self):
+        """The fields the policy does drop are not how any matcher identifies a row."""
+        # This is what makes the motivating cases safe to drop, and it is asserted
+        # rather than assumed: if a future matcher starts reading one of them, the
+        # gate above will silently start exempting it and this test says so first.
+        for object_type in ("dcim.interface", "virtualization.vminterface"):
+            matched = match_participating_fields(object_type)
+            for value_map in _DRIVER_FIELD_RULES[object_type].values():
+                for dependents in value_map.values():
+                    for dependent in dependents:
+                        with self.subTest(object_type=object_type, dependent=dependent):
+                            self.assertNotIn(dependent, matched)
+
+    def _flaky_model_lookup(self, fail_calls=1):
+        """A get_object_type_model that fails its first ``fail_calls`` calls, then works."""
+        real = field_policy.get_object_type_model
+        calls = []
+
+        def flaky(object_type):
+            calls.append(object_type)
+            if len(calls) <= fail_calls:
+                raise RuntimeError("content type lookup unavailable")
+            return real(object_type)
+
+        match_participating_fields.cache_clear()
+        self.addCleanup(match_participating_fields.cache_clear)
+        return flaky, calls
+
+    def test_a_model_lookup_failure_refuses_the_drop_instead_of_licensing_it(self):
+        """A failed model lookup propagates; it never answers "nothing participates"."""
+        # The gate answers "which fields decide WHICH row this payload means". An empty
+        # answer means "none of them", which licenses every drop the gate exists to
+        # refuse -- so a lookup failure must not produce one.
+        flaky, calls = self._flaky_model_lookup()
+        entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+        with mock.patch.object(field_policy, "get_object_type_model", flaky):
+            with self.assertRaises(RuntimeError):
+                submitted_driver_field_drops("ipam.vlan", entity)
+            # nothing was dropped on the way out
+            self.assertEqual(entity, {"qinq_role": "svlan", "qinq_svlan": 7})
+            self.assertEqual(calls, ["ipam.vlan"])
+
+    def test_a_model_lookup_failure_is_not_cached_as_nothing_participates(self):
+        """The recovery half: a transient failure must not poison the lru_cache."""
+        # lru_cache does not cache exceptions, so the next call retries. Returning an
+        # empty frozenset instead would be cached until eviction or restart, and every
+        # later request would treat qinq_svlan as droppable after the database had
+        # recovered -- re-enabling the same-vid wrong-row mutation this gate prevents.
+        flaky, calls = self._flaky_model_lookup()
+        with mock.patch.object(field_policy, "get_object_type_model", flaky):
+            with self.assertRaises(RuntimeError):
+                match_participating_fields("ipam.vlan")
+            # the healthy retry sees the truth
+            self.assertIn("qinq_svlan", match_participating_fields("ipam.vlan"))
+            entity = {"qinq_role": "svlan", "qinq_svlan": 7}
+            out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+        self.assertEqual(len(calls), 2)   # retried once, then served from cache
+
+    def test_shared_policy_keeps_qinq_svlan_on_a_customer_vlan(self):
+        """qinq_role "cvlan" permits qinq_svlan, so an explicit create keeps it."""
+        entity = {"qinq_role": "cvlan", "qinq_svlan": 7}
+        out, dropped = self._drop("ipam.vlan", {}, entity)
+        self.assertEqual(out["qinq_svlan"], 7)
+        self.assertEqual(dropped, {})
+
+    def test_unknown_mode_fails_open(self):
+        """An unknown/unlisted mode value fails open and clears nothing."""
+        prechange = {"mode": "tagged", "tagged_vlans": [101]}
+        entity = {"mode": "future-mode"}
+        out = self._run("dcim.interface", prechange, entity)
+        self.assertNotIn("tagged_vlans", out)  # unknown mode -> clear nothing
+
+    def test_qinq_to_tagged_clears_qinq_svlan_keeps_tagged(self):
+        """Mode 'tagged' forbids only qinq_svlan; tagged_vlans are allowed and kept."""
+        out = self._run(
+            "dcim.interface",
+            {"mode": "q-in-q", "qinq_svlan": 5, "tagged_vlans": [101]},
+            {"mode": "tagged"},
+        )
+        self.assertIsNone(out["qinq_svlan"])
+        self.assertNotIn("tagged_vlans", out)
+
+    def test_vlan_svlan_role_clears_stale_qinq_svlan(self):
+        """qinq_role svlan (not customer) forbids qinq_svlan -> stale value cleared."""
+        out = self._run("ipam.vlan", {"qinq_role": "cvlan", "qinq_svlan": 7}, {"qinq_role": "svlan"})
+        self.assertIsNone(out["qinq_svlan"])
+
+    def test_vlan_empty_role_clears_qinq_svlan(self):
+        """No qinq role forbids qinq_svlan -> cleared."""
+        out = self._run("ipam.vlan", {"qinq_role": "cvlan", "qinq_svlan": 7}, {"qinq_role": ""})
+        self.assertIsNone(out["qinq_svlan"])
+
+    def test_vlan_customer_role_keeps_qinq_svlan(self):
+        """Customer (cvlan) role permits qinq_svlan -> not cleared."""
+        out = self._run("ipam.vlan", {"qinq_role": "cvlan", "qinq_svlan": 7}, {"qinq_role": "cvlan", "name": "x"})
+        self.assertNotIn("qinq_svlan", out)
+
+    def test_interface_nonwireless_type_clears_rf_fields(self):
+        """A non-wireless interface type forbids rf_channel/frequency/width/role -> cleared."""
+        prechange = {"type": "ieee802.11ac", "rf_channel": "ch", "rf_channel_frequency": 2412,
+                     "rf_channel_width": 22, "rf_role": "ap"}
+        out = self._run("dcim.interface", prechange, {"type": "1000base-t"})
+        self.assertIsNone(out["rf_channel"])
+        self.assertIsNone(out["rf_channel_frequency"])
+        self.assertIsNone(out["rf_channel_width"])
+        self.assertIsNone(out["rf_role"])
+
+    def test_interface_wireless_type_keeps_rf_fields(self):
+        """A wireless interface type permits rf fields -> not cleared."""
+        prechange = {"type": "ieee802.11ac", "rf_channel": "ch"}
+        out = self._run("dcim.interface", prechange, {"description": "x"})  # type unchanged (wireless)
+        self.assertNotIn("rf_channel", out)
+
+
+    # --- a driver value must be SUBMITTED to win (N3) -------------------------
+
+    def test_create_omitting_the_driver_field_keeps_its_dependent_fields(self):
+        """A create that simply omits mode keeps the VLANs NetBox would have stored."""
+        # The policy is that a SUBMITTED driver value wins over the fields it forbids.
+        # With no submitted driver value there is nothing to win, so producer data is
+        # left alone: mode absent must not read as mode "" and drop both VLAN fields.
+        entity = {"name": "vmeth0", "untagged_vlan": 601, "tagged_vlans": [602]}
+        out, dropped = self._drop("virtualization.vminterface", {}, entity)
+        self.assertEqual(out["untagged_vlan"], 601)
+        self.assertEqual(out["tagged_vlans"], [602])
+        self.assertEqual(dropped, {})
+
+    def test_explicitly_submitted_empty_driver_value_does_win(self):
+        """An explicitly submitted empty mode IS a submitted value, and forbids the VLANs."""
+        entity = {"name": "vmeth0", "mode": "", "untagged_vlan": 601, "tagged_vlans": [602]}
+        out, dropped = self._drop("virtualization.vminterface", {}, entity)
+        self.assertNotIn("untagged_vlan", out)
+        self.assertNotIn("tagged_vlans", out)
+        self.assertEqual(sorted(dropped), ["tagged_vlans", "untagged_vlan"])
+        # the reason must not claim a value that was never submitted
+        self.assertIn("empty", dropped["tagged_vlans"])
+        self.assertNotIn("''", dropped["tagged_vlans"])
+
+    def test_explicitly_submitted_null_driver_value_does_win(self):
+        """A submitted null mode is submitted too, and reads as no 802.1Q."""
+        out, dropped = self._drop("dcim.interface", {}, {"mode": None, "tagged_vlans": [602]})
+        self.assertNotIn("tagged_vlans", out)
+        self.assertEqual(list(dropped), ["tagged_vlans"])
+
+    def test_stored_driver_value_never_drops_submitted_data(self):
+        """A driver value that was only STORED does not drop submitted data."""
+        # The stored mode forbids tagged_vlans, but the producer submitted no mode, so
+        # there is no submitted driver value to win and the explicit list stands (NetBox
+        # judges it, exactly as it does on develop).
+        out, dropped = self._drop(
+            "dcim.interface", {"mode": "access", "tagged_vlans": [101]}, {"tagged_vlans": [102]},
+        )
+        self.assertEqual(out["tagged_vlans"], [102])
+        self.assertEqual(dropped, {})
+
+    def test_non_string_driver_value_fails_open_in_both_phases(self):
+        """A driver value that is not a string is not one we can reason about."""
+        # A malformed payload must not turn into a TypeError on an unhashable rule key.
+        out, dropped = self._drop(
+            "dcim.interface",
+            {"mode": "tagged", "tagged_vlans": [101]},
+            {"mode": {"vid": 5}, "tagged_vlans": [102]},
+        )
+        self.assertEqual(out["tagged_vlans"], [102])
+        self.assertEqual(dropped, {})
+
+    # --- the clear must converge against what NetBox actually stores (N1) -----
+
+    def test_submitted_forbidden_field_is_removed_not_blanked(self):
+        """A dropped field leaves the payload entirely; no blank is invented for it."""
+        out, dropped = self._drop("dcim.interface", {}, {"type": "1000base-t", "rf_role": "ap"})
+        self.assertNotIn("rf_role", out)
+        self.assertEqual(list(dropped), ["rf_role"])
+
+    def test_type_rf_clear_converges_against_the_blank_string_netbox_stores(self):
+        """The type/rf_* clear plans nothing once NetBox has stored '' for the rf fields."""
+        # rf_channel/rf_role are CharFields with null=False: NetBox coerces the submitted
+        # null to ''. Re-injecting None every round diffed '' vs None and emitted a
+        # spurious UPDATE on every ingest cycle forever.
+        payload = {"type": "1000base-t", "rf_role": "ap", "rf_channel": "2.4g-1-2412-22"}
+        stored = {"type": "ieee802.11ac", "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+                  "rf_channel_frequency": 2412, "rf_channel_width": 22}
+        round1, dropped = self._drop("dcim.interface", dict(stored), dict(payload))
+        self.assertEqual(sorted(dropped), ["rf_channel", "rf_role"])
+        self.assertIsNone(round1["rf_role"])                            # stale value cleared
+        self.assertNotEqual(shallow_compare_dict(stored, round1), {})    # round 1 is a real change
+
+        stored2 = {"type": "1000base-t", "rf_role": "", "rf_channel": "",
+                   "rf_channel_frequency": None, "rf_channel_width": None}
+        round2, dropped2 = self._drop("dcim.interface", dict(stored2), dict(payload))
+        self.assertEqual(sorted(dropped2), ["rf_channel", "rf_role"])    # still reported
+        self.assertNotIn("rf_role", round2)                             # but nothing written
+        self.assertEqual(shallow_compare_dict(stored2, round2), {})      # -> empty plan
+
+    # --- every (driver value, dependent field) pair in the registry -----------
+
+    def _pair_sentinel(self, dependent):
+        """A non-empty submitted value for a dependent field (only truthiness matters)."""
+        return ["x"] if dependent == "tagged_vlans" else "x"
+
+    def _assert_pair_converges(self, object_type, driver_field, driver_value, dependent):
+        """Assert one (driver value, dependent field) pair drops, clears once, then converges."""
+        sentinel = self._pair_sentinel(dependent)
+        submitted = {driver_field: driver_value, dependent: sentinel}
+
+        if dependent in match_participating_fields(object_type):
+            # Exempt: the field identifies the row, so phase 1 must not touch it and
+            # there is nothing for us to converge -- NetBox rejects the payload, which
+            # is develop's behaviour and the safe one. Phase 2 must still clear a stale
+            # STORED value the payload no longer carries.
+            out, dropped = self._drop(object_type, {}, dict(submitted))
+            self.assertEqual(out[dependent], sentinel)
+            self.assertEqual(dropped, {})
+            stored = {driver_field: driver_value, dependent: sentinel}
+            cleared, _ = self._drop(object_type, dict(stored), {driver_field: driver_value})
+            self.assertIn(dependent, cleared)
+            self.assertFalse(cleared[dependent])
+            return
+
+        # 1. a submitted driver value drops the field it forbids, and writes no blank
+        out, dropped = self._drop(object_type, {}, dict(submitted))
+        self.assertNotIn(dependent, out)
+        self.assertIn(dependent, dropped)
+
+        # 2. with no submitted driver value, submitted data survives untouched
+        out, dropped = self._drop(object_type, {}, {dependent: sentinel})
+        self.assertEqual(out[dependent], sentinel)
+        self.assertEqual(dropped, {})
+
+        # 3. a non-empty STORED value is cleared exactly once...
+        stored = {driver_field: driver_value, dependent: sentinel}
+        round1, _ = self._drop(object_type, dict(stored), dict(submitted))
+        self.assertNotEqual(shallow_compare_dict(stored, round1), {})
+
+        # ...and whichever empty representation NetBox then stores, the next round
+        # plans nothing at all for the field.
+        for netbox_stored in ("", None, [], (), {}):
+            with self.subTest(netbox_stored=netbox_stored):
+                stored2 = {driver_field: driver_value, dependent: netbox_stored}
+                round2, _ = self._drop(object_type, dict(stored2), dict(submitted))
+                self.assertNotIn(dependent, round2)
+                self.assertEqual(shallow_compare_dict(stored2, round2), {})
+
+    def test_every_registered_driver_value_dependent_pair_converges(self):
+        """Every (driver value, dependent field) pair in every rule map converges."""
+        # Exhaustive over the registry, including all ~100 non-wireless interface types
+        # in _INTERFACE_TYPE_RF_RULES, so a new rule cannot be added without meeting it.
+        pairs = 0
+        for object_type, rules in _DRIVER_FIELD_RULES.items():
+            for driver_field, value_map in rules.items():
+                for driver_value, dependents in value_map.items():
+                    for dependent in dependents:
+                        with self.subTest(object_type=object_type, driver_field=driver_field,
+                                          driver_value=driver_value, dependent=dependent):
+                            self._assert_pair_converges(
+                                object_type, driver_field, driver_value, dependent,
+                            )
+                        pairs += 1
+        self.assertGreater(pairs, 100)  # the map is generated; guard against an empty sweep
+
+
+class DriverFieldPolicyPruneTests(SimpleTestCase):
+    """Which graph edges and child nodes a phase 1 drop takes with it -- and which it must not."""
+
+    def _ref(self, uuid, object_type="ipam.vlan"):
+        return UnresolvedReference(object_type=object_type, uuid=uuid)
+
+    def _node(self, object_type, uuid, refs=(), **fields):
+        node = {"_object_type": object_type, "_uuid": uuid, "_refs": set(refs), "_warnings": {}}
+        node.update(fields)
+        return node
+
+    def _uuids(self, entities):
+        return sorted(e["_uuid"] for e in entities)
+
+    def _policy(self, entities):
+        """
+        Run the policy the way the transformer does: snapshot, drop, then ONE sweep.
+
+        The drop and the prune are deliberately separate calls -- pruning inside the
+        pass destroys a duplicate child before dedupe can merge it -- so this helper
+        keeps the unit tests exercising the same order the real pipeline uses.
+        """
+        referenced_before = referenced_uuids(entities)
+        released = apply_submitted_driver_field_policy(entities)
+        if not released:
+            return entities
+        return prune_orphaned_nodes(entities, referenced_before)
+
+    def test_a_dropped_nested_reference_takes_its_child_node_with_it(self):
+        """The child node a dropped tagged_vlans created is pruned, and so is its edge."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = self._policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1"])
+        self.assertNotIn("tagged_vlans", iface)
+        self.assertEqual(iface["_refs"], set())
+
+    def test_a_child_the_same_node_still_references_is_kept(self):
+        """One VLAN node reached by BOTH untagged_vlan and tagged_vlans survives the drop."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", mode="access",
+                           untagged_vlan=self._ref("v1"), tagged_vlans=[self._ref("v1")])
+        out = self._policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertEqual(iface["_refs"], {"v1"})       # the untagged_vlan edge stands
+        self.assertEqual(iface["untagged_vlan"], self._ref("v1"))
+
+    def test_a_child_another_node_still_references_is_kept(self):
+        """A second interface still tagging the VLAN keeps its node alive."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        dropped = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                             mode="access", tagged_vlans=[self._ref("v1")])
+        keeper = self._node("dcim.interface", "i2", refs={"v1"}, name="Eth2",
+                            mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = self._policy([vlan, dropped, keeper])
+        self.assertEqual(self._uuids(out), ["i1", "i2", "v1"])
+        self.assertEqual(dropped["_refs"], set())
+        self.assertEqual(keeper["_refs"], {"v1"})
+
+    def test_pruning_is_transitive(self):
+        """A pruned child's own children go too, once nothing reaches them."""
+        group = self._node("ipam.vlangroup", "g1", name="g1", slug="g1")
+        vlan = self._node("ipam.vlan", "v1", refs={"g1"}, vid=101, name="v101",
+                          group=self._ref("g1", "ipam.vlangroup"))
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = self._policy([group, vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1"])
+
+    def test_a_grandchild_something_surviving_needs_is_kept(self):
+        """Transitivity stops at the first node another survivor still references."""
+        group = self._node("ipam.vlangroup", "g1", name="g1", slug="g1")
+        dropped_vlan = self._node("ipam.vlan", "v1", refs={"g1"}, vid=101, name="v101",
+                                  group=self._ref("g1", "ipam.vlangroup"))
+        kept_vlan = self._node("ipam.vlan", "v2", refs={"g1"}, vid=102, name="v102",
+                               group=self._ref("g1", "ipam.vlangroup"))
+        iface = self._node("dcim.interface", "i1", refs={"v1", "v2"}, name="Eth1", mode="access",
+                           untagged_vlan=self._ref("v2"), tagged_vlans=[self._ref("v1")])
+        out = self._policy([group, dropped_vlan, kept_vlan, iface])
+        self.assertEqual(self._uuids(out), ["g1", "i1", "v2"])
+        self.assertEqual(iface["_refs"], {"v2"})
+
+    def test_a_post_create_step_and_its_children_are_never_collateral(self):
+        """A post-create node hangs off its object; a drop elsewhere leaves it alone."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        mac = self._node("dcim.macaddress", "m1", mac_address="00:00:00:00:00:01")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        post_create = self._node(
+            "dcim.interface", "pc1", refs={"i1", "m1"},
+            primary_mac_address=self._ref("m1", "dcim.macaddress"),
+        )
+        post_create["_is_post_create"] = True
+        post_create["_instance"] = "i1"
+        out = self._policy([vlan, mac, iface, post_create])
+        self.assertEqual(self._uuids(out), ["i1", "m1", "pc1"])
+
+    def test_a_root_node_is_never_pruned(self):
+        """A node nothing referenced is the entity's own object: it survives a drop on itself."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        out = self._policy([vlan, iface])
+        self.assertIn("i1", self._uuids(out))
+
+    def test_no_drop_prunes_nothing(self):
+        """With nothing to drop the policy is a pure no-op over the graph."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = self._policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertEqual(iface["tagged_vlans"], [self._ref("v1")])
+        self.assertEqual(iface["_warnings"], {})
+
+    def test_a_drop_with_no_nested_reference_prunes_nothing(self):
+        """Dropping a plain scalar (rf_role) releases no edge and no node."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1", type="1000base-t",
+                           rf_role="ap", mode="tagged", tagged_vlans=[self._ref("v1")])
+        out = self._policy([vlan, iface])
+        self.assertEqual(self._uuids(out), ["i1", "v1"])
+        self.assertNotIn("rf_role", iface)
+        self.assertEqual(iface["_refs"], {"v1"})
+
+    def test_a_gate_failure_takes_the_whole_pass_down_instead_of_dropping(self):
+        """The graph-level pass does not swallow a gate failure into a silent drop."""
+        real = field_policy.get_object_type_model
+
+        def broken(object_type):
+            raise RuntimeError("content type lookup unavailable")
+
+        match_participating_fields.cache_clear()
+        self.addCleanup(match_participating_fields.cache_clear)
+        svlan = self._node("ipam.vlan", "s1", vid=900, name="s900")
+        vlan = self._node("ipam.vlan", "v1", refs={"s1"}, vid=101, name="v101",
+                          qinq_role="svlan", qinq_svlan=self._ref("s1"))
+        with mock.patch.object(field_policy, "get_object_type_model", broken):
+            with self.assertRaises(RuntimeError):
+                apply_submitted_driver_field_policy([svlan, vlan])
+        self.assertEqual(vlan["qinq_svlan"], self._ref("s1"))
+        self.assertEqual(vlan["_refs"], {"s1"})
+        self.assertEqual(vlan["_warnings"], {})
+        # and with the lookup healthy again the gate still refuses the drop
+        self.assertEqual(self._uuids(self._policy([svlan, vlan])), ["s1", "v1"])
+        self.assertEqual(vlan["qinq_svlan"], self._ref("s1"))
+        self.assertIs(real, field_policy.get_object_type_model)
+
+    def test_one_drop_is_reported_once_when_the_policy_runs_twice(self):
+        """The policy is idempotent: a second pass re-reports nothing."""
+        vlan = self._node("ipam.vlan", "v1", vid=101, name="v101")
+        iface = self._node("dcim.interface", "i1", refs={"v1"}, name="Eth1",
+                           mode="access", tagged_vlans=[self._ref("v1")])
+        entities = self._policy([vlan, iface])
+        again = self._policy(entities)          # a second full pass changes nothing
+        self.assertEqual(self._uuids(again), ["i1"])
+        self.assertEqual(len(iface["_warnings"]["tagged_vlans"]), 1)
+
+
+class DedupeDriverFieldPolicyTests(TestCase):
+    """_fingerprint_dedupe normalizes every node it merges, so the result is N-independent."""
+
+    def _iface(self, uuid, **fields):
+        node = {
+            "_object_type": "dcim.interface",
+            "_uuid": uuid,
+            "_refs": {"d1"},
+            "_warnings": {},
+            "name": "Gi1/0/1",
+            "device": UnresolvedReference(object_type="dcim.device", uuid="d1"),
+        }
+        node.update(fields)
+        return node
+
+    def _fragments(self, count):
+        """One driver-only fragment plus ``count - 1`` fragments, each with its own VLAN."""
+        nodes = [self._iface("i0", mode="access")]
+        for k in range(1, count):
+            nodes.append(self._iface(
+                f"i{k}", _refs={"d1", f"v{k}"},
+                tagged_vlans=[UnresolvedReference(object_type="ipam.vlan", uuid=f"v{k}")],
+            ))
+        return nodes
+
+    def _assert_normalized(self, out, released):
+        raise_unsettled_conflicts(out)                    # nothing left to disagree about
+        merged = {entity["_uuid"]: entity for entity in out}
+        self.assertEqual(len(merged), 1, merged)          # all fragments are one node
+        node = next(iter(merged.values()))
+        self.assertEqual(node["mode"], "access")
+        self.assertNotIn("tagged_vlans", node)            # forbidden -> gone
+        self.assertNotIn("_deferred_conflicts", node)     # and never leaks downstream
+        self.assertEqual(node["_refs"], {"d1"})           # every VLAN edge released
+        self.assertTrue(released)                         # so the caller's sweep runs
+        self.assertEqual(len(node["_warnings"]["tagged_vlans"]), 1)
+
+    def test_every_merged_node_is_normalized_before_the_next_duplicate_arrives(self):
+        """Two to six duplicate fragments all end at the same normalized node."""
+        # Normalizing only AFTER dedupe stops working at three: the merge of the first
+        # two leaves the merged node holding both mode and tagged_vlans, and the third
+        # fragment's different tagged_vlans then conflicts inside _merge_nodes, so the
+        # whole entity is rejected before any later pass runs. Normalizing the
+        # merged node inside the loop is what makes the outcome independent of how many
+        # duplicate representations the producer happened to send.
+        for count in range(2, 7):
+            with self.subTest(fragments=count):
+                self._assert_normalized(*_fingerprint_dedupe(self._fragments(count)))
+
+    def test_the_outcome_does_not_depend_on_fragment_order(self):
+        """The driver-carrying fragment arriving last must reach the same node."""
+        for count in range(2, 7):
+            with self.subTest(fragments=count):
+                self._assert_normalized(*_fingerprint_dedupe(self._fragments(count)[::-1]))
+
+    def test_the_merged_node_is_already_normalized_when_dedupe_returns(self):
+        """Which is why the transformer needs no separate post-dedupe pass."""
+        out, _ = _fingerprint_dedupe(self._fragments(3))
+        self.assertNotIn("tagged_vlans", out[0])
+        # a further pass over the result finds nothing left to do
+        self.assertFalse(apply_submitted_driver_field_policy(out))
+
+    def test_an_allowed_field_still_conflicts_after_a_merge(self):
+        """The control: mode "tagged" permits tagged_vlans, so disagreement is still an error."""
+        nodes = self._fragments(3)
+        for node in nodes:
+            node["mode"] = "tagged"
+        out, _ = _fingerprint_dedupe(nodes)
+        with self.assertRaises(serializers.ValidationError) as raised:
+            raise_unsettled_conflicts(out)
+        self.assertIn("Conflicting values", str(raised.exception))
+
+    def test_a_conflict_on_a_field_no_driver_value_can_drop_is_immediate(self):
+        """A field outside the registry is a plain disagreement: raised where it happens."""
+        # Deferral is only for fields a driver value could delete. Everything else keeps
+        # develop's behaviour, including the error's position in the pipeline.
+        nodes = [self._iface("i0", description="from A"),
+                 self._iface("i1", description="from B")]
+        with self.assertRaises(serializers.ValidationError):
+            _fingerprint_dedupe(nodes)
+
+    def test_a_deferred_conflict_releases_the_rejected_copys_edges(self):
+        """The value a deferred conflict declined must not keep its VLAN node alive."""
+        # _merge_nodes unions _refs, so without this the rejected tagged_vlans list would
+        # still reach resolution as an edge and the VLAN would be created anyway -- the
+        # manufactured VLAN the prune sweep exists to prevent, arriving by another route.
+        out, _ = _fingerprint_dedupe(self._fragments(3)[::-1])
+        raise_unsettled_conflicts(out)
+        self.assertEqual(out[0]["_refs"], {"d1"})
+
+    def _shared_vlan_fragments(self):
+        """
+        Fragments whose surviving VLAN is ALSO the untagged one.
+
+        Dropping tagged_vlans then releases no edge -- untagged_vlan still needs it --
+        so the only edge phase 1 gives up is the one the rejected duplicate contributed.
+        """
+        shared = UnresolvedReference(object_type="ipam.vlan", uuid="v1")
+        other = UnresolvedReference(object_type="ipam.vlan", uuid="v2")
+        return [
+            self._iface("i0", _refs={"d1", "v1"}, untagged_vlan=shared, tagged_vlans=[shared]),
+            self._iface("i1", _refs={"d1", "v2"}, tagged_vlans=[other]),
+            self._iface("i2", mode="access"),
+        ]
+
+    def test_a_rejected_values_edge_release_is_reported_to_the_prune_sweep(self):
+        """Dedupe must report the edges the merge released, not only the ones drops did."""
+        out, released = _fingerprint_dedupe(self._shared_vlan_fragments())
+        raise_unsettled_conflicts(out)
+        node = out[0]
+        self.assertNotIn("tagged_vlans", node)
+        self.assertEqual(node["untagged_vlan"].uuid, "v1")
+        self.assertEqual(node["_refs"], {"d1", "v1"})   # the rejected copy's v2 is gone
+        # The drop itself released nothing, so if the merge's release is not reported the
+        # caller skips its one prune sweep and v2 survives as a manufactured VLAN.
+        self.assertTrue(released)
+
+    def test_the_orphan_of_a_rejected_value_is_pruned(self):
+        """Phase 1 in full: only the rejected duplicate's VLAN node disappears."""
+        vlans = [{"_object_type": "ipam.vlan", "_uuid": uuid, "_refs": set(),
+                  "vid": vid, "name": f"dedupe-v{vid}", "status": "active"}
+                 for uuid, vid in (("v1", 981), ("v2", 982))]
+        entities = vlans + self._shared_vlan_fragments()
+        referenced_before = referenced_uuids(entities)
+        released = apply_submitted_driver_field_policy(entities)
+        deduplicated, merge_released = _fingerprint_dedupe(entities)
+        raise_unsettled_conflicts(deduplicated)
+        if released or merge_released:
+            deduplicated = prune_orphaned_nodes(deduplicated, referenced_before)
+        self.assertEqual({entity["_uuid"] for entity in deduplicated}, {"v1", "i0"})
+
+
+class InterfaceModeClearE2ETests(APITestCase):
+    """End-to-end: seed an existing interface, ingest a mode change, assert clear."""
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _device(self):
+        return {
+            "name": "obs3607-sw",
+            "role": {"name": "obs3607-role"},
+            "device_type": {"manufacturer": {"name": "obs3607-mfr"}, "model": "obs3607-model"},
+            "site": {"name": "obs3607-site"},
+        }
+
+    def _diff_apply(self, entity):
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": entity}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        return r1, r2
+
+    def _plan(self, payload):
+        """Generate a diff for a payload and return its change set."""
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs):
+        """Apply a change set and assert it landed without errors."""
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"), r.content)
+        return r
+
+    def _converge(self, payload, label, max_applies=2, quiet_rounds=4):
+        """
+        Apply a payload until its plan is empty, then assert it stays empty.
+
+        Returns the number of applies it took. An empty plan is the strongest
+        available statement of convergence: the change set carries no changes at
+        all, so re-ingest performs no write and logs no object change.
+        """
+        applies = 0
+        for _ in range(max_applies + 1):
+            cs = self._plan(payload)
+            if not cs.get("changes", []):
+                break
+            self._apply(cs)
+            applies += 1
+        else:
+            self.fail(f"{label} did not converge within {max_applies} applies")
+        self.assertLessEqual(applies, max_applies, f"{label} needed {applies} applies")
+        for quiet in range(1, quiet_rounds + 1):
+            self.assertEqual(
+                self._plan(payload).get("changes", []), [],
+                f"{label} re-planned on quiet round {quiet}",
+            )
+        return applies
+
+    def _iface_payload(self, **fields):
+        """Build a dcim.interface generate-diff payload for this test's device."""
+        entity = {"device": self._device()}
+        entity.update(fields)
+        return {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": entity}}
+
+    def _vm_payload(self, **fields):
+        """Build a virtualization.vminterface generate-diff payload."""
+        entity = {"virtual_machine": {"name": "obs3607-vm",
+                                      "cluster": {"name": "obs3607-cl", "type": {"name": "obs3607-ct"}}}}
+        entity.update(fields)
+        return {"timestamp": 1, "object_type": "virtualization.vminterface",
+                "entity": {"vm_interface": entity}}
+
+    def test_tagged_to_access_clears_tagged_vlans_and_is_idempotent(self):
+        """E2E: tagged -> access clears tagged_vlans, keeps untagged_vlan, and re-diffs as NOOP."""
+        create = {
+            "name": "Eth1", "type": "1000base-t", "device": self._device(),
+            "mode": "tagged",
+            "untagged_vlan": {"vid": 100, "name": "v100"},
+            "tagged_vlans": [{"vid": 101, "name": "v101"}, {"vid": 102, "name": "v102"}],
+        }
+        _, apply1 = self._diff_apply(create)
+        self.assertEqual(apply1.status_code, 200)
+        iface = Interface.objects.get(name="Eth1")
+        self.assertEqual(iface.tagged_vlans.count(), 2)
+
+        # change mode to access, do NOT send tagged_vlans
+        update = {"name": "Eth1", "type": "1000base-t", "device": self._device(), "mode": "access"}
+        diff2, apply2 = self._diff_apply(update)
+        # The injected clear must survive into change.data — this is exactly what
+        # #162's preserve_empty enables; assert it so a missing base cannot regress silently.
+        iface_updates = [c for c in diff2.json()["change_set"]["changes"]
+                         if c["object_type"] == "dcim.interface"]
+        self.assertTrue(
+            any(c.get("data", {}).get("tagged_vlans") == [] for c in iface_updates),
+            "expected tagged_vlans:[] in the UPDATE change.data (requires #162 preserve_empty)",
+        )
+        self.assertEqual(apply2.status_code, 200)
+        self.assertIsNone(apply2.json().get("errors"))
+        iface.refresh_from_db()
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)          # cleared
+        self.assertIsNotNone(iface.untagged_vlan)                # preserved
+
+        # re-diff of the same access payload must be a NOOP (idempotency)
+        r3 = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": update}},
+            format="json", **self.auth,
+        )
+        changes = [c for c in r3.json().get("change_set", {}).get("changes", [])
+                   if c["object_type"] == "dcim.interface"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in changes))
+
+    def test_tagged_to_taggedall_clears_tagged_keeps_untagged(self):
+        """E2E: tagged -> tagged-all clears tagged_vlans but keeps untagged_vlan."""
+        create = {
+            "name": "EthTA", "type": "1000base-t", "device": self._device(),
+            "mode": "tagged",
+            "untagged_vlan": {"vid": 200, "name": "v200"},
+            "tagged_vlans": [{"vid": 201, "name": "v201"}],
+        }
+        _, a1 = self._diff_apply(create)
+        self.assertEqual(a1.status_code, 200)
+        update = {"name": "EthTA", "type": "1000base-t", "device": self._device(), "mode": "tagged-all"}
+        _, a2 = self._diff_apply(update)
+        self.assertEqual(a2.status_code, 200)
+        iface = Interface.objects.get(name="EthTA")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertIsNotNone(iface.untagged_vlan)  # untagged allowed for tagged-all
+        r = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": update}},
+            format="json", **self.auth,
+        )
+        ch = [c for c in r.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in ch))  # post-update idempotency
+
+    def test_tagged_to_routed_clears_both_and_is_idempotent(self):
+        """E2E: tagged -> empty (routed) clears both tagged_vlans and untagged_vlan, idempotently."""
+        create = {
+            "name": "EthR", "type": "1000base-t", "device": self._device(),
+            "mode": "tagged",
+            "untagged_vlan": {"vid": 300, "name": "v300"},
+            "tagged_vlans": [{"vid": 301, "name": "v301"}],
+        }
+        _, a1 = self._diff_apply(create)
+        self.assertEqual(a1.status_code, 200)
+        update = {"name": "EthR", "type": "1000base-t", "device": self._device(), "mode": ""}
+        _, a2 = self._diff_apply(update)
+        self.assertEqual(a2.status_code, 200)
+        self.assertIsNone(a2.json().get("errors"))
+        iface = Interface.objects.get(name="EthR")
+        self.assertEqual(iface.mode, "")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertIsNone(iface.untagged_vlan)  # empty mode forbids untagged too
+        # post-update idempotency for the empty-mode FK-clear path (mode:"" vs NOOP detection)
+        r = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": update}},
+            format="json", **self.auth,
+        )
+        ch = [c for c in r.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in ch))
+
+    def test_explicit_incompatible_tagged_vlans_is_dropped_not_rejected(self):
+        """An explicit incompatible mode/tagged_vlans update applies with the field dropped."""
+        # POLICY (reversed): this combination used to be left alone so NetBox could
+        # reject it, which cost the whole entity. The submitted mode now wins: the
+        # update applies, tagged_vlans is dropped, and the drop is surfaced as a
+        # warning on the change set rather than swallowed silently.
+        create = {
+            "name": "EthNeg", "type": "1000base-t", "device": self._device(),
+            "mode": "tagged",
+            "tagged_vlans": [{"vid": 111, "name": "v111"}],
+        }
+        _, apply1 = self._diff_apply(create)
+        self.assertEqual(apply1.status_code, 200)
+        iface = Interface.objects.get(name="EthNeg")
+        self.assertEqual(iface.tagged_vlans.count(), 1)
+
+        bad = {
+            "name": "EthNeg", "type": "1000base-t", "device": self._device(),
+            "mode": "access",
+            "tagged_vlans": [{"vid": 111, "name": "v111"}],  # explicit + incompatible
+        }
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": bad}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+        iface.refresh_from_db()
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # the mode won; the field was dropped
+
+        # and the very same self-contradictory payload re-diffs as a NOOP
+        r3 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        ch = [c for c in r3.json()["change_set"]["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in ch))
+
+    def test_corpus_create_access_mode_with_tagged_vlans_applies(self):
+        """A CREATE naming mode access, untagged_vlan AND tagged_vlans applies and is idempotent."""
+        # Reproduction of the corpus entity "WirelessGigabitEthernet1/0/1", which used to
+        # lose the whole interface to a 400 {"tagged_vlans": ["Interface mode does not
+        # support tagged vlans"]}. The create must now land with the mode honoured, the
+        # untagged VLAN attached and the forbidden tagged VLANs dropped.
+        create = {
+            "name": "WlAccess", "type": "other-wireless", "device": self._device(),
+            "mode": "access",
+            "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+            "untagged_vlan": {"vid": 900, "name": "v900"},
+            "tagged_vlans": [{"vid": 101, "name": "v101"}, {"vid": 102, "name": "v102"}],
+        }
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": create}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        # the create's CREATE change must not carry tagged_vlans at all, and must not
+        # leave a dangling unresolved-reference path for the field it no longer carries
+        iface_creates = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_creates)
+        for c in iface_creates:
+            self.assertNotIn("tagged_vlans", c.get("data", {}))
+            self.assertNotIn("tagged_vlans", c.get("new_refs", []))
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+        iface = Interface.objects.get(name="WlAccess")
+        self.assertEqual(iface.mode, "access")
+        self.assertIsNotNone(iface.untagged_vlan)
+        self.assertEqual(iface.untagged_vlan.vid, 900)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertEqual(iface.rf_channel, "2.4g-1-2412-22")  # wireless type keeps rf fields
+
+        # re-ingesting the identical payload is a no-op
+        r3 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r3.json().get("change_set", {}).get("changes", []), [])
+
+        # and submitting the forbidden field EMPTY under the same mode is a no-op too:
+        # clearing an already-empty submitted value must never plan an update
+        empty = dict(create, tagged_vlans=[])
+        r4 = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": empty}},
+            format="json", **self.auth,
+        )
+        self.assertEqual(r4.json().get("change_set", {}).get("changes", []), [])
+
+    def test_qinq_to_access_clears_qinq_svlan_orm_seed(self):
+        """E2E: an ORM-seeded q-in-q interface moving to access has qinq_svlan cleared."""
+        # ORM-seed a q-in-q interface with a qinq_svlan (ORM .create bypasses full_clean,
+        # so no S-VLAN role setup is needed), then ingest mode=access via Diode and assert
+        # qinq_svlan is cleared. This is the reliable integration cover for the FK->None path.
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+        from ipam.models import VLAN
+
+        site = Site.objects.create(name="qinq-site", slug="qinq-site")
+        mfr = Manufacturer.objects.create(name="qinq-mfr", slug="qinq-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="qinq-model", slug="qinq-model")
+        role = DeviceRole.objects.create(name="qinq-role", slug="qinq-role")
+        dev = Device.objects.create(name="qinq-dev", device_type=dt, role=role, site=site)
+        svlan = VLAN.objects.create(vid=602, name="qinq-svlan", site=site)
+        cvlan = VLAN.objects.create(vid=603, name="qinq-cvlan", site=site)
+        iface = Interface.objects.create(
+            device=dev, name="EthQ", type="1000base-t", mode="q-in-q", qinq_svlan=svlan
+        )
+        iface.tagged_vlans.set([cvlan])  # q-in-q also carries tagged (customer) VLANs
+
+        update = {
+            "name": "EthQ", "type": "1000base-t",
+            "device": {
+                "name": "qinq-dev", "role": {"name": "qinq-role"},
+                "device_type": {"manufacturer": {"name": "qinq-mfr"}, "model": "qinq-model"},
+                "site": {"name": "qinq-site"},
+            },
+            "mode": "access",
+        }
+        _, apply = self._diff_apply(update)
+        self.assertEqual(apply.status_code, 200)
+        self.assertIsNone(apply.json().get("errors"))
+        iface.refresh_from_db()
+        self.assertEqual(iface.mode, "access")
+        self.assertIsNone(iface.qinq_svlan)              # save() never clears this; the hook must
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # q-in-q -> access clears tagged too
+
+    def test_vminterface_mode_change_emits_clear(self):
+        """E2E: vminterface mode change emits tagged_vlans:[] in change.data (non-vacuous)."""
+        # VMInterface's serializer does NO mode->VLAN validation and BaseInterface.save()
+        # auto-clears tagged_vlans on non-tagged modes, so a DB-only assertion would pass
+        # even without the hook (vacuous). Assert the emitted change.data instead: the hook
+        # must inject tagged_vlans:[] for the vminterface object_type too. (Scopeless cluster
+        # + siteless VLAN avoids the serializer's site-consistency check.)
+        vm = {"name": "obs3607-vm", "cluster": {"name": "obs3607-cl", "type": {"name": "obs3607-ct"}}}
+        create = {"name": "vmeth0", "virtual_machine": vm, "mode": "tagged",
+                  "tagged_vlans": [{"vid": 701, "name": "v701"}]}
+        cs = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "virtualization.vminterface", "entity": {"vm_interface": create}},
+            format="json", **self.auth,
+        ).json().get("change_set", {})
+        self.assertEqual(
+            self.client.post(self.apply_url, data=cs, format="json", **self.auth).status_code, 200
+        )
+
+        update = {"name": "vmeth0", "virtual_machine": vm, "mode": "access"}
+        r = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "virtualization.vminterface", "entity": {"vm_interface": update}},
+            format="json", **self.auth,
+        )
+        vm_updates = [c for c in r.json()["change_set"]["changes"]
+                      if c["object_type"] == "virtualization.vminterface"]
+        self.assertTrue(
+            any(c.get("data", {}).get("tagged_vlans") == [] for c in vm_updates),
+            "hook must emit tagged_vlans:[] for vminterface (DB-only assertion is vacuous here)",
+        )
+
+    def test_vminterface_create_drops_tagged_vlans_netbox_would_have_kept(self):
+        """The uniform policy costs a vminterface its tagged VLANs, deliberately."""
+        # virtualization.vminterface is the one registry entry whose serializer does NO
+        # mode/VLAN validation: NetBox accepts mode "access" WITH tagged VLANs on a create
+        # and stores them (BaseInterface.save() only clears on a later save, guarded by
+        # `not self._state.adding`). The shared registry means the driver value wins here
+        # too, so the tagged VLANs are dropped. Pinned so the cost stays a decision.
+        vm = {"name": "drop-vm", "cluster": {"name": "drop-cl", "type": {"name": "drop-ct"}}}
+        create = {"name": "vmeth1", "virtual_machine": vm, "mode": "access",
+                  "tagged_vlans": [{"vid": 711, "name": "v711"}]}
+        payload = {"timestamp": 1, "object_type": "virtualization.vminterface",
+                   "entity": {"vm_interface": create}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json()["change_set"]
+        self.assertIn(
+            "tagged_vlans", cs.get("warnings", {}).get("virtualization.vminterface", {})
+        )
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth1")
+        self.assertEqual(vmi.mode, "access")
+        self.assertEqual(vmi.tagged_vlans.count(), 0)
+
+    def test_interface_wireless_to_ethernet_clears_rf(self):
+        """Type change wireless->ethernet clears stale rf_channel and rf_role."""
+        from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
+        site = Site.objects.create(name="rf-site", slug="rf-site")
+        mfr = Manufacturer.objects.create(name="rf-mfr", slug="rf-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="rf-model", slug="rf-model")
+        role = DeviceRole.objects.create(name="rf-role", slug="rf-role")
+        dev = Device.objects.create(name="rf-dev", device_type=dt, role=role, site=site)
+        iface = Interface.objects.create(device=dev, name="Wl0", type="ieee802.11ac")
+        # Seed stale wireless fields via queryset.update() to bypass save()'s frequency/width
+        # derivation. Use a valid WirelessChannelChoices value so field-level validation
+        # accepts it; the forbidding rule keys on presence. rf_role is load-bearing: without
+        # clearing it, Interface.clean() rejects the non-wireless interface with a wireless role.
+        Interface.objects.filter(pk=iface.pk).update(rf_channel="2.4g-1-2412-22", rf_role="ap")
+        update = {
+            "name": "Wl0", "type": "1000base-t",
+            "device": {"name": "rf-dev", "role": {"name": "rf-role"},
+                       "device_type": {"manufacturer": {"name": "rf-mfr"}, "model": "rf-model"},
+                       "site": {"name": "rf-site"}},
+        }
+        _, apply = self._diff_apply(update)
+        self.assertEqual(apply.status_code, 200)
+        self.assertIsNone(apply.json().get("errors"))
+        iface.refresh_from_db()
+        self.assertEqual(iface.type, "1000base-t")
+        self.assertFalse(iface.rf_channel)  # stale rf_channel cleared
+        self.assertFalse(iface.rf_role)     # stale rf_role cleared (Codex P2)
+
+    def test_vlan_qinq_role_change_clears_qinq_svlan(self):
+        """qinq_role customer->service clears the stale qinq_svlan (ORM-seed + netbox_id match)."""
+        from ipam.models import VLAN
+        svlan = VLAN.objects.create(vid=990, name="qinq-svc")
+        cvlan = VLAN.objects.create(vid=991, name="qinq-cust", qinq_role="cvlan", qinq_svlan=svlan)
+        update = {
+            "vid": 991, "name": "qinq-cust", "qinq_role": "svlan",
+            "metadata": {"source_match": {"netbox_id": cvlan.pk}},
+        }
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": update}}
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        r2 = self.client.post(self.apply_url, data=r1.json().get("change_set", {}), format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+        cvlan.refresh_from_db()
+        self.assertEqual(cvlan.qinq_role, "svlan")
+        self.assertIsNone(cvlan.qinq_svlan)
+
+    # --- N1: the type/rf_* clear converges instead of writing every cycle -----
+
+    def test_type_change_rf_clear_converges_and_stops_writing(self):
+        """A non-wireless type reported with rf_* fields clears once, then plans nothing."""
+        # An interface exists as ieee802.11ac with rf_role/rf_channel set; the producer
+        # now reports it as 1000base-t while STILL reporting the rf fields. Round 1 must
+        # clear the stale values; every round after it must plan nothing. Blanking the
+        # submitted value instead of dropping it made rounds 2+ diff the injected None
+        # against the "" NetBox stores and emit a spurious UPDATE forever.
+        _, a1 = self._diff_apply({
+            "name": "Wl1", "type": "ieee802.11ac", "device": self._device(),
+            "rf_role": "ap", "rf_channel": "2.4g-1-2412-22",
+        })
+        self.assertEqual(a1.status_code, 200)
+        iface = Interface.objects.get(name="Wl1")
+        self.assertEqual(iface.rf_role, "ap")
+        self.assertIsNotNone(iface.rf_channel_frequency)  # derived by Interface.save()
+
+        payload = self._iface_payload(
+            name="Wl1", type="1000base-t", rf_role="ap", rf_channel="2.4g-1-2412-22",
+        )
+        cs = self._plan(payload)
+        self.assertTrue([c for c in cs["changes"] if c["object_type"] == "dcim.interface"])
+        self.assertEqual(
+            sorted(cs.get("warnings", {}).get("dcim.interface", {})), ["rf_channel", "rf_role"],
+        )
+        self._apply(cs)
+        iface.refresh_from_db()
+        self.assertEqual(iface.type, "1000base-t")
+        self.assertEqual(iface.rf_role, "")        # what NetBox stores for these CharFields
+        self.assertEqual(iface.rf_channel, "")
+        self.assertIsNone(iface.rf_channel_frequency)
+        self.assertIsNone(iface.rf_channel_width)
+        last_updated = iface.last_updated
+
+        for quiet in range(1, 6):
+            cs = self._plan(payload)
+            self.assertEqual(cs.get("changes", []), [], f"re-planned on quiet round {quiet}")
+            # still reported by the producer, still dropped, never written again
+            self.assertEqual(
+                sorted(cs.get("warnings", {}).get("dcim.interface", {})),
+                ["rf_channel", "rf_role"],
+            )
+        iface.refresh_from_db()
+        self.assertEqual(iface.last_updated, last_updated)  # no write after round 1
+
+    # --- N3: a create that omits the driver field keeps its data --------------
+
+    def test_vminterface_create_without_mode_keeps_the_vlans_netbox_stores(self):
+        """A vminterface create omitting mode keeps its tagged VLANs, exactly as NetBox does."""
+        # NetBox nulls untagged_vlan itself in BaseInterface.save() but KEEPS tagged_vlans
+        # on a create (_state.adding is True), and the vminterface serializer validates
+        # neither. Nothing may be dropped here: no mode was submitted, so no driver value
+        # won anything, and the payload contradicted nothing.
+        payload = self._vm_payload(
+            name="vmeth0",
+            untagged_vlan={"vid": 3601, "name": "v3601"},
+            tagged_vlans=[{"vid": 3602, "name": "v3602"}],
+        )
+        cs = self._plan(payload)
+        self.assertNotIn("virtualization.vminterface", cs.get("warnings", {}))
+        self._apply(cs)
+
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth0")
+        self.assertFalse(vmi.mode)
+        self.assertIsNone(vmi.untagged_vlan)                                # NetBox's own save()
+        self.assertEqual([v.vid for v in vmi.tagged_vlans.all()], [3602])   # kept, not dropped
+
+    def test_modeless_untagged_vlan_replans_exactly_as_on_develop(self):
+        """A mode-less interface still reporting an untagged VLAN re-plans, as on develop."""
+        # Documented residual, NOT introduced by the driver-field policy: NetBox nulls
+        # untagged_vlan on EVERY save of a mode-less interface, so a producer that keeps
+        # reporting one keeps planning an update. Closing it would mean dropping submitted
+        # data with no submitted driver value to justify it, which is exactly the loss this
+        # scoping exists to prevent, so develop's behaviour is kept and pinned here.
+        payload = self._vm_payload(name="vmeth1", untagged_vlan={"vid": 3611, "name": "v3611"})
+        self._apply(self._plan(payload))
+        from virtualization.models import VMInterface
+        vmi = VMInterface.objects.get(name="vmeth1")
+        self.assertIsNone(vmi.untagged_vlan)
+        vm_changes = [c for c in self._plan(payload).get("changes", [])
+                      if c["object_type"] == "virtualization.vminterface"]
+        self.assertTrue(vm_changes)  # re-plans; the policy deliberately does not silence it
+
+    # --- N2: a dropped match criterion must be dropped BEFORE matching --------
+
+    def test_a_duplicate_node_with_a_different_forbidden_value_still_applies(self):
+        """Two nodes for ONE interface, same submitted mode, different forbidden VLANs."""
+        # The policy used to run AFTER _fingerprint_dedupe, so these two nodes reached
+        # _merge_nodes still carrying tagged_vlans and it rejected the whole entity with
+        # "Conflicting values for 'tagged_vlans'" -- the payload the policy exists to
+        # rescue. Running the policy first drops the forbidden field from both, so they
+        # merge cleanly. The graph nests the same interface twice via the device's
+        # primary_ip4 assignment, which is how one entity legitimately names it twice.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.9.9/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/9", "type": "1000base-t", "mode": "access",
+                "tagged_vlans": [{"vid": 302, "name": "dup-v302", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/9", "type": "1000base-t", "mode": "access",
+            "tagged_vlans": [{"vid": 301, "name": "dup-v301", "status": "active"}],
+        }}}
+        cs = self._plan(payload)
+        self.assertIn("tagged_vlans", cs.get("warnings", {}).get("dcim.interface", {}))
+        for change in cs["changes"]:
+            if change["object_type"] == "dcim.interface":
+                self.assertNotIn("tagged_vlans", change.get("data", {}))
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/9", device__name=dev["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_duplicate_node_with_a_different_ALLOWED_value_still_conflicts(self):
+        """The control: a field the mode PERMITS is a genuine disagreement, still a 400."""
+        # This must NOT be rescued. mode "tagged" allows tagged_vlans, so [401] vs [402]
+        # is two sources disagreeing about real data and nothing can discard either.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.9.10/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/10", "type": "1000base-t", "mode": "tagged",
+                "tagged_vlans": [{"vid": 402, "name": "ctl-v402", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/10", "type": "1000base-t", "mode": "tagged",
+            "tagged_vlans": [{"vid": 401, "name": "ctl-v401", "status": "active"}],
+        }}}
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertIn("Conflicting values", str(r.content))
+
+    def test_a_dropped_copy_still_contributes_before_it_is_pruned(self):
+        """The richer VLAN copy is inside the dropped field: it must merge, not vanish."""
+        # Pruning inside the pre-dedupe pass removed the named copy before
+        # _fingerprint_dedupe could merge it, leaving a survivor with a vid and no name:
+        # 400 {"ipam.vlan": {"name": ["This field cannot be blank."]}} on every round,
+        # blaming a blank VLAN name for an interface mode contradiction. Every earlier
+        # over-prune test specified the VLAN fully on BOTH sides, so the copies were
+        # interchangeable and losing one cost nothing -- this one makes them unequal,
+        # with the richer occurrence inside the field the mode forbids.
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": self._device(), "name": "Gi8/0/2", "type": "1000base-t",
+            "mode": "access",
+            "untagged_vlan": {"vid": 3992},
+            "tagged_vlans": [{"vid": 3992, "name": "v3992"}],
+        }}}
+        cs = self._plan(payload)
+        self._apply(cs)
+        vlan = VLAN.objects.get(vid=3992)
+        self.assertEqual(vlan.name, "v3992")  # inherited from the copy that was dropped
+        iface = Interface.objects.get(name="Gi8/0/2")
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.untagged_vlan.vid, 3992)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 4):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    def test_a_field_only_the_dropped_copy_carried_is_not_lost(self):
+        """The quiet form of the same mechanism: a description only on the tagged copy."""
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": self._device(), "name": "Gi8/0/3", "type": "1000base-t",
+            "mode": "access",
+            "untagged_vlan": {"vid": 3991, "name": "v3991"},
+            "tagged_vlans": [{"vid": 3991, "name": "v3991", "description": "ONLY-ON-TAGGED"}],
+        }}}
+        self._apply(self._plan(payload))
+        self.assertEqual(VLAN.objects.get(vid=3991).description, "ONLY-ON-TAGGED")
+
+    def test_a_contradictory_vlan_payload_never_touches_a_same_vid_row(self):
+        """ipam.vlan is exempt from the drop, so a same-vid VLAN is left alone."""
+        # The regression this pins: dropping qinq_svlan before matching made the entity
+        # satisfy logical_vlan_vid_no_group_or_svlan_or_site ("vid where group IS NULL
+        # AND qinq_svlan IS NULL AND site IS NULL"), i.e. vid alone -- so it adopted
+        # whatever VLAN held that vid and renamed it. Measured: a seeded VLAN was
+        # silently renamed and re-roled where develop wrote nothing at all.
+        from ipam.models import VLAN
+        seeded = VLAN.objects.create(
+            vid=4091, name="lq-someone-elses-vlan", description="OWNED BY ANOTHER SOURCE",
+        )
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 4091, "name": "lq-brand-new-svlan", "qinq_role": "svlan",
+            "qinq_svlan": {"vid": 4090, "name": "lq-parent"},
+        }}}
+        cs = self._plan(payload)
+        # nothing is dropped and nothing is warned about: the field identifies the row
+        self.assertNotIn("ipam.vlan", cs.get("warnings", {}))
+
+        # NetBox rejects the contradiction, which is exactly develop's answer
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertNotEqual(r.status_code, 200, r.content)
+
+        seeded.refresh_from_db()
+        self.assertEqual(seeded.name, "lq-someone-elses-vlan")
+        self.assertEqual(seeded.description, "OWNED BY ANOTHER SOURCE")
+        self.assertFalse(seeded.qinq_role)  # '' or None; both mean 'not a Q-in-Q VLAN'
+        self.assertEqual(VLAN.objects.filter(vid=4091).count(), 1)  # and no duplicate
+
+    def test_vlan_customer_role_keeps_its_service_vlan_and_converges(self):
+        """qinq_role 'cvlan' permits qinq_svlan: it is kept, applied and converges."""
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 3973, "name": "n2-cust", "qinq_role": "cvlan",
+            "qinq_svlan": {"vid": 3972, "name": "n2-svc"},
+        }}}
+        cs = self._plan(payload)
+        self.assertNotIn("ipam.vlan", cs.get("warnings", {}))
+        self._apply(cs)
+        from ipam.models import VLAN
+        vlan = VLAN.objects.get(vid=3973)
+        self.assertEqual(vlan.qinq_svlan.vid, 3972)   # allowed -> kept verbatim
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- the whole mode rule map, end to end, over four quiet rounds ----------
+
+    def test_interface_mode_matrix_applies_and_converges(self):
+        """Every mode in the rule map applies with all three VLAN fields submitted, then converges."""
+        modes = list(_DRIVER_FIELD_RULES["dcim.interface"]["mode"])
+        self.assertEqual(len(modes), 5)
+        for i, mode in enumerate(modes):
+            with self.subTest(mode=mode):
+                payload = self._iface_payload(
+                    name=f"EthM{i}", type="1000base-t", mode=mode,
+                    untagged_vlan={"vid": 3700 + i, "name": f"u{i}"},
+                    tagged_vlans=[{"vid": 3710 + i, "name": f"t{i}"}],
+                    qinq_svlan={"vid": 3720 + i, "name": f"s{i}"},
+                )
+                self._converge(payload, f"dcim.interface mode {mode!r}")
+                iface = Interface.objects.get(name=f"EthM{i}")
+                forbidden = _DRIVER_FIELD_RULES["dcim.interface"]["mode"][mode]
+                if "tagged_vlans" in forbidden:
+                    self.assertEqual(iface.tagged_vlans.count(), 0)
+                else:
+                    self.assertEqual([v.vid for v in iface.tagged_vlans.all()], [3710 + i])
+                if "untagged_vlan" in forbidden:
+                    self.assertIsNone(iface.untagged_vlan)
+                else:
+                    self.assertEqual(iface.untagged_vlan.vid, 3700 + i)
+                if "qinq_svlan" in forbidden:
+                    self.assertIsNone(iface.qinq_svlan)
+                else:
+                    self.assertEqual(iface.qinq_svlan.vid, 3720 + i)
+
+    def test_vminterface_mode_matrix_applies_and_converges(self):
+        """Every mode in the rule map converges for vminterface too, where no serializer polices it."""
+        modes = list(_DRIVER_FIELD_RULES["virtualization.vminterface"]["mode"])
+        for i, mode in enumerate(modes):
+            with self.subTest(mode=mode):
+                payload = self._vm_payload(
+                    name=f"vmethM{i}", mode=mode,
+                    untagged_vlan={"vid": 3730 + i, "name": f"vu{i}"},
+                    tagged_vlans=[{"vid": 3740 + i, "name": f"vt{i}"}],
+                    qinq_svlan={"vid": 3750 + i, "name": f"vs{i}"},
+                )
+                self._converge(payload, f"virtualization.vminterface mode {mode!r}")
+                from virtualization.models import VMInterface
+                vmi = VMInterface.objects.get(name=f"vmethM{i}")
+                forbidden = _DRIVER_FIELD_RULES["virtualization.vminterface"]["mode"][mode]
+                if "tagged_vlans" in forbidden:
+                    self.assertEqual(vmi.tagged_vlans.count(), 0)
+                if "qinq_svlan" in forbidden:
+                    self.assertIsNone(vmi.qinq_svlan)
+
+    def test_interface_type_rf_matrix_applies_and_converges(self):
+        """Representative non-wireless types with all four rf_* fields submitted converge."""
+        # The type rule map is generated as the complement of the wireless allow-set, so
+        # every non-wireless value shares one code path; the exhaustive sweep over all of
+        # them is the unit test above. These are the shapes a producer actually sends.
+        for i, iface_type in enumerate(("1000base-t", "virtual", "lag")):
+            with self.subTest(type=iface_type):
+                payload = self._iface_payload(
+                    name=f"EthT{i}", type=iface_type, rf_role="ap",
+                    rf_channel="2.4g-1-2412-22", rf_channel_frequency=2412, rf_channel_width=22,
+                )
+                self._converge(payload, f"dcim.interface type {iface_type!r}")
+                iface = Interface.objects.get(name=f"EthT{i}")
+                self.assertEqual(iface.type, iface_type)
+                # Measured: a field the payload never carries lands as NULL, while a
+                # field submitted as null lands as '' (see the update case above) — the
+                # SAME CharField, two empty representations. No single blank a planner
+                # could write matches both, which is why the drop removes the field.
+                self.assertFalse(iface.rf_role)
+                self.assertFalse(iface.rf_channel)
+                self.assertIsNone(iface.rf_channel_frequency)
+                self.assertIsNone(iface.rf_channel_width)
+
+    def test_wireless_type_keeps_all_four_rf_fields_and_converges(self):
+        """A wireless type permits the rf fields: they are kept, applied and converge."""
+        payload = self._iface_payload(
+            name="EthW", type="ieee802.11ac", rf_role="ap", rf_channel="2.4g-1-2412-22",
+        )
+        cs = self._plan(payload)
+        self.assertNotIn("dcim.interface", cs.get("warnings", {}))
+        self._apply(cs)
+        iface = Interface.objects.get(name="EthW")
+        self.assertEqual(iface.rf_role, "ap")
+        self.assertEqual(iface.rf_channel, "2.4g-1-2412-22")
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- P2-A: duplicate nodes that SPLIT the contradiction -------------------
+
+    def test_split_duplicate_nodes_do_not_merge_into_the_contradiction(self):
+        """Duplicate nodes that SPLIT mode and tagged_vlans still lose the forbidden field."""
+        # Measured on the pre-dedupe pass alone: neither node triggers the policy, because
+        # phase 1 needs the driver field PRESENT in the node it is looking at. The outer
+        # node carries mode "access" and no tagged_vlans; the nested one (reached through
+        # the device's primary_ip4 assignment) carries tagged_vlans and no mode. _merge_nodes
+        # then combined them INTO the contradiction -- merged data keys held both mode and
+        # tagged_vlans, change_set.warnings was None, and apply was a 400
+        # {"dcim.interface": {"tagged_vlans": ["Interface mode does not support tagged vlans"]}}.
+        # Running the policy a second time on the merged nodes is what closes it.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.20.20/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/20", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 520, "name": "split-v520", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/20", "type": "1000base-t", "mode": "access",
+        }}}
+        cs = self._plan(payload)
+        iface_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_changes)
+        for change in iface_changes:
+            self.assertNotIn("tagged_vlans", change.get("data", {}))
+        # reported exactly once, though two steps could each report it
+        messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
+        self.assertEqual(len(messages or []), 1, messages)
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/20", device__name=dev["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    def test_a_drop_reported_by_two_steps_is_one_warning(self):
+        """The pre-dedupe pass drops from one node, the merge from another: one message."""
+        # The mixed shape: the outer node carries BOTH mode and a forbidden tagged_vlans,
+        # so the pre-dedupe pass drops it and records the warning; the nested node carries
+        # a DIFFERENT tagged_vlans and no mode, so it survives untouched and is dropped
+        # when it merges. Without dedupe on the message, change_set.warnings carried the
+        # same sentence twice for one field.
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.22.22/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/22", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 522, "name": "mix-v522", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/22", "type": "1000base-t", "mode": "access",
+            "tagged_vlans": [{"vid": 523, "name": "mix-v523", "status": "active"}],
+        }}}
+        cs = self._plan(payload)
+        messages = cs["warnings"]["dcim.interface"]["tagged_vlans"]
+        self.assertEqual(len(messages), 1, messages)
+        self._apply(cs)
+        iface = Interface.objects.get(name="Gi1/0/22", device__name=dev["name"])
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    # --- P2-B: the orphan child nodes a drop leaves behind --------------------
+
+    def test_dropping_tagged_vlans_creates_no_orphan_vlan(self):
+        """A dropped nested reference takes its child node with it: no VLAN is manufactured."""
+        # Measured before the fix: planned non-noop ipam.vlan changes = [("create", 621)],
+        # apply 200, VLAN 621 present in NetBox afterwards while the interface had mode
+        # access and tagged_vlans count 0 -- the payload silently created a VLAN it could
+        # not use, and the warning claimed the field had been dropped.
+        from ipam.models import VLAN
+        payload = self._iface_payload(
+            name="Gi1/0/21", type="1000base-t", mode="access",
+            tagged_vlans=[{"vid": 621, "name": "p2b-orphan", "status": "active"}],
+        )
+        cs = self._plan(payload)
+        vlan_changes = [(c["change_type"], c.get("data", {}).get("vid"))
+                        for c in cs["changes"]
+                        if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(vlan_changes, [], vlan_changes)
+        self._apply(cs)
+        self.assertFalse(VLAN.objects.filter(vid=621).exists())
+        iface = Interface.objects.get(name="Gi1/0/21")
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        for quiet in range(1, 5):
+            self.assertEqual(self._plan(payload).get("changes", []), [],
+                             f"re-planned on quiet round {quiet}")
+
+    # --- over-pruning: three ways a dropped child is still needed -------------
+
+    def test_a_vlan_that_is_also_the_untagged_vlan_survives_the_drop(self):
+        """The same VLAN named as both untagged_vlan and a tagged VLAN is still created."""
+        from ipam.models import VLAN
+        payload = self._iface_payload(
+            name="Gi1/0/30", type="1000base-t", mode="access",
+            untagged_vlan={"vid": 632, "name": "keep-v632", "status": "active"},
+            tagged_vlans=[{"vid": 632, "name": "keep-v632", "status": "active"}],
+        )
+        self._converge(payload, "shared untagged/tagged VLAN")
+        self.assertTrue(VLAN.objects.filter(vid=632).exists())
+        iface = Interface.objects.get(name="Gi1/0/30")
+        self.assertEqual(iface.untagged_vlan.vid, 632)   # allowed by 'access' -> linked
+        self.assertEqual(iface.tagged_vlans.count(), 0)  # forbidden -> dropped
+
+    def test_a_shared_vlan_survives_a_drop_on_the_merged_node(self):
+        """After the merge one VLAN node is both untagged_vlan and a tagged VLAN: it survives."""
+        # This is the case a per-node reference count exists for. The outer node carries
+        # mode "access" and untagged_vlan 631; the nested duplicate carries tagged_vlans
+        # [631] and no mode. Fingerprint dedupe collapses the two VLAN nodes into ONE, so
+        # the merged interface points at that single node from both fields. Releasing the
+        # tagged_vlans edge must not release the untagged_vlan edge with it -- if it does,
+        # the node is pruned and untagged_vlan is left dangling.
+        from ipam.models import VLAN
+        dev = self._device()
+        dev_with_ip = dict(dev, primary_ip4={
+            "address": "10.9.31.31/24",
+            "assigned_object_interface": {
+                "device": dev, "name": "Gi1/0/31", "type": "1000base-t",
+                "tagged_vlans": [{"vid": 631, "name": "keep-v631", "status": "active"}],
+            },
+        })
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_with_ip, "name": "Gi1/0/31", "type": "1000base-t", "mode": "access",
+            "untagged_vlan": {"vid": 631, "name": "keep-v631", "status": "active"},
+        }}}
+        self._converge(payload, "shared VLAN node after merge")
+        self.assertTrue(VLAN.objects.filter(vid=631).exists())
+        iface = Interface.objects.get(name="Gi1/0/31", device__name=dev["name"])
+        self.assertEqual(iface.untagged_vlan.vid, 631)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_vlan_a_second_interface_still_tags_survives_the_drop(self):
+        """One VLAN node, two interfaces: the drop on one must not unmake it for the other."""
+        # Gi1/0/40 is named twice (outer node with mode "access", nested duplicate with
+        # tagged_vlans [641]) so the merged node loses tagged_vlans in the post-merge pass.
+        # Gi1/0/42, mode "tagged", legitimately tags the SAME VLAN, and dedupe gives both
+        # interfaces the same VLAN node. Pruning it would strand Gi1/0/42's reference.
+        from ipam.models import VLAN
+        dev = self._device()
+        vlan = {"vid": 641, "name": "keep-v641", "status": "active"}
+        dev_two = dict(
+            dev,
+            primary_ip4={
+                "address": "10.9.40.40/24",
+                "assigned_object_interface": {
+                    "device": dev, "name": "Gi1/0/40", "type": "1000base-t",
+                    "tagged_vlans": [dict(vlan)],
+                },
+            },
+            primary_ip6={
+                "address": "2001:db8:40::42/64",
+                "assigned_object_interface": {
+                    "device": dev, "name": "Gi1/0/42", "type": "1000base-t",
+                    "mode": "tagged", "tagged_vlans": [dict(vlan)],
+                },
+            },
+        )
+        payload = {"timestamp": 1, "object_type": "dcim.interface", "entity": {"interface": {
+            "device": dev_two, "name": "Gi1/0/40", "type": "1000base-t", "mode": "access",
+        }}}
+        self._converge(payload, "VLAN shared by a second interface")
+        self.assertTrue(VLAN.objects.filter(vid=641).exists())
+        dropped_from = Interface.objects.get(name="Gi1/0/40", device__name=dev["name"])
+        self.assertEqual(dropped_from.mode, "access")
+        self.assertEqual(dropped_from.tagged_vlans.count(), 0)
+        kept_by = Interface.objects.get(name="Gi1/0/42", device__name=dev["name"])
+        self.assertEqual([v.vid for v in kept_by.tagged_vlans.all()], [641])
+
+    # --- N-way: one interface arriving as N duplicate fragments ---------------
+
+    def _tagged_copy(self, name, vid, tag):
+        """A duplicate fragment of ``name`` carrying one forbidden tagged VLAN."""
+        return {"device": self._device(), "name": name, "type": "1000base-t",
+                "tagged_vlans": [{"vid": vid, "name": f"{tag}-v{vid}", "status": "active"}]}
+
+    def _fragmented_payload(self, name, tag, octet, vids, driver_last=False):
+        """
+        One interface reached several times in a single payload.
+
+        Each nested copy hangs off a different device IP assignment and carries a
+        DIFFERENT forbidden tagged VLAN, so every merge is a fresh contradiction for the
+        policy to settle. ``driver_last`` moves mode "access" off the root fragment and
+        onto one more nested copy, so the driver value arrives only after the duplicates
+        have already disagreed.
+        """
+        copies = [self._tagged_copy(name, vid, tag) for vid in vids]
+        if driver_last:
+            copies.append({"device": self._device(), "name": name,
+                           "type": "1000base-t", "mode": "access"})
+        assert 2 <= len(copies) <= 4
+        addresses = [f"10.9.{octet}.10/24", f"2001:db8:{octet}::11/64",
+                     f"10.9.{octet}.12/24", f"10.9.{octet}.13/24"]
+        ips = [{"address": address, "assigned_object_interface": copy}
+               for address, copy in zip(addresses, copies, strict=False)]
+        dev = dict(self._device())
+        dev["primary_ip4"], dev["primary_ip6"] = ips[0], ips[1]
+        if len(ips) > 2:
+            dev["oob_ip"] = ips[2]
+        if len(ips) > 3:
+            dev["primary_ip4"]["nat_inside"] = ips[3]
+        root = {"device": dev, "name": name, "type": "1000base-t"}
+        if not driver_last:
+            root["mode"] = "access"
+        return {"timestamp": 1, "object_type": "dcim.interface",
+                "entity": {"interface": root}}
+
+    def _assert_fragments_converge(self, name, tag, octet, vids, driver_last=False):
+        """Plan, apply and re-plan a fragmented payload; assert one drop and no VLANs."""
+        from ipam.models import VLAN
+        payload = self._fragmented_payload(name, tag, octet, vids, driver_last)
+        cs = self._plan(payload)
+        iface_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.interface"]
+        self.assertTrue(iface_changes)
+        for change in iface_changes:
+            self.assertNotIn("tagged_vlans", change.get("data", {}))
+        messages = cs.get("warnings", {}).get("dcim.interface", {}).get("tagged_vlans")
+        self.assertEqual(len(messages or []), 1, messages)
+        vlan_changes = [(c["change_type"], c.get("data", {}).get("vid"))
+                        for c in cs["changes"]
+                        if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(vlan_changes, [], vlan_changes)
+        self._converge(payload, f"fragments of {name}")
+        iface = Interface.objects.get(name=name, device__name=self._device()["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+        self.assertFalse(VLAN.objects.filter(vid__in=vids).exists())
+
+    def test_three_fragments_of_one_interface_still_let_the_driver_win(self):
+        """Root + two nested copies, each with a different forbidden VLAN: still one access iface."""
+        # This is the shape a pass on each side of dedupe could not settle. The root
+        # fragment has no forbidden field and the nested copies have no submitted mode, so
+        # the pre-dedupe pass drops nothing; dedupe merged root + copy 1 into the
+        # contradiction and the SECOND copy's different tagged_vlans then conflicted inside
+        # _merge_nodes, rejecting the whole entity before the mode was ever considered.
+        # One interface really can be reached three times: as the entity, as primary_ip4's
+        # assigned interface, and as primary_ip6's.
+        self._assert_fragments_converge("Gi2/0/3", "n3", 63, [701, 702])
+
+    def test_four_fragments_of_one_interface_still_let_the_driver_win(self):
+        """A fourth copy, via the device's oob_ip, changes nothing."""
+        self._assert_fragments_converge("Gi2/0/4", "n4", 64, [711, 712, 713])
+
+    def test_five_fragments_of_one_interface_still_let_the_driver_win(self):
+        """A fifth copy, via primary_ip4's nat_inside, changes nothing either."""
+        self._assert_fragments_converge("Gi2/0/5", "n5", 65, [721, 722, 723, 724])
+
+    def test_reordering_the_same_fragments_does_not_change_the_outcome(self):
+        """The forbidden values swapped between fragments plan and converge identically."""
+        # Representation independence is the property under test: the same logical
+        # fragments in a different order must not produce a different answer.
+        self._assert_fragments_converge("Gi2/0/6", "n6", 66, [733, 732, 731])
+
+    def test_the_driver_fragment_arriving_last_still_wins(self):
+        """The mode arrives only after two duplicates have already disagreed."""
+        # Measured on the incremental normalization alone: the two tagged-only copies
+        # merge first, _merge_nodes rejects the second one's different tagged_vlans, and
+        # the fragment carrying mode "access" is never reached -- a 400 that depends
+        # purely on which copy the payload happened to nest first. Holding a conflict on
+        # a droppable field until the graph is merged is what removes that dependency.
+        self._assert_fragments_converge("Gi2/0/7", "n7", 67, [741, 742], driver_last=True)
+
+    def test_the_driver_fragment_arriving_last_of_five_still_wins(self):
+        """Three disagreeing copies, then the mode: still one access interface."""
+        self._assert_fragments_converge("Gi2/0/8", "n8", 68, [751, 752, 753],
+                                        driver_last=True)
+
+    def _shared_vlan_fragment_payload(self, name, octet, field, untagged, keep, reject):
+        """
+        Fragments of one interface where the survivor's VLAN is needed twice.
+
+        ``field`` is the forbidden field the copies split; the first copy also points
+        ``untagged_vlan`` at the same VLAN, which mode "access" permits, so dropping
+        ``field`` releases no edge of its own.
+        """
+        def copy(**extra):
+            return {"device": self._device(), "name": name, "type": "1000base-t", **extra}
+
+        dev = dict(self._device())
+        dev["primary_ip4"] = {
+            "address": f"10.6.{octet}.10/24",
+            "assigned_object_interface": copy(untagged_vlan=untagged, **{field: keep}),
+        }
+        dev["primary_ip6"] = {
+            "address": f"2001:db8:6{octet}::11/64",
+            "assigned_object_interface": copy(**{field: reject}),
+        }
+        dev["oob_ip"] = {
+            "address": f"10.6.{octet}.12/24",
+            "assigned_object_interface": copy(mode="access"),
+        }
+        return {"timestamp": 1, "object_type": "dcim.interface", "entity": {
+            "interface": {"device": dev, "name": name, "type": "1000base-t"}}}
+
+    def _assert_rejected_vlan_is_never_created(self, name, octet, field, keep_vid, reject_vid):
+        """The VLAN only a REJECTED duplicate value referenced must not be created."""
+        from ipam.models import VLAN
+        keep = {"vid": keep_vid, "name": f"rej-v{keep_vid}", "status": "active"}
+        reject = {"vid": reject_vid, "name": f"rej-v{reject_vid}", "status": "active"}
+        many = field == "tagged_vlans"
+        payload = self._shared_vlan_fragment_payload(
+            name, octet, field, dict(keep),
+            [dict(keep)] if many else dict(keep),
+            [dict(reject)] if many else dict(reject),
+        )
+        cs = self._plan(payload)
+        planned = [c.get("data", {}).get("vid") for c in cs["changes"]
+                   if c["object_type"] == "ipam.vlan" and c["change_type"] != "noop"]
+        self.assertEqual(planned, [keep_vid], planned)
+        self._converge(payload, f"a rejected duplicate's {field}")
+        self.assertTrue(VLAN.objects.filter(vid=keep_vid).exists())
+        self.assertFalse(VLAN.objects.filter(vid=reject_vid).exists())
+        iface = Interface.objects.get(name=name, device__name=self._device()["name"])
+        self.assertEqual(iface.mode, "access")
+        self.assertEqual(iface.untagged_vlan.vid, keep_vid)
+        self.assertEqual(iface.tagged_vlans.count(), 0)
+
+    def test_a_rejected_duplicates_tagged_vlan_is_never_created(self):
+        """The survivor is also the untagged VLAN, so only the merge released an edge."""
+        # Without the merge's release reaching the prune gate the change set still plans
+        # a create for the rejected copy's VLAN: the interface comes out correct while an
+        # extra VLAN is manufactured out of a value nothing kept.
+        self._assert_rejected_vlan_is_never_created("Gi3/0/1", 71, "tagged_vlans", 671, 672)
+
+    def test_a_rejected_duplicates_qinq_svlan_is_never_created(self):
+        """The same shape on a different forbidden field the interface policy drops."""
+        self._assert_rejected_vlan_is_never_created("Gi3/0/2", 72, "qinq_svlan", 681, 682)
+
+    def test_an_ipam_vlan_ingested_in_its_own_right_is_untouched(self):
+        """A VLAN that is the entity's own primary object is never pruned."""
+        from ipam.models import VLAN
+        payload = {"timestamp": 1, "object_type": "ipam.vlan", "entity": {"vlan": {
+            "vid": 651, "name": "own-right-v651", "status": "active",
+            "group": {"name": "own-right-group", "slug": "own-right-group"},
+        }}}
+        self._converge(payload, "ipam.vlan on its own")
+        vlan = VLAN.objects.get(vid=651, name="own-right-v651")
+        self.assertEqual(vlan.group.name, "own-right-group")

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_matcher_cache.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_matcher_cache.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Matcher Cache Tests."""
+
+from unittest import mock
+
+from dcim.models import Manufacturer
+from django.core.cache import cache as django_cache
+from django.test import TestCase
+
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.matcher import (
+    _find_obj_cache_key,
+    _find_obj_rev_key,
+    find_existing_object,
+    invalidate_find_obj_entry,
+)
+
+
+class FindObjCacheKeyTestCase(TestCase):
+    """Tests for _find_obj_cache_key."""
+
+    def setUp(self):
+        """Clear cache before each test."""
+        django_cache.clear()
+
+    def tearDown(self):
+        """Clear cache after each test."""
+        django_cache.clear()
+
+    def test_simple_scalar_fields(self):
+        """Cache key is generated for data with simple scalar fields."""
+        data = {"name": "Cisco", "_object_type": "dcim.manufacturer", "_uuid": "abc"}
+        key = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertIsNotNone(key)
+        self.assertTrue(key.startswith("diode:fobj:"))
+
+    def test_deterministic(self):
+        """Same data produces same cache key."""
+        data = {"name": "Cisco", "_object_type": "dcim.manufacturer"}
+        key1 = _find_obj_cache_key(data, "dcim.manufacturer")
+        key2 = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertEqual(key1, key2)
+
+    def test_different_data_different_keys(self):
+        """Different data produces different cache keys."""
+        key1 = _find_obj_cache_key({"name": "Cisco"}, "dcim.manufacturer")
+        key2 = _find_obj_cache_key({"name": "Juniper"}, "dcim.manufacturer")
+        self.assertNotEqual(key1, key2)
+
+    def test_different_object_type_different_keys(self):
+        """Same data with different object types produces different cache keys."""
+        data = {"name": "test"}
+        key1 = _find_obj_cache_key(data, "dcim.manufacturer")
+        key2 = _find_obj_cache_key(data, "dcim.site")
+        self.assertNotEqual(key1, key2)
+
+    def test_skips_underscore_prefixed_fields(self):
+        """Fields starting with _ are excluded from cache key."""
+        data1 = {"name": "Cisco", "_object_type": "dcim.manufacturer", "_uuid": "abc"}
+        data2 = {"name": "Cisco", "_object_type": "dcim.manufacturer", "_uuid": "xyz"}
+        key1 = _find_obj_cache_key(data1, "dcim.manufacturer")
+        key2 = _find_obj_cache_key(data2, "dcim.manufacturer")
+        self.assertEqual(key1, key2)
+
+    def test_skips_dicts_and_lists(self):
+        """Dicts and lists are skipped, not rejected."""
+        data_with_list = {"name": "DC-1", "tags": [1, 2, 3]}
+        data_without_list = {"name": "DC-1"}
+        key1 = _find_obj_cache_key(data_with_list, "dcim.site")
+        key2 = _find_obj_cache_key(data_without_list, "dcim.site")
+        self.assertIsNotNone(key1)
+        self.assertEqual(key1, key2)
+
+    def test_unresolved_reference_encoded(self):
+        """UnresolvedReferences are encoded deterministically."""
+        ref = UnresolvedReference("dcim.site", "uuid-123")
+        data = {"name": "device-1", "site_id": ref}
+        key = _find_obj_cache_key(data, "dcim.device")
+        self.assertIsNotNone(key)
+
+    def test_unresolved_reference_same_type_same_key(self):
+        """Different UUIDs for same object type produce the same key."""
+        data1 = {"name": "device-1", "site_id": UnresolvedReference("dcim.site", "uuid-1")}
+        data2 = {"name": "device-1", "site_id": UnresolvedReference("dcim.site", "uuid-2")}
+        key1 = _find_obj_cache_key(data1, "dcim.device")
+        key2 = _find_obj_cache_key(data2, "dcim.device")
+        self.assertEqual(key1, key2)
+
+    def test_unresolved_reference_different_type_different_key(self):
+        """Different unresolved object types produce different keys."""
+        data1 = {"name": "x", "ref_id": UnresolvedReference("dcim.site", "uuid-1")}
+        data2 = {"name": "x", "ref_id": UnresolvedReference("dcim.region", "uuid-1")}
+        key1 = _find_obj_cache_key(data1, "dcim.device")
+        key2 = _find_obj_cache_key(data2, "dcim.device")
+        self.assertNotEqual(key1, key2)
+
+    def test_empty_items_returns_none(self):
+        """Returns None when no cacheable fields exist."""
+        data = {"_uuid": "abc", "_object_type": "dcim.site"}
+        key = _find_obj_cache_key(data, "dcim.site")
+        self.assertIsNone(key)
+
+    def test_only_complex_fields_returns_none(self):
+        """Returns None when only dicts/lists remain after filtering."""
+        data = {"tags": [1, 2], "metadata": {"a": 1}, "_uuid": "abc"}
+        key = _find_obj_cache_key(data, "dcim.site")
+        self.assertIsNone(key)
+
+
+class FindExistingObjectCacheTestCase(TestCase):
+    """Tests for find_existing_object caching behavior."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.manufacturer = Manufacturer.objects.create(
+            name="CacheTestManufacturer",
+            slug="cache-test-manufacturer",
+        )
+        django_cache.clear()
+
+    def tearDown(self):
+        """Clean up cache after each test."""
+        django_cache.clear()
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_cache_miss_populates_cache_on_found(self, _mock_ttl):
+        """First lookup misses cache, finds object, and populates cache."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+
+        self.assertIsNone(django_cache.get(cache_key))
+
+        result = find_existing_object(data, "dcim.manufacturer")
+        self.assertEqual(result.id, self.manufacturer.id)
+
+        # Lookup cache should contain the PK
+        self.assertEqual(django_cache.get(cache_key), self.manufacturer.id)
+
+        # Reverse index should point back to the lookup key
+        rev_key = f"diode:fobj:rev:dcim.manufacturer:{self.manufacturer.id}"
+        self.assertEqual(django_cache.get(rev_key), cache_key)
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_not_found_is_not_cached(self, _mock_ttl):
+        """Not-found results are not cached."""
+        data = {"name": "NonExistent", "_object_type": "dcim.manufacturer"}
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+
+        result = find_existing_object(data, "dcim.manufacturer")
+        self.assertIsNone(result)
+        self.assertIsNone(django_cache.get(cache_key))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_cache_hit_returns_found_object(self, _mock_ttl):
+        """Second lookup hits cache and returns object via PK."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # First call populates cache
+        result1 = find_existing_object(data, "dcim.manufacturer")
+        self.assertEqual(result1.id, self.manufacturer.id)
+
+        # Second call should hit cache
+        with mock.patch(
+            "netbox_diode_plugin.api.matcher.get_model_matchers"
+        ) as mock_matchers:
+            result2 = find_existing_object(data, "dcim.manufacturer")
+            self.assertEqual(result2.id, self.manufacturer.id)
+            mock_matchers.assert_not_called()
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_stale_cache_object_deleted(self, _mock_ttl):
+        """Cached PK for a deleted object falls through to full matcher lookup."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # Populate cache
+        find_existing_object(data, "dcim.manufacturer")
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertEqual(django_cache.get(cache_key), self.manufacturer.id)
+
+        # Delete the object
+        self.manufacturer.delete()
+
+        # Should fall through to matchers, find nothing
+        result = find_existing_object(data, "dcim.manufacturer")
+        self.assertIsNone(result)
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=0,
+    )
+    def test_cache_disabled_when_ttl_zero(self, _mock_ttl):
+        """Cache is bypassed when TTL is 0."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+
+        result = find_existing_object(data, "dcim.manufacturer")
+        self.assertEqual(result.id, self.manufacturer.id)
+        self.assertIsNone(django_cache.get(cache_key))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_deletes_cached_entry(self, _mock_ttl):
+        """Invalidating by PK deletes both lookup and reverse cache entries."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # Populate cache
+        find_existing_object(data, "dcim.manufacturer")
+        cache_key = _find_obj_cache_key(data, "dcim.manufacturer")
+        rev_key = f"diode:fobj:rev:dcim.manufacturer:{self.manufacturer.id}"
+        self.assertIsNotNone(django_cache.get(cache_key))
+        self.assertIsNotNone(django_cache.get(rev_key))
+
+        # Invalidate
+        invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+
+        # Both entries should be gone
+        self.assertIsNone(django_cache.get(cache_key))
+        self.assertIsNone(django_cache.get(rev_key))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_causes_cache_miss_on_next_lookup(self, _mock_ttl):
+        """After invalidation, next lookup goes through matchers."""
+        data = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # Populate cache
+        find_existing_object(data, "dcim.manufacturer")
+
+        # Invalidate
+        invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+
+        # Next lookup should miss cache and go through matchers
+        with mock.patch(
+            "netbox_diode_plugin.api.matcher.get_model_matchers",
+            wraps=__import__(
+                "netbox_diode_plugin.api.matcher", fromlist=["get_model_matchers"]
+            ).get_model_matchers,
+        ) as mock_matchers:
+            result = find_existing_object(data, "dcim.manufacturer")
+            self.assertEqual(result.id, self.manufacturer.id)
+            mock_matchers.assert_called_once()
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_noop_for_uncached_pk(self, _mock_ttl):
+        """Invalidating a PK that was never cached is a no-op."""
+        # Should not raise
+        invalidate_find_obj_entry("dcim.manufacturer", 999999)
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_does_not_affect_other_entries(self, _mock_ttl):
+        """Invalidating one object does not affect other cached objects."""
+        other_mfr = Manufacturer.objects.create(
+            name="OtherManufacturer",
+            slug="other-manufacturer",
+        )
+        data_main = {"name": "CacheTestManufacturer", "_object_type": "dcim.manufacturer"}
+        data_other = {"name": "OtherManufacturer", "_object_type": "dcim.manufacturer"}
+
+        # Populate cache for both
+        find_existing_object(data_main, "dcim.manufacturer")
+        find_existing_object(data_other, "dcim.manufacturer")
+
+        # Invalidate only the main one
+        invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+
+        # Other should still be cached
+        cache_key_other = _find_obj_cache_key(data_other, "dcim.manufacturer")
+        self.assertEqual(django_cache.get(cache_key_other), other_mfr.id)
+
+        # Main should be gone
+        cache_key_main = _find_obj_cache_key(data_main, "dcim.manufacturer")
+        self.assertIsNone(django_cache.get(cache_key_main))
+
+
+BRANCH_SCHEMA_MOCK = "netbox_diode_plugin.api.matcher._get_active_branch_schema"
+
+
+class BranchAwareCacheKeyTestCase(TestCase):
+    """Tests that cache keys are isolated per branch."""
+
+    def setUp(self):
+        """Clear cache before each test."""
+        django_cache.clear()
+
+    def tearDown(self):
+        """Clear cache after each test."""
+        django_cache.clear()
+
+    def test_different_branch_different_cache_key(self):
+        """Same data under different branches produces different cache keys."""
+        data = {"name": "Cisco"}
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            key_a = _find_obj_cache_key(data, "dcim.manufacturer")
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_b"):
+            key_b = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertNotEqual(key_a, key_b)
+
+    def test_same_branch_same_cache_key(self):
+        """Same data under the same branch produces identical cache keys."""
+        data = {"name": "Cisco"}
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            key1 = _find_obj_cache_key(data, "dcim.manufacturer")
+            key2 = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertEqual(key1, key2)
+
+    def test_no_branch_unchanged_from_legacy_format(self):
+        """Without active branch, cache key matches the original format."""
+        data = {"name": "Cisco"}
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            key = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertTrue(key.startswith("diode:fobj:"))
+
+    def test_branch_vs_no_branch_different_keys(self):
+        """A branched key differs from a non-branched key for the same data."""
+        data = {"name": "Cisco"}
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            key_main = _find_obj_cache_key(data, "dcim.manufacturer")
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            key_branch = _find_obj_cache_key(data, "dcim.manufacturer")
+        self.assertNotEqual(key_main, key_branch)
+
+    def test_different_branch_different_rev_key(self):
+        """Reverse-index keys are isolated per branch."""
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            rev_a = _find_obj_rev_key("dcim.manufacturer", 100)
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_b"):
+            rev_b = _find_obj_rev_key("dcim.manufacturer", 100)
+        self.assertNotEqual(rev_a, rev_b)
+        self.assertIn("branch_a", rev_a)
+        self.assertIn("branch_b", rev_b)
+
+    def test_no_branch_rev_key_unchanged(self):
+        """Without active branch, rev key matches the original format."""
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            rev = _find_obj_rev_key("dcim.manufacturer", 100)
+        self.assertEqual(rev, "diode:fobj:rev:dcim.manufacturer:100")
+
+
+class BranchAwareFindExistingObjectTestCase(TestCase):
+    """Tests that find_existing_object cache does not cross branches."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.manufacturer = Manufacturer.objects.create(
+            name="BranchTestMfr",
+            slug="branch-test-mfr",
+        )
+        django_cache.clear()
+
+    def tearDown(self):
+        """Clean up cache after each test."""
+        django_cache.clear()
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_cache_does_not_cross_branches(self, _mock_ttl):
+        """Cache populated under branch A is a miss under branch B."""
+        data = {"name": "BranchTestMfr", "_object_type": "dcim.manufacturer"}
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            result_a = find_existing_object(data, "dcim.manufacturer")
+            self.assertEqual(result_a.id, self.manufacturer.id)
+            cache_key_a = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNotNone(django_cache.get(cache_key_a))
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_b"):
+            cache_key_b = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNone(django_cache.get(cache_key_b))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_does_not_cross_branches(self, _mock_ttl):
+        """Invalidation under branch B does not evict branch A's cache."""
+        data = {"name": "BranchTestMfr", "_object_type": "dcim.manufacturer"}
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            find_existing_object(data, "dcim.manufacturer")
+            cache_key_a = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNotNone(django_cache.get(cache_key_a))
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_b"):
+            invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            self.assertIsNotNone(django_cache.get(cache_key_a))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_invalidate_within_same_branch(self, _mock_ttl):
+        """Invalidation under the same branch correctly evicts cache."""
+        data = {"name": "BranchTestMfr", "_object_type": "dcim.manufacturer"}
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            find_existing_object(data, "dcim.manufacturer")
+            cache_key_a = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNotNone(django_cache.get(cache_key_a))
+            invalidate_find_obj_entry("dcim.manufacturer", self.manufacturer.id)
+            self.assertIsNone(django_cache.get(cache_key_a))
+
+    @mock.patch(
+        "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl",
+        return_value=5,
+    )
+    def test_branch_and_main_caches_independent(self, _mock_ttl):
+        """Cache entries for main (no branch) and a branch are independent."""
+        data = {"name": "BranchTestMfr", "_object_type": "dcim.manufacturer"}
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            find_existing_object(data, "dcim.manufacturer")
+            cache_key_main = _find_obj_cache_key(data, "dcim.manufacturer")
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value="branch_a"):
+            cache_key_branch = _find_obj_cache_key(data, "dcim.manufacturer")
+            self.assertIsNone(django_cache.get(cache_key_branch))
+
+        with mock.patch(BRANCH_SCHEMA_MOCK, return_value=None):
+            self.assertIsNotNone(django_cache.get(cache_key_main))

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_matcher_none_guard.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_matcher_none_guard.py
@@ -1,0 +1,138 @@
+"""Unit tests for the all-None matcher guard and None-safe data preparation."""
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    MACAddress,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleType,
+    Rack,
+    Site,
+    VirtualChassis,
+)
+from django.test import TestCase
+
+from netbox_diode_plugin.api.matcher import find_existing_object, fingerprints, get_model_matchers
+
+
+def _matcher(model_class, name, predicate=None):
+    """
+    Return the matcher registered under the given name.
+
+    Some object types register more than one matcher under the same
+    name (e.g. dcim.macaddress's parented vs. isnull variants both use
+    "logical_mac_address_within_parent"). Pass a predicate to select
+    among same-named matches; otherwise the first match wins.
+    """
+    matches = [m for m in get_model_matchers(model_class) if getattr(m, "name", None) == name]
+    if predicate is not None:
+        matches = [m for m in matches if predicate(m)]
+    if not matches:
+        raise AssertionError(f"matcher {name} not found")
+    return matches[0]
+
+
+def _is_isnull_true_variant(m):
+    """True if the matcher's condition is a single field__isnull=True check."""
+    condition = getattr(m, "condition", None)
+    children = getattr(condition, "children", None)
+    if not children:
+        return False
+    return any(str(k).endswith("__isnull") and v is True for k, v in children)
+
+
+class AllNoneGuardTests(TestCase):
+    """All-None lookups must skip the matcher; partial nulls keep matching."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed rows that today's NULL-lookup hijacks would wrongly bind."""
+        cls.site = Site.objects.create(name="ng-site", slug="ng-site")
+        mfr = Manufacturer.objects.create(name="ng-mfr", slug="ng-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="ng-dt", slug="ng-dt")
+        role = DeviceRole.objects.create(name="ng-role", slug="ng-role")
+        cls.dev = Device.objects.create(name="ng-dev", site=cls.site, device_type=cls.dt, role=role)
+        cls.mt = ModuleType.objects.create(manufacturer=mfr, model="ng-mt")
+        bay = ModuleBay.objects.create(device=cls.dev, name="ng-bay1")
+        # a module with NULL asset_tag — the row the unguarded matcher hijacks
+        cls.module = Module.objects.create(device=cls.dev, module_bay=bay, module_type=cls.mt)
+        # a masterless VC named differently from any payload below
+        cls.vc = VirtualChassis.objects.create(name="ng-vc-existing")
+        # a rack with NULL location — the multi-field clear-FK dedupe case
+        cls.rack = Rack.objects.create(name="ng-rack", site=cls.site)
+
+    def test_single_field_null_lookup_skips_matcher(self):
+        """asset_tag: None must not bind the NULL-asset_tag module."""
+        m = _matcher(Module, "unique_asset_tag")
+        self.assertIsNone(m.build_queryset({"asset_tag": None}))
+        self.assertIsNone(m.fingerprint({"asset_tag": None}))
+
+    def test_unique_master_null_lookup_skips_matcher(self):
+        """master: None must not bind an arbitrary masterless VC (any name)."""
+        found = find_existing_object(
+            {"name": "ng-vc-DIFFERENT", "master": None}, "dcim.virtualchassis"
+        )
+        self.assertIsNone(found)
+
+    def test_partial_null_multi_field_still_matches(self):
+        """Rack (location: None, name) keeps today's clear-FK dedupe."""
+        found = find_existing_object(
+            {"name": "ng-rack", "site": self.site.pk, "location": None}, "dcim.rack"
+        )
+        self.assertEqual(found, self.rack)
+
+    def test_macaddress_isnull_variant_matches_without_crash(self):
+        """Explicit-null assignment matches by MAC via the isnull variant."""
+        mac = MACAddress.objects.create(mac_address="00:11:22:33:44:55")
+        found = find_existing_object(
+            {
+                "mac_address": "00:11:22:33:44:55",
+                "assigned_object_type": None,
+                "assigned_object_id": None,
+            },
+            "dcim.macaddress",
+        )
+        self.assertEqual(found, mac)
+
+    def test_condition_scoped_null_matchers_survive(self):
+        """VM name/cluster-null style matchers still work under the guard."""
+        from virtualization.models import VirtualMachine
+        vm = VirtualMachine.objects.create(name="ng-vm")
+        found = find_existing_object({"name": "ng-vm"}, "virtualization.virtualmachine")
+        self.assertEqual(found, vm)
+
+    def test_gfk_null_payload_does_not_raise(self):
+        """Cleared generic refs must not 500 the matcher loop."""
+        found = find_existing_object(
+            {"name": "ng-cluster-x", "scope_type": None, "scope_id": None},
+            "virtualization.cluster",
+        )
+        self.assertIsNone(found)  # no such cluster; the point is: no exception
+
+    def test_none_keyed_fingerprint_fusion_removed(self):
+        """Two null-asset_tag modules in different bays share NO fingerprint."""
+        a = {"device": self.dev.pk, "module_bay": 1, "module_type": self.mt.pk, "asset_tag": None}
+        b = {"device": self.dev.pk, "module_bay": 2, "module_type": self.mt.pk, "asset_tag": None}
+        shared = set(fingerprints(a, "dcim.module")) & set(fingerprints(b, "dcim.module"))
+        self.assertEqual(shared, set(), shared)
+
+    def test_partial_null_fingerprint_preserved(self):
+        """A partial-null fingerprint must survive (all-None, not any-None, skips)."""
+        m = _matcher(
+            MACAddress,
+            "logical_mac_address_within_parent",
+            predicate=_is_isnull_true_variant,
+        )
+        fp = m.fingerprint({
+            "mac_address": "00:11:22:33:44:66",
+            "assigned_object_type": None,
+            "assigned_object_id": None,
+        })
+        self.assertIsNotNone(fp)
+
+    def test_insensitive_ref_none_fingerprint_does_not_raise(self):
+        """A None value in a case-insensitive ref must not crash fingerprinting."""
+        fps = fingerprints({"name": None, "site": self.site.pk, "tenant": None}, "dcim.device")
+        self.assertIsInstance(fps, list)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_models.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_models.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+from unittest import mock
+
+from django.apps import apps
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from netbox_diode_plugin.models import Setting
+
+
+class SettingModelTestCase(TestCase):
+    """Test case for the models."""
+
+    def test_validators(self):
+        """Check Setting model field validators are functional."""
+        setting = Setting(diode_target="http://localhost:8080")
+
+        with self.assertRaises(ValidationError):
+            setting.clean_fields()
+
+    def test_str(self):
+        """Check Setting model string representation."""
+        setting = Setting(diode_target="http://localhost:8080")
+        self.assertEqual(str(setting), "")
+
+    def test_absolute_url(self):
+        """Check Setting model absolute URL."""
+        setting = Setting()
+        self.assertEqual(setting.get_absolute_url(), "/netbox/plugins/diode/settings/")
+
+    def test_branch_id_field_exists(self):
+        """Check Setting model has branch_id field."""
+        setting = Setting(diode_target="grpc://localhost:8080/diode")
+        self.assertIsNone(setting.branch_id)
+
+        # Set branch_id
+        setting.branch_id = 123
+        self.assertEqual(setting.branch_id, 123)
+
+    def test_branch_property_returns_none_when_no_branch_id(self):
+        """Check branch property returns None when branch_id is not set."""
+        setting = Setting(diode_target="grpc://localhost:8080/diode")
+        self.assertIsNone(setting.branch)
+
+    def test_branch_property_returns_none_when_plugin_not_installed(self):
+        """Check branch property returns None when branching plugin is not installed."""
+        setting = Setting(diode_target="grpc://localhost:8080/diode", branch_id=123)
+
+        # Mock the import to simulate plugin not being available
+        with mock.patch.dict('sys.modules', {'netbox_branching.models': None}):
+            self.assertIsNone(setting.branch)
+
+    def test_branch_property_returns_branch_when_available(self):
+        """Check branch property returns Branch object when available."""
+        if not apps.is_installed("netbox_branching"):
+            self.skipTest("netbox_branching plugin not installed")
+
+        from netbox_branching.models import Branch
+
+        # Create a test branch
+        branch = Branch.objects.create(name="test-branch")
+
+        setting = Setting(diode_target="grpc://localhost:8080/diode", branch_id=branch.id)
+
+        # Check branch property returns the correct branch
+        self.assertEqual(setting.branch.id, branch.id)
+        self.assertEqual(setting.branch.name, "test-branch")
+
+        # Clean up
+        branch.delete()
+
+    def test_branch_setter(self):
+        """Check branch setter updates branch_id."""
+        if not apps.is_installed("netbox_branching"):
+            self.skipTest("netbox_branching plugin not installed")
+
+        from netbox_branching.models import Branch
+
+        # Create a test branch
+        branch = Branch.objects.create(name="test-branch-setter")
+
+        setting = Setting(diode_target="grpc://localhost:8080/diode")
+
+        # Use setter to assign branch
+        setting.branch = branch
+        self.assertEqual(setting.branch_id, branch.id)
+
+        # Set to None
+        setting.branch = None
+        self.assertIsNone(setting.branch_id)
+
+        # Clean up
+        branch.delete()
+
+    def test_branch_schema_id_property(self):
+        """Check branch_schema_id property returns schema_id when branch is set."""
+        if not apps.is_installed("netbox_branching"):
+            self.skipTest("netbox_branching plugin not installed")
+
+        from netbox_branching.models import Branch
+
+        # Create a test branch
+        branch = Branch.objects.create(name="test-branch-schema")
+
+        setting = Setting(diode_target="grpc://localhost:8080/diode", branch_id=branch.id)
+
+        # Check branch_schema_id returns the schema_id
+        self.assertEqual(setting.branch_schema_id, branch.schema_id)
+
+        # Check it returns None when no branch
+        setting.branch_id = None
+        self.assertIsNone(setting.branch_schema_id)
+
+        # Clean up
+        branch.delete()

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_module_adoption.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_module_adoption.py
@@ -1,0 +1,1409 @@
+"""E2E: module/module-bay ingest shapes — create adoption, and the installed_module reverse side."""
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from core.models import ObjectChange, ObjectType
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Module, ModuleBay, ModuleType, Site
+from django.test import SimpleTestCase, TestCase
+from extras.choices import CustomFieldTypeChoices
+from extras.models import CustomField
+from rest_framework import serializers
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api import transformer
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class ModuleAdoptionE2ETests(APITestCase):
+    """Plan-ahead duplicate module CREATEs must adopt, not discard or crash."""
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.site = Site.objects.create(name="ma-site", slug="ma-site")
+        mfr = Manufacturer.objects.create(name="ma-mfr", slug="ma-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="ma-dt", slug="ma-dt")
+        self.role = DeviceRole.objects.create(name="ma-role", slug="ma-role")
+        self.mt = ModuleType.objects.create(manufacturer=mfr, model="ma-linecard")
+        self.dev = Device.objects.create(
+            name="ma-rtr", site=self.site, device_type=self.dt, role=self.role
+        )
+        self.bay = ModuleBay.objects.create(device=self.dev, name="ma-bay1")
+
+    def _dev_ref(self):
+        return {"name": "ma-rtr", "site": {"name": "ma-site"}}
+
+    def _module_entity(self, extra=None):
+        entity = {
+            "device": self._dev_ref(),
+            "module_bay": {"name": "ma-bay1", "device": self._dev_ref()},
+            "module_type": {"manufacturer": {"name": "ma-mfr"}, "model": "ma-linecard"},
+            "status": "active",
+        }
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "dcim.module", "entity": {"module": entity}}
+
+    def _subbay_entity(self):
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "ma-sub1",
+            "module": {
+                "device": self._dev_ref(),
+                "module_bay": {"name": "ma-bay1", "device": self._dev_ref()},
+                "module_type": {"manufacturer": {"name": "ma-mfr"}, "model": "ma-linecard"},
+            },
+        }}}
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIn("change_set", r.json(), r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def test_plan_ahead_duplicate_adopts_and_applies_payload(self):
+        """Both changesets planned before either apply: adopt, don't discard."""
+        cs_a = self._diff(self._module_entity())
+        # round B diverges on serial — the load-bearing lossiness probe
+        cs_b = self._diff(self._subbay_entity())
+        cs_a2 = self._diff(self._module_entity({"serial": "SER-B99"}))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+        self._apply(cs_a2)
+
+        modules = Module.objects.filter(module_bay=self.bay)
+        self.assertEqual(modules.count(), 1)
+        module = modules.first()
+        self.assertEqual(module.serial, "SER-B99")  # applied, not discarded
+        sub = ModuleBay.objects.get(name="ma-sub1")
+        self.assertEqual(sub.module_id, module.pk)  # nesting restored
+
+        # converged: re-plan of both entities is empty
+        for payload in (self._module_entity({"serial": "SER-B99"}), self._subbay_entity()):
+            cs = self._diff(payload)
+            non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+            self.assertEqual(non_noop, [], non_noop)
+
+    def test_null_asset_tag_create_does_not_relocate(self):
+        """The hazard pin: asset_tag null must not adopt an unrelated module."""
+        other_dev = Device.objects.create(
+            name="ma-other", site=self.site, device_type=self.dt, role=self.role
+        )
+        other_bay = ModuleBay.objects.create(device=other_dev, name="ma-obay")
+        other_module = Module.objects.create(
+            device=other_dev, module_bay=other_bay, module_type=self.mt
+        )
+        cs = self._diff(self._module_entity({"asset_tag": None}))
+        self._apply(cs)
+        other_module.refresh_from_db()
+        self.assertEqual(other_module.device_id, other_dev.pk)  # untouched
+        self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)
+
+    def test_occupied_bay_update_last_writer_wins(self):
+        """A planned UPDATE on an occupied bay applies last-writer-wins module_type."""
+        Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
+        mt2 = ModuleType.objects.create(
+            manufacturer=Manufacturer.objects.get(name="ma-mfr"), model="ma-linecard-v2"
+        )
+        payload = self._module_entity()
+        payload["entity"]["module"]["module_type"]["model"] = "ma-linecard-v2"
+        cs = self._diff(payload)
+        self._apply(cs)
+        modules = Module.objects.filter(module_bay=self.bay)
+        self.assertEqual(modules.count(), 1)
+        self.assertEqual(modules.first().module_type_id, mt2.pk)  # last writer wins
+
+    def test_invalid_adoption_payload_aborts_changeset_atomically(self):
+        """
+        A 400 against the adopted instance rolls back sibling changes.
+
+        Hand-crafted changeset (deterministic): a device/bay-mismatched module
+        CREATE plus an innocent sibling site CREATE. Today the mismatch is
+        swallowed (ValidationError fallback returns the existing module) and
+        the changeset succeeds with the sibling applied; with adoption the
+        mismatch surfaces as 400 and the whole changeset rolls back.
+        """
+        Module.objects.create(device=self.dev, module_bay=self.bay, module_type=self.mt)
+        wrong_dev = Device.objects.create(
+            name="ma-wrong", site=self.site, device_type=self.dt, role=self.role
+        )
+        cs = {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {"id": str(uuid.uuid4()), "change_type": "create", "object_type": "dcim.site",
+                 "ref_id": "s1", "data": {"name": "ma-sibling-site", "slug": "ma-sibling-site"}},
+                {"id": str(uuid.uuid4()), "change_type": "create", "object_type": "dcim.module",
+                 "ref_id": "m1", "data": {"device": wrong_dev.pk, "module_bay": self.bay.pk,
+                                          "module_type": self.mt.pk, "status": "active"}},
+            ],
+        }
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertFalse(Site.objects.filter(name="ma-sibling-site").exists())  # atomic abort
+
+    def test_miss_then_create_still_works(self):
+        """Find-first miss on an empty bay falls through to a normal create."""
+        cs = self._diff(self._module_entity())
+        self._apply(cs)
+        self.assertEqual(Module.objects.filter(module_bay=self.bay).count(), 1)
+
+
+class ModuleBayInstalledModuleE2ETests(APITestCase):
+    """
+    The reverse side of the module/bay relation: dcim.modulebay.installed_module.
+
+    A producer walking a device's bays naturally nests the module inside the
+    bay it occupies, and the nested module has to name its own module_bay
+    (Module.module_bay is a required OneToOneField). That names the outer bay
+    back, so the pair only plans if the reverse-side write is deferred.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        site = Site.objects.create(name="im-site", slug="im-site")
+        mfr = Manufacturer.objects.create(name="im-mfr", slug="im-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="im-dt", slug="im-dt")
+        role = DeviceRole.objects.create(name="im-role", slug="im-role")
+        self.mt = ModuleType.objects.create(manufacturer=mfr, model="im-linecard")
+        self.dev = Device.objects.create(
+            name="im-rtr", site=site, device_type=dt, role=role
+        )
+
+    def _dev_ref(self):
+        return {"name": "im-rtr", "site": {"name": "im-site"}}
+
+    def _module_ref(self, bay_name):
+        return {
+            "device": self._dev_ref(),
+            "module_bay": {"device": self._dev_ref(), "name": bay_name},
+            "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+            "serial": "IM-SER-1",
+        }
+
+    def _installed_module_entity(self, bay_name="im-bay1"):
+        """A bay carrying the module installed in it — the natural shape."""
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": bay_name,
+            "label": "IM-1",
+            "installed_module": self._module_ref(bay_name),
+        }}}
+
+    def _parent_module_entity(self, bay_name="im-bay2"):
+        """The same bay claiming the module as its PARENT — contradictory data."""
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": bay_name,
+            "module": self._module_ref(bay_name),
+        }}}
+
+    def _diff(self, payload, expect=200):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r.json().get("change_set", {}) or {}
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def _non_noop(self, cs):
+        return [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+
+    def test_installed_module_natural_shape_installs_the_module(self):
+        """The bay-carries-its-module shape plans, applies, and lands in the DB."""
+        self._apply(self._diff(self._installed_module_entity()))
+
+        bay = ModuleBay.objects.get(device=self.dev, name="im-bay1")
+        self.assertEqual(bay.label, "IM-1")
+        module = Module.objects.get(module_bay=bay)
+        self.assertEqual(module.device_id, self.dev.pk)
+        self.assertEqual(module.module_type_id, self.mt.pk)
+        self.assertEqual(module.serial, "IM-SER-1")
+        # the reverse accessor the field is named after now resolves
+        self.assertEqual(bay.installed_module.pk, module.pk)
+        self.assertEqual(Module.objects.filter(device=self.dev).count(), 1)
+
+        # and it converges: a second plan of the same payload is a no-op
+        self.assertEqual(self._non_noop(self._diff(self._installed_module_entity())), [])
+
+    def _mismatched_entity(self, outer_bay, inner_bay):
+        """A bay carrying a module whose own module_bay names a DIFFERENT bay."""
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": outer_bay,
+            "label": "IM-X",
+            "installed_module": self._module_ref(inner_bay),
+        }}}
+
+    def test_a_module_naming_another_bay_is_refused(self):
+        """
+        The two sides must name one bay, because only one of them installs it.
+
+        Deferring installed_module buys a plannable ORDER, not a write: the
+        module's own module_bay FK is what installs it, and the deferred reverse
+        update only touches the related object in memory. So a bay carrying a
+        module whose module_bay names a different bay describes something no
+        write can produce.
+
+        Measured before this check, bay A carrying a module naming bay B: both
+        bays and the module were created, apply answered 200 with errors null,
+        the module landed in B with A empty, and every later ingest of the
+        identical payload re-planned the same reverse-side update to no effect.
+        A success that never converges.
+
+        Refused rather than resolved in the outer bay's favour: the two
+        statements are equally explicit and nothing in the payload marks either
+        as the mistake, so silently rewriting the module's own module_bay would
+        be a guess.
+        """
+        r = self.client.post(
+            self.diff_url, data=self._mismatched_entity("im-bayX", "im-bayY"),
+            format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        self.assertIn("im-bayY", errors)
+        self.assertIn("im-bayX", errors)
+        self.assertEqual(
+            ModuleBay.objects.filter(device=self.dev, name="im-bayX").count(), 0,
+            "the refused payload created a bay anyway",
+        )
+        self.assertEqual(Module.objects.filter(device=self.dev).count(), 0)
+
+    def test_a_module_naming_its_own_bay_is_still_accepted(self):
+        """The control: the natural shape names the outer bay and still applies."""
+        self._apply(self._diff(self._installed_module_entity("im-bayok")))
+        bay = ModuleBay.objects.get(device=self.dev, name="im-bayok")
+        self.assertEqual(bay.installed_module.module_bay_id, bay.pk)
+
+
+    def _mismatched_camel_entity(self, outer_bay, inner_bay):
+        """The same contradiction, in the camelCase protoJSON spelling."""
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": outer_bay,
+            "installedModule": {
+                "device": self._dev_ref(),
+                "moduleBay": {"device": self._dev_ref(), "name": inner_bay},
+                "moduleType": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+                "serial": "IM-SER-1",
+            },
+        }}}
+
+    def test_a_camelcase_module_naming_another_bay_is_refused(self):
+        """
+        The refusal must not depend on which spelling the producer sent.
+
+        _ensure_snake_case is shallow: it rewrites the keys of the object being
+        transformed, and every nested object is normalized later by its own
+        recursion. So when the check runs, a camelCase producer's nested module
+        still carries `moduleBay`, and reading only the snake spelling saw
+        nothing at all.
+
+        Measured with the snake-only lookup: this payload planned
+        [create bay, create bay, create module, update bay], applied 200 with
+        errors null, left the outer bay empty with the module in the inner bay,
+        and re-planned the same no-op update on every later ingest -- the exact
+        non-converging success the check exists to refuse, reachable by sending
+        the supported camelCase form of a payload the check already caught.
+        """
+        r = self.client.post(
+            self.diff_url, data=self._mismatched_camel_entity("cc-bayX", "cc-bayY"),
+            format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        self.assertIn("cc-bayX", errors)
+        self.assertIn("cc-bayY", errors)
+        self.assertEqual(ModuleBay.objects.filter(device=self.dev).count(), 0)
+        self.assertEqual(Module.objects.filter(device=self.dev).count(), 0)
+
+    def test_a_module_naming_a_same_named_bay_on_another_device_is_refused(self):
+        """
+        A bare device name is not a device, so the comparison carries its scope.
+
+        Device is unique on (Lower(name), site, tenant), so two devices may
+        share a name in different sites -- and then two bays sharing a name are
+        still two different bays. Comparing bays by (device_name, bay_name)
+        collapsed them into one.
+
+        Measured with the name-only comparison: this payload applied 200 with
+        errors null and installed the module in the OTHER site's bay, leaving
+        this site's bay empty and re-planning the reverse update on every later
+        ingest.
+        """
+        site2 = Site.objects.create(name="im-site2", slug="im-site2")
+        Device.objects.create(
+            name="im-rtr", site=site2, device_type=self.dev.device_type,
+            role=self.dev.role,
+        )
+        other_device = {"name": "im-rtr", "site": {"name": "im-site2"}}
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "sc-bay",
+            "installed_module": {
+                "device": other_device,
+                "module_bay": {"device": other_device, "name": "sc-bay"},
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+                "serial": "IM-SER-1",
+            },
+        }}}
+        r = self.client.post(self.diff_url, data=entity, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        # both bays are named 'sc-bay' on a device named 'im-rtr', so the scope
+        # is the only thing that tells the two sides apart -- an error naming
+        # the same bay twice would be unactionable
+        self.assertIn("name='im-site'", errors)
+        self.assertIn("name='im-site2'", errors)
+        self.assertEqual(ModuleBay.objects.filter(name="sc-bay").count(), 0)
+        self.assertEqual(Module.objects.count(), 0)
+
+    def test_a_module_naming_a_bay_on_a_device_with_another_asset_tag_is_refused(self):
+        """
+        A device reference can identify its device without naming it.
+
+        Device is unique on asset_tag alone, so two references carrying
+        different asset_tags are two devices even with no name on either side.
+        Comparing only name/site/tenant found nothing asserted on both sides
+        and read that as compatible.
+
+        Measured with name/site/tenant only: this payload applied 200 with
+        errors null, installed the module in the OTHER device's bay, and left
+        this one empty to be re-planned on every later ingest.
+        """
+        dev_a = Device.objects.create(
+            name="im-at-a", site=self.dev.site, device_type=self.dev.device_type,
+            role=self.dev.role, asset_tag="AT-A",
+        )
+        Device.objects.create(
+            name="im-at-b", site=self.dev.site, device_type=self.dev.device_type,
+            role=self.dev.role, asset_tag="AT-B",
+        )
+        other = {"asset_tag": "AT-B"}
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": {"asset_tag": "AT-A"},
+            "name": "at-bay",
+            "installed_module": {
+                "device": other,
+                "module_bay": {"device": other, "name": "at-bay"},
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+                "serial": "IM-SER-1",
+            },
+        }}}
+        r = self.client.post(self.diff_url, data=entity, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        # both bays are named 'at-bay' and neither device is named, so the
+        # asset tags are the only thing telling the two sides apart
+        self.assertIn("AT-A", errors)
+        self.assertIn("AT-B", errors)
+        self.assertEqual(ModuleBay.objects.filter(device=dev_a).count(), 0)
+        self.assertEqual(Module.objects.count(), 0)
+
+    def test_a_module_naming_a_different_addressed_bay_is_refused(self):
+        """
+        A payload can address its row by primary key and name nothing at all.
+
+        metadata.source_match.netbox_id is the strongest identity in the
+        pipeline, and a PK-addressed reference need carry no name, so a
+        comparison over names and selectors alone found nothing asserted on
+        both sides and read that as compatible.
+
+        The outer entity's metadata is popped before this check runs -- it
+        would not survive _ensure_snake_case -- so the check is handed it
+        explicitly; without that the outer side cannot say which row it
+        addresses.
+
+        Measured before the fix: 200 with errors null, the module installed in
+        bay B, and bay A given no change at all -- the two PK-addressed bay
+        nodes merged into one and arrival order decided which id survived. It
+        then CONVERGED on the wrong row, which is worse than the re-planning
+        shapes above: nothing further would ever mention it.
+        """
+        bay_a = ModuleBay.objects.create(device=self.dev, name="pk-bayA")
+        bay_b = ModuleBay.objects.create(device=self.dev, name="pk-bayB")
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "metadata": {"source_match": {"netbox_id": bay_a.pk}},
+            "installed_module": {
+                "device": self._dev_ref(),
+                "module_bay": {"metadata": {"source_match": {"netbox_id": bay_b.pk}}},
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+                "serial": "IM-SER-1",
+            },
+        }}}
+
+        r = self.client.post(self.diff_url, data=entity, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        # It must be THIS guard that refused, not the addressed-row merge
+        # refusal downstream: that one catches the same payload (measured --
+        # they are independent layers), so asserting only on the status and the
+        # ids would pass with the outer metadata never reaching this check.
+        self.assertIn("whose module_bay is", errors)
+        # neither side names anything, so the ids are all the message has
+        self.assertIn(str(bay_a.pk), errors)
+        self.assertIn(str(bay_b.pk), errors)
+        self.assertEqual(Module.objects.count(), 0)
+        bay_a.refresh_from_db()
+        bay_b.refresh_from_db()
+        self.assertIsNone(getattr(bay_a, "installed_module", None))
+        self.assertIsNone(getattr(bay_b, "installed_module", None))
+
+    def _pk_addressed_entity(self, bay_pk, nested_bay_name):
+        """Outer bay addressed by pk ALONE; nested module_bay named normally."""
+        return {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "metadata": {"source_match": {"netbox_id": bay_pk}},
+            "installed_module": {
+                "device": self._dev_ref(),
+                "module_bay": {"device": self._dev_ref(), "name": nested_bay_name},
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+                "serial": "IM-SER-1",
+            },
+        }}}
+
+    def test_a_module_naming_another_bay_than_the_addressed_one_is_refused(self):
+        """
+        A partial reference need not repeat the name, so one side can be silent.
+
+        With the outer bay addressed by pk alone, a comparison over asserted
+        selectors finds nothing on that side to read: the two sides share no
+        criterion and look compatible. Measured before the fix: 200 with errors
+        null, the module installed in the NAMED bay, the addressed bay left
+        empty, and the ineffective reverse update re-planned on every ingest.
+
+        The addressed side is now resolved -- the row is the authority on what
+        it is -- and the ordinary compatibility relation does the rest.
+        """
+        bay_a = ModuleBay.objects.create(device=self.dev, name="os-bayA")
+        ModuleBay.objects.create(device=self.dev, name="os-bayB")
+
+        r = self.client.post(
+            self.diff_url, data=self._pk_addressed_entity(bay_a.pk, "os-bayB"),
+            format="json", **self.auth)
+
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        self.assertIn("whose module_bay is", errors)
+        # resolving means the message can name the row, not just its id
+        self.assertIn("os-bayA", errors)
+        self.assertIn("os-bayB", errors)
+        self.assertIn(str(bay_a.pk), errors)
+        self.assertEqual(Module.objects.count(), 0)
+
+    def test_a_module_naming_the_addressed_bay_itself_still_applies(self):
+        """
+        The control, and the reason the fix resolves instead of refusing.
+
+        Naming by pk on one side and by name on the other is a legitimate way
+        to describe ONE bay. Treating an incomparable pair as a conflict would
+        have closed the hole above by breaking this, so it is asserted right
+        beside it: it applies, installs the module in the addressed bay, and
+        converges.
+        """
+        bay_a = ModuleBay.objects.create(device=self.dev, name="os-bayA")
+        ModuleBay.objects.create(device=self.dev, name="os-bayB")
+
+        entity = self._pk_addressed_entity(bay_a.pk, "os-bayA")
+        self._apply(self._diff(entity))
+
+        bay_a.refresh_from_db()
+        self.assertEqual(bay_a.installed_module.module_bay_id, bay_a.pk)
+        self.assertEqual(Module.objects.count(), 1)
+        self.assertEqual(self._non_noop(self._diff(entity)), [])
+
+    def test_a_module_naming_a_same_named_bay_when_the_addressed_side_omits_its_device(self):
+        """
+        Carrying a name does not make a bay comparable; its criterion is (name, device).
+
+        The addressed side here gives its pk AND its name but no device, which
+        a partial reference may do. The old hydration gate declined to resolve
+        it for exactly that reason -- it had a name -- and the equal names then
+        compared as compatible with a same-named bay on ANOTHER device.
+
+        Measured before the fix: 200 with errors null, the module installed in
+        the other device's bay, this one left empty, and the ineffective
+        reverse update re-planned on every ingest.
+        """
+        other_dev = Device.objects.create(
+            name="hy-rtrB", site=self.dev.site, device_type=self.dev.device_type,
+            role=self.dev.role)
+        mine = ModuleBay.objects.create(device=self.dev, name="hy-bay")
+        ModuleBay.objects.create(device=other_dev, name="hy-bay")
+        other_ref = {"name": "hy-rtrB", "site": {"name": "im-site"}}
+
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "metadata": {"source_match": {"netbox_id": mine.pk}},
+            "name": "hy-bay",
+            "installed_module": {
+                "device": other_ref,
+                "module_bay": {"device": other_ref, "name": "hy-bay"},
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+                "serial": "IM-SER-1",
+            },
+        }}}
+        r = self.client.post(self.diff_url, data=entity, format="json", **self.auth)
+
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        self.assertIn("whose module_bay is", errors)
+        # the bay names are equal, so only the devices tell the sides apart
+        self.assertIn("name='im-rtr'", errors)
+        self.assertIn("name='hy-rtrB'", errors)
+        self.assertEqual(Module.objects.count(), 0)
+
+    def test_a_module_naming_a_bay_reached_by_a_disjoint_selector_is_refused(self):
+        """
+        The residue the payload comparison cannot see, refused after resolution.
+
+        The outer bay's device is named by asset_tag and the nested module's by
+        (name, site). Those criteria do not overlap, so no payload comparison
+        can settle them -- and that limit was stated as a bound for several
+        revisions while remaining a non-converging success, which is the one
+        outcome this branch does not accept.
+
+        Measured before the post-resolution pass: the outer bay resolved to one
+        device's bay and the nested module_bay to another's, apply answered 200
+        with errors null, the module landed in the nested bay, and the deferred
+        reverse update re-planned against the empty outer bay forever.
+
+        Refused now by _check_reverse_side_resolves_to_its_parent, which sees
+        primary keys rather than selectors.
+        """
+        dev_a = Device.objects.create(
+            name="dj-rtrA", site=self.dev.site, device_type=self.dev.device_type,
+            role=self.dev.role, asset_tag="DJ-A")
+        dev_b = Device.objects.create(
+            name="dj-rtrB", site=self.dev.site, device_type=self.dev.device_type,
+            role=self.dev.role, asset_tag="DJ-B")
+        bay_a = ModuleBay.objects.create(device=dev_a, name="dj-bay")
+        bay_b = ModuleBay.objects.create(device=dev_b, name="dj-bay")
+        nested_dev = {"name": "dj-rtrB", "site": {"name": "im-site"}}
+
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": {"asset_tag": "DJ-A"},
+            "name": "dj-bay",
+            "installed_module": {
+                "device": nested_dev,
+                "module_bay": {"device": nested_dev, "name": "dj-bay"},
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+                "serial": "IM-SER-1",
+            },
+        }}}
+        r = self.client.post(self.diff_url, data=entity, format="json", **self.auth)
+
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        # the message names both resolved rows, which is all that is left to
+        # distinguish them once the selectors are gone
+        self.assertIn(str(bay_a.pk), errors)
+        self.assertIn(str(bay_b.pk), errors)
+        self.assertEqual(Module.objects.count(), 0)
+        bay_a.refresh_from_db()
+        self.assertIsNone(getattr(bay_a, "installed_module", None))
+
+    def test_the_natural_shape_survives_the_post_resolution_check(self):
+        """
+        The control for the pass above: it must not refuse the ordinary case.
+
+        Both sides resolve to the SAME bay here -- whether that bay already
+        exists or is created by this very change set -- so a check comparing
+        resolved identities has to accept both, and converge.
+        """
+        # a bay this change set creates
+        entity = self._installed_module_entity("pr-newbay")
+        self._apply(self._diff(entity))
+        bay = ModuleBay.objects.get(device=self.dev, name="pr-newbay")
+        self.assertEqual(bay.installed_module.module_bay_id, bay.pk)
+        self.assertEqual(self._non_noop(self._diff(entity)), [])
+
+        # and a bay that already existed before the payload arrived
+        existing = ModuleBay.objects.create(device=self.dev, name="pr-oldbay")
+        again = self._installed_module_entity("pr-oldbay")
+        self._apply(self._diff(again))
+        existing.refresh_from_db()
+        self.assertEqual(existing.installed_module.module_bay_id, existing.pk)
+        self.assertEqual(self._non_noop(self._diff(again)), [])
+
+    def test_a_bay_nesting_an_existing_module_installed_elsewhere_is_refused(self):
+        """
+        The child must be found after its reference became a primary key.
+
+        _resolve_existing_references replaces a reference to an ALREADY-EXISTING
+        object with its pk, which drops the pointer to the node that described
+        it. Following only the reference form meant a payload describing an
+        existing module skipped the post-resolution check entirely -- and the
+        devices here are reached by disjoint selectors, so the payload-level
+        check cannot settle it either.
+
+        Measured before the fix: plan [update dcim.modulebay <bay A>], apply 200
+        with errors null, the module still installed in bay B, bay A still
+        empty, and the same ineffective update re-planned on every ingest.
+        """
+        dev_a = Device.objects.create(
+            name="ex-rtrA", site=self.dev.site, device_type=self.dev.device_type,
+            role=self.dev.role, asset_tag="EX-A")
+        dev_b = Device.objects.create(
+            name="ex-rtrB", site=self.dev.site, device_type=self.dev.device_type,
+            role=self.dev.role, asset_tag="EX-B")
+        bay_a = ModuleBay.objects.create(device=dev_a, name="ex-bay")
+        bay_b = ModuleBay.objects.create(device=dev_b, name="ex-bay")
+        module = Module.objects.create(
+            device=dev_b, module_bay=bay_b, module_type=self.mt, asset_tag="EX-MOD")
+        nested_dev = {"name": "ex-rtrB", "site": {"name": "im-site"}}
+
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": {"asset_tag": "EX-A"},
+            "name": "ex-bay",
+            "installed_module": {
+                "asset_tag": "EX-MOD",
+                "device": nested_dev,
+                "module_bay": {"device": nested_dev, "name": "ex-bay"},
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+            },
+        }}}
+        r = self.client.post(self.diff_url, data=entity, format="json", **self.auth)
+
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        self.assertIn(str(bay_a.pk), errors)
+        self.assertIn(str(bay_b.pk), errors)
+        module.refresh_from_db()
+        self.assertEqual(module.module_bay_id, bay_b.pk, "the module was moved")
+        bay_a.refresh_from_db()
+        self.assertIsNone(getattr(bay_a, "installed_module", None))
+
+    def test_reingesting_an_existing_module_in_its_own_bay_is_still_a_noop(self):
+        """
+        The control: describing an existing module correctly must stay a no-op.
+
+        The pk lookup added for the case above makes every existing child
+        visible to the check, so the ordinary converged state is exactly what
+        it must not refuse.
+        """
+        bay = ModuleBay.objects.create(device=self.dev, name="ex-ok-bay")
+        Module.objects.create(
+            device=self.dev, module_bay=bay, module_type=self.mt, asset_tag="EX-OK")
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "ex-ok-bay",
+            "installed_module": {
+                "asset_tag": "EX-OK",
+                "device": self._dev_ref(),
+                "module_bay": {"device": self._dev_ref(), "name": "ex-ok-bay"},
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+            },
+        }}}
+        self.assertEqual(self._non_noop(self._diff(entity)), [])
+
+    def test_a_bay_nesting_an_existing_module_without_naming_its_bay_is_refused(self):
+        """
+        A payload asserting no forward FK still has to be carried out by something.
+
+        Nesting an EXISTING module by asset_tag and omitting its module_bay
+        contradicts nothing -- and nothing performs the write either. The
+        deferred installed_module update does not persist a reverse one-to-one,
+        and the module's own forward FK is left exactly as it was.
+
+        Measured before the fix: plan [update dcim.modulebay <bay A>], apply 200
+        with errors null, the module still in its old bay, bay A still empty,
+        and the same ineffective update re-planned on every ingest.
+
+        So the child's CURRENT parent is what the deferred write must agree
+        with when the payload names none.
+        """
+        bay_a = ModuleBay.objects.create(device=self.dev, name="nb-bayA")
+        bay_b = ModuleBay.objects.create(device=self.dev, name="nb-bayB")
+        module = Module.objects.create(
+            device=self.dev, module_bay=bay_b, module_type=self.mt, asset_tag="NB-MOD")
+
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "nb-bayA",
+            "installed_module": {
+                "asset_tag": "NB-MOD",
+                "device": self._dev_ref(),
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+            },
+        }}}
+        r = self.client.post(self.diff_url, data=entity, format="json", **self.auth)
+
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = str(r.json().get("errors"))
+        self.assertIn(str(bay_a.pk), errors)
+        self.assertIn(str(bay_b.pk), errors)
+        # the message must say the payload does not move it, not that it
+        # contradicts a submitted value -- there is no submitted value
+        self.assertIn("does not move it", errors)
+        module.refresh_from_db()
+        self.assertEqual(module.module_bay_id, bay_b.pk, "the module was moved")
+
+    def test_an_existing_module_already_in_the_bay_needs_no_forward_fk(self):
+        """
+        The control, and the reason this reads the row instead of refusing.
+
+        Omitting module_bay for a module that is ALREADY in this bay describes
+        the converged state. Refusing every payload that names no forward FK
+        would have closed the case above by breaking this one, so it is
+        asserted beside it: no changes planned at all.
+        """
+        bay = ModuleBay.objects.create(device=self.dev, name="nb-okbay")
+        Module.objects.create(
+            device=self.dev, module_bay=bay, module_type=self.mt, asset_tag="NB-OK")
+
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "nb-okbay",
+            "installed_module": {
+                "asset_tag": "NB-OK",
+                "device": self._dev_ref(),
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+            },
+        }}}
+        self.assertEqual(self._non_noop(self._diff(entity)), [])
+
+    def test_a_new_module_naming_no_bay_is_refused_by_the_required_field(self):
+        """
+        The third variant, pinned because the guard above relies on it.
+
+        _child_parent_identity returns no verdict for a child this change set
+        creates that names no parent -- there is nothing to read yet. That is
+        only safe because the forward FK is non-nullable, so validation refuses
+        it first. If that ever stopped being true, this test is what says so.
+        """
+        entity = {"timestamp": 1, "object_type": "dcim.modulebay", "entity": {"module_bay": {
+            "device": self._dev_ref(),
+            "name": "nb-newbay",
+            "installed_module": {
+                "device": self._dev_ref(),
+                "serial": "NB-NEW",
+                "module_type": {"manufacturer": {"name": "im-mfr"}, "model": "im-linecard"},
+            },
+        }}}
+        r = self.client.post(self.diff_url, data=entity, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertIn("module_bay", str(r.json().get("errors")))
+        self.assertEqual(Module.objects.count(), 0)
+
+    def test_reingest_of_an_already_installed_module_is_a_noop(self):
+        """
+        Rows already correct in the DB must survive a second pass.
+
+        This is the convergence case: _topo_sort runs before
+        _resolve_existing_references, so an undeclared cycle rejects the
+        payload at plan time even when the database already agrees with it.
+        """
+        bay = ModuleBay.objects.create(device=self.dev, name="im-bay1", label="IM-1")
+        module = Module.objects.create(
+            device=self.dev, module_bay=bay, module_type=self.mt, serial="IM-SER-1"
+        )
+
+        self.assertEqual(self._non_noop(self._diff(self._installed_module_entity())), [])
+
+        module.refresh_from_db()
+        self.assertEqual(module.module_bay_id, bay.pk)
+        self.assertEqual(Module.objects.filter(device=self.dev).count(), 1)
+
+    def test_deferred_reverse_write_records_an_update_with_no_prechange(self):
+        """
+        Pin the changelog shape of the deferred (ref_id) UPDATE branch.
+
+        This shape is the cleanest probe of that branch there is: the deferred
+        write persists nothing at all (installed_module is a reverse
+        one-to-one, so asserting it only mutates the related object in memory),
+        which makes the row's presence in the changelog depend entirely on
+        whether the branch takes a prechange snapshot. NetBox's
+        ObjectChange.has_changes drops an update whose prechange equals its
+        postchange, so populating prechange_data here removes the 'update' row
+        outright -- measured: ['create', 'update'] becomes ['create'].
+
+        The branch re-reads its row (to keep a counter honest, see
+        test_virtualchassis_ingest) and a re-read makes a snapshot cheap to
+        take, which is exactly why this needs pinning in whichever direction it
+        ships: a changelog behaviour change must be a decision, not a side
+        effect of an unrelated fix. Shipped direction: unchanged from before
+        the re-read -- both rows recorded, neither carrying a prechange.
+        """
+        self._apply(self._diff(self._installed_module_entity()))
+
+        bay = ModuleBay.objects.get(device=self.dev, name="im-bay1")
+        rows = list(ObjectChange.objects.filter(
+            changed_object_type__app_label="dcim",
+            changed_object_type__model="modulebay",
+            changed_object_id=bay.pk,
+        ).order_by("pk"))
+
+        self.assertEqual([r.action for r in rows], ["create", "update"], rows)
+        for row in rows:
+            self.assertIsNone(row.prechange_data, row)
+            self.assertIsNotNone(row.postchange_data, row)
+
+    def test_parent_module_field_still_reports_the_recursion_error(self):
+        """
+        dcim.modulebay.module stays a better-error path, NOT a working shape.
+
+        Its table entry exists to reach NetBox's own recursion message instead
+        of the opaque plan-time cycle error; a bay cannot be a sub-bay of the
+        module installed in it. Declaring installed_module must not turn this
+        contradiction into a success.
+        """
+        cs = self._diff(self._parent_module_entity())
+        r = self._apply(cs, expect=400)
+        self.assertIn(
+            "A module bay cannot belong to a module installed within it.",
+            r.content.decode(),
+        )
+        # the failed bay update aborts the whole change set
+        self.assertFalse(Module.objects.filter(device=self.dev).exists())
+
+
+class ReferencesConflictRuleTests(TestCase):
+    """
+    The rule table for `references_conflict`, without the pipeline.
+
+    The relation answers one question -- can these two payloads denote the same
+    object? -- and it is a COMPATIBILITY relation, not equality: only a field
+    both sides assert, with values that disagree, proves two objects. A field
+    one side leaves out cannot contradict anything, which is what keeps the
+    natural shape (the nested module naming its bay less fully than the outer
+    payload does) from being refused.
+
+    Every row here predates the relation being DERIVED from the matchers. They
+    are kept, unchanged, precisely for that: three hand-written comparisons
+    (bay, device, scope) were replaced by one that reads its criteria from
+    get_model_matchers, and this table is the evidence the replacement decides
+    every case the hand-written ones did -- ModuleBay unique on
+    ('name', 'device'), Device on (Lower(name), site, tenant) and on asset_tag,
+    Site and Tenant on name alone and slug alone.
+
+    It is a TestCase rather than a SimpleTestCase because the criteria now come
+    from the model registry, and reference fields recurse into the referenced
+    type's own identity. No row queries a row.
+    """
+
+    def _bay(self, name, device=None):
+        payload = {"name": name}
+        if device is not None:
+            payload["device"] = device
+        return payload
+
+    def test_the_rule_table(self):
+        """Each decision the relation makes, and its symmetry, in one table."""
+        dev = {"name": "rtr", "site": {"name": "s1"}}
+        cases = [
+            # (description, mine, theirs, conflict?)
+            ("identical", self._bay("b", dev), self._bay("b", dev), False),
+            ("different bay name", self._bay("b1", dev), self._bay("b2", dev), True),
+            ("different bay name, no device anywhere",
+             self._bay("b1"), self._bay("b2"), True),
+            # Lower(name) is Device identity, so casing is not a difference.
+            # An exact compare here refused a bay as differing from itself.
+            ("device name differs only in case",
+             self._bay("b", {"name": "RTR", "site": {"name": "s1"}}),
+             self._bay("b", dev), False),
+            ("device name differs",
+             self._bay("b", {"name": "rtr-a"}), self._bay("b", {"name": "rtr-b"}), True),
+            # the finding: same names, different sites, two real devices
+            ("same device name, different site",
+             self._bay("b", {"name": "rtr", "site": {"name": "s2"}}),
+             self._bay("b", dev), True),
+            ("same device name, different site slug",
+             self._bay("b", {"name": "rtr", "site": {"slug": "s2"}}),
+             self._bay("b", {"name": "rtr", "site": {"slug": "s1"}}), True),
+            ("same device name, different tenant",
+             self._bay("b", {"name": "rtr", "tenant": {"name": "t2"}}),
+             self._bay("b", {"name": "rtr", "tenant": {"name": "t1"}}), True),
+            # compatibility, not equality: what one side omits cannot contradict
+            ("one side omits the site", self._bay("b", {"name": "rtr"}),
+             self._bay("b", dev), False),
+            ("one side omits the tenant",
+             self._bay("b", {"name": "rtr", "site": {"name": "s1"}, "tenant": {"name": "t"}}),
+             self._bay("b", dev), False),
+            ("one side omits the device", self._bay("b"), self._bay("b", dev), False),
+            ("device as a bare name string", self._bay("b", "rtr"),
+             self._bay("b", dev), False),
+            ("bare name string that disagrees", self._bay("b", "other"),
+             self._bay("b", dev), True),
+            # asset_tag is unique on its own, so it settles the question
+            # outright -- and settling it FIRST is what stops a differing name
+            # from refusing two references to one device
+            ("different asset_tag, neither side named",
+             self._bay("b", {"asset_tag": "A1"}),
+             self._bay("b", {"asset_tag": "A2"}), True),
+            ("different asset_tag, same name",
+             self._bay("b", {"asset_tag": "A1", "name": "rtr"}),
+             self._bay("b", {"asset_tag": "A2", "name": "rtr"}), True),
+            ("same asset_tag, different names",
+             self._bay("b", {"asset_tag": "A1", "name": "rtr-a"}),
+             self._bay("b", {"asset_tag": "A1", "name": "rtr-b"}), False),
+            ("same asset_tag, different sites",
+             self._bay("b", {"asset_tag": "A1", "site": {"name": "s1"}}),
+             self._bay("b", {"asset_tag": "A1", "site": {"name": "s2"}}), False),
+            ("asset_tag on one side only falls back to the name",
+             self._bay("b", {"asset_tag": "A1", "name": "rtr"}),
+             self._bay("b", {"name": "other"}), True),
+            # an explicit primary key is the strongest identity there is, so
+            # it decides ahead of every selector below it
+            ("different addressed rows, nothing else asserted",
+             {"metadata": {"source_match": {"netbox_id": 1}}},
+             {"metadata": {"source_match": {"netbox_id": 2}}}, True),
+            ("different addressed rows, same bay and device names",
+             {"name": "b", "device": {"name": "rtr"},
+              "metadata": {"source_match": {"netbox_id": 1}}},
+             {"name": "b", "device": {"name": "rtr"},
+              "metadata": {"source_match": {"netbox_id": 2}}}, True),
+            ("same addressed row, different bay names",
+             {"name": "b1", "metadata": {"source_match": {"netbox_id": 1}}},
+             {"name": "b2", "metadata": {"source_match": {"netbox_id": 1}}}, False),
+            ("addressed on one side only falls back to the names",
+             {"name": "b1", "metadata": {"source_match": {"netbox_id": 1}}},
+             {"name": "b2"}, True),
+            ("an unusable netbox_id is ignored, as the node builder ignores it",
+             {"name": "b", "metadata": {"source_match": {"netbox_id": "nope"}}},
+             {"name": "b", "metadata": {"source_match": {"netbox_id": 2}}}, False),
+            # the stated bound: no criterion in common, so nothing to compare
+            ("disjoint selectors stay compatible",
+             self._bay("b", {"asset_tag": "A1"}), self._bay("b", {"name": "rtr"}), False),
+            # not comparable at all -> never a refusal
+            ("no bay name on one side", {"device": dev}, self._bay("b", dev), False),
+            ("empty bay name", self._bay("", dev), self._bay("b", dev), False),
+            ("nested side is not a dict", None, self._bay("b", dev), False),
+        ]
+        for description, mine, theirs, expected in cases:
+            with self.subTest(description):
+                self.assertEqual(
+                    transformer.references_conflict("dcim.modulebay", mine, theirs), expected)
+                # the relation must not depend on which side is which
+                self.assertEqual(
+                    transformer.references_conflict("dcim.modulebay", theirs, mine), expected,
+                    f"{description}: not symmetric")
+
+    def test_a_camelcase_parent_key_is_read(self):
+        """
+        The nested payload has not been snake_cased when the check reads it.
+
+        This is the whole of the camelCase finding in one assertion: the guard
+        looks up the nested object's `module_bay`, and a camelCase producer
+        spells it `moduleBay`.
+        """
+        nested = {"moduleBay": {"name": "b2", "device": {"name": "rtr"}}}
+        self.assertEqual(
+            transformer._asserted(nested, "module_bay"),
+            {"name": "b2", "device": {"name": "rtr"}},
+        )
+        self.assertIsNone(transformer._asserted(nested, "serial"))
+        # an explicit snake_case key still wins
+        self.assertEqual(
+            transformer._asserted({"module_bay": {"name": "snake"}}, "module_bay"),
+            {"name": "snake"},
+        )
+
+
+class AddressedRowMergeTests(SimpleTestCase):
+    """
+    Two nodes addressing DIFFERENT rows must not become one node.
+
+    _carry_addressed_row picks whichever side carries an explicit
+    metadata.source_match.netbox_id, which is only unambiguous if two different
+    ids never reach it. An earlier revision asserted they could not, on the
+    strength of vc_identities_conflict and the _fingerprint_dedupe
+    qualification -- but both are dcim.virtualchassis machinery, so for every
+    other type two differently-addressed nodes with nothing else to fingerprint
+    merged, and arrival order decided which row the plan then wrote.
+    """
+
+    def _node(self, netbox_id=None, **fields):
+        node = {"_object_type": "dcim.modulebay", "_uuid": "u", "_refs": set(),
+                "_warnings": {}, **fields}
+        if netbox_id is not None:
+            node["_netbox_id"] = netbox_id
+        return node
+
+    def test_two_different_addressed_rows_are_refused(self):
+        """Two primary keys are two rows; that needs no interpretation."""
+        with self.assertRaises(serializers.ValidationError) as caught:
+            transformer._merge_nodes(self._node(1547), self._node(1548))
+        message = str(caught.exception)
+        self.assertIn("1547", message)
+        self.assertIn("1548", message)
+        self.assertIn("netbox_id", message)
+
+    def test_the_same_addressed_row_still_merges(self):
+        """The refusal is about disagreement, not about being addressed."""
+        merged = transformer._merge_nodes(
+            self._node(1547, name="b"), self._node(1547, label="L"))
+        self.assertEqual(merged["_netbox_id"], 1547)
+        self.assertEqual(merged["name"], "b")
+        self.assertEqual(merged["label"], "L")
+
+    def test_one_addressed_side_still_carries_the_id(self):
+        """Either order keeps the id, which is what _carry_addressed_row is for."""
+        for a, b in ((self._node(1547), self._node()),
+                     (self._node(), self._node(1547))):
+            self.assertEqual(transformer._merge_nodes(a, b)["_netbox_id"], 1547)
+
+
+class HydrateAddressedSidesTests(TestCase):
+    """
+    What hydration produces, and when the caller asks for it at all.
+
+    The lookup exists for one situation -- the payload comparison did not reach
+    a verdict and one side says which row it is. An earlier revision gated it on
+    a side merely CARRYING a name, which went stale against the criteria
+    immediately: ModuleBay is identified by (name, device), so an addressed bay
+    that named itself but omitted its device was treated as comparable and a
+    same-named bay on another device compared as compatible.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """One device and one bay, to hydrate against."""
+        site = Site.objects.create(name="cb-site", slug="cb-site")
+        mfr = Manufacturer.objects.create(name="cb-mfr", slug="cb-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="cb-dt", slug="cb-dt")
+        role = DeviceRole.objects.create(name="cb-role", slug="cb-role")
+        cls.dev = Device.objects.create(
+            name="cb-rtr", site=site, device_type=dt, role=role, asset_tag="CB-1")
+        cls.bay = ModuleBay.objects.create(device=cls.dev, name="cb-bay")
+
+    def _sides(self, mine, theirs):
+        return transformer._hydrate_addressed_sides("dcim.modulebay", mine, theirs)
+
+    def test_an_addressed_side_gains_what_the_row_actually_is(self):
+        """Derived from the row, in the terms the comparison reads."""
+        addressed = {"metadata": {"source_match": {"netbox_id": self.bay.pk}}}
+        named = {"name": "other", "device": {"name": "cb-rtr"}}
+
+        mine, theirs = self._sides(addressed, named)
+
+        self.assertEqual(mine["name"], "cb-bay")
+        self.assertEqual(mine["device"]["name"], "cb-rtr")
+        self.assertEqual(mine["device"]["site"]["name"], "cb-site")
+        self.assertEqual(mine["device"]["asset_tag"], "CB-1")
+        # the id survives, so the message can name what the producer addressed
+        self.assertEqual(transformer._addressed_row_of(mine), self.bay.pk)
+        self.assertIs(theirs, named, "the un-addressed side was hydrated too")
+        # and the hydrated pair is now comparable, which is the whole point
+        self.assertTrue(transformer.references_conflict("dcim.modulebay", mine, theirs))
+
+    def test_either_side_may_be_the_addressed_one(self):
+        """Symmetric, like the relation it feeds."""
+        named = {"name": "other", "device": {"name": "cb-rtr"}}
+        addressed = {"metadata": {"source_match": {"netbox_id": self.bay.pk}}}
+
+        mine, theirs = self._sides(named, addressed)
+
+        self.assertIs(mine, named)
+        self.assertEqual(theirs["name"], "cb-bay")
+
+    def test_an_addressed_side_naming_only_itself_is_still_incomplete(self):
+        """
+        The finding the old gate missed, as a property rather than a payload.
+
+        A bay carrying its name has NOT become comparable, because its identity
+        criterion is (name, device). So the comparison must still return
+        UNKNOWN here -- which is what makes the caller hydrate.
+        """
+        addressed = {"name": "cb-bay",
+                     "metadata": {"source_match": {"netbox_id": self.bay.pk}}}
+        named = {"name": "cb-bay", "device": {"name": "somewhere-else"}}
+
+        self.assertEqual(
+            transformer._compare_references("dcim.modulebay", addressed, named),
+            transformer._UNKNOWN)
+        # hydrating settles it
+        mine, theirs = self._sides(addressed, named)
+        self.assertTrue(transformer.references_conflict("dcim.modulebay", mine, theirs))
+
+    def test_a_conclusive_comparison_needs_no_lookup(self):
+        """
+        The caller only hydrates on UNKNOWN, so these never reach the database.
+
+        Two addressed sides decide each other by id, and a disagreeing name is
+        already proof -- asserted as verdicts because that is what the caller
+        branches on. The query count is what pins "no lookup": zero further
+        queries once the criteria are cached means no row was fetched.
+        """
+        a = {"metadata": {"source_match": {"netbox_id": self.bay.pk}}}
+        b = {"metadata": {"source_match": {"netbox_id": self.bay.pk + 1}}}
+        # Warm the criteria cache first. get_model_matchers reads the model's
+        # unique custom fields from the database, once per model and then
+        # cached, which is not a row lookup -- measuring it here would make
+        # this assert the wrong thing.
+        transformer._compare_references("dcim.modulebay", {"name": "w"}, {"name": "w"})
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                transformer._compare_references("dcim.modulebay", a, b),
+                transformer._DIFFERENT)
+            self.assertEqual(
+                transformer._compare_references(
+                    "dcim.modulebay", {"name": "x"}, {"name": "y"}),
+                transformer._DIFFERENT)
+
+    def test_an_unknown_row_is_left_for_the_resolver_to_report(self):
+        """
+        A bad id is not this check's error to raise.
+
+        _resolve_by_netbox_id already fails with a message about the id, and
+        refusing here first would replace it with one about bay names.
+        """
+        missing = {"metadata": {"source_match": {"netbox_id": self.bay.pk + 10_000}}}
+        named = {"name": "other"}
+
+        mine, theirs = self._sides(missing, named)
+
+        self.assertIs(mine, missing)
+        self.assertFalse(transformer.references_conflict("dcim.modulebay", mine, theirs))
+
+
+class DerivedIdentityCriteriaTests(TestCase):
+    """
+    The relation reads its criteria from the matchers, for any type.
+
+    The table above proves the derivation reproduces what three hand-written
+    comparisons decided for one shape. These assert the part that makes the
+    replacement worth having: the same rules applied to types nobody wrote a
+    comparison for, and the two asymmetric rules stated once.
+    """
+
+    def _conflict(self, object_type, a, b):
+        first = transformer.references_conflict(object_type, a, b)
+        self.assertEqual(
+            first, transformer.references_conflict(object_type, b, a),
+            "the relation is not symmetric")
+        return first
+
+    def test_a_type_nobody_wrote_a_comparison_for(self):
+        """dcim.site was only ever compared by a hardcoded (name, slug) pair."""
+        self.assertTrue(self._conflict("dcim.site", {"name": "s1"}, {"name": "s2"}))
+        self.assertTrue(self._conflict("dcim.site", {"slug": "s1"}, {"slug": "s2"}))
+        # unique on name alone, so equal names are one site
+        self.assertFalse(self._conflict("dcim.site", {"name": "s"}, {"name": "s"}))
+        # disjoint selectors: no criterion in common, so nothing is proved
+        self.assertFalse(self._conflict("dcim.site", {"name": "s"}, {"slug": "s"}))
+
+    def test_sameness_outranks_difference(self):
+        """
+        A satisfied unique constraint is the stronger statement.
+
+        Site is unique on name alone AND on slug alone, so two payloads
+        agreeing on the name are one site even where the slugs disagree -- that
+        disagreement is a field conflict on that row for _merge_nodes to
+        report, not evidence of a second row.
+        """
+        self.assertFalse(self._conflict(
+            "dcim.site", {"name": "s", "slug": "x"}, {"name": "s", "slug": "y"}))
+
+    def test_difference_needs_only_one_field(self):
+        """
+        Because a field is single-valued, not because it is unique.
+
+        A device's name identifies nothing on its own -- Device is unique on
+        (Lower(name), site, tenant) -- but a row still has one name, so two
+        payloads disagreeing about it are two rows.
+        """
+        self.assertTrue(self._conflict(
+            "dcim.device", {"name": "rtr-a"}, {"name": "rtr-b"}))
+
+    def test_case_insensitivity_comes_from_the_constraint(self):
+        """
+        Lower(F(name)) in the constraint is why the name compares insensitively.
+
+        Asserted with tenant on both sides so the (Lower(name), site, tenant)
+        matcher is complete: it then reports SAME, which it can only do if the
+        casing was folded. Without that, the differing name would be DIFFERENT
+        and this pair would conflict.
+        """
+        scope = {"site": {"name": "s"}, "tenant": {"name": "t"}}
+        self.assertFalse(self._conflict(
+            "dcim.device", {"name": "RTR", **scope}, {"name": "rtr", **scope}))
+        # and the same shape with a genuinely different name still conflicts
+        self.assertTrue(self._conflict(
+            "dcim.device", {"name": "rtr-a", **scope}, {"name": "rtr-b", **scope}))
+
+    def test_a_conditional_constraint_does_not_prove_sameness(self):
+        """
+        dcim_device_unique_name_site applies only where tenant IS NULL.
+
+        A payload silent about tenant has not said that, so its equality on
+        (name, site) is not proof of one row -- two devices with that name and
+        site can exist under different tenants. Left UNKNOWN, which refuses
+        nothing, rather than read as SAME.
+        """
+        pair = {"name": "rtr", "site": {"name": "s"}}
+        # equal on (name, site) and NOT declared the same object...
+        self.assertFalse(self._conflict("dcim.device", dict(pair), dict(pair)))
+        # ...which is visible here: a tenant disagreement still conflicts,
+        # where a SAME verdict on (name, site) would have outranked it
+        self.assertTrue(self._conflict(
+            "dcim.device",
+            {**pair, "tenant": {"name": "t1"}}, {**pair, "tenant": {"name": "t2"}}))
+
+    def test_references_recurse_into_their_own_identity(self):
+        """A device's site is compared as a site, not as text."""
+        # same site named two ways -> no criterion in common -> not a conflict
+        self.assertFalse(self._conflict(
+            "dcim.device",
+            {"name": "rtr", "site": {"name": "s"}},
+            {"name": "rtr", "site": {"slug": "s"}}))
+        # a site that is definitely another site -> conflict, from depth 2
+        self.assertTrue(self._conflict(
+            "dcim.device",
+            {"name": "rtr", "site": {"name": "s1"}},
+            {"name": "rtr", "site": {"name": "s2"}}))
+
+    def test_identity_the_model_does_not_have_is_not_invented(self):
+        """
+        dcim.virtualchassis has no unique name, so two names prove nothing.
+
+        This is the property that makes deriving safer than restating: the
+        relation cannot claim identity the constraints do not give it, which is
+        the whole reason VirtualChassis needed its own partition in the first
+        place.
+        """
+        self.assertFalse(self._conflict(
+            "dcim.virtualchassis", {"name": "stack-a"}, {"name": "stack-b"}))
+
+    def test_an_unknown_type_refuses_nothing(self):
+        """No criteria to read means no evidence, not an error."""
+        self.assertFalse(self._conflict(
+            "nosuch.type", {"name": "a"}, {"name": "b"}))
+
+    def test_a_bare_int_is_not_read_as_a_primary_key(self):
+        """Guessing that would be exactly the interpretation this must not do."""
+        self.assertFalse(self._conflict("dcim.site", 1, 2))
+
+
+class UniqueCustomFieldIdentityTests(TestCase):
+    """
+    A reference may be identified only by a unique custom field.
+
+    CustomFieldMatcher is built solely from CustomField(unique=True), so it is
+    a real identity criterion -- and for a producer keying devices by an
+    external id it can be the ONLY selector a reference carries. It declares no
+    field tuple, and an earlier revision skipped every such hand-written
+    matcher, so two different values compared as UNKNOWN and the contradiction
+    was accepted.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A unique text custom field on Device, and two devices keyed by it."""
+        site = Site.objects.create(name="cf-site", slug="cf-site")
+        mfr = Manufacturer.objects.create(name="cf-mfr", slug="cf-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="cf-dt", slug="cf-dt")
+        role = DeviceRole.objects.create(name="cf-role", slug="cf-role")
+        cls.field = CustomField.objects.create(
+            name="cf_key", type=CustomFieldTypeChoices.TYPE_TEXT,
+            required=False, unique=True)
+        cls.field.object_types.set([ObjectType.objects.get_for_model(Device)])
+        cls.field.save()
+        cls.dev_a = Device.objects.create(
+            name="cf-rtr-a", site=site, device_type=dt, role=role,
+            custom_field_data={"cf_key": "KEY-A"})
+        cls.dev_b = Device.objects.create(
+            name="cf-rtr-b", site=site, device_type=dt, role=role,
+            custom_field_data={"cf_key": "KEY-B"})
+
+    def _ref(self, value):
+        """A device reference carrying only the custom field, in payload form."""
+        return {"custom_fields": {"cf_key": {"text": value}}}
+
+    def test_two_values_of_a_unique_custom_field_are_two_objects(self):
+        """Unique, so different values cannot be one row."""
+        self.assertTrue(transformer.references_conflict(
+            "dcim.device", self._ref("KEY-A"), self._ref("KEY-B")))
+
+    def test_one_value_of_a_unique_custom_field_is_one_object(self):
+        """And equal values prove sameness, outranking a differing name."""
+        self.assertFalse(transformer.references_conflict(
+            "dcim.device", self._ref("KEY-A"), self._ref("KEY-A")))
+        self.assertFalse(transformer.references_conflict(
+            "dcim.device",
+            {**self._ref("KEY-A"), "name": "cf-rtr-a"},
+            {**self._ref("KEY-A"), "name": "something-else"}))
+
+    def test_the_untyped_form_compares_the_same_way(self):
+        """
+        The envelope is unwrapped later, so both forms reach this comparison.
+
+        _prepare_custom_fields turns {"text": v} into v, and this check runs
+        before that -- reading only one form would have been a second way to
+        miss the selector.
+        """
+        self.assertTrue(transformer.references_conflict(
+            "dcim.device",
+            {"custom_fields": {"cf_key": "KEY-A"}},
+            {"custom_fields": {"cf_key": "KEY-B"}}))
+
+    def test_values_of_different_primitive_kinds_are_not_compared(self):
+        """
+        A raw "5" and a raw 5 are one value that transform would coerce alike.
+
+        Calling those different would refuse a payload that ingests perfectly
+        well, so the comparison declines rather than guessing.
+        """
+        self.assertFalse(transformer.references_conflict(
+            "dcim.device",
+            {"custom_fields": {"cf_key": "5"}},
+            {"custom_fields": {"cf_key": 5}}))
+
+    def test_a_non_unique_custom_field_is_not_identity(self):
+        """Only unique=True produces a matcher, so nothing else may decide."""
+        other = CustomField.objects.create(
+            name="cf_note", type=CustomFieldTypeChoices.TYPE_TEXT,
+            required=False, unique=False)
+        other.object_types.set([ObjectType.objects.get_for_model(Device)])
+        other.save()
+        self.assertFalse(transformer.references_conflict(
+            "dcim.device",
+            {"custom_fields": {"cf_note": {"text": "A"}}},
+            {"custom_fields": {"cf_note": {"text": "B"}}}))
+
+    def test_the_message_shows_the_selector_that_decided(self):
+        """
+        Otherwise the error names the same bay twice.
+
+        Measured with the description hand-written: two bays named 'hy-bay' on
+        two devices distinguished only by this field rendered as
+        "module_bay is 'hy-bay', not 'hy-bay'".
+        """
+        described = transformer._describe_payload(
+            "dcim.modulebay", {"name": "b", "device": self._ref("KEY-A")})
+        self.assertIn("cf_key='KEY-A'", described)
+        self.assertIn("name='b'", described)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_moduletype_attributes_e2e.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_moduletype_attributes_e2e.py
@@ -1,0 +1,123 @@
+"""E2E: moduletype attributes ingest, apply, and re-diff convergence."""
+import json
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Manufacturer, ModuleType, ModuleTypeProfile
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class ModuleTypeAttributesE2ETests(APITestCase):
+    """Aliased 'attributes' must ingest, persist raw, and re-diff as NOOP."""
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        mfr = Manufacturer.objects.create(name="attr-mfr", slug="attr-mfr")
+        profile = ModuleTypeProfile.objects.create(
+            name="attr-profile",
+            schema={"properties": {"ram": {"type": "integer", "title": "RAM (GB)"}}},
+        )
+        self.mt = ModuleType.objects.create(
+            manufacturer=mfr, model="attr-mt", profile=profile,
+            attribute_data={"ram": 32},
+        )
+
+    def _payload(self, attributes):
+        # the wire carries JSON-blob fields (like every entry in
+        # _FORMAT_TRANSFORMATIONS keyed to parse_json) as an encoded string
+        return {
+            "timestamp": 1,
+            "object_type": "dcim.moduletype",
+            "entity": {"module_type": {
+                "manufacturer": {"name": "attr-mfr"},
+                "model": "attr-mt",
+                "attributes": json.dumps(attributes),
+            }},
+        }
+
+    def test_update_persists_raw_and_rediff_is_noop(self):
+        """Update attribute_data via the wire alias, then converge to NOOP."""
+        r1 = self.client.post(
+            self.diff_url, data=self._payload({"ram": 64}), format="json", **self.auth
+        )
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        # the aliased field must not be warned away
+        self.assertNotIn("attributes", str(cs.get("warnings")))
+        updates = [c for c in cs.get("changes", [])
+                   if c["object_type"] == "dcim.moduletype" and c["change_type"] == "update"]
+        self.assertTrue(any(c.get("data", {}).get("attributes") == {"ram": 64} for c in updates))
+
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+        self.mt.refresh_from_db()
+        self.assertEqual(self.mt.attribute_data, {"ram": 64})  # raw keys, not titled
+
+        # convergence: identical payload must re-diff as NOOP
+        r3 = self.client.post(
+            self.diff_url, data=self._payload({"ram": 64}), format="json", **self.auth
+        )
+        self.assertEqual(r3.status_code, 200)
+        changes = [c for c in r3.json().get("change_set", {}).get("changes", [])
+                   if c["object_type"] == "dcim.moduletype"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in changes), changes)
+
+    def test_subset_update_merges_and_converges(self):
+        """A payload omitting stored keys merges on apply and re-diffs as NOOP."""
+        # AttributesField merges non-empty update payloads into the stored
+        # value, so the planned postchange must predict that merge.
+        ModuleTypeProfile.objects.filter(pk=self.mt.profile_id).update(
+            schema={"properties": {
+                "ram": {"type": "integer", "title": "RAM (GB)"},
+                "cpus": {"type": "integer", "title": "CPU count"},
+            }},
+        )
+        ModuleType.objects.filter(pk=self.mt.pk).update(
+            attribute_data={"ram": 32, "cpus": 8},
+        )
+
+        r1 = self.client.post(
+            self.diff_url, data=self._payload({"ram": 64}), format="json", **self.auth
+        )
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        updates = [c for c in cs.get("changes", [])
+                   if c["object_type"] == "dcim.moduletype" and c["change_type"] == "update"]
+        self.assertTrue(
+            any(c.get("data", {}).get("attributes") == {"ram": 64, "cpus": 8} for c in updates),
+            updates,
+        )
+
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertIsNone(r2.json().get("errors"))
+        self.mt.refresh_from_db()
+        self.assertEqual(self.mt.attribute_data, {"ram": 64, "cpus": 8})  # omitted key preserved
+
+        # a converged subset payload must re-diff as NOOP, not the same UPDATE forever
+        r3 = self.client.post(
+            self.diff_url, data=self._payload({"ram": 64}), format="json", **self.auth
+        )
+        self.assertEqual(r3.status_code, 200)
+        changes = [c for c in r3.json().get("change_set", {}).get("changes", [])
+                   if c["object_type"] == "dcim.moduletype"]
+        self.assertTrue(all(c["change_type"] == "noop" for c in changes), changes)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_plugin_config.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_plugin_config.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from netbox_diode_plugin.plugin_config import _parse_diode_target, get_diode_auth_introspect_url, get_diode_user
+
+User = get_user_model()
+
+
+class PluginConfigTestCase(TestCase):
+    """Test case for plugin config helpers."""
+
+    def test_get_diode_auth_introspect_url(self):
+        """Test get_diode_auth_introspect_url function."""
+        expected = "http://localhost:8080/diode/auth/introspect"
+        self.assertEqual(get_diode_auth_introspect_url(), expected)
+
+    def test_get_diode_user(self):
+        """Test get_diode_user function."""
+        diode_user = get_diode_user()
+        expected_diode_user = User.objects.get(username="diode")
+        self.assertEqual(diode_user, expected_diode_user)
+
+    def test__parse_diode_target_handles_ftp_prefix(self):
+        """Check that _parse_diode_target raises an error when the target contains ftp://."""
+        with pytest.raises(ValueError):
+            _parse_diode_target("ftp://localhost:8081")
+
+    def test__parse_diode_target_parses_authority_correctly(self):
+        """Check that _parse_diode_target parses the authority correctly."""
+        authority, path, tls_verify = _parse_diode_target("grpc://localhost:8081")
+        assert authority == "localhost:8081"
+        assert path == ""
+        assert tls_verify is False
+
+    def test__parse_diode_target_adds_default_port_if_missing(self):
+        """Check that _parse_diode_target adds the default port if missing."""
+        authority, _, _ = _parse_diode_target("grpc://localhost")
+        assert authority == "localhost:80"
+        authority, _, _ = _parse_diode_target("http://localhost")
+        assert authority == "localhost:80"
+        authority, _, _ = _parse_diode_target("grpcs://localhost")
+        assert authority == "localhost:443"
+        authority, _, _ = _parse_diode_target("https://localhost")
+        assert authority == "localhost:443"
+
+    def test__parse_diode_target_parses_path_correctly(self):
+        """Check that _parse_diode_target parses the path correctly."""
+        _, path, _ = _parse_diode_target("grpc://localhost:8081/my/path")
+        assert path == "/my/path"
+
+    def test__parse_diode_target_handles_no_path(self):
+        """Check that _parse_diode_target handles no path."""
+        _, path, _ = _parse_diode_target("grpc://localhost:8081")
+        assert path == ""
+
+    def test__parse_diode_target_parses_tls_verify_correctly(self):
+        """Check that _parse_diode_target parses tls_verify correctly."""
+        _, _, tls_verify = _parse_diode_target("grpc://localhost:8081")
+        assert tls_verify is False
+        _, _, tls_verify = _parse_diode_target("http://localhost:8081")
+        assert tls_verify is False
+        _, _, tls_verify = _parse_diode_target("grpcs://localhost:8081")
+        assert tls_verify is True
+        _, _, tls_verify = _parse_diode_target("https://localhost:8081")
+        assert tls_verify is True

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_plugin_config.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_plugin_config.py
@@ -71,7 +71,8 @@ class PluginConfigTestCase(TestCase):
 
 
 class PluginCompatibilityTestCase(TestCase):
-    """Guards for the plugin's own compatibility declarations.
+    """
+    Guards for the plugin's own compatibility declarations.
 
     A stale max_version does not break this test suite (it runs with the
     plugin already loaded) - it breaks NetBox upgrades in the field, which
@@ -101,7 +102,8 @@ class PluginCompatibilityTestCase(TestCase):
         )
 
     def test_diode_user_is_active_superuser(self):
-        """NetBox 4.7 permission-scopes attribute-based related-object resolution.
+        """
+        NetBox 4.7 permission-scopes attribute-based related-object resolution.
 
         The service user must be an active superuser or every name-based
         reference in an applied change set fails as 'related object not

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_plugin_config.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_plugin_config.py
@@ -68,3 +68,52 @@ class PluginConfigTestCase(TestCase):
         assert tls_verify is True
         _, _, tls_verify = _parse_diode_target("https://localhost:8081")
         assert tls_verify is True
+
+
+class PluginCompatibilityTestCase(TestCase):
+    """Guards for the plugin's own compatibility declarations.
+
+    A stale max_version does not break this test suite (it runs with the
+    plugin already loaded) - it breaks NetBox upgrades in the field, which
+    is exactly how the 4.6->4.7 gap was noticed. This ties the declared
+    range to whatever NetBox version the suite runs against.
+    """
+
+    def test_declared_version_range_covers_running_netbox(self):
+        """The running NetBox version must fall inside min/max_version."""
+        from django.conf import settings
+        from packaging import version
+
+        from netbox_diode_plugin import NetBoxDiodePluginConfig
+
+        current = version.parse(settings.RELEASE.version)
+        self.assertGreaterEqual(
+            current,
+            version.parse(NetBoxDiodePluginConfig.min_version),
+            "running NetBox is older than the plugin's min_version",
+        )
+        self.assertLessEqual(
+            current,
+            version.parse(NetBoxDiodePluginConfig.max_version),
+            "running NetBox is newer than the plugin's max_version - "
+            "bump max_version (and the README compatibility table) before "
+            "supporting a new NetBox release",
+        )
+
+    def test_diode_user_is_active_superuser(self):
+        """NetBox 4.7 permission-scopes attribute-based related-object resolution.
+
+        The service user must be an active superuser or every name-based
+        reference in an applied change set fails as 'related object not
+        found'.
+        """
+        diode_user = get_diode_user()
+        self.assertTrue(diode_user.is_active)
+        self.assertTrue(diode_user.is_superuser)
+
+    def test_diode_user_upgraded_lazily(self):
+        """Rows created by older plugin versions are upgraded on access."""
+        User.objects.filter(username="diode").update(is_superuser=False, is_active=False)
+        diode_user = get_diode_user()
+        self.assertTrue(diode_user.is_active)
+        self.assertTrue(diode_user.is_superuser)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_plugin_config.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_plugin_config.py
@@ -101,21 +101,66 @@ class PluginCompatibilityTestCase(TestCase):
             "supporting a new NetBox release",
         )
 
-    def test_diode_user_is_active_superuser(self):
+    def test_diode_user_is_not_superuser_and_cannot_log_in(self):
         """
-        NetBox 4.7 permission-scopes attribute-based related-object resolution.
+        The service user stays unprivileged at the account level.
 
-        The service user must be an active superuser or every name-based
-        reference in an applied change set fails as 'related object not
-        found'.
+        Superuser was revoked for cause (migration
+        0005_revoke_superuser_status); NetBox 4.7's permission needs are
+        met by explicit ObjectPermissions instead. The password must be
+        unusable so no login path can ever authenticate as this account.
         """
         diode_user = get_diode_user()
-        self.assertTrue(diode_user.is_active)
-        self.assertTrue(diode_user.is_superuser)
+        self.assertFalse(diode_user.is_superuser)
+        self.assertFalse(diode_user.has_usable_password())
 
-    def test_diode_user_upgraded_lazily(self):
-        """Rows created by older plugin versions are upgraded on access."""
-        User.objects.filter(username="diode").update(is_superuser=False, is_active=False)
+    def test_deactivated_diode_user_stays_deactivated(self):
+        """Deactivation is an operator kill switch and must be respected."""
+        get_diode_user()
+        User.objects.filter(username="diode").update(is_active=False)
         diode_user = get_diode_user()
-        self.assertTrue(diode_user.is_active)
-        self.assertTrue(diode_user.is_superuser)
+        self.assertFalse(diode_user.is_active)
+
+    def test_provisioned_view_permission_covers_all_object_types(self):
+        """
+        NetBox 4.7 scopes attribute-based reference resolution by view permission.
+
+        The provisioned grant must span every object type, or references
+        to a type NetBox adds later fail as 'related object not found' -
+        a data-shaped symptom pointing away from the real cause.
+        """
+        from core.models import ObjectType
+        from users.models import ObjectPermission
+
+        from netbox_diode_plugin.provisioning import (
+            VIEW_PERMISSION_NAME,
+            provision_diode_permissions,
+        )
+
+        provision_diode_permissions()
+        permission = ObjectPermission.objects.get(name=VIEW_PERMISSION_NAME)
+        self.assertTrue(permission.enabled)
+        self.assertEqual(permission.actions, ["view"])
+        self.assertIsNone(permission.constraints)
+        self.assertIn(get_diode_user(), permission.users.all())
+        self.assertEqual(
+            set(permission.object_types.values_list("pk", flat=True)),
+            set(ObjectType.objects.values_list("pk", flat=True)),
+        )
+
+    def test_diode_user_can_resolve_by_attributes_and_add_macaddress(self):
+        """The two NetBox 4.7 permission gates are open for the service user."""
+        from dcim.models import Site
+        from utilities.api import get_related_object_by_attrs
+
+        from netbox_diode_plugin.provisioning import provision_diode_permissions
+
+        provision_diode_permissions()
+        site = Site.objects.create(name="Perm Probe Site", slug="perm-probe-site")
+        diode_user = get_diode_user()
+
+        resolved = get_related_object_by_attrs(
+            Site.objects.all(), {"name": "Perm Probe Site"}, user=diode_user
+        )
+        self.assertEqual(resolved, site)
+        self.assertTrue(diode_user.has_perm("dcim.add_macaddress"))

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_prefix_adoption.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_prefix_adoption.py
@@ -1,0 +1,148 @@
+"""E2E: duplicate prefix creates adopt the existing prefix at apply time."""
+from types import SimpleNamespace
+from unittest import mock
+
+from ipam.models import VRF, Prefix
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class PrefixAdoptionE2ETests(APITestCase):
+    """
+    Concurrently planned duplicate prefix CREATEs must adopt, not duplicate.
+
+    NetBox permits duplicate prefixes: Prefix.Meta declares only ordering and
+    indexes, and the duplicate check in Prefix.clean() is gated on
+    ENFORCE_GLOBAL_UNIQUE or the VRF's enforce_unique flag, neither of which
+    the applier reaches because it saves through DRF serializers without
+    full_clean(). So nothing below the matcher stops a second insert, which is
+    why ipam.prefix needs the pre-save match.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.vrf = VRF.objects.create(name="pa-vrf", rd="64805:7")
+
+    def _prefix_entity(self, prefix="10.9.16.0/22", vrf=True, extra=None):
+        entity = {"prefix": prefix}
+        if vrf:
+            entity["vrf"] = {"name": "pa-vrf", "rd": "64805:7"}
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "ipam.prefix", "entity": {"prefix": entity}}
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIn("change_set", r.json(), r.content)
+        return r.json().get("change_set", {})
+
+    def _apply(self, cs, expect=200):
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, expect, r.content)
+        return r
+
+    def test_plan_ahead_duplicate_within_vrf_adopts(self):
+        """
+        Two changesets planned before either apply yield one prefix, not two.
+
+        This is the reported shape: both plans see no existing prefix, so both
+        emit CREATE, and without the pre-save match both inserts succeed.
+        """
+        cs_a = self._diff(self._prefix_entity())
+        cs_b = self._diff(self._prefix_entity(extra={"description": "second planner"}))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+
+        prefixes = Prefix.objects.filter(prefix="10.9.16.0/22", vrf=self.vrf)
+        self.assertEqual(prefixes.count(), 1)
+        self.assertEqual(prefixes.first().description, "second planner")
+
+        # converged: re-planning the same entity produces no real change
+        cs = self._diff(self._prefix_entity(extra={"description": "second planner"}))
+        non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+        self.assertEqual(non_noop, [], non_noop)
+
+    def test_plan_ahead_duplicate_in_global_table_adopts(self):
+        """
+        The vrf-is-NULL matcher needs the same protection as the VRF one.
+
+        ipam.prefix has two logical matchers, split on whether vrf is NULL, so
+        a global-table prefix takes a different path and is covered separately.
+        """
+        cs_a = self._diff(self._prefix_entity(prefix="10.9.20.0/22", vrf=False))
+        cs_b = self._diff(self._prefix_entity(prefix="10.9.20.0/22", vrf=False))
+
+        self._apply(cs_a)
+        self._apply(cs_b)
+
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.20.0/22", vrf__isnull=True).count(), 1
+        )
+
+    def test_same_prefix_in_different_vrfs_stays_distinct(self):
+        """
+        The hazard pin: adoption must not collapse genuinely distinct rows.
+
+        The same network in two different VRFs is two legitimate objects. If
+        the pre-save match ignored the VRF it would adopt across them, which
+        would be worse than the duplicate it exists to prevent.
+        """
+        other = VRF.objects.create(name="pa-vrf-b", rd="64805:8")
+        self._apply(self._diff(self._prefix_entity()))
+        self._apply(
+            self._diff(
+                {
+                    "timestamp": 1,
+                    "object_type": "ipam.prefix",
+                    "entity": {
+                        "prefix": {
+                            "prefix": "10.9.16.0/22",
+                            "vrf": {"name": "pa-vrf-b", "rd": "64805:8"},
+                        }
+                    },
+                }
+            )
+        )
+
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.16.0/22").count(), 2)
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.16.0/22", vrf=self.vrf).count(), 1
+        )
+        self.assertEqual(
+            Prefix.objects.filter(prefix="10.9.16.0/22", vrf=other).count(), 1
+        )
+
+    def test_global_and_vrf_prefix_stay_distinct(self):
+        """
+        A prefix in the global table and the same one in a VRF are distinct.
+
+        The two matchers are conditioned on vrf being NULL or NOT NULL, so this
+        pins that the global-table row is not adopted by the VRF-scoped one.
+        """
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.24.0/22", vrf=False)))
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.24.0/22")))
+
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.24.0/22").count(), 2)
+
+    def test_miss_then_create_still_works(self):
+        """Find-first miss on an empty table falls through to a normal create."""
+        self._apply(self._diff(self._prefix_entity(prefix="10.9.28.0/22")))
+        self.assertEqual(Prefix.objects.filter(prefix="10.9.28.0/22").count(), 1)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_serializer_only_warning.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_serializer_only_warning.py
@@ -1,0 +1,77 @@
+"""E2E: serializer-only fields get a specific, non-fatal warning."""
+from types import SimpleNamespace
+from unittest import mock
+
+from circuits.models import Circuit
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.transformer import SERIALIZER_ONLY_FIELD_WARNING
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class SerializerOnlyWarningE2ETests(APITestCase):
+    """Ingesting a serializer-only field warns specifically and still applies."""
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+    def test_circuit_assignments_warns_specifically_and_applies(self):
+        """Assignments is dropped with the specific message; the circuit lands."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "circuits.circuit",
+            "entity": {"circuit": {
+                "cid": "so-circ-1",
+                "provider": {"name": "so-prov"},
+                "type": {"name": "so-ctype"},
+                "assignments": [{"id": 1}],
+            }},
+        }
+        r1 = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r1.status_code, 200)
+        cs = r1.json().get("change_set", {})
+        self.assertIn(SERIALIZER_ONLY_FIELD_WARNING, str(cs.get("warnings")))
+        r2 = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 200)
+        self.assertTrue(Circuit.objects.filter(cid="so-circ-1").exists())
+
+    def test_unknown_stale_wire_keeps_generic_warning(self):
+        """A version-stale wire (dcim.frontport.rear_port, not serializer-only) keeps the generic text."""
+        payload = {
+            "timestamp": 1,
+            "object_type": "dcim.frontport",
+            "entity": {"front_port": {
+                "name": "so-fp-1",
+                "type": "8p8c",
+                "rear_port": {"name": "so-rp-1"},
+                "device": {
+                    "name": "so-dev-1",
+                    "device_type": {
+                        "model": "so-dtype-1",
+                        "manufacturer": {"name": "so-manu-1"},
+                    },
+                    "role": {"name": "so-role-1"},
+                    "site": {"name": "so-site-1"},
+                },
+            }},
+        }
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200)
+        warnings = str(r.json().get("change_set", {}).get("warnings"))
+        self.assertIn("Ignored unsupported field.", warnings)
+        self.assertNotIn(SERIALIZER_ONLY_FIELD_WARNING, warnings)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_supported_models_gate.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_supported_models_gate.py
@@ -1,0 +1,60 @@
+"""Unit tests for the serializer-aware supported-models gate."""
+from django.test import TestCase
+
+from netbox_diode_plugin.api.supported_models import extract_supported_models
+
+
+class SerializerAwareGateTests(TestCase):
+    """The gate classifies legal wire fields against the running serializer."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Extract once; the function is process-cached."""
+        cls.supported = extract_supported_models()
+
+    def test_aliased_field_supported_with_source(self):
+        """Moduletype 'attributes' is supported, backed by attribute_data."""
+        info = self.supported["dcim.moduletype"]["fields"]["attributes"]
+        self.assertEqual(info["source"], "attribute_data")
+        self.assertEqual(info["type"], "JSONField")
+
+    def test_every_entry_has_source_and_id(self):
+        """Every fields entry carries source; id is present on every type."""
+        for object_type, entry in self.supported.items():
+            self.assertIn("id", entry["fields"], object_type)
+            for wire, info in entry["fields"].items():
+                self.assertIn("source", info, f"{object_type}.{wire}")
+
+    def test_custom_fields_never_in_fields(self):
+        """custom_fields stays owned by its dedicated path, not the gate."""
+        for object_type, entry in self.supported.items():
+            self.assertNotIn("custom_fields", entry["fields"], object_type)
+
+    def test_serializer_only_fields(self):
+        """Writable serializer fields with no model field are set aside."""
+        self.assertIn("adopt_components", self.supported["dcim.module"]["serializer_only_fields"])
+        self.assertIn("replicate_components", self.supported["dcim.module"]["serializer_only_fields"])
+        self.assertIn("assignments", self.supported["circuits.circuit"]["serializer_only_fields"])
+        self.assertIn("a_terminations", self.supported["dcim.cable"]["serializer_only_fields"])
+        self.assertIn("b_terminations", self.supported["dcim.cable"]["serializer_only_fields"])
+
+    def test_version_stale_wires_dropped(self):
+        """Wires absent from this version's serializer are not supported."""
+        fp = self.supported["dcim.frontport"]
+        self.assertNotIn("rear_port", fp["fields"])
+        self.assertNotIn("rear_port", fp["serializer_only_fields"])
+        self.assertNotIn("rear_port_position", fp["fields"])
+        self.assertNotIn("group", self.supported["tenancy.contact"]["fields"])
+
+    def test_no_serializer_fallback(self):
+        """Models without a serializer keep the legacy model-walk behavior."""
+        entry = self.supported.get("core.managedfile")
+        if entry is None:
+            self.skipTest("core.managedfile not extracted on this version")
+        self.assertEqual(entry["serializer_only_fields"], set())
+        self.assertNotIn("file", entry["fields"])
+
+    def test_every_type_has_serializer_only_key(self):
+        """The new entry key exists for every extracted type."""
+        for object_type, entry in self.supported.items():
+            self.assertIn("serializer_only_fields", entry, object_type)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_supported_models_guardrail.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_supported_models_guardrail.py
@@ -1,0 +1,78 @@
+"""Guardrail: every legal wire field must be accounted for by the gate."""
+from django.test import TestCase
+
+from netbox_diode_plugin.api.plugin_utils import get_json_ref_info, legal_fields
+from netbox_diode_plugin.api.supported_models import (
+    extract_supported_models,
+    get_serializer_for_model,
+)
+
+# Wires with dedicated ingest paths outside the per-field gate.
+EXEMPT_WIRES = {"custom_fields", "metadata"}
+
+# Models with no DRF serializer; the gate falls back to the legacy model walk.
+NO_SERIALIZER_TYPES = {"core.managedfile"}
+
+# The only intended supported-set changes of the serializer-aware gate on this
+# NetBox version. Anything else appearing in the delta is an unreviewed
+# behavior change: triage it against the design spec before touching this.
+EXPECTED_GAINS = ["dcim.moduletype.attributes"]
+# Phantom entries: the model keeps deprecated device/virtual_machine fields
+# but the serializer replaced them with the parent generic FK, and the
+# pre-gate compat migration rewrites those wires to parent_object_* anyway —
+# the old gate's "support" was unreachable and the applier ignored the keys.
+EXPECTED_LOSSES = [
+    "ipam.service.device",
+    "ipam.service.virtual_machine",
+]
+
+
+def _legacy_model_walk(model_class):
+    """Frozen copy of the pre-serializer-gate field selection (names only)."""
+    legal = legal_fields(model_class)
+    names = set()
+    for field in model_class._meta.get_fields():
+        if field.name in legal or field.name == "id":
+            names.add(field.name)
+    return names
+
+
+class LegalFieldAccountingTests(TestCase):
+    """No legal field may be silently unclassified, and the delta is pinned."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Extract once; the function is process-cached."""
+        cls.supported = extract_supported_models()
+
+    def test_every_legal_field_is_accounted_for(self):
+        """Each legal wire is supported, loud, ref-handled, stale, or exempt."""
+        unaccounted = []
+        for object_type, entry in self.supported.items():
+            if object_type in NO_SERIALIZER_TYPES:
+                continue
+            ser_fields = get_serializer_for_model(entry["model"])().get_fields()
+            for wire in legal_fields(object_type):
+                if wire in EXEMPT_WIRES:
+                    continue
+                if wire in entry["fields"] or wire in entry["serializer_only_fields"]:
+                    continue
+                ref_info = get_json_ref_info(object_type, wire)
+                if ref_info is not None and ref_info.is_generic_object:
+                    continue  # ref-handled (e.g. cable terminations)
+                f = ser_fields.get(wire)
+                if f is None or f.read_only:
+                    continue  # version-stale on this NetBox version
+                unaccounted.append(f"{object_type}.{wire}")
+        self.assertEqual(unaccounted, [])
+
+    def test_gate_delta_vs_legacy_walk_is_exactly_intended(self):
+        """The old-vs-new supported-fields diff equals the documented delta."""
+        gains, losses = [], []
+        for object_type, entry in self.supported.items():
+            legacy = _legacy_model_walk(entry["model"])
+            new = set(entry["fields"])
+            gains += [f"{object_type}.{w}" for w in sorted(new - legacy)]
+            losses += [f"{object_type}.{w}" for w in sorted(legacy - new)]
+        self.assertEqual(sorted(gains), EXPECTED_GAINS)
+        self.assertEqual(sorted(losses), EXPECTED_LOSSES)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_transformer_cabling.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_transformer_cabling.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests - cabling generic-object transform."""
+
+from django.test import SimpleTestCase, TestCase
+
+from netbox_diode_plugin.api import transformer
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.supported_models import extract_supported_models
+
+
+class TransformerImportTestCase(SimpleTestCase):
+    """Imports needed by the generic-object-list arm are wired."""
+
+    def test_get_generic_object_variant_imported(self):
+        """Get generic object variant imported."""
+        self.assertTrue(
+            hasattr(transformer, "get_generic_object_variant"),
+            "transformer must import get_generic_object_variant from plugin_utils",
+        )
+
+
+class IsSupportedGenericObjectTestCase(TestCase):
+    """is_supported() accepts the generic-object-list field by its list name."""
+
+    def test_a_terminations_is_supported(self):
+        """A terminations is supported."""
+        supported = extract_supported_models()
+        result = transformer._transform_proto_json_1(
+            {"a_terminations": [], "b_terminations": []},
+            "dcim.cable",
+            supported,
+        )
+        node = result[0]
+        # empty lists are legal fields and must NOT be warned as unsupported
+        self.assertNotIn("a_terminations", node["_warnings"])
+        self.assertNotIn("b_terminations", node["_warnings"])
+
+    def test_a_terminations_list_processing_non_empty(self):
+        """
+        Non-empty a_terminations with a valid generic-object item returns 200.
+
+        Each item is a GenericObject dict such as {"object_interface": {...}}.
+        The list-processing branch calls get_generic_object_variant to resolve
+        the concrete object_type ("dcim.interface") and recurses with that type.
+        The termination list item is emitted as
+        {'object_type': 'dcim.interface', 'object_id': UnresolvedReference(...)}.
+        A payload with non-empty terminations must not raise ValidationError.
+        """
+        supported = extract_supported_models()
+        # minimal payload: one interface termination on side A
+        payload = {
+            "a_terminations": [
+                {"object_interface": {"name": "eth0", "device": {"name": "router1"}}}
+            ],
+            "b_terminations": [],
+        }
+        # Must not raise — the list loop resolves the concrete object_type.
+        result = transformer._transform_proto_json_1(payload, "dcim.cable", supported)
+        cable_node = result[0]
+
+        # a_terminations must be present and not warned as unsupported
+        self.assertNotIn("a_terminations", cable_node["_warnings"])
+
+        # The field is stored as a list of termination dicts
+        a_terms = cable_node.get("a_terminations")
+        self.assertIsInstance(a_terms, list)
+        self.assertEqual(len(a_terms), 1)
+
+        term = a_terms[0]
+        self.assertIsInstance(term, dict, "termination item must be a dict")
+        self.assertEqual(term.get("object_type"), "dcim.interface")
+        self.assertIsInstance(
+            term.get("object_id"),
+            UnresolvedReference,
+            "object_id must be an UnresolvedReference before resolution",
+        )
+        self.assertEqual(term["object_id"].object_type, "dcim.interface")
+
+    def test_a_terminations_unknown_variant_warns_and_skips(self):
+        """An unrecognised variant key emits a warning and skips the item."""
+        supported = extract_supported_models()
+        payload = {
+            "a_terminations": [
+                {"object_totally_unknown_thing": {"name": "x"}}
+            ],
+            "b_terminations": [],
+        }
+        result = transformer._transform_proto_json_1(payload, "dcim.cable", supported)
+        cable_node = result[0]
+
+        # The item is skipped; a warning is recorded on a_terminations
+        self.assertIn("a_terminations", cable_node["_warnings"])
+        # The list is present but empty (item was skipped)
+        a_terms = cable_node.get("a_terminations")
+        self.assertIsInstance(a_terms, list)
+        self.assertEqual(len(a_terms), 0)
+
+
+def _wrap(variant_key, inner):
+    return {variant_key: inner}
+
+
+class GenericObjectListExtractionTestCase(TestCase):
+    """Each certified termination variant extracts to {object_type, object_id}."""
+
+    CERTIFIED = [
+        ("object_interface", "dcim.interface"),
+        ("object_front_port", "dcim.frontport"),
+        ("object_rear_port", "dcim.rearport"),
+        ("object_console_port", "dcim.consoleport"),
+        ("object_console_server_port", "dcim.consoleserverport"),
+        ("object_power_port", "dcim.powerport"),
+        ("object_power_outlet", "dcim.poweroutlet"),
+        ("object_power_feed", "dcim.powerfeed"),
+        ("object_circuit_termination", "circuits.circuittermination"),
+    ]
+
+    def _inner_for(self, object_type):
+        if object_type == "circuits.circuittermination":
+            return {"term_side": "A", "circuit": {"cid": "C1"}}
+        if object_type == "dcim.powerfeed":
+            return {"name": "feed1", "power_panel": {"name": "panel1"}}
+        return {"name": "p1", "device": {"name": "Device A"}}
+
+    def test_each_variant_extracts_termination_dict_and_refs(self):
+        """Each variant extracts termination dict and refs."""
+        supported = extract_supported_models()
+        for variant_key, expected_ot in self.CERTIFIED:
+            with self.subTest(variant=variant_key):
+                entity = {
+                    "a_terminations": [_wrap(variant_key, self._inner_for(expected_ot))],
+                    "b_terminations": [_wrap("object_interface", {"name": "eth1", "device": {"name": "Device B"}})],
+                }
+                nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+                cable = nodes[0]
+                self.assertNotIn("a_terminations", cable["_warnings"])
+                terms = cable["a_terminations"]
+                self.assertEqual(len(terms), 1)
+                t = terms[0]
+                self.assertEqual(set(t.keys()), {"object_type", "object_id"})
+                self.assertEqual(t["object_type"], expected_ot)
+                self.assertIsInstance(t["object_id"], UnresolvedReference)
+                self.assertEqual(t["object_id"].object_type, expected_ot)
+                self.assertIn(t["object_id"].uuid, cable["_refs"])
+                child_types = {n["_object_type"] for n in nodes[1:]}
+                self.assertIn(expected_ot, child_types)
+
+
+class UnsupportedVariantTestCase(TestCase):
+    """Unknown/unsupported variant warns and skips that one termination."""
+
+    def test_unknown_key_warns_and_skips_keeps_cable(self):
+        """Unknown key warns and skips keeps cable."""
+        supported = extract_supported_models()
+        entity = {
+            "a_terminations": [
+                {"object_interface": {"name": "eth0", "device": {"name": "Device A"}}},
+                {"object_not_a_real_variant": {"name": "x"}},
+            ],
+            "b_terminations": [
+                {"object_cable_termination": {"foo": "bar"}},  # deprecated -> variant map returns None
+                {"object_interface": {"name": "eth1", "device": {"name": "Device B"}}},
+            ],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        self.assertEqual(len(cable["a_terminations"]), 1)
+        self.assertEqual(cable["a_terminations"][0]["object_type"], "dcim.interface")
+        self.assertEqual(len(cable["b_terminations"]), 1)
+        self.assertEqual(cable["b_terminations"][0]["object_type"], "dcim.interface")
+        self.assertIn("a_terminations", cable["_warnings"])
+        self.assertIn("b_terminations", cable["_warnings"])
+        self.assertTrue(any("object_not_a_real_variant" in w for w in cable["_warnings"]["a_terminations"]))
+        self.assertTrue(any("object_cable_termination" in w for w in cable["_warnings"]["b_terminations"]))
+
+    def test_non_terminable_variant_skipped_without_creating_child(self):
+        """
+        A supported-but-non-terminable variant (object_device) is rejected up front.
+
+        object_device maps to dcim.device (a supported model) but is not a valid
+        cable endpoint. It must warn + skip WITHOUT recursing to create the
+        device node, so no stray dependency object is planned for a cable that
+        would fail at apply.
+        """
+        supported = extract_supported_models()
+        entity = {
+            "a_terminations": [
+                {"object_device": {"name": "Bogus Device", "site": {"name": "S"}}},
+                {"object_interface": {"name": "eth0", "device": {"name": "Device A"}}},
+            ],
+            "b_terminations": [
+                {"object_interface": {"name": "eth1", "device": {"name": "Device B"}}},
+            ],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        # only the interface termination survived on end A
+        self.assertEqual(len(cable["a_terminations"]), 1)
+        self.assertEqual(cable["a_terminations"][0]["object_type"], "dcim.interface")
+        self.assertIn("a_terminations", cable["_warnings"])
+        self.assertTrue(
+            any("not a valid cable termination type" in w for w in cable["_warnings"]["a_terminations"])
+        )
+        # the rejected termination's device node was NOT created (the valid
+        # interface still brings its own parent device, "Device A")
+        device_names = {n.get("name") for n in nodes if n["_object_type"] == "dcim.device"}
+        self.assertNotIn("Bogus Device", device_names)
+
+
+class MultiTerminationTransformTestCase(TestCase):
+    """Termination payloads transform cleanly; multi-object-per-end is supported."""
+
+    def test_both_end_payload_extracts_both_interfaces(self):
+        """Both-end termination payload extracts both interfaces."""
+        # NOTE: IsSupportedGenericObjectTestCase.test_a_terminations_list_processing_non_empty
+        # already covers the single-interface-per-end path.  This test is distinct in that it
+        # exercises both a_terminations AND b_terminations simultaneously and asserts the two
+        # child interface nodes are emitted (len == 2), which the earlier test does not check.
+        supported = extract_supported_models()
+        entity = {
+            "a_terminations": [{"object_interface": {"name": "eth0", "device": {"name": "A"}}}],
+            "b_terminations": [{"object_interface": {"name": "eth1", "device": {"name": "B"}}}],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        self.assertEqual(cable["a_terminations"][0]["object_type"], "dcim.interface")
+        self.assertEqual(cable["b_terminations"][0]["object_type"], "dcim.interface")
+        ifaces = [n for n in nodes[1:] if n["_object_type"] == "dcim.interface"]
+        self.assertEqual(len(ifaces), 2)
+        a_uuid = cable["a_terminations"][0]["object_id"].uuid
+        b_uuid = cable["b_terminations"][0]["object_id"].uuid
+        self.assertIn(a_uuid, cable["_refs"])
+        self.assertIn(b_uuid, cable["_refs"])
+
+    def test_multi_object_per_end(self):
+        """Multi object per end."""
+        supported = extract_supported_models()
+        entity = {
+            "a_terminations": [
+                {"object_interface": {"name": "eth0", "device": {"name": "A"}}},
+                {"object_interface": {"name": "eth1", "device": {"name": "A"}}},
+            ],
+            "b_terminations": [
+                {"object_front_port": {"name": "fp0", "device": {"name": "B"}}},
+                {"object_front_port": {"name": "fp1", "device": {"name": "B"}}},
+            ],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        self.assertEqual(len(cable["a_terminations"]), 2)
+        self.assertEqual(len(cable["b_terminations"]), 2)
+        self.assertEqual({t["object_type"] for t in cable["a_terminations"]}, {"dcim.interface"})
+        self.assertEqual({t["object_type"] for t in cable["b_terminations"]}, {"dcim.frontport"})
+        for end in ("a_terminations", "b_terminations"):
+            for t in cable[end]:
+                self.assertIn(t["object_id"].uuid, cable["_refs"])
+        for end in ("a_terminations", "b_terminations"):
+            for t in cable[end]:
+                hash(t["object_id"])  # must not raise
+
+
+class SameTerminationObjectBothEndsTestCase(TestCase):
+    """
+    Same logical object in two termination slots dedupes with no dangling ref.
+
+    Before the fix, _update_dict_refs did not recurse into dict items of
+    termination lists, so when the two identical interfaces deduped to one
+    surviving uuid, the second termination kept a stale uuid that was never
+    created -- and _pre_apply's created[stale_uuid] raised an uncaught
+    KeyError (HTTP 500). Runs the FULL pipeline
+    (transform_proto_json) because the rewrite happens in the dedup stage.
+    """
+
+    def test_same_interface_both_ends_no_dangling_ref(self):
+        """Same interface on both ends -> both refs point to the survivor."""
+        supported = extract_supported_models()
+        iface = {"name": "eth0", "device": {"name": "router1"}}
+        entity = {
+            "a_terminations": [{"object_interface": dict(iface)}],
+            "b_terminations": [{"object_interface": dict(iface)}],
+        }
+        entities = transformer.transform_proto_json(entity, "dcim.cable", supported)
+        cable = next(e for e in entities if e["_object_type"] == "dcim.cable")
+        iface_uuids = {
+            e["_uuid"] for e in entities if e["_object_type"] == "dcim.interface"
+        }
+        # the two identical interfaces dedupe to exactly one surviving node
+        self.assertEqual(len(iface_uuids), 1)
+        a_ref = cable["a_terminations"][0]["object_id"]
+        b_ref = cable["b_terminations"][0]["object_id"]
+        self.assertIsInstance(a_ref, UnresolvedReference)
+        self.assertIsInstance(b_ref, UnresolvedReference)
+        # BOTH terminations reference the surviving interface (no dangling uuid)
+        self.assertIn(a_ref.uuid, iface_uuids)
+        self.assertIn(b_ref.uuid, iface_uuids)
+        self.assertEqual(a_ref.uuid, b_ref.uuid)
+
+
+class CamelCaseTerminationTestCase(TestCase):
+    """
+    camelCase protoJSON terminations resolve like snake_case ones.
+
+    Top-level keys are normalized by _ensure_snake_case, but the nested
+    GenericObject variant key (e.g. "objectInterface") arrives untouched and
+    must be normalized before the variant-map lookup.
+    """
+
+    def test_camel_case_variant_keys_extract(self):
+        """aTerminations/objectInterface payload extracts both terminations."""
+        supported = extract_supported_models()
+        entity = {
+            "aTerminations": [{"objectInterface": {"name": "eth0", "device": {"name": "A"}}}],
+            "bTerminations": [{"objectInterface": {"name": "eth1", "device": {"name": "B"}}}],
+        }
+        nodes = transformer._transform_proto_json_1(entity, "dcim.cable", supported)
+        cable = nodes[0]
+        self.assertNotIn("a_terminations", cable["_warnings"])
+        self.assertNotIn("b_terminations", cable["_warnings"])
+        for end in ("a_terminations", "b_terminations"):
+            self.assertEqual(len(cable[end]), 1)
+            self.assertEqual(cable[end][0]["object_type"], "dcim.interface")
+            self.assertIsInstance(cable[end][0]["object_id"], UnresolvedReference)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_transformer_vc_circular.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_transformer_vc_circular.py
@@ -1,0 +1,241 @@
+"""Transformer behavior for circular device<->virtual_chassis references."""
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site, VirtualChassis
+from django.test import SimpleTestCase, TestCase
+
+from netbox_diode_plugin.api import transformer
+from netbox_diode_plugin.api.common import VC_MEMBER_HINT, ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
+
+
+def _device_entity(name, extra=None):
+    entity = {
+        "name": name,
+        "site": {"name": "vctf-site"},
+        "role": {"name": "vctf-role"},
+        "device_type": {"manufacturer": {"name": "vctf-mfr"}, "model": "vctf-dt"},
+    }
+    entity.update(extra or {})
+    return entity
+
+
+class VcCircularTransformTests(TestCase):
+    """Natural VC shapes must transform cycle-free with position preserved."""
+
+    def test_natural_master_shape_plans_without_cycle(self):
+        """A master device carrying its own VC ref must not cycle."""
+        entity = _device_entity("vctf-sw1", {
+            "vc_position": 1,
+            "vc_priority": 200,
+            "virtual_chassis": {
+                "name": "vctf-stack",
+                "master": {"name": "vctf-sw1", "site": {"name": "vctf-site"}},
+            },
+        })
+        result = generate_changeset(entity, "dcim.device")
+        self.assertIsNone(result.errors)
+        types = [c.object_type for c in result.change_set.changes]
+        self.assertIn("dcim.virtualchassis", types)
+
+    def test_deferred_update_carries_position_and_priority(self):
+        """The deferred VC-set must re-assert position/priority after the signal."""
+        entity = _device_entity("vctf-sw2", {
+            "vc_position": 3,
+            "vc_priority": 128,
+            "virtual_chassis": {
+                "name": "vctf-stack2",
+                "master": {"name": "vctf-sw2", "site": {"name": "vctf-site"}},
+            },
+        })
+        result = generate_changeset(entity, "dcim.device")
+        self.assertIsNone(result.errors)
+        deferred = [
+            c for c in result.change_set.changes
+            if c.object_type == "dcim.device" and c.change_type == ChangeType.UPDATE
+            and "virtual_chassis" in (c.data or {})
+        ]
+        self.assertTrue(deferred, result.change_set.changes)
+        self.assertEqual(deferred[0].data.get("vc_position"), 3)
+        self.assertEqual(deferred[0].data.get("vc_priority"), 128)
+
+    def test_explicit_vc_clear_does_not_crash(self):
+        """virtual_chassis: {} must plan a clear, not an internal error."""
+        site = Site.objects.create(name="vctf-site", slug="vctf-site")
+        mfr = Manufacturer.objects.create(name="vctf-mfr", slug="vctf-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="vctf-dt", slug="vctf-dt")
+        role = DeviceRole.objects.create(name="vctf-role", slug="vctf-role")
+        member = Device.objects.create(name="vctf-member", site=site, device_type=dt, role=role)
+        vc = VirtualChassis.objects.create(name="vctf-stack3")
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=vc, vc_position=2)
+
+        entity = _device_entity("vctf-member", {"virtual_chassis": {}})
+        result = generate_changeset(entity, "dcim.device")
+        self.assertIsNone(result.errors)
+        clears = [
+            c for c in result.change_set.changes
+            if c.object_type == "dcim.device"
+            and "virtual_chassis" in (c.data or {})
+            and c.data["virtual_chassis"] is None
+        ]
+        self.assertTrue(clears, result.change_set.changes)
+
+    def test_primary_ip_empty_clear_does_not_crash(self):
+        """The pre-existing clear-branch defect: primary_ip4: {} must not 500."""
+        entity = _device_entity("vctf-sw4", {"primary_ip4": {}})
+        result = generate_changeset(entity, "dcim.device")
+        self.assertIsNone(result.errors)
+
+
+class FingerprintDedupePostCreateIsolationTests(TestCase):
+    """A post-create node must never register fingerprints in `_fingerprint_dedupe`."""
+
+    def test_post_create_node_does_not_corrupt_site_dedupe(self):
+        """A post-create node sandwiched between duplicate sites must not steal their fingerprint slot."""
+        site_a = {
+            "_uuid": "site-a-uuid",
+            "_object_type": "dcim.site",
+            "_refs": set(),
+            "name": "vctf-dedupe-site",
+        }
+        device_post_create = {
+            "_uuid": "device-pc-uuid",
+            "_object_type": "dcim.device",
+            "_refs": set(),
+            "_is_post_create": True,
+            "_instance": "device-instance-uuid",
+            "vc_position": 2,
+        }
+        site_b_dup = {
+            "_uuid": "site-b-uuid",
+            "_object_type": "dcim.site",
+            "_refs": set(),
+            "name": "vctf-dedupe-site",
+        }
+
+        # _fingerprint_dedupe returns (entities, refs_released) since the driver-field
+        # policy landed on develop; only the entity list matters here.
+        result, _ = transformer._fingerprint_dedupe([site_a, device_post_create, site_b_dup])
+        self.assertEqual(len(result), 3)
+
+        # (a) the duplicate site must dedupe onto the FIRST site entity.
+        self.assertEqual(result[0]["_uuid"], "site-a-uuid")
+        self.assertEqual(result[2]["_uuid"], "site-a-uuid")
+        self.assertIs(result[0], result[2])
+
+        # (b) the post-create node must keep ONLY its own fields: it must not
+        # absorb the site's fields (e.g. 'name') nor its fingerprints.
+        device_result = result[1]
+        self.assertEqual(device_result["_uuid"], "device-pc-uuid")
+        self.assertNotIn("name", device_result)
+        self.assertEqual(device_result["vc_position"], 2)
+class MemberHintMergeTests(SimpleTestCase):
+    """
+    _merge_nodes must UNION the member-device hint, not prefer a's copy.
+
+    Private keys are otherwise "prefer a's value", which for this key would make
+    the rule it feeds read "prefer the chassis the FIRST-named member already
+    belongs to" -- an arbitrary choice of exactly the kind the whole policy
+    exists to remove.
+
+    Asserted directly on _merge_nodes because no single-entity payload can reach
+    it: a dcim.device entity nests one chassis reference, so the fingerprint
+    dedupe that merges two chassis nodes needs two member devices in one
+    transform, which the SDK shapes this plugin accepts do not produce today. A
+    guard nothing can reach through the API is still a guard, and mutation
+    testing found this one unpinned without this test.
+    """
+
+    @staticmethod
+    def _node(uuid, hint):
+        return {
+            "_object_type": "dcim.virtualchassis",
+            "_uuid": uuid,
+            "_refs": set(),
+            "_warnings": {},
+            "name": "stack",
+            VC_MEMBER_HINT: list(hint),
+        }
+
+    def test_both_members_survive_the_merge(self):
+        """Two chassis nodes, one member each: the merged node knows both."""
+        merged = transformer._merge_nodes(self._node("a", [7]), self._node("b", [9]))
+        self.assertEqual(merged[VC_MEMBER_HINT], [7, 9])
+
+    def test_the_union_does_not_duplicate_or_reorder(self):
+        """Idempotent on the overlap, and stable for the reader."""
+        merged = transformer._merge_nodes(
+            self._node("a", [7, 9]), self._node("b", [9, 11]))
+        self.assertEqual(merged[VC_MEMBER_HINT], [7, 9, 11])
+
+    def test_a_node_without_the_hint_contributes_nothing(self):
+        """A chassis node reached other than through a member has no hint."""
+        bare = self._node("b", [])
+        del bare[VC_MEMBER_HINT]
+        self.assertEqual(
+            transformer._merge_nodes(self._node("a", [7]), bare)[VC_MEMBER_HINT], [7])
+        self.assertEqual(
+            transformer._merge_nodes(bare, self._node("a", [7]))[VC_MEMBER_HINT], [7])
+
+    def test_neither_side_is_mutated(self):
+        """The union must not accumulate into the inputs' own lists."""
+        a, b = self._node("a", [7]), self._node("b", [9])
+        transformer._merge_nodes(a, b)
+        self.assertEqual(a[VC_MEMBER_HINT], [7])
+        self.assertEqual(b[VC_MEMBER_HINT], [9])
+
+
+class ConsolidatedPostCreateOrderTests(SimpleTestCase):
+    """Merging two deferred steps must not move a reference before its node."""
+
+    @staticmethod
+    def _step(uuid, instance, refs, **extra):
+        return dict({
+            "_uuid": uuid, "_object_type": "dcim.device", "_refs": set(refs),
+            "_instance": instance, "_is_post_create": True,
+        }, **extra)
+
+    def test_the_merged_step_lands_after_every_reference_it_inherited(self):
+        """
+        Consolidation unions the refs, so it must take the LATER position.
+
+        Two deferred steps for one device can depend on different nodes -- one
+        on the chassis it is joining, one on a primary_ip4 created for it -- and
+        those nodes sit at different points in the order. Merging into the
+        EARLIER step's slot carries the later step's reference back with it, so
+        the step can precede a node it now depends on, and
+        _check_unresolved_refs rejects the whole payload as circular.
+
+        Measured with the chassis-dependent step at index 2, the IP at index 3
+        and the IP-dependent step at index 4: the merged step landed at index 2
+        holding a reference to index 3.
+
+        The last contributor's position is always sound, because each step was
+        individually ordered after its own dependencies.
+        """
+        device = {"_uuid": "dev", "_object_type": "dcim.device",
+                  "_refs": set(), "name": "d"}
+        chassis = {"_uuid": "vc", "_object_type": "dcim.virtualchassis", "_refs": set()}
+        ip = {"_uuid": "ip", "_object_type": "ipam.ipaddress", "_refs": set()}
+        entities = [
+            device,
+            chassis,
+            self._step("sa", "dev", {"dev", "vc"}, vc_position=5),
+            ip,
+            self._step("sb", "dev", {"dev", "ip"}, primary_ip4="held"),
+        ]
+
+        out = transformer._consolidate_post_creates(entities)
+
+        steps = [e for e in out if e.get("_is_post_create")]
+        self.assertEqual(len(steps), 1, "the two steps for one device did not merge")
+        merged = steps[0]
+        self.assertEqual(merged["vc_position"], 5)
+        self.assertEqual(merged["primary_ip4"], "held")
+
+        order = [e["_uuid"] for e in out]
+        step_at = order.index(merged["_uuid"])
+        for ref in merged["_refs"]:
+            if ref in order:
+                self.assertLessEqual(
+                    order.index(ref), step_at,
+                    f"reference {ref} is ordered after the step that needs it",
+                )

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_updates.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_updates.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Diode NetBox Plugin - Tests."""
+
+import inspect
+import json
+import logging
+import os
+from types import SimpleNamespace
+from unittest import mock
+
+from django.db.models import QuerySet
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.common import harmonize_formats
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+logger = logging.getLogger(__name__)
+
+
+def _harmonize_formats(data):
+    data = harmonize_formats(data)
+    return _tuples_to_lists(data)
+
+def _tuples_to_lists(data):
+    if isinstance(data, tuple | list):
+        return [_tuples_to_lists(d) for d in data]
+    if isinstance(data, dict):
+        return {k: _tuples_to_lists(v) for k, v in data.items()}
+    return data
+
+def load_test_cases(cls):
+    """Class decorator to load test cases and create test methods."""
+    logger.debug("Loading apply updates test cases")
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    test_data_path = os.path.join(current_dir, "test_updates_cases.json")
+
+    if not os.path.exists(test_data_path):
+        raise FileNotFoundError(f"Test data file not found at {test_data_path}")
+
+    def _create_and_update_test_case(case):
+        object_type = case["object_type"]
+
+        def test_func(self):
+            model = get_object_type_model(object_type)
+
+            payload = {
+                "timestamp": 1,
+                "object_type": object_type,
+                "entity": case["create"],
+            }
+            res = self.send_request(self.diff_url, payload)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+            diff = res.json().get("change_set", {})
+            res = self.client.post(
+                self.apply_url, data=diff, format="json", **self.authorization_header
+            )
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+            # lookup the object and check fields
+            obj = model.objects.get(**case["lookup"])
+            self._check_expect(obj, case["create_expect"])
+
+            # resending the same payload should not change anything
+            payload = {
+                "timestamp": 2,
+                "object_type": object_type,
+                "entity": case["create"],
+            }
+            res = self.send_request(self.diff_url, payload)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+            change_set = res.json().get("change_set", {})
+            if change_set.get("changes", []) != []:
+                logger.error(f"Unexpected change set {json.dumps(change_set, indent=4)}")
+
+            self.assertEqual(res.json().get("change_set", {}).get("changes", []), [])
+
+            # updating the object
+            payload = {
+                "timestamp": 3,
+                "object_type": object_type,
+                "entity": case["update"],
+            }
+            res = self.send_request(self.diff_url, payload)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+            diff = res.json().get("change_set", {})
+            res = self.client.post(
+                self.apply_url, data=diff, format="json", **self.authorization_header
+            )
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+            obj = model.objects.get(**case["lookup"])
+            self._check_expect(obj, case["update_expect"])
+
+        test_func.__name__ = f"test_updates_{case['name']}"
+        return test_func
+
+    with open(test_data_path) as f:
+        test_cases = json.load(f)
+        for case in test_cases:
+            t = _create_and_update_test_case(case)
+            logger.debug(f"Creating test case {t.__name__}")
+            setattr(cls, t.__name__, t)
+
+    return cls
+
+@load_test_cases
+class ApplyUpdatesTestCase(APITestCase):
+    """diff/create/update test cases."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test cases."""
+        super().setUpClass()
+
+    def setUp(self):
+        """Set up the test case."""
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.authorization_header = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        self.diode_user = SimpleNamespace(
+            user = get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"}
+        )
+
+        self.introspect_patcher = mock.patch.object(
+            DiodeOAuth2Authentication,
+            '_introspect_token',
+            return_value=self.diode_user
+        )
+        self.introspect_patcher.start()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        self.introspect_patcher.stop()
+        super().tearDown()
+
+    def _follow_path(self, obj, path):
+        cur = obj
+        for i, p in enumerate(path):
+            if p.isdigit():
+                p = int(p)
+                cur = cur[p]
+            else:
+                cur = getattr(cur, p)
+            if i != len(path) - 1:
+                self.assertIsNotNone(cur)
+            if callable(cur):
+                try:
+                    signature = inspect.signature(cur)
+                    if len(signature.parameters) == 0:
+                        cur = cur()
+                except ValueError:
+                    pass
+            if isinstance(cur, QuerySet):
+                cur = list(cur)
+        return cur
+
+    def _check_set_by(self, obj, path, value):
+        key = path[-1][len("__by_"):]
+        path = path[:-1]
+        cur = self._follow_path(obj, path)
+
+        if isinstance(value, list | tuple):
+            vals = set(value)
+        else:
+            vals = {value}
+
+        cvals = {_harmonize_formats(getattr(c, key)) for c in cur}
+        self.assertEqual(cvals, vals)
+
+    def _check_equals(self, obj, path, value):
+        cur = self._follow_path(obj, path)
+        cur = _harmonize_formats(cur)
+        self.assertEqual(cur, value)
+
+    def _check_expect(self, obj, expect):
+        for field, value in expect.items():
+            path = field.strip().split(".")
+            if path[-1].startswith("__by_"):
+                self._check_set_by(obj, path, value)
+            else:
+                self._check_equals(obj, path, value)
+
+    def send_request(self, url, payload, status_code=status.HTTP_200_OK):
+        """Post the payload to the url and return the response."""
+        response = self.client.post(
+            url, data=payload, format="json", **self.authorization_header
+        )
+        self.assertEqual(response.status_code, status_code)
+        return response

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_updates_cases.json
@@ -10492,5 +10492,64 @@
                 "tcp/853"
             ]
         }
+    },
+    {
+        "name": "dcim_interface_flat_mac_1",
+        "object_type": "dcim.interface",
+        "lookup": {
+            "name": "FlatMac1/0/1"
+        },
+        "create_expect": {
+            "name": "FlatMac1/0/1",
+            "primary_mac_address.mac_address": "00:0F:1A:2B:3C:4D"
+        },
+        "create": {
+            "interface": {
+                "name": "FlatMac1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "type": "1000base-t",
+                "mac_address": "00:0F:1A:2B:3C:4D"
+            }
+        },
+        "update": {
+            "interface": {
+                "name": "FlatMac1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "type": "1000base-t",
+                "mac_address": "00:0F:1A:2B:3C:4D",
+                "description": "flat mac shortcut Updated"
+            }
+        },
+        "update_expect": {
+            "description": "flat mac shortcut Updated"
+        }
     }
 ]

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_updates_cases.json
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_updates_cases.json
@@ -1,0 +1,10496 @@
+[
+    {
+        "name": "ipam_asn_1",
+        "object_type": "ipam.asn",
+        "lookup": {
+            "asn": 555
+        },
+        "create_expect": {
+            "asn": 555,
+            "description": "ASN 555 Description",
+            "rir.name": "RIR 1"
+        },
+        "create": {
+            "asn": {
+                "asn": "555",
+                "rir": {
+                    "name": "RIR 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "description": "ASN 555 Description",
+                "comments": "ASN 555 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "asn": {
+                "asn": "555",
+                "rir": {
+                    "name": "RIR 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "description": "ASN 555 Description Updated",
+                "comments": "ASN 555 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "ASN 555 Description Updated"
+        }
+    },
+    {
+        "name": "ipam_asnrange_1",
+        "object_type": "ipam.asnrange",
+        "lookup": {
+            "name": "ASN Range 1"
+        },
+        "create_expect": {
+            "name": "ASN Range 1",
+            "start": 1,
+            "end": 2,
+            "rir.name": "RIR 1"
+        },
+        "create": {
+            "asn_range": {
+                "name": "ASN Range 1",
+                "slug": "asn-range-1",
+                "rir": {
+                    "name": "RIR 1"
+                },
+                "start": "1",
+                "end": "2",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "description": "ASN Range 1 Description",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "asn_range": {
+                "name": "ASN Range 1",
+                "slug": "asn-range-1",
+                "rir": {
+                    "name": "RIR 1"
+                },
+                "start": "1",
+                "end": "2",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "description": "ASN Range 1 Description Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "ASN Range 1 Description Updated"
+        }
+    },
+    {
+        "name": "ipam_aggregate_1",
+        "object_type": "ipam.aggregate",
+        "lookup": {
+            "prefix": "182.82.82.0/24"
+        },
+        "create_expect": {
+            "prefix": "182.82.82.0/24",
+            "rir.name": "RIR 1",
+            "description": "Aggregate Description"
+        },
+        "create": {
+            "aggregate": {
+                "prefix": "182.82.82.0/24",
+                "rir": {
+                    "name": "RIR 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "date_added": "2025-04-14T08:08:55Z",
+                "description": "Aggregate Description",
+                "comments": "Aggregate Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "aggregate": {
+                "prefix": "182.82.82.0/24",
+                "rir": {
+                    "name": "RIR 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "date_added": "2025-04-14T08:08:55Z",
+                "description": "Aggregate Description Updated",
+                "comments": "Aggregate Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Aggregate Description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuit_1",
+        "object_type": "circuits.circuit",
+        "lookup": {
+            "cid": "Circuit 1"
+        },
+        "create_expect": {
+            "cid": "Circuit 1",
+            "provider.name": "Provider 1",
+            "type.name": "Circuit Type 1",
+            "description": "Circuit 1 Description"
+        },
+        "create": {
+            "circuit": {
+                "cid": "Circuit 1",
+                "provider": {
+                    "name": "Provider 1"
+                },
+                "provider_account": {
+                    "provider": {
+                        "name": "Provider 1"
+                    },
+                    "account": "account1"
+                },
+                "type": {
+                    "name": "Circuit Type 1"
+                },
+                "status": "offline",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "install_date": "2025-04-14T00:00:00Z",
+                "termination_date": "2025-04-14T00:00:00Z",
+                "commit_rate": "10",
+                "description": "Circuit 1 Description",
+                "distance": 12.4,
+                "distance_unit": "ft",
+                "comments": "Circuit 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "circuit": {
+                "cid": "Circuit 1",
+                "provider": {
+                    "name": "Provider 1"
+                },
+                "provider_account": {
+                    "provider": {
+                        "name": "Provider 1"
+                    },
+                    "account": "account1"
+                },
+                "type": {
+                    "name": "Circuit Type 1"
+                },
+                "status": "offline",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "install_date": "2025-04-14T00:00:00Z",
+                "termination_date": "2025-04-14T00:00:00Z",
+                "commit_rate": "10",
+                "description": "Circuit 1 Description Updated",
+                "distance": 12.4,
+                "distance_unit": "ft",
+                "comments": "Circuit 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Circuit 1 Description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuitgroup_1",
+        "object_type": "circuits.circuitgroup",
+        "lookup": {
+            "name": "Circuit Group 1"
+        },
+        "create_expect": {
+            "name": "Circuit Group 1",
+            "description": "Circuit Group 1 Description"
+        },
+        "create": {
+            "circuit_group": {
+                "name": "Circuit Group 1",
+                "description": "Circuit Group 1 Description",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "circuit_group": {
+                "name": "Circuit Group 1",
+                "description": "Circuit Group 1 Description Updated",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Circuit Group 1 Description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuitgroupassignment_1",
+        "object_type": "circuits.circuitgroupassignment",
+        "lookup": {
+            "group__name": "Circuit Group 1"
+        },
+        "create_expect": {
+            "group.name": "Circuit Group 1",
+            "member.cid": "Circuit 1",
+            "priority": "tertiary"
+        },
+        "create": {
+            "circuit_group_assignment": {
+                "group": {
+                    "name": "Circuit Group 1"
+                },
+                "member_circuit": {
+                    "cid": "Circuit 1",
+                    "type": {
+                        "name": "Circuit Type 1"
+                    },
+                    "provider": {
+                        "name": "Provider 1"
+                    }
+                },
+                "priority": "tertiary"
+            }
+        },
+        "update": {
+            "circuit_group_assignment": {
+                "group": {
+                    "name": "Circuit Group 1"
+                },
+                "member_circuit": {
+                    "cid": "Circuit 1",
+                    "type": {
+                        "name": "Circuit Type 1"
+                    },
+                    "provider": {
+                        "name": "Provider 1"
+                    }
+                },
+                "priority": "secondary"
+            }
+        },
+        "update_expect": {
+            "priority": "secondary"
+        }
+    },
+    {
+        "name": "circuits_circuitgroupassignment_2",
+        "object_type": "circuits.circuitgroupassignment",
+        "lookup": {
+            "group__name": "Circuit Group 1"
+        },
+        "create_expect": {
+            "group.name": "Circuit Group 1",
+            "member.cid": "Virtual Circuit 1",
+            "priority": "tertiary"
+        },
+        "create": {
+            "circuit_group_assignment": {
+                "group": {
+                    "name": "Circuit Group 1"
+                },
+                "member_virtual_circuit": {
+                    "cid": "Virtual Circuit 1",
+                    "type": {
+                        "name": "Virtual Circuit Type 1"
+                    },
+                    "provider_network": {
+                        "name": "Provider Network 1",
+                        "provider": {
+                            "name": "Provider 1"
+                        }
+                    }
+                },
+                "priority": "tertiary"
+            }
+        },
+        "update": {
+            "circuit_group_assignment": {
+                "group": {
+                    "name": "Circuit Group 1"
+                },
+                "member_virtual_circuit": {
+                    "cid": "Virtual Circuit 1",
+                    "type": {
+                        "name": "Virtual Circuit Type 1"
+                    },
+                    "provider_network": {
+                        "name": "Provider Network 1",
+                        "provider": {
+                            "name": "Provider 1"
+                        }
+                    }
+                },
+                "priority": "secondary"
+            }
+        },
+        "update_expect": {
+            "priority": "secondary"
+        }
+    },
+    {
+        "name": "circuits_circuittermination_1",
+        "object_type": "circuits.circuittermination",
+        "lookup": {
+            "circuit__cid": "Circuit 1",
+            "term_side": "A"
+        },
+        "create_expect": {
+            "circuit.cid": "Circuit 1",
+            "term_side": "A",
+            "port_speed": 9600,
+            "description": "description"
+        },
+        "create": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {
+                        "name": "Circuit Type 1"
+                    },
+                    "provider": {
+                        "name": "Provider 1"
+                    }
+                },
+                "term_side": "A",
+                "termination_location": {
+                    "name": "attic",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {
+                        "name": "Circuit Type 1"
+                    },
+                    "provider": {
+                        "name": "Provider 1"
+                    }
+                },
+                "term_side": "A",
+                "termination_location": {
+                    "name": "attic",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuittermination_2",
+        "object_type": "circuits.circuittermination",
+        "lookup": {
+            "circuit__cid": "Circuit 1",
+            "term_side": "A"
+        },
+        "create_expect": {
+            "circuit.cid": "Circuit 1",
+            "term_side": "A",
+            "port_speed": 9600,
+            "description": "description"
+        },
+        "create": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {
+                        "name": "Circuit Type 1"
+                    },
+                    "provider": {
+                        "name": "Provider 1"
+                    }
+                },
+                "term_side": "A",
+                "termination_provider_network": {
+                    "provider": {
+                        "name": "Provider 1"
+                    },
+                    "name": "Provider Network 1",
+                    "service_id": "service.1"
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {
+                        "name": "Circuit Type 1"
+                    },
+                    "provider": {
+                        "name": "Provider 1"
+                    }
+                },
+                "term_side": "A",
+                "termination_provider_network": {
+                    "provider": {
+                        "name": "Provider 1"
+                    },
+                    "name": "Provider Network 1",
+                    "service_id": "service.1"
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuittermination_3",
+        "object_type": "circuits.circuittermination",
+        "lookup": {
+            "circuit__cid": "Circuit 1",
+            "term_side": "A"
+        },
+        "create_expect": {
+            "circuit.cid": "Circuit 1",
+            "term_side": "A",
+            "port_speed": 9600,
+            "description": "description"
+        },
+        "create": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {
+                        "name": "Circuit Type 1"
+                    },
+                    "provider": {
+                        "name": "Provider 1"
+                    }
+                },
+                "term_side": "A",
+                "termination_site": {
+                    "name": "Site 1"
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "circuit_termination": {
+                "circuit": {
+                    "cid": "Circuit 1",
+                    "type": {
+                        "name": "Circuit Type 1"
+                    },
+                    "provider": {
+                        "name": "Provider 1"
+                    }
+                },
+                "term_side": "A",
+                "termination_site": {
+                    "name": "Site 1"
+                },
+                "port_speed": "9600",
+                "upstream_speed": "14400",
+                "xconnect_id": "xconnect.1",
+                "pp_info": "pp info",
+                "description": "description Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "description Updated"
+        }
+    },
+    {
+        "name": "circuits_circuittype_1",
+        "object_type": "circuits.circuittype",
+        "lookup": {
+            "name": "Circuit Type 1"
+        },
+        "create_expect": {
+            "name": "Circuit Type 1",
+            "description": "Circuit Type 1 Description"
+        },
+        "create": {
+            "circuit_type": {
+                "name": "Circuit Type 1",
+                "slug": "circuit-type-1",
+                "color": "0000ff",
+                "description": "Circuit Type 1 Description",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "circuit_type": {
+                "name": "Circuit Type 1",
+                "slug": "circuit-type-1",
+                "color": "0000ff",
+                "description": "Circuit Type 1 Description Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Circuit Type 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_cluster_1",
+        "object_type": "virtualization.cluster",
+        "lookup": {
+            "name": "Cluster A"
+        },
+        "create_expect": {
+            "name": "Cluster A",
+            "type.name": "Cluster Type 1",
+            "description": "Cluster 1 Description"
+        },
+        "create": {
+            "cluster": {
+                "name": "Cluster A",
+                "type": {
+                    "name": "Cluster Type 1"
+                },
+                "group": {
+                    "name": "Cluster Group 1"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "scope_location": {
+                    "name": "Location 1",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "description": "Cluster 1 Description",
+                "comments": "Cluster 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cluster": {
+                "name": "Cluster A",
+                "type": {
+                    "name": "Cluster Type 1"
+                },
+                "group": {
+                    "name": "Cluster Group 1"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "scope_location": {
+                    "name": "Location 1",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "description": "Cluster 1 Description Updated",
+                "comments": "Cluster 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_cluster_2",
+        "object_type": "virtualization.cluster",
+        "lookup": {
+            "name": "Cluster 2"
+        },
+        "create_expect": {
+            "name": "Cluster 2",
+            "type.name": "Cluster Type 1",
+            "description": "Cluster 1 Description"
+        },
+        "create": {
+            "cluster": {
+                "name": "Cluster 2",
+                "type": {
+                    "name": "Cluster Type 1"
+                },
+                "group": {
+                    "name": "Cluster Group 1"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "scope_region": {
+                    "name": "Region 1"
+                },
+                "description": "Cluster 1 Description",
+                "comments": "Cluster 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cluster": {
+                "name": "Cluster 2",
+                "type": {
+                    "name": "Cluster Type 1"
+                },
+                "group": {
+                    "name": "Cluster Group 1"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "scope_region": {
+                    "name": "Region 1"
+                },
+                "description": "Cluster 1 Description Updated",
+                "comments": "Cluster 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_cluster_3",
+        "object_type": "virtualization.cluster",
+        "lookup": {
+            "name": "Cluster 3"
+        },
+        "create_expect": {
+            "name": "Cluster 3",
+            "type.name": "Cluster Type 1",
+            "description": "Cluster 1 Description"
+        },
+        "create": {
+            "cluster": {
+                "name": "Cluster 3",
+                "type": {
+                    "name": "Cluster Type 1"
+                },
+                "group": {
+                    "name": "Cluster Group 1"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "scope_site": {
+                    "name": "Site 1"
+                },
+                "description": "Cluster 1 Description",
+                "comments": "Cluster 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cluster": {
+                "name": "Cluster 3",
+                "type": {
+                    "name": "Cluster Type 1"
+                },
+                "group": {
+                    "name": "Cluster Group 1"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "scope_site": {
+                    "name": "Site 1"
+                },
+                "description": "Cluster 1 Description Updated",
+                "comments": "Cluster 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_cluster_4",
+        "object_type": "virtualization.cluster",
+        "lookup": {
+            "name": "Cluster 4"
+        },
+        "create_expect": {
+            "name": "Cluster 4",
+            "type.name": "Cluster Type 1",
+            "description": "Cluster 1 Description"
+        },
+        "create": {
+            "cluster": {
+                "name": "Cluster 4",
+                "type": {
+                    "name": "Cluster Type 1"
+                },
+                "group": {
+                    "name": "Cluster Group 1"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "scope_site_group": {
+                    "name": "Site Group 1"
+                },
+                "description": "Cluster 1 Description",
+                "comments": "Cluster 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cluster": {
+                "name": "Cluster 4",
+                "type": {
+                    "name": "Cluster Type 1"
+                },
+                "group": {
+                    "name": "Cluster Group 1"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "scope_site_group": {
+                    "name": "Site Group 1"
+                },
+                "description": "Cluster 1 Description Updated",
+                "comments": "Cluster 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_clustergroup_1",
+        "object_type": "virtualization.clustergroup",
+        "lookup": {
+            "name": "Cluster Group 1"
+        },
+        "create_expect": {
+            "name": "Cluster Group 1",
+            "description": "Cluster Group 1 Description"
+        },
+        "create": {
+            "cluster_group": {
+                "name": "Cluster Group 1",
+                "description": "Cluster Group 1 Description",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cluster_group": {
+                "name": "Cluster Group 1",
+                "description": "Cluster Group 1 Description Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster Group 1 Description Updated"
+        }
+    },
+    {
+        "name": "virtualization_clustertype_1",
+        "object_type": "virtualization.clustertype",
+        "lookup": {
+            "name": "Cluster Type 1"
+        },
+        "create_expect": {
+            "name": "Cluster Type 1",
+            "description": "Cluster Type 1 Description"
+        },
+        "create": {
+            "cluster_type": {
+                "name": "Cluster Type 1",
+                "description": "Cluster Type 1 Description",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cluster_type": {
+                "name": "Cluster Type 1",
+                "description": "Cluster Type 1 Description Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Cluster Type 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_consoleport_1",
+        "object_type": "dcim.consoleport",
+        "lookup": {
+            "name": "Console Port 1"
+        },
+        "create_expect": {
+            "name": "Console Port 1",
+            "description": "Console Port 1 Description"
+        },
+        "create": {
+            "console_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Manufacturer 1"
+                        },
+                        "model": "Module Type 1"
+                    }
+                },
+                "name": "Console Port 1",
+                "label": "Console Port 1 Label",
+                "type": "db-25",
+                "speed": "1200",
+                "description": "Console Port 1 Description",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "console_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Manufacturer 1"
+                        },
+                        "model": "Module Type 1"
+                    }
+                },
+                "name": "Console Port 1",
+                "label": "Console Port 1 Label",
+                "type": "db-25",
+                "speed": "1200",
+                "description": "Console Port 1 Description Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Console Port 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_consoleserverport_1",
+        "object_type": "dcim.consoleserverport",
+        "lookup": {
+            "name": "Console Server Port 1"
+        },
+        "create_expect": {
+            "name": "Console Server Port 1",
+            "description": "Console Server Port 1 Description"
+        },
+        "create": {
+            "console_server_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Manufacturer 1"
+                        },
+                        "model": "Module Type 1"
+                    }
+                },
+                "name": "Console Server Port 1",
+                "label": "Console Server Port 1 Label",
+                "type": "db-25",
+                "speed": "1200",
+                "description": "Console Server Port 1 Description",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "console_server_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Manufacturer 1"
+                        },
+                        "model": "Module Type 1"
+                    }
+                },
+                "name": "Console Server Port 1",
+                "label": "Console Server Port 1 Label",
+                "type": "db-25",
+                "speed": "1200",
+                "description": "Console Server Port 1 Description Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Console Server Port 1 Description Updated"
+        }
+    },
+    {
+        "name": "tenancy_contact_1",
+        "object_type": "tenancy.contact",
+        "lookup": {
+            "name": "Contact 1"
+        },
+        "create_expect": {
+            "name": "Contact 1",
+            "groups.all.__by_name": [
+                "Contact Group 1"
+            ],
+            "description": "Contact 1 Description"
+        },
+        "create": {
+            "contact": {
+                "group": {
+                    "name": "Contact Group 1"
+                },
+                "name": "Contact 1",
+                "title": "Contact 1 Title",
+                "phone": "1234567890",
+                "email": "contact1@example.com",
+                "address": "1234 Main St, Anytown, USA",
+                "link": "https://example.com",
+                "description": "Contact 1 Description",
+                "comments": "Contact 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "contact": {
+                "group": {
+                    "name": "Contact Group 1"
+                },
+                "name": "Contact 1",
+                "title": "Contact 1 Title",
+                "phone": "1234567890",
+                "email": "contact1@example.com",
+                "address": "1234 Main St, Anytown, USA",
+                "link": "https://example.com",
+                "description": "Contact 1 Description Updated",
+                "comments": "Contact 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Contact 1 Description Updated"
+        }
+    },
+    {
+        "name": "tenancy_contactassignment_1",
+        "object_type": "tenancy.contactassignment",
+        "lookup": {
+            "contact__name": "Contact 1",
+            "role__name": "Contact Role 1"
+        },
+        "create_expect": {
+            "contact.name": "Contact 1",
+            "role.name": "Contact Role 1",
+            "priority": "primary"
+        },
+        "create": {
+            "contact_assignment": {
+                "contact": {
+                    "name": "Contact 1",
+                    "group": {
+                        "name": "Contact Group 1"
+                    },
+                    "title": "Contact 1 Title"
+                },
+                "role": {
+                    "name": "Contact Role 1"
+                },
+                "priority": "primary",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ],
+                "object_site": {
+                    "name": "Site 1"
+                }
+            }
+        },
+        "update": {
+            "contact_assignment": {
+                "contact": {
+                    "name": "Contact 1",
+                    "group": {
+                        "name": "Contact Group 1"
+                    },
+                    "title": "Contact 1 Title"
+                },
+                "role": {
+                    "name": "Contact Role 1"
+                },
+                "priority": "secondary",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ],
+                "object_site": {
+                    "name": "Site 1"
+                }
+            }
+        },
+        "update_expect": {
+            "priority": "secondary"
+        }
+    },
+    {
+        "name": "tenancy_contactgroup_1",
+        "object_type": "tenancy.contactgroup",
+        "lookup": {
+            "name": "Contact Group 1"
+        },
+        "create_expect": {
+            "name": "Contact Group 1",
+            "description": "Contact Group 1 Description"
+        },
+        "create": {
+            "contact_group": {
+                "name": "Contact Group 1",
+                "parent": {
+                    "name": "Contact Group 2"
+                },
+                "description": "Contact Group 1 Description",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "contact_group": {
+                "name": "Contact Group 1",
+                "parent": {
+                    "name": "Contact Group 2"
+                },
+                "description": "Contact Group 1 Description Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Contact Group 1 Description Updated"
+        }
+    },
+    {
+        "name": "tenancy_contactrole_1",
+        "object_type": "tenancy.contactrole",
+        "lookup": {
+            "name": "Contact Role 1"
+        },
+        "create_expect": {
+            "name": "Contact Role 1",
+            "description": "Contact Role 1 Description"
+        },
+        "create": {
+            "contact_role": {
+                "name": "Contact Role 1",
+                "description": "Contact Role 1 Description",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "contact_role": {
+                "name": "Contact Role 1",
+                "description": "Contact Role 1 Description Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Contact Role 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_device_1",
+        "object_type": "dcim.device",
+        "lookup": {
+            "name": "Device ABC"
+        },
+        "create_expect": {
+            "name": "Device ABC",
+            "device_type.manufacturer.name": "Cisco",
+            "device_type.model": "C2960S",
+            "role.name": "Device Role 1",
+            "description": "Device 1 Description"
+        },
+        "create": {
+            "device": {
+                "name": "Device ABC",
+                "device_type": {
+                    "manufacturer": {
+                        "name": "Cisco"
+                    },
+                    "model": "C2960S"
+                },
+                "role": {
+                    "name": "Device Role 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "platform": {
+                    "name": "Platform 1"
+                },
+                "serial": "1234567890",
+                "asset_tag": "asset.1",
+                "site": {
+                    "name": "Site 1"
+                },
+                "location": {
+                    "name": "Location 1",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "rack": {
+                    "name": "Rack 1",
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "location": {
+                        "name": "Location 1",
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "position": 1.0,
+                "face": "front",
+                "status": "active",
+                "airflow": "bottom-to-top",
+                "description": "Device 1 Description",
+                "comments": "Device 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "device": {
+                "name": "Device ABC",
+                "device_type": {
+                    "manufacturer": {
+                        "name": "Cisco"
+                    },
+                    "model": "C2960S"
+                },
+                "role": {
+                    "name": "Device Role 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "platform": {
+                    "name": "Platform 1"
+                },
+                "serial": "1234567890",
+                "asset_tag": "asset.1",
+                "site": {
+                    "name": "Site 1"
+                },
+                "location": {
+                    "name": "Location 1",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "rack": {
+                    "name": "Rack 1",
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "location": {
+                        "name": "Location 1",
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "position": 1.0,
+                "face": "front",
+                "status": "active",
+                "airflow": "bottom-to-top",
+                "description": "Device 1 Description Updated",
+                "comments": "Device 1 Comments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Device 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_devicebay_1",
+        "object_type": "dcim.devicebay",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "Device Bay 1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "Device Bay 1",
+            "description": "Device Bay 1 Description"
+        },
+        "create": {
+            "device_bay": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C3P0",
+                        "subdevice_role": "parent"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Device Bay 1",
+                "label": "Device Bay 1 Label",
+                "description": "Device Bay 1 Description",
+                "installed_device": {
+                    "name": "Device 2",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "device_bay": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C3P0",
+                        "subdevice_role": "parent"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Device Bay 1",
+                "label": "Device Bay 1 Label",
+                "description": "Device Bay 1 Description Updated",
+                "installed_device": {
+                    "name": "Device 2",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Device Bay 1 Description Updated"
+        }
+    },
+    {
+        "name": "dcim_devicerole_1",
+        "object_type": "dcim.devicerole",
+        "lookup": {
+            "name": "Core Router"
+        },
+        "create_expect": {
+            "name": "Core Router",
+            "description": "Primary network routing device"
+        },
+        "create": {
+            "device_role": {
+                "name": "Core Router",
+                "slug": "core-router",
+                "color": "ff0000",
+                "vm_role": true,
+                "description": "Primary network routing device",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "device_role": {
+                "name": "Core Router",
+                "slug": "core-router",
+                "color": "ff0000",
+                "vm_role": true,
+                "description": "Primary network routing device Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary network routing device Updated"
+        }
+    },
+    {
+        "name": "dcim_devicetype_1",
+        "object_type": "dcim.devicetype",
+        "lookup": {
+            "manufacturer__name": "Cisco",
+            "model": "Catalyst 9300"
+        },
+        "create_expect": {
+            "manufacturer.name": "Cisco",
+            "model": "Catalyst 9300",
+            "description": "Enterprise Series Switch"
+        },
+        "create": {
+            "device_type": {
+                "manufacturer": {
+                    "name": "Cisco"
+                },
+                "default_platform": {
+                    "name": "IOS-XE"
+                },
+                "model": "Catalyst 9300",
+                "slug": "catalyst-9300",
+                "part_number": "C9300-48P-E",
+                "u_height": 1.0,
+                "exclude_from_utilization": false,
+                "is_full_depth": true,
+                "subdevice_role": "parent",
+                "airflow": "front-to-rear",
+                "weight": 14.5,
+                "weight_unit": "lb",
+                "description": "Enterprise Series Switch",
+                "comments": "High-performance access switch",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "device_type": {
+                "manufacturer": {
+                    "name": "Cisco"
+                },
+                "default_platform": {
+                    "name": "IOS-XE"
+                },
+                "model": "Catalyst 9300",
+                "slug": "catalyst-9300",
+                "part_number": "C9300-48P-E",
+                "u_height": 1.0,
+                "exclude_from_utilization": false,
+                "is_full_depth": true,
+                "subdevice_role": "parent",
+                "airflow": "front-to-rear",
+                "weight": 14.5,
+                "weight_unit": "lb",
+                "description": "Enterprise Series Switch Updated",
+                "comments": "High-performance access switch",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Enterprise Series Switch Updated"
+        }
+    },
+    {
+        "name": "ipam_fhrpgroup_1",
+        "object_type": "ipam.fhrpgroup",
+        "lookup": {
+            "name": "HSRP Group 10"
+        },
+        "create_expect": {
+            "name": "HSRP Group 10",
+            "protocol": "hsrp",
+            "group_id": 10,
+            "description": "Core Router HSRP Group"
+        },
+        "create": {
+            "fhrp_group": {
+                "name": "HSRP Group 10",
+                "protocol": "hsrp",
+                "group_id": "10",
+                "auth_type": "md5",
+                "auth_key": "secretkey123",
+                "description": "Core Router HSRP Group",
+                "comments": "Primary gateway redundancy group",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "fhrp_group": {
+                "name": "HSRP Group 10",
+                "protocol": "hsrp",
+                "group_id": "10",
+                "auth_type": "md5",
+                "auth_key": "secretkey123",
+                "description": "Core Router HSRP Group Updated",
+                "comments": "Primary gateway redundancy group",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Core Router HSRP Group Updated"
+        }
+    },
+    {
+        "name": "ipam_fhrpgroupassignment_1",
+        "object_type": "ipam.fhrpgroupassignment",
+        "lookup": {
+            "group__name": "HSRP Group 10"
+        },
+        "create_expect": {
+            "group.name": "HSRP Group 10",
+            "priority": 100
+        },
+        "create": {
+            "fhrp_group_assignment": {
+                "group": {
+                    "name": "HSRP Group 10",
+                    "protocol": "hsrp",
+                    "group_id": "10"
+                },
+                "interface_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "priority": 100
+            }
+        },
+        "update": {
+            "fhrp_group_assignment": {
+                "group": {
+                    "name": "HSRP Group 10",
+                    "protocol": "hsrp",
+                    "group_id": "10"
+                },
+                "interface_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "priority": 200
+            }
+        },
+        "update_expect": {
+            "priority": 200
+        }
+    },
+    {
+        "name": "dcim_frontport_1",
+        "object_type": "dcim.frontport",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "Front Port 1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "Front Port 1",
+            "description": "Front fiber port"
+        },
+        "create": {
+            "front_port": {
+                "device": {
+                    "name": "Device 1",
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "name": "Front Port 1",
+                "label": "FP1",
+                "type": "lc-apc",
+                "color": "0000ff",
+                "rear_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Rear Port 1",
+                    "type": "lc-apc"
+                },
+                "rear_port_position": "1",
+                "description": "Front fiber port",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "front_port": {
+                "device": {
+                    "name": "Device 1",
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "name": "Front Port 1",
+                "label": "FP1",
+                "type": "lc-apc",
+                "color": "0000ff",
+                "rear_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Rear Port 1",
+                    "type": "lc-apc"
+                },
+                "rear_port_position": "1",
+                "description": "Front fiber port Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Front fiber port Updated"
+        }
+    },
+    {
+        "name": "vpn_ikepolicy_1",
+        "object_type": "vpn.ikepolicy",
+        "lookup": {
+            "name": "IKE-POLICY-1"
+        },
+        "create_expect": {
+            "name": "IKE-POLICY-1",
+            "version": 2,
+            "description": "Main IPSec IKE Policy"
+        },
+        "create": {
+            "ike_policy": {
+                "name": "IKE-POLICY-1",
+                "description": "Main IPSec IKE Policy",
+                "version": "2",
+                "preshared_key": "secretPSK123!",
+                "comments": "Primary IKE policy for VPN tunnels",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "proposals": [
+                    {
+                        "name": "IKE-PROPOSAL-1",
+                        "description": "AES-256 with SHA-256",
+                        "authentication_method": "preshared-keys",
+                        "encryption_algorithm": "aes-256-cbc",
+                        "authentication_algorithm": "hmac-sha256",
+                        "group": "14",
+                        "sa_lifetime": "28800"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "ike_policy": {
+                "name": "IKE-POLICY-1",
+                "description": "Main IPSec IKE Policy Updated",
+                "version": "2",
+                "preshared_key": "secretPSK123!",
+                "comments": "Primary IKE policy for VPN tunnels",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "proposals": [
+                    {
+                        "name": "IKE-PROPOSAL-1",
+                        "description": "AES-256 with SHA-256",
+                        "authentication_method": "preshared-keys",
+                        "encryption_algorithm": "aes-256-cbc",
+                        "authentication_algorithm": "hmac-sha256",
+                        "group": "14",
+                        "sa_lifetime": "28800"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Main IPSec IKE Policy Updated"
+        }
+    },
+    {
+        "name": "vpn_ikeproposal_1",
+        "object_type": "vpn.ikeproposal",
+        "lookup": {
+            "name": "IKE-PROPOSAL-2"
+        },
+        "create_expect": {
+            "name": "IKE-PROPOSAL-2",
+            "description": "High Security IKE Proposal"
+        },
+        "create": {
+            "ike_proposal": {
+                "name": "IKE-PROPOSAL-2",
+                "description": "High Security IKE Proposal",
+                "authentication_method": "certificates",
+                "encryption_algorithm": "aes-256-gcm",
+                "authentication_algorithm": "hmac-sha512",
+                "group": "21",
+                "sa_lifetime": "86400",
+                "comments": "Enhanced security proposal for critical VPNs",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "ike_proposal": {
+                "name": "IKE-PROPOSAL-2",
+                "description": "High Security IKE Proposal Updated",
+                "authentication_method": "certificates",
+                "encryption_algorithm": "aes-256-gcm",
+                "authentication_algorithm": "hmac-sha512",
+                "group": "21",
+                "sa_lifetime": "86400",
+                "comments": "Enhanced security proposal for critical VPNs",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "High Security IKE Proposal Updated"
+        }
+    },
+    {
+        "name": "ipam_ipaddress_1",
+        "object_type": "ipam.ipaddress",
+        "lookup": {
+            "address": "192.168.100.1/24"
+        },
+        "create_expect": {
+            "address": "192.168.100.1/24",
+            "vrf.name": "PROD-VRF",
+            "description": "Production VIP Address"
+        },
+        "create": {
+            "ip_address": {
+                "address": "192.168.100.1/24",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": "vip",
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t"
+                },
+                "nat_inside": {
+                    "address": "10.0.0.1/24"
+                },
+                "dns_name": "prod-vip.example.com",
+                "description": "Production VIP Address",
+                "comments": "Primary virtual IP for load balancing",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "ip_address": {
+                "address": "192.168.100.1/24",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": "vip",
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t"
+                },
+                "nat_inside": {
+                    "address": "10.0.0.1/24"
+                },
+                "dns_name": "prod-vip.example.com",
+                "description": "Production VIP Address Updated",
+                "comments": "Primary virtual IP for load balancing",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Production VIP Address Updated"
+        }
+    },
+    {
+        "name": "ipam_iprange_1",
+        "object_type": "ipam.iprange",
+        "lookup": {
+            "start_address": "10.100.0.1",
+            "end_address": "10.100.0.254"
+        },
+        "create_expect": {
+            "start_address": "10.100.0.1/32",
+            "end_address": "10.100.0.254/32",
+            "description": "Production Server IP Range"
+        },
+        "create": {
+            "ip_range": {
+                "start_address": "10.100.0.1",
+                "end_address": "10.100.0.254",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Server Pool",
+                    "slug": "server-pool"
+                },
+                "description": "Production Server IP Range",
+                "comments": "Allocated for production server deployments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "mark_utilized": true
+            }
+        },
+        "update": {
+            "ip_range": {
+                "start_address": "10.100.0.1",
+                "end_address": "10.100.0.254",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Server Pool",
+                    "slug": "server-pool"
+                },
+                "description": "Production Server IP Range Updated",
+                "comments": "Allocated for production server deployments",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "mark_utilized": true
+            }
+        },
+        "update_expect": {
+            "description": "Production Server IP Range Updated"
+        }
+    },
+    {
+        "name": "vpn_ipsecpolicy_1",
+        "object_type": "vpn.ipsecpolicy",
+        "lookup": {
+            "name": "IPSEC-POLICY-1"
+        },
+        "create_expect": {
+            "name": "IPSEC-POLICY-1",
+            "description": "Site-to-Site VPN Policy"
+        },
+        "create": {
+            "ip_sec_policy": {
+                "name": "IPSEC-POLICY-1",
+                "description": "Site-to-Site VPN Policy",
+                "pfs_group": "14",
+                "comments": "High-security IPSec policy for site-to-site VPN",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "proposals": [
+                    {
+                        "name": "IPSEC-PROPOSAL-1",
+                        "description": "AES-256-GCM with ESP",
+                        "encryption_algorithm": "aes-256-gcm",
+                        "sa_lifetime_seconds": "28800",
+                        "sa_lifetime_data": "28800",
+                        "comments": "Strong encryption proposal for VPN tunnels"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "ip_sec_policy": {
+                "name": "IPSEC-POLICY-1",
+                "description": "Site-to-Site VPN Policy Updated",
+                "pfs_group": "14",
+                "comments": "High-security IPSec policy for site-to-site VPN",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "proposals": [
+                    {
+                        "name": "IPSEC-PROPOSAL-1",
+                        "description": "AES-256-GCM with ESP",
+                        "encryption_algorithm": "aes-256-gcm",
+                        "sa_lifetime_seconds": "28800",
+                        "sa_lifetime_data": "28800",
+                        "comments": "Strong encryption proposal for VPN tunnels"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Site-to-Site VPN Policy Updated"
+        }
+    },
+    {
+        "name": "vpn_ipsecprofile_1",
+        "object_type": "vpn.ipsecprofile",
+        "lookup": {
+            "name": "IPSEC-PROFILE-1"
+        },
+        "create_expect": {
+            "name": "IPSEC-PROFILE-1",
+            "description": "Remote Access VPN Profile"
+        },
+        "create": {
+            "ip_sec_profile": {
+                "name": "IPSEC-PROFILE-1",
+                "description": "Remote Access VPN Profile",
+                "mode": "esp",
+                "ike_policy": {
+                    "name": "IKE-POLICY-1",
+                    "version": "2",
+                    "preshared_key": "secretkey123"
+                },
+                "ipsec_policy": {
+                    "name": "IPSEC-POLICY-1",
+                    "description": "Strong encryption policy",
+                    "pfs_group": "14"
+                },
+                "comments": "Standard IPSec profile for remote access VPN tunnels",
+                "tags": [
+                    {
+                        "name": "VPN"
+                    },
+                    {
+                        "name": "Remote-Access"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "ip_sec_profile": {
+                "name": "IPSEC-PROFILE-1",
+                "description": "Remote Access VPN Profile Updated",
+                "mode": "esp",
+                "ike_policy": {
+                    "name": "IKE-POLICY-1",
+                    "version": "2",
+                    "preshared_key": "secretkey123"
+                },
+                "ipsec_policy": {
+                    "name": "IPSEC-POLICY-1",
+                    "description": "Strong encryption policy",
+                    "pfs_group": "14"
+                },
+                "comments": "Standard IPSec profile for remote access VPN tunnels",
+                "tags": [
+                    {
+                        "name": "VPN"
+                    },
+                    {
+                        "name": "Remote-Access"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Remote Access VPN Profile Updated"
+        }
+    },
+    {
+        "name": "vpn_ipsecproposal_1",
+        "object_type": "vpn.ipsecproposal",
+        "lookup": {
+            "name": "IPSec-Proposal-AES256"
+        },
+        "create_expect": {
+            "name": "IPSec-Proposal-AES256",
+            "description": "High security IPSec proposal using AES-256-GCM"
+        },
+        "create": {
+            "ip_sec_proposal": {
+                "name": "IPSec-Proposal-AES256",
+                "description": "High security IPSec proposal using AES-256-GCM",
+                "encryption_algorithm": "aes-256-gcm",
+                "authentication_algorithm": "hmac-sha512",
+                "sa_lifetime_seconds": "28800",
+                "sa_lifetime_data": "42949",
+                "comments": "Used for critical infrastructure VPNs",
+                "tags": [
+                    {
+                        "name": "high-security",
+                        "slug": "high-security",
+                        "color": "0000ff"
+                    },
+                    {
+                        "name": "production",
+                        "slug": "production",
+                        "color": "0000ff"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "ip_sec_proposal": {
+                "name": "IPSec-Proposal-AES256",
+                "description": "High security IPSec proposal using AES-256-GCM Updated",
+                "encryption_algorithm": "aes-256-gcm",
+                "authentication_algorithm": "hmac-sha512",
+                "sa_lifetime_seconds": "28800",
+                "sa_lifetime_data": "42949",
+                "comments": "Used for critical infrastructure VPNs",
+                "tags": [
+                    {
+                        "name": "high-security",
+                        "slug": "high-security",
+                        "color": "0000ff"
+                    },
+                    {
+                        "name": "production",
+                        "slug": "production",
+                        "color": "0000ff"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "High security IPSec proposal using AES-256-GCM Updated"
+        }
+    },
+    {
+        "name": "dcim_interface_1",
+        "object_type": "dcim.interface",
+        "lookup": {
+            "name": "GigabitEthernet1/0/1"
+        },
+        "create_expect": {
+            "name": "GigabitEthernet1/0/1",
+            "label": "Core Link 1",
+            "tagged_vlans.all.__by_vid": [
+                101,
+                102
+            ]
+        },
+        "create": {
+            "interface": {
+                "name": "GigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "1000base-t",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "lag": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Port-Channel2",
+                    "type": "lag"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "tagged",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "mgmt_only": false,
+                "poe_mode": "pse",
+                "poe_type": "type3-ieee802.3bt",
+                "untagged_vlan": {
+                    "vid": 100,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ],
+                "tagged_vlans": [
+                    {
+                        "vid": 101,
+                        "name": "Voice VLAN",
+                        "status": "active"
+                    },
+                    {
+                        "vid": 102,
+                        "name": "Data VLAN",
+                        "status": "active"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "interface": {
+                "name": "GigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "1000base-t",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "lag": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Port-Channel2",
+                    "type": "lag"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "q-in-q",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    },
+                    {
+                        "name": "Tag 3"
+                    }
+                ],
+                "mgmt_only": false,
+                "poe_mode": "pse",
+                "poe_type": "type3-ieee802.3bt",
+                "untagged_vlan": {
+                    "vid": 100,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ],
+                "tagged_vlans": [
+                    {
+                        "vid": 101,
+                        "name": "Voice VLAN",
+                        "status": "active"
+                    },
+                    {
+                        "vid": 102,
+                        "name": "Data VLAN",
+                        "status": "active"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "tags.all.__by_name": [
+                "Tag 1",
+                "Tag 2",
+                "Tag 3"
+            ]
+        }
+    },
+    {
+        "name": "dcim_interface_2",
+        "object_type": "dcim.interface",
+        "lookup": {
+            "name": "WirelessGigabitEthernet1/0/1"
+        },
+        "create_expect": {
+            "name": "WirelessGigabitEthernet1/0/1",
+            "label": "Core Link 1",
+            "mode": "access",
+            "untagged_vlan.vid": 900,
+            "tagged_vlans.all": []
+        },
+        "create": {
+            "interface": {
+                "name": "WirelessGigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "other-wireless",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "lag": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Port-Channel2",
+                    "type": "lag"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "rf_role": "ap",
+                "rf_channel": "2.4g-1-2412-22",
+                "tx_power": "20",
+                "wireless_lans": [
+                    {
+                        "ssid": "Corp-Secure",
+                        "description": "Corporate secure wireless network",
+                        "group": {
+                            "name": "Corporate Networks",
+                            "slug": "corporate-networks"
+                        },
+                        "status": "active",
+                        "vlan": {
+                            "vid": 800,
+                            "name": "Production Servers"
+                        },
+                        "tenant": {
+                            "name": "Tenant 1"
+                        }
+                    }
+                ],
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "access",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "mgmt_only": false,
+                "untagged_vlan": {
+                    "vid": 900,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ],
+                "tagged_vlans": [
+                    {
+                        "vid": 101,
+                        "name": "Voice VLAN",
+                        "status": "active"
+                    },
+                    {
+                        "vid": 102,
+                        "name": "Data VLAN",
+                        "status": "active"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "interface": {
+                "name": "WirelessGigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "other-wireless",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "lag": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Port-Channel2",
+                    "type": "lag"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "rf_role": "ap",
+                "rf_channel": "2.4g-1-2412-22",
+                "tx_power": "20",
+                "wireless_lans": [
+                    {
+                        "ssid": "Corp-Secure",
+                        "description": "Corporate secure wireless network",
+                        "group": {
+                            "name": "Corporate Networks",
+                            "slug": "corporate-networks"
+                        },
+                        "status": "active",
+                        "vlan": {
+                            "vid": 800,
+                            "name": "Production Servers"
+                        },
+                        "tenant": {
+                            "name": "Tenant 1"
+                        }
+                    }
+                ],
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "access",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    },
+                    {
+                        "name": "Tag 3"
+                    }
+                ],
+                "mgmt_only": false,
+                "untagged_vlan": {
+                    "vid": 900,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ],
+                "tagged_vlans": [
+                    {
+                        "vid": 101,
+                        "name": "Voice VLAN",
+                        "status": "active"
+                    },
+                    {
+                        "vid": 102,
+                        "name": "Data VLAN",
+                        "status": "active"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "tags.all.__by_name": [
+                "Tag 1",
+                "Tag 2",
+                "Tag 3"
+            ],
+            "mode": "access",
+            "untagged_vlan.vid": 900,
+            "tagged_vlans.all": []
+        }
+    },
+    {
+        "name": "dcim_interface_3",
+        "object_type": "dcim.interface",
+        "lookup": {
+            "name": "VirtualGigabitEthernet1/0/1"
+        },
+        "create_expect": {
+            "name": "VirtualGigabitEthernet1/0/1",
+            "label": "Core Link 1"
+        },
+        "create": {
+            "interface": {
+                "name": "VirtualGigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "parent": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Port-Channel1",
+                    "type": "1000base-t"
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "virtual",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "q-in-q",
+                "mark_connected": false,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "mgmt_only": false,
+                "untagged_vlan": {
+                    "vid": 444,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "qinq_svlan": {
+                    "vid": 2000,
+                    "name": "Service VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "interface": {
+                "name": "VirtualGigabitEthernet1/0/1",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "parent": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Port-Channel1",
+                    "type": "1000base-t"
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "label": "Core Link 1",
+                "type": "virtual",
+                "enabled": true,
+                "bridge": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Bridge1",
+                    "type": "bridge"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:11:22:33:44:55"
+                },
+                "speed": "1000000000",
+                "duplex": "full",
+                "wwn": "50:01:43:80:00:00:00:00",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "description": "Core network interface",
+                "mode": "q-in-q",
+                "mark_connected": false,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    },
+                    {
+                        "name": "Tag 3"
+                    }
+                ],
+                "mgmt_only": false,
+                "untagged_vlan": {
+                    "vid": 444,
+                    "name": "Data VLAN",
+                    "status": "active"
+                },
+                "qinq_svlan": {
+                    "vid": 2000,
+                    "name": "Service VLAN",
+                    "status": "active"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Translation Policy",
+                    "description": "VLAN translation for customer traffic"
+                },
+                "vdcs": [
+                    {
+                        "name": "VDC1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "identifier": 1,
+                        "status": "active",
+                        "description": "Primary VDC"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "tags.all.__by_name": [
+                "Tag 1",
+                "Tag 2",
+                "Tag 3"
+            ]
+        }
+    },
+    {
+        "name": "vpn_l2vpn_1",
+        "object_type": "vpn.l2vpn",
+        "lookup": {
+            "name": "Customer-VPLS-1"
+        },
+        "create_expect": {
+            "name": "Customer-VPLS-1",
+            "type": "vpls",
+            "description": "Customer VPLS service for multi-site connectivity"
+        },
+        "create": {
+            "l2vpn": {
+                "name": "Customer-VPLS-1",
+                "slug": "customer-vpls-1",
+                "type": "vpls",
+                "identifier": "65000",
+                "import_targets": [
+                    {
+                        "name": "65000:1001",
+                        "description": "Primary import target"
+                    },
+                    {
+                        "name": "65000:1002",
+                        "description": "Secondary import target"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:1003",
+                        "description": "Primary export target"
+                    }
+                ],
+                "description": "Customer VPLS service for multi-site connectivity",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "l2vpn": {
+                "name": "Customer-VPLS-1",
+                "slug": "customer-vpls-1",
+                "type": "vpls",
+                "identifier": "65000",
+                "import_targets": [
+                    {
+                        "name": "65000:1001",
+                        "description": "Primary import target"
+                    },
+                    {
+                        "name": "65000:1002",
+                        "description": "Secondary import target"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:1003",
+                        "description": "Primary export target"
+                    }
+                ],
+                "description": "Customer VPLS service for multi-site connectivity Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Customer VPLS service for multi-site connectivity Updated"
+        }
+    },
+    {
+        "name": "dcim_inventoryitem_1",
+        "object_type": "dcim.inventoryitem",
+        "lookup": {
+            "name": "Power Supply 1"
+        },
+        "create_expect": {
+            "name": "Power Supply 1",
+            "description": "715W AC Power Supply"
+        },
+        "create": {
+            "inventory_item": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "parent": {
+                    "name": "Chassis 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "name": "Power Supply 1",
+                "label": "PSU1",
+                "role": {
+                    "name": "Power Supply",
+                    "color": "00ff00"
+                },
+                "manufacturer": {
+                    "name": "Cisco"
+                },
+                "part_id": "PWR-C1-715WAC",
+                "serial": "ABC123XYZ",
+                "asset_tag": "ASSET-001",
+                "discovered": true,
+                "description": "715W AC Power Supply",
+                "status": "active",
+                "component_power_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "PSU1 Power Port",
+                    "type": "iec-60320-c14",
+                    "maximum_draw": 715,
+                    "allocated_draw": 500,
+                    "description": "Power input port for PSU1"
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "inventory_item": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "parent": {
+                    "name": "Chassis 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "name": "Power Supply 1",
+                "label": "PSU1",
+                "role": {
+                    "name": "Power Supply",
+                    "color": "00ff00"
+                },
+                "manufacturer": {
+                    "name": "Cisco"
+                },
+                "part_id": "PWR-C1-715WAC",
+                "serial": "ABC123XYZ",
+                "asset_tag": "ASSET-001",
+                "discovered": true,
+                "description": "715W AC Power Supply Updated",
+                "status": "active",
+                "component_power_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "PSU1 Power Port",
+                    "type": "iec-60320-c14",
+                    "maximum_draw": 715,
+                    "allocated_draw": 500,
+                    "description": "Power input port for PSU1"
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "715W AC Power Supply Updated"
+        }
+    },
+    {
+        "name": "dcim_inventoryitemrole_1",
+        "object_type": "dcim.inventoryitemrole",
+        "lookup": {
+            "name": "Line Card"
+        },
+        "create_expect": {
+            "name": "Line Card",
+            "description": "Network switch line card module"
+        },
+        "create": {
+            "inventory_item_role": {
+                "name": "Line Card",
+                "slug": "line-card",
+                "color": "0000ff",
+                "description": "Network switch line card module",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "inventory_item_role": {
+                "name": "Line Card",
+                "slug": "line-card",
+                "color": "0000ff",
+                "description": "Network switch line card module Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Network switch line card module Updated"
+        }
+    },
+    {
+        "name": "vpn_l2vpn_1",
+        "object_type": "vpn.l2vpn",
+        "lookup": {
+            "name": "Customer-VPLS-1"
+        },
+        "create_expect": {
+            "name": "Customer-VPLS-1",
+            "type": "vpls",
+            "identifier": 65000,
+            "description": "Customer VPLS service for multi-site connectivity"
+        },
+        "create": {
+            "l2vpn": {
+                "name": "Customer-VPLS-1",
+                "slug": "customer-vpls-1",
+                "type": "vpls",
+                "identifier": "65000",
+                "import_targets": [
+                    {
+                        "name": "65000:1001",
+                        "description": "Primary import target"
+                    },
+                    {
+                        "name": "65000:1002",
+                        "description": "Secondary import target"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:1003",
+                        "description": "Primary export target"
+                    }
+                ],
+                "description": "Customer VPLS service for multi-site connectivity",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "l2vpn": {
+                "name": "Customer-VPLS-1",
+                "slug": "customer-vpls-1",
+                "type": "vpls",
+                "identifier": "65000",
+                "import_targets": [
+                    {
+                        "name": "65000:1001",
+                        "description": "Primary import target"
+                    },
+                    {
+                        "name": "65000:1002",
+                        "description": "Secondary import target"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:1003",
+                        "description": "Primary export target"
+                    }
+                ],
+                "description": "Customer VPLS service for multi-site connectivity Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Customer VPLS service for multi-site connectivity Updated"
+        }
+    },
+    {
+        "name": "vpn_l2vpntermination_1",
+        "object_type": "vpn.l2vpntermination",
+        "lookup": {
+            "l2vpn__name": "Customer-VPLS-1"
+        },
+        "create_expect": {
+            "l2vpn.name": "Customer-VPLS-1",
+            "l2vpn.type": "vpls"
+        },
+        "create": {
+            "l2vpn_termination": {
+                "l2vpn": {
+                    "name": "Customer-VPLS-1",
+                    "type": "vpls",
+                    "identifier": "65000"
+                },
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "l2vpn_termination": {
+                "l2vpn": {
+                    "name": "Customer-VPLS-1",
+                    "type": "vpls",
+                    "identifier": "65000"
+                },
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    },
+                    {
+                        "name": "Tag 3"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "tags.all.__by_name": [
+                "Tag 1",
+                "Tag 2",
+                "Tag 3"
+            ]
+        }
+    },
+    {
+        "name": "dcim_location_1",
+        "object_type": "dcim.location",
+        "lookup": {
+            "name": "Data Center East Wing"
+        },
+        "create_expect": {
+            "name": "Data Center East Wing",
+            "description": "East wing of the main data center facility"
+        },
+        "create": {
+            "location": {
+                "name": "Data Center East Wing",
+                "slug": "dc-east-wing",
+                "site": {
+                    "name": "Site 1"
+                },
+                "parent": {
+                    "name": "Main Data Center",
+                    "slug": "main-dc",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "facility": "Building A, Floor 3",
+                "description": "East wing of the main data center facility",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "location": {
+                "name": "Data Center East Wing",
+                "slug": "dc-east-wing",
+                "site": {
+                    "name": "Site 1"
+                },
+                "parent": {
+                    "name": "Main Data Center",
+                    "slug": "main-dc",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "facility": "Building A, Floor 3",
+                "description": "East wing of the main data center facility Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "East wing of the main data center facility Updated"
+        }
+    },
+    {
+        "name": "dcim_macaddress_1",
+        "object_type": "dcim.macaddress",
+        "lookup": {
+            "mac_address": "00:1A:2B:3C:4D:5E"
+        },
+        "create_expect": {
+            "mac_address": "00:1A:2B:3C:4D:5E",
+            "description": "Primary management interface MAC"
+        },
+        "create": {
+            "mac_address": {
+                "mac_address": "00:1A:2B:3C:4D:5E",
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "description": "Primary management interface MAC",
+                "comments": "Reserved for network management access",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "mac_address": {
+                "mac_address": "00:1A:2B:3C:4D:5E",
+                "assigned_object_interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "GigabitEthernet1/0/1",
+                    "type": "1000base-t",
+                    "enabled": true
+                },
+                "description": "Primary management interface MAC Updated",
+                "comments": "Reserved for network management access",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary management interface MAC Updated"
+        }
+    },
+    {
+        "name": "dcim_manufacturer_1",
+        "object_type": "dcim.manufacturer",
+        "lookup": {
+            "name": "Arista Networks"
+        },
+        "create_expect": {
+            "name": "Arista Networks",
+            "slug": "arista-networks",
+            "description": "Leading provider of cloud networking solutions"
+        },
+        "create": {
+            "manufacturer": {
+                "name": "Arista Networks",
+                "slug": "arista-networks",
+                "description": "Leading provider of cloud networking solutions",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "manufacturer": {
+                "name": "Arista Networks",
+                "slug": "arista-networks",
+                "description": "Leading provider of cloud networking solutions Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Leading provider of cloud networking solutions Updated"
+        }
+    },
+    {
+        "name": "dcim_module_1",
+        "object_type": "dcim.module",
+        "lookup": {
+            "asset_tag": "MOD-001"
+        },
+        "create_expect": {
+            "status": "active",
+            "serial": "MOD123XYZ",
+            "asset_tag": "MOD-001",
+            "description": "Stacking module for switch interconnect"
+        },
+        "create": {
+            "module": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module_bay": {
+                    "name": "Module Bay 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "module_type": {
+                    "manufacturer": {
+                        "name": "Cisco"
+                    },
+                    "model": "C2960S-STACK"
+                },
+                "status": "active",
+                "serial": "MOD123XYZ",
+                "asset_tag": "MOD-001",
+                "description": "Stacking module for switch interconnect",
+                "comments": "Primary stack member module",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "module": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module_bay": {
+                    "name": "Module Bay 1",
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "module_type": {
+                    "manufacturer": {
+                        "name": "Cisco"
+                    },
+                    "model": "C2960S-STACK"
+                },
+                "status": "active",
+                "serial": "MOD123XYZ",
+                "asset_tag": "MOD-001",
+                "description": "Stacking module for switch interconnect Updated",
+                "comments": "Primary stack member module",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Stacking module for switch interconnect Updated"
+        }
+    },
+    {
+        "name": "dcim_modulebay_1",
+        "object_type": "dcim.modulebay",
+        "lookup": {
+            "name": "Stack Module Bay 2"
+        },
+        "create_expect": {
+            "name": "Stack Module Bay 2",
+            "description": "Secondary stacking module bay"
+        },
+        "create": {
+            "module_bay": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Stack Module Bay 2",
+                "label": "STACK-2",
+                "position": "Rear",
+                "description": "Secondary stacking module bay",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "module_bay": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Stack Module Bay 2",
+                "label": "STACK-2",
+                "position": "Rear",
+                "description": "Secondary stacking module bay Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Secondary stacking module bay Updated"
+        }
+    },
+    {
+        "name": "dcim_moduletype_1",
+        "object_type": "dcim.moduletype",
+        "lookup": {
+            "manufacturer__name": "Cisco",
+            "model": "C9300-NM-8X"
+        },
+        "create_expect": {
+            "manufacturer.name": "Cisco",
+            "model": "C9300-NM-8X",
+            "description": "Catalyst 9300 8 x 10GE Network Module"
+        },
+        "create": {
+            "module_type": {
+                "manufacturer": {
+                    "name": "Cisco"
+                },
+                "model": "C9300-NM-8X",
+                "part_number": "C9300-NM-8X=",
+                "airflow": "front-to-rear",
+                "weight": 0.7,
+                "weight_unit": "kg",
+                "description": "Catalyst 9300 8 x 10GE Network Module",
+                "comments": "Hot-swappable uplink module for C9300 series switches",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "module_type": {
+                "manufacturer": {
+                    "name": "Cisco"
+                },
+                "model": "C9300-NM-8X",
+                "part_number": "C9300-NM-8X=",
+                "airflow": "front-to-rear",
+                "weight": 0.7,
+                "weight_unit": "kg",
+                "description": "Catalyst 9300 8 x 10GE Network Module Updated",
+                "comments": "Hot-swappable uplink module for C9300 series switches",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Catalyst 9300 8 x 10GE Network Module Updated"
+        }
+    },
+    {
+        "name": "dcim_moduletypeprofile_1",
+        "object_type": "dcim.moduletypeprofile",
+        "lookup": {
+            "name": "Module Type Profile 1"
+        },
+        "create_expect": {
+            "name": "Module Type Profile 1",
+            "description": "This is a module type profile"
+        },
+        "create": {
+            "module_type_profile": {
+                "name": "Module Type Profile 1",
+                "description": "This is a module type profile",
+                "schema": "{\"$schema\": \"https://json-schema.org/draft/2020-12/schema\", \"$id\": \"https://example.com/product.schema.json\", \"title\": \"Product\", \"description\": \"A product from Acme's catalog\", \"type\": \"object\", \"properties\": {\"productId\": {\"description\": \"The unique identifier for a product\", \"type\": \"integer\"}}}",
+                "comments": "This is a module type profile comment"
+            }
+        },
+        "update": {
+            "module_type_profile": {
+                "name": "Module Type Profile 1",
+                "description": "This is a module type profile updated",
+                "schema": "{\"$schema\": \"https://json-schema.org/draft/2020-12/schema\", \"$id\": \"https://example.com/product.schema.json\", \"title\": \"Product\", \"description\": \"A product from Acme's catalog\", \"type\": \"object\", \"properties\": {\"productId\": {\"description\": \"The unique identifier for a product\", \"type\": \"integer\"}}}",
+                "comments": "This is a module type profile comment"
+            }
+        },
+        "update_expect": {
+            "description": "This is a module type profile updated"
+        }
+    },
+    {
+        "name": "dcim_platform_1",
+        "object_type": "dcim.platform",
+        "lookup": {
+            "name": "Cisco IOS-XE"
+        },
+        "create_expect": {
+            "name": "Cisco IOS-XE",
+            "manufacturer.name": "Cisco",
+            "description": "Enterprise-class IOS operating system for Catalyst switches and ISR routers"
+        },
+        "create": {
+            "platform": {
+                "name": "Cisco IOS-XE",
+                "slug": "cisco-ios-xe",
+                "manufacturer": {
+                    "name": "Cisco"
+                },
+                "description": "Enterprise-class IOS operating system for Catalyst switches and ISR routers",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "platform": {
+                "name": "Cisco IOS-XE",
+                "slug": "cisco-ios-xe",
+                "manufacturer": {
+                    "name": "Cisco"
+                },
+                "description": "Enterprise-class IOS operating system for Catalyst switches and ISR routers Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Enterprise-class IOS operating system for Catalyst switches and ISR routers Updated"
+        }
+    },
+    {
+        "name": "dcim_powerfeed_1",
+        "object_type": "dcim.powerfeed",
+        "lookup": {
+            "name": "Power Feed A1"
+        },
+        "create_expect": {
+            "name": "Power Feed A1",
+            "power_panel.name": "Panel A",
+            "description": "Primary power feed for network equipment rack"
+        },
+        "create": {
+            "power_feed": {
+                "power_panel": {
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "name": "Panel A"
+                },
+                "rack": {
+                    "name": "Rack 1",
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "location": {
+                        "name": "Location 1",
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "name": "Power Feed A1",
+                "status": "active",
+                "type": "primary",
+                "supply": "ac",
+                "phase": "three-phase",
+                "voltage": "208",
+                "amperage": "30",
+                "max_utilization": "80",
+                "mark_connected": true,
+                "description": "Primary power feed for network equipment rack",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "comments": "Connected to UPS system A with redundant backup",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "power_feed": {
+                "power_panel": {
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "name": "Panel A"
+                },
+                "rack": {
+                    "name": "Rack 1",
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "location": {
+                        "name": "Location 1",
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "name": "Power Feed A1",
+                "status": "active",
+                "type": "primary",
+                "supply": "ac",
+                "phase": "three-phase",
+                "voltage": "208",
+                "amperage": "30",
+                "max_utilization": "80",
+                "mark_connected": true,
+                "description": "Primary power feed for network equipment rack Updated",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "comments": "Connected to UPS system A with redundant backup",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary power feed for network equipment rack Updated"
+        }
+    },
+    {
+        "name": "dcim_poweroutlet_1",
+        "object_type": "dcim.poweroutlet",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "PSU1-Outlet1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "PSU1-Outlet1",
+            "description": "Power outlet for network switch PSU"
+        },
+        "create": {
+            "power_outlet": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "PWR-C1-715WAC"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    }
+                },
+                "name": "PSU1-Outlet1",
+                "label": "OUT-1",
+                "type": "iec-60320-c13",
+                "color": "0000ff",
+                "power_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "PSU1"
+                },
+                "feed_leg": "A",
+                "description": "Power outlet for network switch PSU",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "power_outlet": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "PWR-C1-715WAC"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    }
+                },
+                "name": "PSU1-Outlet1",
+                "label": "OUT-1",
+                "type": "iec-60320-c13",
+                "color": "0000ff",
+                "power_port": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "PSU1"
+                },
+                "feed_leg": "A",
+                "description": "Power outlet for network switch PSU Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Power outlet for network switch PSU Updated"
+        }
+    },
+    {
+        "name": "dcim_powerpanel_1",
+        "object_type": "dcim.powerpanel",
+        "lookup": {
+            "site__name": "Site 1",
+            "name": "Panel A"
+        },
+        "create_expect": {
+            "site.name": "Site 1",
+            "name": "Panel A",
+            "description": "Main power distribution panel"
+        },
+        "create": {
+            "power_panel": {
+                "site": {
+                    "name": "Site 1"
+                },
+                "location": {
+                    "name": "Location 1",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Panel A",
+                "description": "Main power distribution panel",
+                "comments": "Primary power distribution for data center",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "power_panel": {
+                "site": {
+                    "name": "Site 1"
+                },
+                "location": {
+                    "name": "Location 1",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Panel A",
+                "description": "Main power distribution panel Updated",
+                "comments": "Primary power distribution for data center",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Main power distribution panel Updated"
+        }
+    },
+    {
+        "name": "dcim_powerport_1",
+        "object_type": "dcim.powerport",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "PSU1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "PSU1",
+            "description": "Primary power supply unit"
+        },
+        "create": {
+            "power_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "PWR-C1-715WAC"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    }
+                },
+                "name": "PSU1",
+                "label": "PSU-1",
+                "type": "iec-60320-c14",
+                "maximum_draw": 715,
+                "allocated_draw": 650,
+                "description": "Primary power supply unit",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "power_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "PWR-C1-715WAC"
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    }
+                },
+                "name": "PSU1",
+                "label": "PSU-1",
+                "type": "iec-60320-c14",
+                "maximum_draw": 715,
+                "allocated_draw": 650,
+                "description": "Primary power supply unit Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary power supply unit Updated"
+        }
+    },
+    {
+        "name": "ipam_prefix_1",
+        "object_type": "ipam.prefix",
+        "lookup": {
+            "prefix": "10.100.0.0/16"
+        },
+        "create_expect": {
+            "prefix": "10.100.0.0/16",
+            "description": "Production network address space"
+        },
+        "create": {
+            "prefix": {
+                "prefix": "10.100.0.0/16",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "scope_site": {
+                    "name": "Site 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "vlan": {
+                    "name": "Production VLAN",
+                    "vid": "112"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "is_pool": true,
+                "mark_utilized": true,
+                "description": "Production network address space",
+                "comments": "Primary address allocation for production services",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "prefix": {
+                "prefix": "10.100.0.0/16",
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "scope_site": {
+                    "name": "Site 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "vlan": {
+                    "name": "Production VLAN",
+                    "vid": "112"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "is_pool": true,
+                "mark_utilized": true,
+                "description": "Production network address space Updated",
+                "comments": "Primary address allocation for production services",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Production network address space Updated"
+        }
+    },
+    {
+        "name": "circuits_provider_1",
+        "object_type": "circuits.provider",
+        "lookup": {
+            "name": "Level 3 Communications"
+        },
+        "create_expect": {
+            "name": "Level 3 Communications",
+            "slug": "level3",
+            "description": "Global Tier 1 Internet Service Provider"
+        },
+        "create": {
+            "provider": {
+                "name": "Level 3 Communications",
+                "slug": "level3",
+                "description": "Global Tier 1 Internet Service Provider",
+                "comments": "Primary transit provider for data center connectivity",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "accounts": [
+                    {
+                        "provider": {
+                            "name": "Level 3 Communications"
+                        },
+                        "name": "East Coast Account",
+                        "account": "L3-12345",
+                        "description": "East Coast regional services account",
+                        "comments": "Managed through regional NOC"
+                    },
+                    {
+                        "provider": {
+                            "name": "Level 3 Communications"
+                        },
+                        "name": "West Coast Account",
+                        "account": "L3-67890",
+                        "description": "West Coast regional services account",
+                        "comments": "Managed through regional NOC"
+                    }
+                ],
+                "asns": [
+                    {
+                        "asn": "3356",
+                        "rir": {
+                            "name": "ARIN"
+                        },
+                        "tenant": {
+                            "name": "Tenant 1"
+                        },
+                        "description": "Level 3 Global ASN",
+                        "comments": "Primary transit ASN"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "provider": {
+                "name": "Level 3 Communications",
+                "slug": "level3",
+                "description": "Global Tier 1 Internet Service Provider Updated",
+                "comments": "Primary transit provider for data center connectivity",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "accounts": [
+                    {
+                        "provider": {
+                            "name": "Level 3 Communications"
+                        },
+                        "name": "East Coast Account",
+                        "account": "L3-12345",
+                        "description": "East Coast regional services account",
+                        "comments": "Managed through regional NOC"
+                    },
+                    {
+                        "provider": {
+                            "name": "Level 3 Communications"
+                        },
+                        "name": "West Coast Account",
+                        "account": "L3-67890",
+                        "description": "West Coast regional services account",
+                        "comments": "Managed through regional NOC"
+                    }
+                ],
+                "asns": [
+                    {
+                        "asn": "3356",
+                        "rir": {
+                            "name": "ARIN"
+                        },
+                        "tenant": {
+                            "name": "Tenant 1"
+                        },
+                        "description": "Level 3 Global ASN",
+                        "comments": "Primary transit ASN"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Global Tier 1 Internet Service Provider Updated"
+        }
+    },
+    {
+        "name": "circuits_provideraccount_1",
+        "object_type": "circuits.provideraccount",
+        "lookup": {
+            "provider__name": "Level 3 Communications",
+            "account": "ACCT-12345"
+        },
+        "create_expect": {
+            "provider.name": "Level 3 Communications",
+            "account": "ACCT-12345",
+            "description": "Primary enterprise account"
+        },
+        "create": {
+            "provider_account": {
+                "provider": {
+                    "name": "Level 3 Communications"
+                },
+                "account": "ACCT-12345",
+                "name": "L3 Enterprise",
+                "description": "Primary enterprise account",
+                "comments": "Global services contract",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "provider_account": {
+                "provider": {
+                    "name": "Level 3 Communications"
+                },
+                "account": "ACCT-12345",
+                "name": "L3 Enterprise",
+                "description": "Primary enterprise account Updated",
+                "comments": "Global services contract",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary enterprise account Updated"
+        }
+    },
+    {
+        "name": "circuits_providernetwork_1",
+        "object_type": "circuits.providernetwork",
+        "lookup": {
+            "name": "Global MPLS Network"
+        },
+        "create_expect": {
+            "name": "Global MPLS Network",
+            "provider.name": "Level 3 Communications",
+            "description": "Global MPLS backbone network"
+        },
+        "create": {
+            "provider_network": {
+                "provider": {
+                    "name": "Level 3 Communications"
+                },
+                "name": "Global MPLS Network",
+                "service_id": "L3-MPLS-001",
+                "description": "Global MPLS backbone network",
+                "comments": "Primary enterprise MPLS network infrastructure",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "provider_network": {
+                "provider": {
+                    "name": "Level 3 Communications"
+                },
+                "name": "Global MPLS Network",
+                "service_id": "L3-MPLS-001",
+                "description": "Global MPLS backbone network Updated",
+                "comments": "Primary enterprise MPLS network infrastructure",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Global MPLS backbone network Updated"
+        }
+    },
+    {
+        "name": "extras_custom_field_1",
+        "object_type": "extras.customfield",
+        "lookup": {
+            "name": "wlans"
+        },
+        "create_expect": {
+            "name": "wlans",
+            "label": "WLANs",
+            "type": "multiobject"
+        },
+        "create": {
+            "custom_field": {
+                "name": "wlans",
+                "label": "WLANs",
+                "object_types": [
+                    "dcim.device"
+                ],
+                "type": "multiobject",
+                "related_object_type": "wireless.wirelesslan",
+                "search_weight": 1000,
+                "filter_logic": "loose"
+            }
+        },
+        "update": {
+            "custom_field": {
+                "name": "wlans",
+                "label": "WLANs Served",
+                "object_types": [
+                    "dcim.device"
+                ],
+                "type": "multiobject",
+                "related_object_type": "wireless.wirelesslan",
+                "search_weight": 1000,
+                "filter_logic": "loose"
+            }
+        },
+        "update_expect": {
+            "label": "WLANs Served"
+        }
+    },
+    {
+        "name": "extras_customfieldchoiceset_1",
+        "object_type": "extras.customfieldchoiceset",
+        "lookup": {
+            "name": "scope_choices"
+        },
+        "create": {
+            "custom_field_choice_set": {
+                "name": "scope_choices",
+                "extra_choices": [
+                    "site:Site",
+                    "virtual_machine:Virtual Machine",
+                    "toadstool"
+                ]
+            }
+        },
+        "create_expect": {
+            "name": "scope_choices",
+            "extra_choices": [
+                [
+                    "site",
+                    "Site"
+                ],
+                [
+                    "virtual_machine",
+                    "Virtual Machine"
+                ],
+                [
+                    "toadstool",
+                    "toadstool"
+                ]
+            ]
+        },
+        "update": {
+            "custom_field_choice_set": {
+                "name": "scope_choices",
+                "extra_choices": [
+                    "site:Site",
+                    "virtual_machine:Virtual Machine",
+                    "toadstool:Toad Stool"
+                ]
+            }
+        },
+        "update_expect": {
+            "extra_choices": [
+                [
+                    "site",
+                    "Site"
+                ],
+                [
+                    "virtual_machine",
+                    "Virtual Machine"
+                ],
+                [
+                    "toadstool",
+                    "Toad Stool"
+                ]
+            ]
+        }
+    },
+    {
+        "name": "extras_custom_link_1",
+        "object_type": "extras.customlink",
+        "lookup": {
+            "name": "Custom Link 1"
+        },
+        "create": {
+            "custom_link": {
+                "name": "Custom Link 1",
+                "enabled": true,
+                "link_text": "Custom Link 1",
+                "link_url": "https://www.google.com",
+                "object_types": [
+                    "dcim.device"
+                ]
+            }
+        },
+        "create_expect": {
+            "name": "Custom Link 1",
+            "link_text": "Custom Link 1",
+            "link_url": "https://www.google.com"
+        },
+        "update": {
+            "custom_link": {
+                "name": "Custom Link 1",
+                "enabled": true,
+                "link_text": "Custom Link 1 Updated",
+                "link_url": "https://www.google.com",
+                "object_types": [
+                    "dcim.device"
+                ]
+            }
+        },
+        "update_expect": {
+            "link_text": "Custom Link 1 Updated"
+        }
+    },
+    {
+        "name": "extras_journal_entry_1",
+        "object_type": "extras.journalentry",
+        "lookup": {
+            "comments": "This is a journal entry"
+        },
+        "create": {
+            "journal_entry": {
+                "assigned_object_site": {
+                    "name": "Journal Test Site"
+                },
+                "comments": "This is a journal entry",
+                "kind": "info"
+            }
+        },
+        "create_expect": {
+            "assigned_object.name": "Journal Test Site",
+            "comments": "This is a journal entry",
+            "kind": "info"
+        },
+        "update": {
+            "journal_entry": {
+                "assigned_object_site": {
+                    "name": "Journal Test Site"
+                },
+                "comments": "This is a journal entry",
+                "kind": "danger"
+            }
+        },
+        "update_expect": {
+            "assigned_object.name": "Journal Test Site",
+            "comments": "This is a journal entry",
+            "kind": "danger"
+        }
+    },
+    {
+        "name": "ipam_rir_1",
+        "object_type": "ipam.rir",
+        "lookup": {
+            "name": "ARIN"
+        },
+        "create_expect": {
+            "name": "ARIN",
+            "description": "American Registry for Internet Numbers"
+        },
+        "create": {
+            "rir": {
+                "name": "ARIN",
+                "slug": "arin",
+                "is_private": false,
+                "description": "American Registry for Internet Numbers",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "rir": {
+                "name": "ARIN",
+                "slug": "arin",
+                "is_private": false,
+                "description": "American Registry for Internet Numbers Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "American Registry for Internet Numbers Updated"
+        }
+    },
+    {
+        "name": "dcim_rack_1",
+        "object_type": "dcim.rack",
+        "lookup": {
+            "asset_tag": "RACK-009"
+        },
+        "create_expect": {
+            "name": "Rack ZZ",
+            "site.name": "Site 1",
+            "description": "Standard 42U server rack"
+        },
+        "create": {
+            "rack": {
+                "name": "Rack ZZ",
+                "facility_id": "FAC-001",
+                "site": {
+                    "name": "Site 1"
+                },
+                "location": {
+                    "name": "Data Center East Wing",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Server Rack",
+                    "slug": "server-rack",
+                    "color": "0000ff",
+                    "description": "Primary server rack role"
+                },
+                "serial": "RACK123XYZ",
+                "asset_tag": "RACK-009",
+                "rack_type": {
+                    "manufacturer": {
+                        "name": "Manufacturer 1"
+                    },
+                    "model": "R2000",
+                    "slug": "r2000",
+                    "form_factor": "4-post-cabinet"
+                },
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "airflow": "front-to-rear",
+                "description": "Standard 42U server rack",
+                "comments": "Located in primary data center",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "rack": {
+                "name": "Rack ZZ",
+                "facility_id": "FAC-001",
+                "site": {
+                    "name": "Site 1"
+                },
+                "location": {
+                    "name": "Data Center East Wing",
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Server Rack",
+                    "slug": "server-rack",
+                    "color": "0000ff",
+                    "description": "Primary server rack role"
+                },
+                "serial": "RACK123XYZ",
+                "asset_tag": "RACK-009",
+                "rack_type": {
+                    "manufacturer": {
+                        "name": "Manufacturer 1"
+                    },
+                    "model": "R2000",
+                    "slug": "r2000",
+                    "form_factor": "4-post-cabinet"
+                },
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "mounting_depth": "30",
+                "airflow": "front-to-rear",
+                "description": "Standard 42U server rack Updated",
+                "comments": "Located in primary data center",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Standard 42U server rack Updated"
+        }
+    },
+    {
+        "name": "dcim_rackrole_1",
+        "object_type": "dcim.rackrole",
+        "lookup": {
+            "name": "Network Equipment"
+        },
+        "create_expect": {
+            "name": "Network Equipment",
+            "description": "Dedicated racks for network infrastructure"
+        },
+        "create": {
+            "rack_role": {
+                "name": "Network Equipment",
+                "slug": "network-equipment",
+                "color": "0000ff",
+                "description": "Dedicated racks for network infrastructure",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "rack_role": {
+                "name": "Network Equipment",
+                "slug": "network-equipment",
+                "color": "0000ff",
+                "description": "Dedicated racks for network infrastructure Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Dedicated racks for network infrastructure Updated"
+        }
+    },
+    {
+        "name": "dcim_racktype_1",
+        "object_type": "dcim.racktype",
+        "lookup": {
+            "manufacturer__name": "Manufacturer 1",
+            "model": "R2000"
+        },
+        "create_expect": {
+            "manufacturer.name": "Manufacturer 1",
+            "model": "R2000",
+            "description": "Standard 42U server rack"
+        },
+        "create": {
+            "rack_type": {
+                "manufacturer": {
+                    "name": "Manufacturer 1"
+                },
+                "model": "R2000",
+                "slug": "r2000",
+                "description": "Standard 42U server rack",
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "outer_width": "24",
+                "outer_depth": "36",
+                "outer_unit": "in",
+                "weight": "350.5",
+                "max_weight": "1000",
+                "weight_unit": "lb",
+                "mounting_depth": "30",
+                "comments": "Standard enterprise rack configuration",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "rack_type": {
+                "manufacturer": {
+                    "name": "Manufacturer 1"
+                },
+                "model": "R2000",
+                "slug": "r2000",
+                "description": "Standard 42U server rack Updated",
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "outer_width": "24",
+                "outer_depth": "36",
+                "outer_unit": "in",
+                "weight": "350.5",
+                "max_weight": "1000",
+                "weight_unit": "lb",
+                "mounting_depth": "30",
+                "comments": "Standard enterprise rack configuration",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Standard 42U server rack Updated"
+        }
+    },
+    {
+        "name": "dcim_rearport_1",
+        "object_type": "dcim.rearport",
+        "lookup": {
+            "device__name": "Device 1",
+            "name": "Rear Port 1"
+        },
+        "create_expect": {
+            "device.name": "Device 1",
+            "name": "Rear Port 1",
+            "description": "Rear fiber port"
+        },
+        "create": {
+            "rear_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "name": "Rear Port 1",
+                "label": "RP1",
+                "type": "lc-apc",
+                "color": "0000ff",
+                "positions": "1",
+                "description": "Rear fiber port",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "rear_port": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "module": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "module_bay": {
+                        "name": "Module Bay 1",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    },
+                    "module_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S-MODULE"
+                    }
+                },
+                "name": "Rear Port 1",
+                "label": "RP1",
+                "type": "lc-apc",
+                "color": "0000ff",
+                "positions": "1",
+                "description": "Rear fiber port Updated",
+                "mark_connected": true,
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Rear fiber port Updated"
+        }
+    },
+    {
+        "name": "dcim_region_1",
+        "object_type": "dcim.region",
+        "lookup": {
+            "name": "North America"
+        },
+        "create_expect": {
+            "name": "North America",
+            "parent.name": "Global",
+            "description": "North American Region"
+        },
+        "create": {
+            "region": {
+                "name": "North America",
+                "slug": "north-america",
+                "parent": {
+                    "name": "Global",
+                    "slug": "global",
+                    "description": "Global Region",
+                    "tags": [
+                        {
+                            "name": "Tag 1"
+                        }
+                    ]
+                },
+                "description": "North American Region",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "region": {
+                "name": "North America",
+                "slug": "north-america",
+                "parent": {
+                    "name": "Global",
+                    "slug": "global",
+                    "description": "Global Region",
+                    "tags": [
+                        {
+                            "name": "Tag 1"
+                        }
+                    ]
+                },
+                "description": "North American Region Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "North American Region Updated"
+        }
+    },
+    {
+        "name": "ipam_role_1",
+        "object_type": "ipam.role",
+        "lookup": {
+            "name": "Network Administrator"
+        },
+        "create_expect": {
+            "name": "Network Administrator",
+            "weight": 1000,
+            "description": "Primary network administration role"
+        },
+        "create": {
+            "role": {
+                "name": "Network Administrator",
+                "slug": "network-admin",
+                "weight": "1000",
+                "description": "Primary network administration role",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "role": {
+                "name": "Network Administrator",
+                "slug": "network-admin",
+                "weight": "1000",
+                "description": "Primary network administration role Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary network administration role Updated"
+        }
+    },
+    {
+        "name": "ipam_routetarget_1",
+        "object_type": "ipam.routetarget",
+        "lookup": {
+            "name": "65000:1001"
+        },
+        "create_expect": {
+            "name": "65000:1001",
+            "tenant.name": "Tenant 1",
+            "description": "Primary route target for MPLS VPN"
+        },
+        "create": {
+            "route_target": {
+                "name": "65000:1001",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "description": "Primary route target for MPLS VPN",
+                "comments": "Used for customer VPN service",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "route_target": {
+                "name": "65000:1001",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "description": "Primary route target for MPLS VPN Updated",
+                "comments": "Used for customer VPN service",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary route target for MPLS VPN Updated"
+        }
+    },
+    {
+        "name": "ipam_service_1",
+        "object_type": "ipam.service",
+        "lookup": {
+            "name": "Web Server"
+        },
+        "create_expect": {
+            "name": "Web Server",
+            "protocol": "tcp",
+            "ports": [
+                80,
+                443
+            ],
+            "description": "Primary web server service"
+        },
+        "create": {
+            "service": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Web Server",
+                "protocol": "tcp",
+                "ports": [
+                    "80",
+                    "443"
+                ],
+                "description": "Primary web server service",
+                "comments": "Handles HTTPS traffic for main website",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "ipaddresses": [
+                    {
+                        "address": "192.168.1.100/24",
+                        "status": "active",
+                        "dns_name": "web.example.com"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "service": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Web Server",
+                "protocol": "tcp",
+                "ports": [
+                    "80",
+                    "443"
+                ],
+                "description": "Primary web server service Updated",
+                "comments": "Handles HTTPS traffic for main website",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "ipaddresses": [
+                    {
+                        "address": "192.168.1.100/24",
+                        "status": "active",
+                        "dns_name": "web.example.com"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary web server service Updated"
+        }
+    },
+    {
+        "name": "dcim_site_1",
+        "object_type": "dcim.site",
+        "lookup": {
+            "name": "Data Center West"
+        },
+        "create_expect": {
+            "name": "Data Center West",
+            "region.name": "North America",
+            "group.name": "Primary Data Centers",
+            "description": "Primary West Coast Data Center"
+        },
+        "create": {
+            "site": {
+                "name": "Data Center West",
+                "slug": "dc-west",
+                "status": "active",
+                "region": {
+                    "name": "North America",
+                    "slug": "north-america"
+                },
+                "group": {
+                    "name": "Primary Data Centers",
+                    "slug": "primary-dcs"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "facility": "Building 7",
+                "time_zone": "America/Los_Angeles",
+                "description": "Primary West Coast Data Center",
+                "physical_address": "123 Tech Drive, San Jose, CA 95134",
+                "shipping_address": "Receiving Dock 3, 123 Tech Drive, San Jose, CA 95134",
+                "latitude": 37.3382,
+                "longitude": -121.8863,
+                "comments": "24x7 access requires security clearance",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "asns": [
+                    {
+                        "asn": "555",
+                        "rir": {
+                            "name": "RIR 1"
+                        },
+                        "tenant": {
+                            "name": "Tenant 1"
+                        },
+                        "description": "ASN 555 Description",
+                        "comments": "ASN 555 Comments",
+                        "tags": [
+                            {
+                                "name": "Tag 1"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "update": {
+            "site": {
+                "name": "Data Center West",
+                "slug": "dc-west",
+                "status": "active",
+                "region": {
+                    "name": "North America",
+                    "slug": "north-america"
+                },
+                "group": {
+                    "name": "Primary Data Centers",
+                    "slug": "primary-dcs"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "facility": "Building 7",
+                "time_zone": "America/Los_Angeles",
+                "description": "Primary West Coast Data Center Updated",
+                "physical_address": "123 Tech Drive, San Jose, CA 95134",
+                "shipping_address": "Receiving Dock 3, 123 Tech Drive, San Jose, CA 95134",
+                "latitude": 37.3382,
+                "longitude": -121.8863,
+                "comments": "24x7 access requires security clearance",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "asns": [
+                    {
+                        "asn": "555",
+                        "rir": {
+                            "name": "RIR 1"
+                        },
+                        "tenant": {
+                            "name": "Tenant 1"
+                        },
+                        "description": "ASN 555 Description",
+                        "comments": "ASN 555 Comments",
+                        "tags": [
+                            {
+                                "name": "Tag 1"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary West Coast Data Center Updated"
+        }
+    },
+    {
+        "name": "dcim_sitegroup_1",
+        "object_type": "dcim.sitegroup",
+        "lookup": {
+            "name": "Global Data Centers"
+        },
+        "create_expect": {
+            "name": "Global Data Centers",
+            "parent.name": "Infrastructure",
+            "description": "Worldwide data center facilities"
+        },
+        "create": {
+            "site_group": {
+                "name": "Global Data Centers",
+                "slug": "global-dcs",
+                "parent": {
+                    "name": "Infrastructure",
+                    "slug": "infrastructure"
+                },
+                "description": "Worldwide data center facilities",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "site_group": {
+                "name": "Global Data Centers",
+                "slug": "global-dcs",
+                "parent": {
+                    "name": "Infrastructure",
+                    "slug": "infrastructure"
+                },
+                "description": "Worldwide data center facilities Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Worldwide data center facilities Updated"
+        }
+    },
+    {
+        "name": "extras_tag_1",
+        "object_type": "extras.tag",
+        "lookup": {
+            "name": "Production"
+        },
+        "create_expect": {
+            "name": "Production",
+            "slug": "production",
+            "color": "ff0000"
+        },
+        "create": {
+            "tag": {
+                "name": "Production",
+                "slug": "production",
+                "color": "ff0000"
+            }
+        },
+        "update": {
+            "tag": {
+                "name": "Production",
+                "slug": "production",
+                "color": "00ff00"
+            }
+        },
+        "update_expect": {
+            "color": "00ff00"
+        }
+    },
+    {
+        "name": "tenancy_tenant_1",
+        "object_type": "tenancy.tenant",
+        "lookup": {
+            "name": "Acme Corporation"
+        },
+        "create_expect": {
+            "name": "Acme Corporation",
+            "slug": "acme-corp",
+            "description": "Global technology solutions provider"
+        },
+        "create": {
+            "tenant": {
+                "name": "Acme Corporation",
+                "slug": "acme-corp",
+                "group": {
+                    "name": "Enterprise Customers",
+                    "slug": "enterprise-customers"
+                },
+                "description": "Global technology solutions provider",
+                "comments": "Fortune 500 company with worldwide operations",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "tenant": {
+                "name": "Acme Corporation",
+                "slug": "acme-corp",
+                "group": {
+                    "name": "Enterprise Customers",
+                    "slug": "enterprise-customers"
+                },
+                "description": "Global technology solutions provider Updated",
+                "comments": "Fortune 500 company with worldwide operations",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Global technology solutions provider Updated"
+        }
+    },
+    {
+        "name": "tenancy_tenantgroup_1",
+        "object_type": "tenancy.tenantgroup",
+        "lookup": {
+            "name": "Financial Services"
+        },
+        "create_expect": {
+            "name": "Financial Services",
+            "description": "Banking and financial industry customers"
+        },
+        "create": {
+            "tenant_group": {
+                "name": "Financial Services",
+                "slug": "financial-services",
+                "parent": {
+                    "name": "Enterprise Sectors",
+                    "slug": "enterprise-sectors"
+                },
+                "description": "Banking and financial industry customers",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "tenant_group": {
+                "name": "Financial Services",
+                "slug": "financial-services",
+                "parent": {
+                    "name": "Enterprise Sectors",
+                    "slug": "enterprise-sectors"
+                },
+                "description": "Banking and financial industry customers Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Banking and financial industry customers Updated"
+        }
+    },
+    {
+        "name": "vpn_tunnel_1",
+        "object_type": "vpn.tunnel",
+        "lookup": {
+            "name": "DC-West-to-East-Primary"
+        },
+        "create_expect": {
+            "name": "DC-West-to-East-Primary",
+            "status": "active"
+        },
+        "create": {
+            "tunnel": {
+                "name": "DC-West-to-East-Primary",
+                "status": "active",
+                "group": {
+                    "name": "Inter-DC Tunnels",
+                    "slug": "inter-dc-tunnels"
+                },
+                "encapsulation": "ipsec-tunnel",
+                "ipsec_profile": {
+                    "name": "IPSEC-PROFILE-1",
+                    "mode": "esp",
+                    "ike_policy": {
+                        "name": "IKE-POLICY-TUN-1",
+                        "version": "2",
+                        "preshared_key": "1234567890",
+                        "comments": "Using AES-256-GCM encryption with PFS"
+                    },
+                    "ipsec_policy": {
+                        "name": "IPSEC-POLICY-1",
+                        "pfs_group": "2"
+                    }
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "tunnel_id": "1001",
+                "description": "Primary IPSec tunnel between West and East data centers",
+                "comments": "Using AES-256-GCM encryption with PFS",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "tunnel": {
+                "name": "DC-West-to-East-Primary",
+                "status": "active",
+                "group": {
+                    "name": "Inter-DC Tunnels",
+                    "slug": "inter-dc-tunnels"
+                },
+                "encapsulation": "ipsec-tunnel",
+                "ipsec_profile": {
+                    "name": "IPSEC-PROFILE-1",
+                    "mode": "esp",
+                    "ike_policy": {
+                        "name": "IKE-POLICY-TUN-1",
+                        "version": "2",
+                        "preshared_key": "1234567890",
+                        "comments": "Using AES-256-GCM encryption with PFS"
+                    },
+                    "ipsec_policy": {
+                        "name": "IPSEC-POLICY-1",
+                        "pfs_group": "2"
+                    }
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "tunnel_id": "1001",
+                "description": "Primary IPSec tunnel between West and East data centers Updated",
+                "comments": "Using AES-256-GCM encryption with PFS",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary IPSec tunnel between West and East data centers Updated"
+        }
+    },
+    {
+        "name": "vpn_tunnel_group_1",
+        "object_type": "vpn.tunnelgroup",
+        "lookup": {
+            "name": "Regional Backbones"
+        },
+        "create_expect": {
+            "name": "Regional Backbones",
+            "description": "High-capacity encrypted tunnels between regional data centers"
+        },
+        "create": {
+            "tunnel_group": {
+                "name": "Regional Backbones",
+                "slug": "regional-backbones",
+                "description": "High-capacity encrypted tunnels between regional data centers",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "tunnel_group": {
+                "name": "Regional Backbones",
+                "slug": "regional-backbones",
+                "description": "High-capacity encrypted tunnels between regional data centers Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "High-capacity encrypted tunnels between regional data centers Updated"
+        }
+    },
+    {
+        "name": "vpn_tunneltermination_1",
+        "object_type": "vpn.tunneltermination",
+        "lookup": {
+            "tunnel__name": "DC-West-to-East-Primary"
+        },
+        "create_expect": {
+            "tunnel.name": "DC-West-to-East-Primary",
+            "role": "hub"
+        },
+        "create": {
+            "tunnel_termination": {
+                "tunnel": {
+                    "name": "DC-West-to-East-Primary",
+                    "status": "active",
+                    "encapsulation": "ipsec-tunnel"
+                },
+                "role": "hub",
+                "termination_device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "outside_ip": {
+                    "address": "203.0.113.1/24",
+                    "status": "active",
+                    "dns_name": "vpn1.example.com"
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "tunnel_termination": {
+                "tunnel": {
+                    "name": "DC-West-to-East-Primary",
+                    "status": "active",
+                    "encapsulation": "ipsec-tunnel"
+                },
+                "role": "hub",
+                "termination_device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "outside_ip": {
+                    "address": "203.0.113.1/24",
+                    "status": "active",
+                    "dns_name": "vpn1.example.com"
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    },
+                    {
+                        "name": "Tag 3"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "tags.all.__by_name": [
+                "Tag 1",
+                "Tag 2",
+                "Tag 3"
+            ]
+        }
+    },
+    {
+        "name": "ipam_vlan_1",
+        "object_type": "ipam.vlan",
+        "lookup": {
+            "vid": 807
+        },
+        "create_expect": {
+            "vid": 807,
+            "name": "Production Servers"
+        },
+        "create": {
+            "vlan": {
+                "group": {
+                    "name": "Production VLANs",
+                    "slug": "production-vlans"
+                },
+                "vid": "807",
+                "name": "Production Servers",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "description": "Primary production server network",
+                "qinq_role": "cvlan",
+                "qinq_svlan": {
+                    "vid": "1909",
+                    "name": "Service Provider VLAN"
+                },
+                "comments": "Used for customer-facing production workloads",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "vlan": {
+                "group": {
+                    "name": "Production VLANs",
+                    "slug": "production-vlans"
+                },
+                "vid": "807",
+                "name": "Production Servers",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "description": "Primary production server network Updated",
+                "qinq_role": "cvlan",
+                "qinq_svlan": {
+                    "vid": "1909",
+                    "name": "Service Provider VLAN"
+                },
+                "comments": "Used for customer-facing production workloads",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary production server network Updated"
+        }
+    },
+    {
+        "name": "ipam_vlan_2",
+        "object_type": "ipam.vlan",
+        "lookup": {
+            "vid": 807
+        },
+        "create_expect": {
+            "vid": 807,
+            "name": "Production Servers",
+            "site.name": "Site 1"
+        },
+        "create": {
+            "vlan": {
+                "vid": "807",
+                "name": "Production Servers",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "site": {
+                    "name": "Site 1"
+                },
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "description": "Primary production server network",
+                "comments": "Used for customer-facing production workloads",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "vlan": {
+                "vid": "807",
+                "name": "Production Servers",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "site": {
+                    "name": "Site 1"
+                },
+                "role": {
+                    "name": "Production",
+                    "slug": "production"
+                },
+                "description": "Primary production server network Updated",
+                "comments": "Used for customer-facing production workloads",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary production server network Updated",
+            "site.name": "Site 1"
+        }
+    },
+    {
+        "name": "ipam_vlan_group_1",
+        "object_type": "ipam.vlangroup",
+        "lookup": {
+            "name": "Data Center Core"
+        },
+        "create_expect": {
+            "name": "Data Center Core",
+            "slug": "dc-core",
+            "description": "Core network VLANs for data center infrastructure"
+        },
+        "create": {
+            "vlan_group": {
+                "name": "Data Center Core",
+                "slug": "dc-core",
+                "scope_site": {
+                    "name": "Data Center West",
+                    "slug": "dc-west",
+                    "status": "active"
+                },
+                "vid_ranges": [
+                    "101",
+                    "102",
+                    "99",
+                    "100"
+                ],
+                "description": "Core network VLANs for data center infrastructure",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "vlan_group": {
+                "name": "Data Center Core",
+                "slug": "dc-core",
+                "scope_site": {
+                    "name": "Data Center West",
+                    "slug": "dc-west",
+                    "status": "active"
+                },
+                "vid_ranges": [
+                    "101",
+                    "102",
+                    "99",
+                    "100"
+                ],
+                "description": "Core network VLANs for data center infrastructure Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Core network VLANs for data center infrastructure Updated",
+            "vid_ranges": [
+                [
+                    99,
+                    100
+                ],
+                [
+                    101,
+                    102
+                ]
+            ]
+        }
+    },
+    {
+        "name": "ipam_vlan_translation_policy_1",
+        "object_type": "ipam.vlantranslationpolicy",
+        "lookup": {
+            "name": "Customer Edge Translation"
+        },
+        "create_expect": {
+            "name": "Customer Edge Translation",
+            "description": "VLAN translation policy for customer edge interfaces"
+        },
+        "create": {
+            "vlan_translation_policy": {
+                "name": "Customer Edge Translation",
+                "description": "VLAN translation policy for customer edge interfaces"
+            }
+        },
+        "update": {
+            "vlan_translation_policy": {
+                "name": "Customer Edge Translation",
+                "description": "VLAN translation policy for customer edge interfaces Updated"
+            }
+        },
+        "update_expect": {
+            "description": "VLAN translation policy for customer edge interfaces Updated"
+        }
+    },
+    {
+        "name": "ipam_vlan_translation_rule_1",
+        "object_type": "ipam.vlantranslationrule",
+        "lookup": {
+            "policy__name": "Customer Edge Translation",
+            "local_vid": "100"
+        },
+        "create_expect": {
+            "policy.name": "Customer Edge Translation",
+            "local_vid": 100,
+            "remote_vid": 1100,
+            "description": "Map customer VLAN 100 to provider VLAN 1100"
+        },
+        "create": {
+            "vlan_translation_rule": {
+                "policy": {
+                    "name": "Customer Edge Translation",
+                    "description": "VLAN translation policy for customer edge interfaces"
+                },
+                "local_vid": "100",
+                "remote_vid": "1100",
+                "description": "Map customer VLAN 100 to provider VLAN 1100"
+            }
+        },
+        "update": {
+            "vlan_translation_rule": {
+                "policy": {
+                    "name": "Customer Edge Translation",
+                    "description": "VLAN translation policy for customer edge interfaces"
+                },
+                "local_vid": "100",
+                "remote_vid": "1100",
+                "description": "Map customer VLAN 100 to provider VLAN 1100 Updated"
+            }
+        },
+        "update_expect": {
+            "description": "Map customer VLAN 100 to provider VLAN 1100 Updated"
+        }
+    },
+    {
+        "name": "virtualization_vminterface_1",
+        "object_type": "virtualization.vminterface",
+        "lookup": {
+            "name": "eth0"
+        },
+        "create_expect": {
+            "name": "eth0",
+            "description": "Primary network interface"
+        },
+        "create": {
+            "vm_interface": {
+                "virtual_machine": {
+                    "name": "web-server-01",
+                    "status": "active",
+                    "role": {
+                        "name": "Web Server"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "eth0",
+                "enabled": true,
+                "parent": {
+                    "virtual_machine": {
+                        "name": "web-server-01",
+                        "status": "active",
+                        "role": {
+                            "name": "Web Server"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "bond0"
+                },
+                "bridge": {
+                    "virtual_machine": {
+                        "name": "web-server-01",
+                        "status": "active",
+                        "role": {
+                            "name": "Web Server"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "br0"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:1A:2B:3C:4D:5E"
+                },
+                "description": "Primary network interface",
+                "mode": "q-in-q",
+                "untagged_vlan": {
+                    "vid": "1101",
+                    "name": "Production Servers"
+                },
+                "qinq_svlan": {
+                    "vid": "1000",
+                    "name": "Service Provider VLAN"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Edge Translation"
+                },
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "vm_interface": {
+                "virtual_machine": {
+                    "name": "web-server-01",
+                    "status": "active",
+                    "role": {
+                        "name": "Web Server"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "eth0",
+                "enabled": true,
+                "parent": {
+                    "virtual_machine": {
+                        "name": "web-server-01",
+                        "status": "active",
+                        "role": {
+                            "name": "Web Server"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "bond0"
+                },
+                "bridge": {
+                    "virtual_machine": {
+                        "name": "web-server-01",
+                        "status": "active",
+                        "role": {
+                            "name": "Web Server"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "br0"
+                },
+                "mtu": "9000",
+                "primary_mac_address": {
+                    "mac_address": "00:1A:2B:3C:4D:5E"
+                },
+                "description": "Primary network interface Updated",
+                "mode": "q-in-q",
+                "untagged_vlan": {
+                    "vid": "1101",
+                    "name": "Production Servers"
+                },
+                "qinq_svlan": {
+                    "vid": "1000",
+                    "name": "Service Provider VLAN"
+                },
+                "vlan_translation_policy": {
+                    "name": "Customer Edge Translation"
+                },
+                "vrf": {
+                    "name": "PROD-VRF",
+                    "rd": "65000:1"
+                },
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary network interface Updated"
+        }
+    },
+    {
+        "name": "ipam_vrf_1",
+        "object_type": "ipam.vrf",
+        "lookup": {
+            "name": "Customer-A-VRF"
+        },
+        "create_expect": {
+            "name": "Customer-A-VRF",
+            "rd": "65000:100",
+            "tenant.name": "Tenant 1",
+            "enforce_unique": true,
+            "description": "Isolated routing domain for Customer A",
+            "comments": "Used for customer's private network services"
+        },
+        "create": {
+            "vrf": {
+                "name": "Customer-A-VRF",
+                "rd": "65000:100",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "enforce_unique": true,
+                "description": "Isolated routing domain for Customer A",
+                "comments": "Used for customer's private network services",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "import_targets": [
+                    {
+                        "name": "65000:100"
+                    },
+                    {
+                        "name": "65000:101"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:103"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "vrf": {
+                "name": "Customer-A-VRF",
+                "rd": "65000:100",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "enforce_unique": true,
+                "description": "Isolated routing domain for Customer A Updated",
+                "comments": "Used for customer's private network services",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ],
+                "import_targets": [
+                    {
+                        "name": "65000:100"
+                    },
+                    {
+                        "name": "65000:101"
+                    }
+                ],
+                "export_targets": [
+                    {
+                        "name": "65000:103"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Isolated routing domain for Customer A Updated"
+        }
+    },
+    {
+        "name": "dcim_virtualchassis_1",
+        "object_type": "dcim.virtualchassis",
+        "lookup": {
+            "name": "Stack-DC1-Core"
+        },
+        "create_expect": {
+            "name": "Stack-DC1-Core",
+            "domain": "dc1-core.example.com"
+        },
+        "create": {
+            "virtual_chassis": {
+                "name": "Stack-DC1-Core",
+                "domain": "dc1-core.example.com",
+                "master": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "description": "Core switch stack in DC1",
+                "comments": "Primary switching infrastructure for data center 1",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_chassis": {
+                "name": "Stack-DC1-Core",
+                "domain": "dc1-core.example.com",
+                "master": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "description": "Core switch stack in DC1 Updated",
+                "comments": "Primary switching infrastructure for data center 1",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Core switch stack in DC1 Updated"
+        }
+    },
+    {
+        "name": "circuits_virtualcircuit_1",
+        "object_type": "circuits.virtualcircuit",
+        "lookup": {
+            "cid": "VC-001-LAX-NYC"
+        },
+        "create_expect": {
+            "cid": "VC-001-LAX-NYC"
+        },
+        "create": {
+            "virtual_circuit": {
+                "cid": "VC-001-LAX-NYC",
+                "provider_network": {
+                    "provider": {
+                        "name": "Level 3 Communications"
+                    },
+                    "name": "Global MPLS Network",
+                    "service_id": "L3-MPLS-001"
+                },
+                "provider_account": {
+                    "provider": {
+                        "name": "Level 3 Communications"
+                    },
+                    "name": "East Coast Account",
+                    "account": "L3-12345"
+                },
+                "type": {
+                    "name": "MPLS L3VPN",
+                    "slug": "mpls-l3vpn"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "description": "LAX to NYC MPLS circuit",
+                "comments": "Primary east-west connectivity",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_circuit": {
+                "cid": "VC-001-LAX-NYC",
+                "provider_network": {
+                    "provider": {
+                        "name": "Level 3 Communications"
+                    },
+                    "name": "Global MPLS Network",
+                    "service_id": "L3-MPLS-001"
+                },
+                "provider_account": {
+                    "provider": {
+                        "name": "Level 3 Communications"
+                    },
+                    "name": "East Coast Account",
+                    "account": "L3-12345"
+                },
+                "type": {
+                    "name": "MPLS L3VPN",
+                    "slug": "mpls-l3vpn"
+                },
+                "status": "active",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "description": "LAX to NYC MPLS circuit Updated",
+                "comments": "Primary east-west connectivity",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "LAX to NYC MPLS circuit Updated"
+        }
+    },
+    {
+        "name": "circuits_virtualcircuittermination_1",
+        "object_type": "circuits.virtualcircuittermination",
+        "lookup": {
+            "virtual_circuit__cid": "VC-001-LAX-NYC"
+        },
+        "create_expect": {
+            "virtual_circuit.cid": "VC-001-LAX-NYC",
+            "role": "hub",
+            "interface.device.name": "Device 1"
+        },
+        "create": {
+            "virtual_circuit_termination": {
+                "virtual_circuit": {
+                    "cid": "VC-001-LAX-NYC",
+                    "provider_network": {
+                        "provider": {
+                            "name": "Level 3 Communications"
+                        },
+                        "name": "Global MPLS Network"
+                    },
+                    "type": {
+                        "name": "MPLS L3VPN",
+                        "slug": "mpls-l3vpn"
+                    }
+                },
+                "role": "hub",
+                "interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "MegabitEthernet1/0/1",
+                    "type": "virtual",
+                    "enabled": true
+                },
+                "description": "LAX hub termination for east-west MPLS circuit",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_circuit_termination": {
+                "virtual_circuit": {
+                    "cid": "VC-001-LAX-NYC",
+                    "provider_network": {
+                        "provider": {
+                            "name": "Level 3 Communications"
+                        },
+                        "name": "Global MPLS Network"
+                    },
+                    "type": {
+                        "name": "MPLS L3VPN",
+                        "slug": "mpls-l3vpn"
+                    }
+                },
+                "role": "hub",
+                "interface": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "MegabitEthernet1/0/1",
+                    "type": "virtual",
+                    "enabled": true
+                },
+                "description": "LAX hub termination for east-west MPLS circuit Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "LAX hub termination for east-west MPLS circuit Updated"
+        }
+    },
+    {
+        "name": "circuits_virtualcircuittype_1",
+        "object_type": "circuits.virtualcircuittype",
+        "lookup": {
+            "name": "EVPN-VXLAN"
+        },
+        "create_expect": {
+            "name": "EVPN-VXLAN",
+            "description": "Data center interconnect using EVPN-VXLAN overlay"
+        },
+        "create": {
+            "virtual_circuit_type": {
+                "name": "EVPN-VXLAN",
+                "slug": "evpn-vxlan",
+                "color": "0000ff",
+                "description": "Data center interconnect using EVPN-VXLAN overlay",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_circuit_type": {
+                "name": "EVPN-VXLAN",
+                "slug": "evpn-vxlan",
+                "color": "0000ff",
+                "description": "Data center interconnect using EVPN-VXLAN overlay Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Data center interconnect using EVPN-VXLAN overlay Updated"
+        }
+    },
+    {
+        "name": "dcim_virtualdevicecontext_1",
+        "object_type": "dcim.virtualdevicecontext",
+        "lookup": {
+            "name": "VDC-Production"
+        },
+        "create_expect": {
+            "name": "VDC-Production",
+            "description": "Production virtual device context",
+            "comments": "Isolated network context for production services",
+            "identifier": 1,
+            "device.name": "Device 1",
+            "primary_ip4.address": "192.168.1.1/32",
+            "primary_ip6.address": "2001:db8::1/128"
+        },
+        "create": {
+            "virtual_device_context": {
+                "name": "VDC-Production",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "identifier": "1",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "primary_ip4": {
+                    "address": "192.168.1.1",
+                    "assigned_object_interface": {
+                        "type": "1000base-t",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "name": "eth0"
+                    }
+                },
+                "primary_ip6": {
+                    "address": "2001:db8::1",
+                    "assigned_object_interface": {
+                        "type": "1000base-t",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "name": "eth0"
+                    }
+                },
+                "status": "active",
+                "description": "Production virtual device context",
+                "comments": "Isolated network context for production services",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_device_context": {
+                "name": "VDC-Production",
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "identifier": "1",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "primary_ip4": {
+                    "address": "192.168.1.1",
+                    "assigned_object_interface": {
+                        "type": "1000base-t",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "name": "eth0"
+                    }
+                },
+                "primary_ip6": {
+                    "address": "2001:db8::1",
+                    "assigned_object_interface": {
+                        "type": "1000base-t",
+                        "device": {
+                            "name": "Device 1",
+                            "role": {
+                                "name": "Device Role 1"
+                            },
+                            "device_type": {
+                                "manufacturer": {
+                                    "name": "Cisco"
+                                },
+                                "model": "C2960S"
+                            },
+                            "site": {
+                                "name": "Site 1"
+                            }
+                        },
+                        "name": "eth0"
+                    }
+                },
+                "status": "active",
+                "description": "Production virtual device context Updated",
+                "comments": "Isolated network context for production services",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Production virtual device context Updated"
+        }
+    },
+    {
+        "name": "virtualization_virtualdisk_1",
+        "object_type": "virtualization.virtualdisk",
+        "lookup": {
+            "name": "root-volume"
+        },
+        "create_expect": {
+            "name": "root-volume",
+            "description": "Primary system disk"
+        },
+        "create": {
+            "virtual_disk": {
+                "virtual_machine": {
+                    "name": "web-server-01",
+                    "status": "active",
+                    "role": {
+                        "name": "Web Server"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "root-volume",
+                "description": "Primary system disk",
+                "size": "182400",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_disk": {
+                "virtual_machine": {
+                    "name": "web-server-01",
+                    "status": "active",
+                    "role": {
+                        "name": "Web Server"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "root-volume",
+                "description": "Primary system disk Updated",
+                "size": "182400",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary system disk Updated"
+        }
+    },
+    {
+        "name": "virtualization_virtualmachine_1",
+        "object_type": "virtualization.virtualmachine",
+        "lookup": {
+            "name": "app-server-01"
+        },
+        "create_expect": {
+            "name": "app-server-01",
+            "description": "Primary application server instance",
+            "comments": "Hosts critical business applications"
+        },
+        "create": {
+            "virtual_machine": {
+                "name": "app-server-01",
+                "status": "active",
+                "site": {
+                    "name": "Site 1"
+                },
+                "cluster": {
+                    "name": "Cluster 1",
+                    "type": {
+                        "name": "Cluster Type 1"
+                    },
+                    "scope_site": {
+                        "name": "Site 1"
+                    }
+                },
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "cluster": {
+                        "name": "Cluster 1",
+                        "type": {
+                            "name": "Cluster Type 1"
+                        },
+                        "scope_site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "serial": "VM-2023-001",
+                "role": {
+                    "name": "Application Server"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "platform": {
+                    "name": "Ubuntu 22.04"
+                },
+                "primary_ip4": {
+                    "address": "192.168.2.99",
+                    "assigned_object_vm_interface": {
+                        "virtual_machine": {
+                            "name": "app-server-01",
+                            "cluster": {
+                                "name": "Cluster 1",
+                                "type": {
+                                    "name": "Cluster Type 1"
+                                },
+                                "scope_site": {
+                                    "name": "Site 1"
+                                }
+                            },
+                            "tenant": {
+                                "name": "Tenant 1"
+                            }
+                        },
+                        "name": "eth0",
+                        "enabled": true,
+                        "mtu": "1500"
+                    }
+                },
+                "primary_ip6": {
+                    "address": "2001:db8::99",
+                    "assigned_object_vm_interface": {
+                        "virtual_machine": {
+                            "name": "app-server-01",
+                            "cluster": {
+                                "name": "Cluster 1",
+                                "type": {
+                                    "name": "Cluster Type 1"
+                                },
+                                "scope_site": {
+                                    "name": "Site 1"
+                                }
+                            },
+                            "tenant": {
+                                "name": "Tenant 1"
+                            }
+                        },
+                        "name": "eth0",
+                        "enabled": true,
+                        "mtu": "1500"
+                    }
+                },
+                "vcpus": 4.0,
+                "memory": "214748364",
+                "disk": "147483647",
+                "description": "Primary application server instance",
+                "comments": "Hosts critical business applications",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_machine": {
+                "name": "app-server-01",
+                "status": "active",
+                "site": {
+                    "name": "Site 1"
+                },
+                "cluster": {
+                    "name": "Cluster 1",
+                    "type": {
+                        "name": "Cluster Type 1"
+                    },
+                    "scope_site": {
+                        "name": "Site 1"
+                    }
+                },
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "cluster": {
+                        "name": "Cluster 1",
+                        "type": {
+                            "name": "Cluster Type 1"
+                        },
+                        "scope_site": {
+                            "name": "Site 1"
+                        }
+                    }
+                },
+                "serial": "VM-2023-001",
+                "role": {
+                    "name": "Application Server"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "platform": {
+                    "name": "Ubuntu 22.04"
+                },
+                "primary_ip4": {
+                    "address": "192.168.2.99",
+                    "assigned_object_vm_interface": {
+                        "virtual_machine": {
+                            "name": "app-server-01",
+                            "cluster": {
+                                "name": "Cluster 1",
+                                "type": {
+                                    "name": "Cluster Type 1"
+                                },
+                                "scope_site": {
+                                    "name": "Site 1"
+                                }
+                            },
+                            "tenant": {
+                                "name": "Tenant 1"
+                            }
+                        },
+                        "name": "eth0",
+                        "enabled": true,
+                        "mtu": "1500"
+                    }
+                },
+                "primary_ip6": {
+                    "address": "2001:db8::99",
+                    "assigned_object_vm_interface": {
+                        "virtual_machine": {
+                            "name": "app-server-01",
+                            "cluster": {
+                                "name": "Cluster 1",
+                                "type": {
+                                    "name": "Cluster Type 1"
+                                },
+                                "scope_site": {
+                                    "name": "Site 1"
+                                }
+                            },
+                            "tenant": {
+                                "name": "Tenant 1"
+                            }
+                        },
+                        "name": "eth0",
+                        "enabled": true,
+                        "mtu": "1500"
+                    }
+                },
+                "vcpus": 4.0,
+                "memory": "214748364",
+                "disk": "147483647",
+                "description": "Primary application server instance Updated",
+                "comments": "Hosts critical business applications",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary application server instance Updated"
+        }
+    },
+    {
+        "name": "wireless_wirelesslan_1",
+        "object_type": "wireless.wirelesslan",
+        "lookup": {
+            "ssid": "Corp-Secure"
+        },
+        "create_expect": {
+            "ssid": "Corp-Secure",
+            "group.name": "Corporate Networks",
+            "description": "Corporate secure wireless network"
+        },
+        "create": {
+            "wireless_lan": {
+                "ssid": "Corp-Secure",
+                "description": "Corporate secure wireless network",
+                "group": {
+                    "name": "Corporate Networks",
+                    "slug": "corporate-networks"
+                },
+                "status": "active",
+                "vlan": {
+                    "vid": 100,
+                    "name": "Production Servers"
+                },
+                "scope_site": {
+                    "name": "Site 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "auth_type": "wpa-enterprise",
+                "auth_cipher": "aes",
+                "auth_psk": "SecureWiFiKey123!",
+                "comments": "Primary corporate wireless network with 802.1X authentication",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "wireless_lan": {
+                "ssid": "Corp-Secure",
+                "description": "Corporate secure wireless network Updated",
+                "group": {
+                    "name": "Corporate Networks",
+                    "slug": "corporate-networks"
+                },
+                "status": "active",
+                "vlan": {
+                    "vid": 100,
+                    "name": "Production Servers"
+                },
+                "scope_site": {
+                    "name": "Site 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "auth_type": "wpa-enterprise",
+                "auth_cipher": "aes",
+                "auth_psk": "SecureWiFiKey123!",
+                "comments": "Primary corporate wireless network with 802.1X authentication",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Corporate secure wireless network Updated"
+        }
+    },
+    {
+        "name": "wireless_wirelesslangroup_1",
+        "object_type": "wireless.wirelesslangroup",
+        "lookup": {
+            "name": "Corporate Networks"
+        },
+        "create_expect": {
+            "name": "Corporate Networks",
+            "parent.name": "All Networks",
+            "description": "Enterprise corporate wireless networks"
+        },
+        "create": {
+            "wireless_lan_group": {
+                "name": "Corporate Networks",
+                "slug": "corporate-networks",
+                "parent": {
+                    "name": "All Networks",
+                    "slug": "all-networks"
+                },
+                "description": "Enterprise corporate wireless networks",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "wireless_lan_group": {
+                "name": "Corporate Networks",
+                "slug": "corporate-networks",
+                "parent": {
+                    "name": "All Networks",
+                    "slug": "all-networks"
+                },
+                "description": "Enterprise corporate wireless networks Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Enterprise corporate wireless networks Updated"
+        }
+    },
+    {
+        "name": "wireless_wirelesslink_1",
+        "object_type": "wireless.wirelesslink",
+        "lookup": {
+            "ssid": "P2P-Link-1"
+        },
+        "create_expect": {
+            "interface_a.device.name": "Device 1",
+            "interface_b.device.name": "Device 2",
+            "description": "Point-to-point wireless backhaul link"
+        },
+        "create": {
+            "wireless_link": {
+                "interface_a": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Radio0/1",
+                    "type": "ieee802.11ac",
+                    "enabled": true
+                },
+                "interface_b": {
+                    "device": {
+                        "name": "Device 2",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Radio0/1",
+                    "type": "ieee802.11ac",
+                    "enabled": true
+                },
+                "ssid": "P2P-Link-1",
+                "status": "connected",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "auth_type": "wpa-personal",
+                "auth_cipher": "aes",
+                "auth_psk": "P2PLinkKey123!",
+                "distance": 1.5,
+                "distance_unit": "km",
+                "description": "Point-to-point wireless backhaul link",
+                "comments": "Building A to Building B wireless bridge",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "wireless_link": {
+                "interface_a": {
+                    "device": {
+                        "name": "Device 1",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Radio0/1",
+                    "type": "ieee802.11ac",
+                    "enabled": true
+                },
+                "interface_b": {
+                    "device": {
+                        "name": "Device 2",
+                        "role": {
+                            "name": "Device Role 1"
+                        },
+                        "device_type": {
+                            "manufacturer": {
+                                "name": "Cisco"
+                            },
+                            "model": "C2960S"
+                        },
+                        "site": {
+                            "name": "Site 1"
+                        }
+                    },
+                    "name": "Radio0/1",
+                    "type": "ieee802.11ac",
+                    "enabled": true
+                },
+                "ssid": "P2P-Link-1",
+                "status": "connected",
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "auth_type": "wpa-personal",
+                "auth_cipher": "aes",
+                "auth_psk": "P2PLinkKey123!",
+                "distance": 1.5,
+                "distance_unit": "km",
+                "description": "Point-to-point wireless backhaul link Updated",
+                "comments": "Building A to Building B wireless bridge",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Point-to-point wireless backhaul link Updated"
+        }
+    },
+    {
+        "name": "users_owner_1",
+        "object_type": "users.owner",
+        "lookup": {
+            "name": "Owner 1"
+        },
+        "create_expect": {
+            "name": "Owner 1",
+            "description": "Primary network owner",
+            "group.name": "Owner Group 1"
+        },
+        "create": {
+            "owner": {
+                "name": "Owner 1",
+                "group": {
+                    "name": "Owner Group 1"
+                },
+                "description": "Primary network owner"
+            }
+        },
+        "update": {
+            "owner": {
+                "name": "Owner 1",
+                "group": {
+                    "name": "Owner Group 1"
+                },
+                "description": "Primary network owner updated"
+            }
+        },
+        "update_expect": {
+            "description": "Primary network owner updated"
+        }
+    },
+    {
+        "name": "users_ownergroup_1",
+        "object_type": "users.ownergroup",
+        "lookup": {
+            "name": "Owner Group 1"
+        },
+        "create_expect": {
+            "name": "Owner Group 1",
+            "description": "Network operations team"
+        },
+        "create": {
+            "owner_group": {
+                "name": "Owner Group 1",
+                "description": "Network operations team"
+            }
+        },
+        "update": {
+            "owner_group": {
+                "name": "Owner Group 1",
+                "description": "Network operations team updated"
+            }
+        },
+        "update_expect": {
+            "description": "Network operations team updated"
+        }
+    },
+    {
+        "name": "circuits_circuit_with_owner_1",
+        "object_type": "circuits.circuit",
+        "lookup": {
+            "cid": "CIRCUIT-OWNER-001"
+        },
+        "create_expect": {
+            "cid": "CIRCUIT-OWNER-001",
+            "provider.name": "Provider 1",
+            "type.name": "Circuit Type 1",
+            "owner.name": "Owner 1"
+        },
+        "create": {
+            "circuit": {
+                "cid": "CIRCUIT-OWNER-001",
+                "provider": {
+                    "name": "Provider 1"
+                },
+                "type": {
+                    "name": "Circuit Type 1"
+                },
+                "owner": {
+                    "name": "Owner 1",
+                    "group": {
+                        "name": "Owner Group 1"
+                    }
+                },
+                "status": "active",
+                "description": "Circuit with owner",
+                "comments": "Test circuit ownership",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "circuit": {
+                "cid": "CIRCUIT-OWNER-001",
+                "provider": {
+                    "name": "Provider 1"
+                },
+                "type": {
+                    "name": "Circuit Type 1"
+                },
+                "owner": {
+                    "name": "Owner 1",
+                    "group": {
+                        "name": "Owner Group 1"
+                    }
+                },
+                "status": "active",
+                "description": "Circuit with owner updated",
+                "comments": "Test circuit ownership",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Circuit with owner updated"
+        }
+    },
+    {
+        "name": "dcim_device_with_owner_1",
+        "object_type": "dcim.device",
+        "lookup": {
+            "name": "Device With Owner 1"
+        },
+        "create_expect": {
+            "name": "Device With Owner 1",
+            "role.name": "Device Role 1",
+            "device_type.manufacturer.name": "Cisco",
+            "device_type.model": "C9300",
+            "site.name": "Site 1",
+            "owner.name": "Owner 1"
+        },
+        "create": {
+            "device": {
+                "name": "Device With Owner 1",
+                "role": {
+                    "name": "Device Role 1"
+                },
+                "device_type": {
+                    "manufacturer": {
+                        "name": "Cisco"
+                    },
+                    "model": "C9300"
+                },
+                "site": {
+                    "name": "Site 1"
+                },
+                "owner": {
+                    "name": "Owner 1",
+                    "group": {
+                        "name": "Owner Group 1"
+                    }
+                },
+                "status": "active",
+                "description": "Device with owner",
+                "comments": "Test device ownership",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "device": {
+                "name": "Device With Owner 1",
+                "role": {
+                    "name": "Device Role 1"
+                },
+                "device_type": {
+                    "manufacturer": {
+                        "name": "Cisco"
+                    },
+                    "model": "C9300"
+                },
+                "site": {
+                    "name": "Site 1"
+                },
+                "owner": {
+                    "name": "Owner 1",
+                    "group": {
+                        "name": "Owner Group 1"
+                    }
+                },
+                "status": "active",
+                "description": "Device with owner updated",
+                "comments": "Test device ownership",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Device with owner updated"
+        }
+    },
+    {
+        "name": "dcim_cablebundle_1",
+        "object_type": "dcim.cablebundle",
+        "lookup": {
+            "name": "Bundle 1"
+        },
+        "create_expect": {
+            "name": "Bundle 1",
+            "description": "Primary fiber bundle",
+            "comments": "Routed through riser A"
+        },
+        "create": {
+            "cable_bundle": {
+                "name": "Bundle 1",
+                "description": "Primary fiber bundle",
+                "comments": "Routed through riser A",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cable_bundle": {
+                "name": "Bundle 1",
+                "description": "Primary fiber bundle Updated",
+                "comments": "Routed through riser A and B",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary fiber bundle Updated",
+            "comments": "Routed through riser A and B"
+        }
+    },
+    {
+        "name": "dcim_rackgroup_1",
+        "object_type": "dcim.rackgroup",
+        "lookup": {
+            "slug": "rack-group-1"
+        },
+        "create_expect": {
+            "name": "Rack Group 1",
+            "slug": "rack-group-1",
+            "description": "Primary rack group"
+        },
+        "create": {
+            "rack_group": {
+                "name": "Rack Group 1",
+                "slug": "rack-group-1",
+                "description": "Primary rack group",
+                "comments": "Top of data center",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "rack_group": {
+                "name": "Rack Group 1",
+                "slug": "rack-group-1",
+                "description": "Primary rack group Updated",
+                "comments": "Top of data center",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Primary rack group Updated"
+        }
+    },
+    {
+        "name": "virtualization_virtualmachinetype_1",
+        "object_type": "virtualization.virtualmachinetype",
+        "lookup": {
+            "slug": "vm-type-1"
+        },
+        "create_expect": {
+            "name": "VM Type 1",
+            "slug": "vm-type-1",
+            "description": "Standard 4GB VM profile",
+            "default_memory": 4096
+        },
+        "create": {
+            "virtual_machine_type": {
+                "name": "VM Type 1",
+                "slug": "vm-type-1",
+                "description": "Standard 4GB VM profile",
+                "default_memory": "4096",
+                "default_vcpus": 2.0,
+                "default_platform": {
+                    "name": "Ubuntu 22.04",
+                    "slug": "ubuntu-22-04"
+                },
+                "comments": "General purpose template",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_machine_type": {
+                "name": "VM Type 1",
+                "slug": "vm-type-1",
+                "description": "Standard 4GB VM profile",
+                "default_memory": "8192",
+                "default_vcpus": 2.0,
+                "default_platform": {
+                    "name": "Ubuntu 22.04",
+                    "slug": "ubuntu-22-04"
+                },
+                "comments": "General purpose template",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "default_memory": 8192
+        }
+    },
+    {
+        "name": "dcim_rack_with_group_1",
+        "object_type": "dcim.rack",
+        "lookup": {
+            "asset_tag": "RACK-010"
+        },
+        "create_expect": {
+            "name": "Rack With Group",
+            "site.name": "Site 1",
+            "group.name": "Rack Group A",
+            "description": "Rack assigned to Group A"
+        },
+        "create": {
+            "rack": {
+                "name": "Rack With Group",
+                "facility_id": "FAC-010",
+                "site": {
+                    "name": "Site 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Server Rack",
+                    "slug": "server-rack",
+                    "color": "0000ff"
+                },
+                "group": {
+                    "name": "Rack Group A",
+                    "slug": "rack-group-a"
+                },
+                "serial": "RACK010XYZ",
+                "asset_tag": "RACK-010",
+                "rack_type": {
+                    "manufacturer": {
+                        "name": "Manufacturer 1"
+                    },
+                    "model": "R2000",
+                    "slug": "r2000",
+                    "form_factor": "4-post-cabinet"
+                },
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "airflow": "front-to-rear",
+                "description": "Rack assigned to Group A",
+                "comments": "First rack in group A",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "rack": {
+                "name": "Rack With Group",
+                "facility_id": "FAC-010",
+                "site": {
+                    "name": "Site 1"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "status": "active",
+                "role": {
+                    "name": "Server Rack",
+                    "slug": "server-rack",
+                    "color": "0000ff"
+                },
+                "group": {
+                    "name": "Rack Group B",
+                    "slug": "rack-group-b"
+                },
+                "serial": "RACK010XYZ",
+                "asset_tag": "RACK-010",
+                "rack_type": {
+                    "manufacturer": {
+                        "name": "Manufacturer 1"
+                    },
+                    "model": "R2000",
+                    "slug": "r2000",
+                    "form_factor": "4-post-cabinet"
+                },
+                "form_factor": "4-post-cabinet",
+                "width": "19",
+                "u_height": "42",
+                "starting_unit": "1",
+                "desc_units": false,
+                "airflow": "front-to-rear",
+                "description": "Rack assigned to Group A",
+                "comments": "First rack in group A",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "group.name": "Rack Group B"
+        }
+    },
+    {
+        "name": "virtualization_virtualmachine_with_type_1",
+        "object_type": "virtualization.virtualmachine",
+        "lookup": {
+            "name": "vm-with-type-01"
+        },
+        "create_expect": {
+            "name": "vm-with-type-01",
+            "virtual_machine_type.name": "VM Type A",
+            "description": "VM with a virtual_machine_type"
+        },
+        "create": {
+            "virtual_machine": {
+                "name": "vm-with-type-01",
+                "status": "active",
+                "site": {
+                    "name": "Site 1"
+                },
+                "cluster": {
+                    "name": "Cluster 1",
+                    "type": {
+                        "name": "Cluster Type 1"
+                    },
+                    "scope_site": {
+                        "name": "Site 1"
+                    }
+                },
+                "role": {
+                    "name": "Application Server"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "virtual_machine_type": {
+                    "name": "VM Type A",
+                    "slug": "vm-type-a",
+                    "description": "Type A profile"
+                },
+                "vcpus": 4.0,
+                "memory": "8192",
+                "disk": "100",
+                "description": "VM with a virtual_machine_type",
+                "comments": "Linked to VM Type A",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "virtual_machine": {
+                "name": "vm-with-type-01",
+                "status": "active",
+                "site": {
+                    "name": "Site 1"
+                },
+                "cluster": {
+                    "name": "Cluster 1",
+                    "type": {
+                        "name": "Cluster Type 1"
+                    },
+                    "scope_site": {
+                        "name": "Site 1"
+                    }
+                },
+                "role": {
+                    "name": "Application Server"
+                },
+                "tenant": {
+                    "name": "Tenant 1"
+                },
+                "virtual_machine_type": {
+                    "name": "VM Type B",
+                    "slug": "vm-type-b",
+                    "description": "Type B profile"
+                },
+                "vcpus": 4.0,
+                "memory": "8192",
+                "disk": "100",
+                "description": "VM with a virtual_machine_type",
+                "comments": "Linked to VM Type A",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    },
+                    {
+                        "name": "Tag 2"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "virtual_machine_type.name": "VM Type B"
+        }
+    },
+    {
+        "name": "dcim_cable_iface_iface",
+        "object_type": "dcim.cable",
+        "lookup": {
+            "label": "Cable A-B"
+        },
+        "create_expect": {
+            "label": "Cable A-B",
+            "status": "connected",
+            "type": "cat6",
+            "a_terminations.0.name": "GigabitEthernet0/1",
+            "b_terminations.0.name": "GigabitEthernet0/2"
+        },
+        "create": {
+            "cable": {
+                "label": "Cable A-B",
+                "status": "connected",
+                "type": "cat6",
+                "a_terminations": [
+                    {
+                        "object_interface": {
+                            "name": "GigabitEthernet0/1",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": "Cable Device A",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_interface": {
+                            "name": "GigabitEthernet0/2",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": "Cable Device B",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cable": {
+                "label": "Cable A-B",
+                "status": "connected",
+                "type": "cat6a",
+                "a_terminations": [
+                    {
+                        "object_interface": {
+                            "name": "GigabitEthernet0/2",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": "Cable Device B",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_interface": {
+                            "name": "GigabitEthernet0/1",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": "Cable Device A",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "length": 5.0,
+                "length_unit": "m"
+            }
+        },
+        "update_expect": {
+            "type": "cat6a",
+            "length": 5.0,
+            "length_unit": "m"
+        }
+    },
+    {
+        "name": "dcim_cable_frontport_rearport",
+        "object_type": "dcim.cable",
+        "lookup": {
+            "label": "Cable FP-RP"
+        },
+        "create_expect": {
+            "label": "Cable FP-RP",
+            "status": "connected",
+            "a_terminations.0.name": "FrontPort1",
+            "b_terminations.0.name": "RearPort2"
+        },
+        "create": {
+            "cable": {
+                "label": "Cable FP-RP",
+                "status": "connected",
+                "a_terminations": [
+                    {
+                        "object_front_port": {
+                            "name": "FrontPort1",
+                            "type": "8p8c",
+                            "device": {
+                                "name": "Patch Panel A",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            },
+                            "rear_port": {
+                                "name": "RearPort1",
+                                "type": "8p8c",
+                                "device": {
+                                    "name": "Patch Panel A",
+                                    "role": {
+                                        "name": "Device Role 1"
+                                    },
+                                    "device_type": {
+                                        "manufacturer": {
+                                            "name": "Cisco"
+                                        },
+                                        "model": "C2960S"
+                                    },
+                                    "site": {
+                                        "name": "Site 1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_rear_port": {
+                            "name": "RearPort2",
+                            "type": "8p8c",
+                            "device": {
+                                "name": "Patch Panel B",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cable": {
+                "label": "Cable FP-RP",
+                "status": "planned",
+                "a_terminations": [
+                    {
+                        "object_front_port": {
+                            "name": "FrontPort1",
+                            "type": "8p8c",
+                            "device": {
+                                "name": "Patch Panel A",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            },
+                            "rear_port": {
+                                "name": "RearPort1",
+                                "type": "8p8c",
+                                "device": {
+                                    "name": "Patch Panel A",
+                                    "role": {
+                                        "name": "Device Role 1"
+                                    },
+                                    "device_type": {
+                                        "manufacturer": {
+                                            "name": "Cisco"
+                                        },
+                                        "model": "C2960S"
+                                    },
+                                    "site": {
+                                        "name": "Site 1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_rear_port": {
+                            "name": "RearPort2",
+                            "type": "8p8c",
+                            "device": {
+                                "name": "Patch Panel B",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "status": "planned"
+        }
+    },
+    {
+        "name": "dcim_cable_power",
+        "object_type": "dcim.cable",
+        "lookup": {
+            "label": "Cable PWR"
+        },
+        "create_expect": {
+            "label": "Cable PWR",
+            "a_terminations.0.name": "PowerPort1",
+            "b_terminations.0.name": "PowerOutlet1"
+        },
+        "create": {
+            "cable": {
+                "label": "Cable PWR",
+                "status": "connected",
+                "a_terminations": [
+                    {
+                        "object_power_port": {
+                            "name": "PowerPort1",
+                            "device": {
+                                "name": "PDU Consumer",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_power_outlet": {
+                            "name": "PowerOutlet1",
+                            "device": {
+                                "name": "PDU Source",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cable": {
+                "label": "Cable PWR",
+                "status": "connected",
+                "color": "ff0000",
+                "a_terminations": [
+                    {
+                        "object_power_port": {
+                            "name": "PowerPort1",
+                            "device": {
+                                "name": "PDU Consumer",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_power_outlet": {
+                            "name": "PowerOutlet1",
+                            "device": {
+                                "name": "PDU Source",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "color": "ff0000"
+        }
+    },
+    {
+        "name": "dcim_cable_console",
+        "object_type": "dcim.cable",
+        "lookup": {
+            "label": "Cable CON"
+        },
+        "create_expect": {
+            "label": "Cable CON",
+            "a_terminations.0.name": "ConsolePort1",
+            "b_terminations.0.name": "ConsoleServerPort1"
+        },
+        "create": {
+            "cable": {
+                "label": "Cable CON",
+                "status": "connected",
+                "a_terminations": [
+                    {
+                        "object_console_port": {
+                            "name": "ConsolePort1",
+                            "device": {
+                                "name": "Console Device",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_console_server_port": {
+                            "name": "ConsoleServerPort1",
+                            "device": {
+                                "name": "Console Server",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cable": {
+                "label": "Cable CON",
+                "status": "decommissioning",
+                "a_terminations": [
+                    {
+                        "object_console_port": {
+                            "name": "ConsolePort1",
+                            "device": {
+                                "name": "Console Device",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_console_server_port": {
+                            "name": "ConsoleServerPort1",
+                            "device": {
+                                "name": "Console Server",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "status": "decommissioning"
+        }
+    },
+    {
+        "name": "dcim_cable_circuit",
+        "object_type": "dcim.cable",
+        "lookup": {
+            "label": "Cable CKT"
+        },
+        "create_expect": {
+            "label": "Cable CKT",
+            "a_terminations.0.term_side": "A",
+            "b_terminations.0.name": "eth-ckt"
+        },
+        "create": {
+            "cable": {
+                "label": "Cable CKT",
+                "status": "connected",
+                "a_terminations": [
+                    {
+                        "object_circuit_termination": {
+                            "term_side": "A",
+                            "circuit": {
+                                "cid": "CKT-1",
+                                "provider": {
+                                    "name": "Provider 1"
+                                },
+                                "type": {
+                                    "name": "Circuit Type 1"
+                                }
+                            },
+                            "termination_site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_interface": {
+                            "name": "eth-ckt",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": "CKT Device",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cable": {
+                "label": "Cable CKT",
+                "status": "planned",
+                "a_terminations": [
+                    {
+                        "object_circuit_termination": {
+                            "term_side": "A",
+                            "circuit": {
+                                "cid": "CKT-1",
+                                "provider": {
+                                    "name": "Provider 1"
+                                },
+                                "type": {
+                                    "name": "Circuit Type 1"
+                                }
+                            },
+                            "termination_site": {
+                                "name": "Site 1"
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_interface": {
+                            "name": "eth-ckt",
+                            "type": "1000base-t",
+                            "device": {
+                                "name": "CKT Device",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "status": "planned"
+        }
+    },
+    {
+        "name": "dcim_cable_powerfeed",
+        "object_type": "dcim.cable",
+        "lookup": {
+            "label": "Cable PF"
+        },
+        "create_expect": {
+            "label": "Cable PF",
+            "a_terminations.0.name": "Feed1",
+            "b_terminations.0.name": "PowerPortPF"
+        },
+        "create": {
+            "cable": {
+                "label": "Cable PF",
+                "status": "connected",
+                "a_terminations": [
+                    {
+                        "object_power_feed": {
+                            "name": "Feed1",
+                            "power_panel": {
+                                "name": "Panel 1",
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_power_port": {
+                            "name": "PowerPortPF",
+                            "device": {
+                                "name": "PF Consumer",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update": {
+            "cable": {
+                "label": "Cable PF",
+                "status": "connected",
+                "color": "00ff00",
+                "a_terminations": [
+                    {
+                        "object_power_feed": {
+                            "name": "Feed1",
+                            "power_panel": {
+                                "name": "Panel 1",
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "b_terminations": [
+                    {
+                        "object_power_port": {
+                            "name": "PowerPortPF",
+                            "device": {
+                                "name": "PF Consumer",
+                                "role": {
+                                    "name": "Device Role 1"
+                                },
+                                "device_type": {
+                                    "manufacturer": {
+                                        "name": "Cisco"
+                                    },
+                                    "model": "C2960S"
+                                },
+                                "site": {
+                                    "name": "Site 1"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "color": "00ff00"
+        }
+    },
+    {
+        "name": "obs3607_iface_tagged_to_access",
+        "object_type": "dcim.interface",
+        "lookup": {
+            "name": "obs3607-eth-access"
+        },
+        "create_expect": {
+            "mode": "tagged",
+            "untagged_vlan.vid": 100,
+            "tagged_vlans.all.__by_vid": [
+                101,
+                102
+            ]
+        },
+        "create": {
+            "interface": {
+                "name": "obs3607-eth-access",
+                "type": "1000base-t",
+                "device": {
+                    "name": "obs3607-dev-1",
+                    "role": {
+                        "name": "obs3607-role"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "obs3607-mfr"
+                        },
+                        "model": "obs3607-model"
+                    },
+                    "site": {
+                        "name": "obs3607-site"
+                    }
+                },
+                "mode": "tagged",
+                "untagged_vlan": {
+                    "vid": 100,
+                    "name": "obs3607-v100"
+                },
+                "tagged_vlans": [
+                    {
+                        "vid": 101,
+                        "name": "obs3607-v101"
+                    },
+                    {
+                        "vid": 102,
+                        "name": "obs3607-v102"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "interface": {
+                "name": "obs3607-eth-access",
+                "type": "1000base-t",
+                "device": {
+                    "name": "obs3607-dev-1",
+                    "role": {
+                        "name": "obs3607-role"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "obs3607-mfr"
+                        },
+                        "model": "obs3607-model"
+                    },
+                    "site": {
+                        "name": "obs3607-site"
+                    }
+                },
+                "mode": "access"
+            }
+        },
+        "update_expect": {
+            "mode": "access",
+            "untagged_vlan.vid": 100,
+            "tagged_vlans.all.__by_vid": []
+        }
+    },
+    {
+        "name": "obs3607_iface_tagged_to_taggedall",
+        "object_type": "dcim.interface",
+        "lookup": {
+            "name": "obs3607-eth-taggedall"
+        },
+        "create_expect": {
+            "mode": "tagged",
+            "tagged_vlans.all.__by_vid": [
+                201
+            ]
+        },
+        "create": {
+            "interface": {
+                "name": "obs3607-eth-taggedall",
+                "type": "1000base-t",
+                "device": {
+                    "name": "obs3607-dev-1",
+                    "role": {
+                        "name": "obs3607-role"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "obs3607-mfr"
+                        },
+                        "model": "obs3607-model"
+                    },
+                    "site": {
+                        "name": "obs3607-site"
+                    }
+                },
+                "mode": "tagged",
+                "untagged_vlan": {
+                    "vid": 200,
+                    "name": "obs3607-v200"
+                },
+                "tagged_vlans": [
+                    {
+                        "vid": 201,
+                        "name": "obs3607-v201"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "interface": {
+                "name": "obs3607-eth-taggedall",
+                "type": "1000base-t",
+                "device": {
+                    "name": "obs3607-dev-1",
+                    "role": {
+                        "name": "obs3607-role"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "obs3607-mfr"
+                        },
+                        "model": "obs3607-model"
+                    },
+                    "site": {
+                        "name": "obs3607-site"
+                    }
+                },
+                "mode": "tagged-all"
+            }
+        },
+        "update_expect": {
+            "mode": "tagged-all",
+            "untagged_vlan.vid": 200,
+            "tagged_vlans.all.__by_vid": []
+        }
+    },
+    {
+        "name": "obs3607_iface_tagged_to_routed",
+        "object_type": "dcim.interface",
+        "lookup": {
+            "name": "obs3607-eth-routed"
+        },
+        "create_expect": {
+            "mode": "tagged",
+            "untagged_vlan.vid": 300,
+            "tagged_vlans.all.__by_vid": [
+                301
+            ]
+        },
+        "create": {
+            "interface": {
+                "name": "obs3607-eth-routed",
+                "type": "1000base-t",
+                "device": {
+                    "name": "obs3607-dev-1",
+                    "role": {
+                        "name": "obs3607-role"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "obs3607-mfr"
+                        },
+                        "model": "obs3607-model"
+                    },
+                    "site": {
+                        "name": "obs3607-site"
+                    }
+                },
+                "mode": "tagged",
+                "untagged_vlan": {
+                    "vid": 300,
+                    "name": "obs3607-v300"
+                },
+                "tagged_vlans": [
+                    {
+                        "vid": 301,
+                        "name": "obs3607-v301"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "interface": {
+                "name": "obs3607-eth-routed",
+                "type": "1000base-t",
+                "device": {
+                    "name": "obs3607-dev-1",
+                    "role": {
+                        "name": "obs3607-role"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "obs3607-mfr"
+                        },
+                        "model": "obs3607-model"
+                    },
+                    "site": {
+                        "name": "obs3607-site"
+                    }
+                },
+                "mode": ""
+            }
+        },
+        "update_expect": {
+            "mode": "",
+            "untagged_vlan": null,
+            "tagged_vlans.all.__by_vid": []
+        }
+    },
+    {
+        "name": "dcim_modulebaytype_1",
+        "object_type": "dcim.modulebaytype",
+        "lookup": {
+            "slug": "pcie-x16"
+        },
+        "create_expect": {
+            "name": "PCIe x16",
+            "slug": "pcie-x16",
+            "description": "Full-length PCIe x16 bay"
+        },
+        "create": {
+            "module_bay_type": {
+                "name": "PCIe x16",
+                "slug": "pcie-x16",
+                "description": "Full-length PCIe x16 bay",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update": {
+            "module_bay_type": {
+                "name": "PCIe x16",
+                "slug": "pcie-x16",
+                "description": "Full-length PCIe x16 bay Updated",
+                "tags": [
+                    {
+                        "name": "Tag 1"
+                    }
+                ]
+            }
+        },
+        "update_expect": {
+            "description": "Full-length PCIe x16 bay Updated"
+        }
+    },
+    {
+        "name": "dcim_coolingsource_1",
+        "object_type": "dcim.coolingsource",
+        "lookup": {
+            "name": "Chiller 1"
+        },
+        "create_expect": {
+            "name": "Chiller 1",
+            "type": "chiller",
+            "description": "Primary water-glycol chiller"
+        },
+        "create": {
+            "cooling_source": {
+                "site": {
+                    "name": "Site 1"
+                },
+                "name": "Chiller 1",
+                "type": "chiller",
+                "description": "Primary water-glycol chiller"
+            }
+        },
+        "update": {
+            "cooling_source": {
+                "site": {
+                    "name": "Site 1"
+                },
+                "name": "Chiller 1",
+                "type": "chiller",
+                "description": "Primary water-glycol chiller Updated"
+            }
+        },
+        "update_expect": {
+            "description": "Primary water-glycol chiller Updated"
+        }
+    },
+    {
+        "name": "dcim_coolingfeed_1",
+        "object_type": "dcim.coolingfeed",
+        "lookup": {
+            "name": "Feed A"
+        },
+        "create_expect": {
+            "name": "Feed A",
+            "description": "Loop to rack row A"
+        },
+        "create": {
+            "cooling_feed": {
+                "cooling_source": {
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "name": "Chiller 1",
+                    "type": "chiller"
+                },
+                "name": "Feed A",
+                "description": "Loop to rack row A"
+            }
+        },
+        "update": {
+            "cooling_feed": {
+                "cooling_source": {
+                    "site": {
+                        "name": "Site 1"
+                    },
+                    "name": "Chiller 1",
+                    "type": "chiller"
+                },
+                "name": "Feed A",
+                "description": "Loop to rack row A Updated"
+            }
+        },
+        "update_expect": {
+            "description": "Loop to rack row A Updated"
+        }
+    },
+    {
+        "name": "dcim_coolingintake_1",
+        "object_type": "dcim.coolingintake",
+        "lookup": {
+            "name": "Intake 1"
+        },
+        "create_expect": {
+            "name": "Intake 1",
+            "type": "qdc"
+        },
+        "create": {
+            "cooling_intake": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Intake 1",
+                "type": "qdc",
+                "description": "CDU supply side"
+            }
+        },
+        "update": {
+            "cooling_intake": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "Intake 1",
+                "type": "qdc",
+                "description": "CDU supply side Updated"
+            }
+        },
+        "update_expect": {
+            "description": "CDU supply side Updated"
+        }
+    },
+    {
+        "name": "ipam_service_port_mappings_1",
+        "object_type": "ipam.service",
+        "lookup": {
+            "name": "DNS"
+        },
+        "create_expect": {
+            "name": "DNS",
+            "port_mappings": [
+                "tcp/53",
+                "udp/53"
+            ]
+        },
+        "create": {
+            "service": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "DNS",
+                "port_mappings": [
+                    "tcp/53",
+                    "udp/53"
+                ],
+                "description": "Resolver on both protocols"
+            }
+        },
+        "update": {
+            "service": {
+                "device": {
+                    "name": "Device 1",
+                    "role": {
+                        "name": "Device Role 1"
+                    },
+                    "device_type": {
+                        "manufacturer": {
+                            "name": "Cisco"
+                        },
+                        "model": "C2960S"
+                    },
+                    "site": {
+                        "name": "Site 1"
+                    }
+                },
+                "name": "DNS",
+                "port_mappings": [
+                    "tcp/53",
+                    "udp/53",
+                    "tcp/853"
+                ],
+                "description": "Resolver on both protocols"
+            }
+        },
+        "update_expect": {
+            "port_mappings": [
+                "tcp/53",
+                "udp/53",
+                "tcp/853"
+            ]
+        }
+    }
+]

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_user_rackreservation.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_user_rackreservation.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - User (match-only) + RackReservation ingest tests."""
+
+from dcim.models import RackReservation
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api import transformer
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import Change, ChangeSet, ChangeSetException, ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.supported_models import extract_supported_models
+
+
+class MatchOnlyUserTransformTestCase(TestCase):
+    """The plan path (transformer) never creates a user for an unresolved ref."""
+
+    def test_unknown_user_ref_deviates_not_create(self):
+        """An unresolved users.user ref raises a deviation, not a CREATE."""
+        supported = extract_supported_models()
+        with self.assertRaises(ChangeSetException):
+            transformer.transform_proto_json({"username": "ghost"}, "users.user", supported)
+        self.assertFalse(User.objects.filter(username="ghost").exists())
+
+
+class MatchOnlyUserApplyTestCase(TestCase):
+    """The direct-apply path (applier) rejects create/update of users.user."""
+
+    def test_direct_create_user_changeset_rejected(self):
+        """A CREATE changeset for users.user is rejected by the match-only guard."""
+        # Serializer-valid payload (password present) so the assertion detects
+        # the guard specifically, not incidental UserSerializer validation.
+        cs = ChangeSet(id="cs-u-create", changes=[Change(
+            change_type=ChangeType.CREATE, object_type="users.user",
+            ref_id="new_object:users.user:x",
+            data={"username": "should-not-create", "password": "Str0ng-P@ssw0rd!"}, new_refs=[])])
+        with self.assertRaises(ChangeSetException) as cm:
+            apply_changeset(cs, request=None)
+        self.assertIn("match-only", str(cm.exception))
+        self.assertFalse(User.objects.filter(username="should-not-create").exists())
+
+    def test_direct_update_user_changeset_rejected_username_unchanged(self):
+        """An UPDATE changeset for users.user is rejected; the username is unchanged."""
+        u = User.objects.create(username="keep-me")
+        cs = ChangeSet(id="cs-u-update", changes=[Change(
+            change_type=ChangeType.UPDATE, object_type="users.user",
+            object_id=u.pk, data={"username": "renamed"}, new_refs=[])])
+        with self.assertRaises(ChangeSetException):
+            apply_changeset(cs, request=None)
+        u.refresh_from_db()
+        self.assertEqual(u.username, "keep-me")
+
+
+class RackReservationApplyTestCase(TestCase):
+    """
+    RackReservation ingests end-to-end with a match-only user reference.
+
+    Only the user is pre-seeded; the site + rack are created by the ingest.
+    (dcim.rack has no reliable natural-key match when location is null, so
+    assertions key off the reservation's resolved user, not a pre-seeded rack.)
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed only the existing user the reservation will reference."""
+        cls.user = User.objects.create(username="rr-owner")
+
+    def _entity(self, username):
+        return {"rack": {"name": "RR-Rack", "site": {"name": "RR-Site"}},
+                "units": [1, 2, 3], "description": "reserved",
+                "user": {"username": username}}
+
+    def test_reservation_with_existing_user_applies(self):
+        """A reservation referencing an existing user resolves that user + applies."""
+        r = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+        # match-only: the matched user is a pure reference — NO users.user change
+        self.assertFalse(any(c.object_type == "users.user" for c in r.change_set.changes))
+        apply_changeset(r.change_set, request=None)
+        self.assertEqual(RackReservation.objects.count(), 1)
+        rr = RackReservation.objects.first()
+        self.assertEqual(rr.user_id, self.user.pk)  # matched existing user, not created
+        self.assertEqual(rr.rack.name, "RR-Rack")
+        self.assertEqual(sorted(rr.units), [1, 2, 3])
+        # match-only: no new user was minted
+        self.assertEqual(User.objects.filter(username="rr-owner").count(), 1)
+
+    def test_reservation_with_unknown_user_deviates(self):
+        """An unknown user -> clean deviation, no user created, no reservation."""
+        with self.assertRaises(ChangeSetException):
+            generate_changeset(self._entity("ghost"), "dcim.rackreservation")
+        self.assertFalse(User.objects.filter(username="ghost").exists())
+        self.assertEqual(RackReservation.objects.count(), 0)
+
+    def test_reservation_case_mismatch_username_deviates(self):
+        """Username matching is exact/case-sensitive: a case variant deviates."""
+        with self.assertRaises(ChangeSetException):
+            generate_changeset(self._entity("RR-OWNER"), "dcim.rackreservation")
+        self.assertFalse(User.objects.filter(username="RR-OWNER").exists())
+        self.assertEqual(RackReservation.objects.count(), 0)
+
+    def test_reservation_missing_user_deviates(self):
+        """RackReservation.user is required; omitting it -> deviation, no row created."""
+        entity = {"rack": {"name": "RR-Rack", "site": {"name": "RR-Site"}},
+                  "units": [1, 2, 3], "description": "reserved"}
+        with self.assertRaises(ChangeSetException):
+            r = generate_changeset(entity, "dcim.rackreservation")
+            apply_changeset(r.change_set, request=None)
+        self.assertEqual(RackReservation.objects.count(), 0)
+
+    def test_existing_user_resolution_is_idempotent(self):
+        """
+        Re-ingesting resolves the same existing user each time; never mints one.
+
+        Scoped to the USER guarantee: the match-only user is resolved (never
+        duplicated or created) and the reservation's user never changes across
+        re-ingests. NOTE: a full-changeset NOOP is NOT asserted here because
+        dcim.rackreservation is keyless AND its nested dcim.rack has no reliable
+        natural-key match when location is null (a re-diff re-creates the rack
+        and re-points the reservation) — both pre-existing behaviors unrelated
+        to this feature. The user, correctly, is the one node that stays matched.
+        """
+        for _ in range(2):
+            r = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+            # user is always a pure reference — never a change node
+            self.assertFalse(any(c.object_type == "users.user" for c in r.change_set.changes))
+            apply_changeset(r.change_set, request=None)
+        self.assertEqual(User.objects.filter(username="rr-owner").count(), 1)
+        self.assertTrue(all(rr.user_id == self.user.pk for rr in RackReservation.objects.all()))

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_vc_adoption_matrix.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_vc_adoption_matrix.py
@@ -1,0 +1,1116 @@
+"""
+Exhaustive enumeration of the VirtualChassis adoption decision space.
+
+Adoption (applier._try_adopt_masterless_virtualchassis) is the only place a
+master-bearing dcim.virtualchassis CREATE may bind a pre-existing row instead of
+inserting one. Every earlier revision of this branch was reported green by
+scenario tests and every one of them still had a cell that either wrote the
+wrong row or refused forever. Scenario tests pick cells; this file enumerates
+them, over the product of every axis the decision can read:
+
+  - 0/1/2 same-named MASTERLESS candidates, each empty / populated /
+    populated-and-labelled (a domain the payload may or may not assert)
+  - a same-named MASTERED row present or absent (it is outside the candidate
+    queryset, but it is what the create path falls back onto)
+  - the requested master: free / already a member of a candidate / a member of
+    an unrelated chassis / mastering another chassis / not a device at all
+  - the payload's domain: absent / "" / identifying / contradicting
+  - the changeset shape: a STANDALONE virtual_chassis change, or the
+    member-first pair (create chassis + update the device with its membership)
+  - the member already in the candidate at the master's site or at another one
+
+and asserts the four properties the design has to hold in EVERY cell:
+
+  NO-REFUSE   adoption itself never raises. The only errors reachable on this
+              path are the two that are facts about the master rather than about
+              the ambiguity of the name: it is a member of another chassis
+              (a reported conflict, remedied by moving the device) or its pk is
+              not a device at all (a dangling reference). Both are re-tested
+              here for convergence AFTER the remedy, so neither is permanent.
+  NO-HIJACK   a pre-existing row is written only where identity is strong: it
+              already holds the requested master, an asserted non-empty domain
+              identifies it, it is empty, or this changeset plans the master's
+              membership of the chassis it is creating. Never on the name alone.
+  NO-MOVE     no device that was already a member of a pre-existing row leaves
+              it, in any cell.
+  FULFILLED   in every non-error cell the request is carried out: the named
+              master ends up mastering a chassis of that name.
+
+The table itself is printed on failure, so a regression names its own cell.
+"""
+import itertools
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site, VirtualChassis
+from django.db import transaction
+from django.test import TestCase
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.common import (
+    VC_MEMBER_HINT,
+    Change,
+    ChangeSet,
+    ChangeSetException,
+    ChangeType,
+)
+from netbox_diode_plugin.api.matcher import AmbiguousObjectMatch, find_existing_object
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+NAME = "mx-stack"
+LABEL = "mx-lab"
+OTHER_LABEL = "mx-nope"
+
+
+class _Rollback(Exception):
+    """Sentinel: unwind one cell's writes without failing the test."""
+
+
+class VirtualChassisAdoptionMatrixTests(TestCase):
+    """The whole adoption decision space, cell by cell."""
+
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        """A device pool, so a cell costs FK updates rather than inserts."""
+        cls.site = Site.objects.create(name="mx-site", slug="mx-site")
+        cls.site_b = Site.objects.create(name="mx-site-b", slug="mx-site-b")
+        mfr = Manufacturer.objects.create(name="mx-mfr", slug="mx-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="mx-dt", slug="mx-dt")
+        cls.role = DeviceRole.objects.create(name="mx-role", slug="mx-role")
+        cls.master = Device.objects.create(
+            name="mx-master", site=cls.site, device_type=cls.dt, role=cls.role)
+        # occupants: one per candidate slot, at each site, plus the ones that
+        # populate the mastered same-named row and the unrelated rows.
+        cls.occupants = {}
+        for key in ("c0", "c1", "c2", "c0b", "c1b", "c2b", "mstr", "else", "own"):
+            cls.occupants[key] = Device.objects.create(
+                name=f"mx-occ-{key}",
+                site=cls.site_b if key.endswith("b") else cls.site,
+                device_type=cls.dt, role=cls.role)
+
+    # ---- cell construction ------------------------------------------------
+
+    def _place(self, device, vc, position):
+        Device.objects.filter(pk=device.pk).update(
+            virtual_chassis=vc, vc_position=position)
+
+    def _build(self, shapes, mastered, master_state, cross_site):
+        """Create the pre-existing rows for one cell. Returns (candidates, extras)."""
+        candidates = []
+        for index, shape in enumerate(shapes):
+            vc = VirtualChassis.objects.create(
+                name=NAME, domain=LABEL if shape == "L" else "")
+            if shape in ("P", "L"):
+                key = f"c{index}b" if cross_site else f"c{index}"
+                self._place(self.occupants[key], vc, 9)
+            candidates.append(vc)
+
+        extras = {}
+        if mastered:
+            row = VirtualChassis.objects.create(name=NAME)
+            self._place(self.occupants["mstr"], row, 1)
+            row.refresh_from_db()
+            row.master = self.occupants["mstr"]
+            row.save()
+            extras["mastered"] = row
+
+        master_pk = self.master.pk
+        if master_state == "in_candidate":
+            self._place(self.master, candidates[0], 5)
+        elif master_state == "in_other":
+            elsewhere = VirtualChassis.objects.create(name="mx-elsewhere")
+            self._place(self.master, elsewhere, 2)
+            extras["elsewhere"] = elsewhere
+        elif master_state == "masters_other":
+            owned = VirtualChassis.objects.create(name="mx-owned")
+            self._place(self.master, owned, 1)
+            owned.refresh_from_db()
+            owned.master = self.master
+            owned.save()
+            extras["owned"] = owned
+        elif master_state == "missing":
+            master_pk = (Device.objects.order_by("-pk").first().pk) + 9999
+
+        return candidates, extras, master_pk
+
+    def _snapshot(self):
+        rows = {
+            vc.pk: (vc.name, vc.domain, vc.master_id, vc.last_updated, vc.description,
+                    tuple(sorted(vc.members.values_list("pk", "vc_position"))))
+            for vc in VirtualChassis.objects.all()
+        }
+        devices = dict(Device.objects.values_list("pk", "virtual_chassis_id"))
+        return rows, devices
+
+    def _run_cell(self, shapes, mastered, master_state, domain, shape, cross_site):
+        candidates, extras, master_pk = self._build(
+            shapes, mastered, master_state, cross_site)
+        before_rows, before_devices = self._snapshot()
+
+        data = {"name": NAME, "master": master_pk, "description": "mx-probe"}
+        if domain is not None:
+            data["domain"] = domain
+
+        extra_changes = ()
+        if shape == "member_first":
+            extra_changes = (Change(
+                change_type=ChangeType.UPDATE,
+                object_type="dcim.device",
+                object_id=master_pk,
+                data={"virtual_chassis": "vc1", "vc_position": 1},
+                new_refs=["virtual_chassis"],
+            ),)
+
+        cs = ChangeSet(changes=[
+            Change(change_type=ChangeType.CREATE, object_type="dcim.virtualchassis",
+                   ref_id="vc1", data=data),
+            *extra_changes,
+        ])
+
+        outcome = {"error": None}
+        try:
+            apply_changeset(cs, SimpleNamespace(user=None))
+        except ChangeSetException as exc:
+            outcome["error"] = exc.errors
+        except AmbiguousObjectMatch as exc:  # pragma: no cover - subclass of the above
+            outcome["error"] = exc.errors
+
+        after_rows, after_devices = self._snapshot()
+        # A row is WRITTEN if its own columns changed or it gained a member.
+        # Losing a member is a different phenomenon (NO-MOVE) and is counted
+        # separately, or a device dragged away by NetBox's own create signal
+        # would read as "adoption wrote this row".
+        written = []
+        lost_members = []
+        for pk, state in after_rows.items():
+            if pk not in before_rows:
+                continue
+            was = before_rows[pk]
+            if state[:5] != was[:5] or set(state[5]) - set(was[5]):
+                written.append(pk)
+            if set(was[5]) - set(state[5]):
+                lost_members.append(pk)
+        outcome.update(
+            lost_members=sorted(lost_members),
+            candidates=[c.pk for c in candidates],
+            extras={k: v.pk for k, v in extras.items()},
+            master_pk=master_pk,
+            written=sorted(written),
+            new_rows=sorted(set(after_rows) - set(before_rows)),
+            named_rows=sorted(
+                pk for pk, state in after_rows.items() if state[0] == NAME),
+            masters=[pk for pk, state in after_rows.items() if state[2] == master_pk],
+            moved=sorted(
+                pk for pk, vc in after_devices.items()
+                if before_devices.get(pk) is not None and before_devices[pk] != vc),
+            before_rows=before_rows,
+            after_rows=after_rows,
+        )
+        return outcome
+
+    # ---- the enumeration --------------------------------------------------
+
+    def _cells(self):
+        # 0/1/2 candidates, not 0..3. The adoption decision cannot tell three
+        # same-named rows from two. narrow_vc_candidates is a per-element filter
+        # with one empty/non-empty check, so it is cardinality-blind, and every
+        # cardinality test _choose_adoption_candidate makes is a zero-, one- or
+        # more-than-one test -- all five of them: len(strong) == 1,
+        # len(strong) > 1 (unreachable while Device.virtual_chassis is a single
+        # FK, so at most one row can hold the master), `not candidates`,
+        # `identified and len(candidates) == 1`, and len(candidates) != 1.
+        # Every branch past narrowing reads one row, `only`. Two candidates
+        # already reach "more than one", so a third adds cells, not states.
+        #
+        # Measured, not reasoned: the 4240 length-3 cells produced no behaviour
+        # signature the shorter 1824 did not. Dropping them, together with the
+        # matching cap on the matcher enumeration below, took the two
+        # enumerations from 224.3s to 54.3s on v4.5.5 -- run back to back under
+        # the same machine load, because timings on a loaded laptop move by 2x
+        # and a cross-run comparison here would prove nothing.
+        shapes_axis = [
+            tuple(combo)
+            for length in range(3)
+            for combo in itertools.product("EPL", repeat=length)
+        ]
+        for shapes in shapes_axis:
+            for mastered in (False, True):
+                for master_state in (
+                        "free", "in_candidate", "in_other", "masters_other", "missing"):
+                    if master_state == "in_candidate" and not shapes:
+                        continue
+                    for domain in (None, "", LABEL, OTHER_LABEL):
+                        for shape in ("standalone", "member_first"):
+                            for cross_site in (False, True):
+                                if cross_site and not any(
+                                        s in ("P", "L") for s in shapes):
+                                    continue
+                                yield (shapes, mastered, master_state, domain,
+                                       shape, cross_site)
+
+    def test_the_whole_adoption_decision_space(self):
+        """Every cell: no refusal for ambiguity, no hijack, no move, request fulfilled."""
+        failures = []
+        table = []
+        counted = 0
+        for cell in self._cells():
+            shapes, mastered, master_state, domain, shape, cross_site = cell
+            sid = transaction.savepoint()
+            try:
+                outcome = self._run_cell(*cell)
+                counted += 1
+                verdict = self._classify(cell, outcome)
+                failures.extend(
+                    f"{cell}: {problem}" for problem in self._check(cell, outcome, verdict)
+                )
+                verdict["licences"] = outcome.get("licences", [])
+                table.append((cell, verdict))
+            finally:
+                transaction.savepoint_rollback(sid)
+
+        # Exact, not a floor: this guard exists to catch an enumeration that
+        # silently stopped enumerating, and a floor cannot see a narrowed axis.
+        self.assertEqual(counted, 1824, "the enumeration changed size")
+        census = {}
+        licences = {}
+        for cell, verdict in table:
+            key = (verdict["kind"], bool(verdict.get("master_yanked")))
+            census.setdefault(key, []).append(cell)
+            for licence in verdict.get("licences", ()):
+                licences.setdefault(licence, 0)
+                licences[licence] += 1
+        print("\n== adoption census ==")
+        for key in sorted(census, key=lambda k: (str(k[0]), k[1])):
+            print(f"  {key}: {len(census[key])} cells   e.g. {census[key][0]}")
+        yanked = [c for (kind, y), cells in census.items() if y for c in cells]
+        print(f"== cells where the create path pulled the master out of its "
+              f"chassis: {len(yanked)} ==")
+        for cell in yanked[:6]:
+            print(f"   {cell}")
+        print("== which licence each adoption used ==")
+        for licence, count in sorted(licences.items()):
+            print(f"  {licence}: {count} cells")
+        conflicts = [c for c, v in table if v["kind"] == "conflict"]
+        print(f"== cells that reported the IN_OTHER_CHASSIS conflict: "
+              f"{len(conflicts)} ==")
+        for cell in conflicts[:6]:
+            print(f"   {cell}")
+        # Every axis value has to actually occur, or a skipped combination is
+        # silently narrowing the proof.
+        for expected in ("adopt", "create", "conflict", "dangling"):
+            self.assertTrue(
+                any(v["kind"] == expected for _, v in table),
+                f"no cell exercised {expected}")
+        self.assertEqual(failures, [], "\n".join(failures[:40]))
+
+    def _classify(self, cell, outcome):
+        shapes, mastered, master_state, domain, shape, cross_site = cell
+        if outcome["error"]:
+            message = str(outcome["error"])
+            kind = "conflict" if "is a member of" in message else "dangling"
+            return {"kind": kind, "message": message}
+        if outcome["written"]:
+            return {"kind": "adopt", "rows": outcome["written"]}
+        return {"kind": "create", "rows": outcome["new_rows"]}
+
+    def _check(self, cell, outcome, verdict):
+        """The four properties. Returns one string per violation."""
+        return [
+            *self._check_no_refuse(cell, outcome, verdict),
+            *self._check_no_hijack(cell, outcome),
+            *self._check_no_move_and_fulfilled(cell, outcome, verdict),
+        ]
+
+    @staticmethod
+    def _check_no_refuse(cell, outcome, verdict):
+        """NO-REFUSE: an error is only ever a fact about the master."""
+        shapes, _mastered, master_state, domain, _shape, _cross_site = cell
+        problems = []
+        # "in_candidate" used to mean the master sits in the row adoption would
+        # take, so no conflict could arise there. That stopped being true when a
+        # non-empty asserted discriminator began excluding rows before any other
+        # rule (applier._choose_adoption_candidate, matching resolve): the row
+        # holding the master can now be excluded, adoption picks the row the
+        # payload actually identifies, and the master is then in a chassis this
+        # payload is not describing. The conflict is still a fact about the
+        # master -- "it is a member of a different chassis" -- and it still names
+        # a remedy, since a Device change asserting the membership licenses the
+        # move (_changeset_plans_membership). So the exemption is widened by
+        # exactly that case and no further.
+        master_row_domain = LABEL if shapes and shapes[0] == "L" else ""
+        master_row_excluded = (
+            master_state == "in_candidate"
+            and bool(domain)
+            and domain != master_row_domain
+        )
+        if (verdict["kind"] == "conflict"
+                and master_state != "in_other"
+                and not master_row_excluded):
+            problems.append(f"conflict raised with master_state={master_state}")
+        if verdict["kind"] == "dangling" and master_state != "missing":
+            problems.append(f"dangling error raised with master_state={master_state}")
+        # Same widening, same reason: the master is only "usable" for this
+        # payload while the chassis it sits in is one this payload could be
+        # describing. Once an asserted discriminator excludes that row, the
+        # master is somewhere else as far as this payload is concerned, and
+        # saying so is the designed IN_OTHER_CHASSIS conflict -- which names the
+        # move to make and applies unchanged on the next pass.
+        usable = ("free", "in_candidate", "masters_other")
+        if master_state in usable and outcome["error"] and not master_row_excluded:
+            problems.append(f"refused a cell with a usable master: {outcome['error']}")
+        return problems
+
+    @staticmethod
+    def _check_no_hijack(cell, outcome):
+        """NO-HIJACK: only strong identity licenses writing a pre-existing row."""
+        shapes, _mastered, master_state, domain, shape, _cross_site = cell
+        problems = []
+
+        # The licence is recomputed here from the cell's axes, independently of
+        # the implementation, including the narrowing an asserted domain does
+        # (matcher.narrow_vc_candidates) -- "" excludes every LABELLED row while
+        # identifying none, a non-empty value both excludes and identifies.
+        row_domain = {"E": "", "P": "", "L": LABEL}
+        if domain is None:
+            narrowed = list(range(len(shapes)))
+            identified = False
+        else:
+            narrowed = [i for i, sh in enumerate(shapes) if row_domain[sh] == domain]
+            identified = bool(domain) and bool(narrowed)
+        for pk in outcome["written"]:
+            if pk not in outcome["candidates"]:
+                problems.append(f"wrote a non-candidate row {pk}")
+                continue
+            index = outcome["candidates"].index(pk)
+            row_shape = shapes[index]
+            # A NON-EMPTY asserted discriminator the row does not carry
+            # excludes it before any rule, so holding the master no longer
+            # licenses writing it -- mirroring
+            # matcher.contradicting_vc_discriminator exactly, which is
+            # non-empty-only: `domain: ""` does NOT exclude a labelled row here
+            # either. Without this the licence table granted "holds-master"
+            # regardless, which is why 1824 cells passed while adoption
+            # relabelled a row whose domain the payload contradicted.
+            contradicted = bool(domain) and row_domain[row_shape] != domain
+            already_holds = (
+                master_state == "in_candidate" and index == 0 and not contradicted)
+            sole = narrowed == [index]
+            unasserted = row_shape == "L" and not domain
+            licences = {
+                "holds-master": already_holds,
+                "domain-identified": identified and sole,
+                "single-empty": sole and row_shape == "E",
+                # No "member-first" licence: adoption on planned membership
+                # alone was removed, so granting it here would let that rule be
+                # re-added with the matrix still green.
+            }
+            granted = [key for key, value in licences.items() if value]
+            outcome.setdefault("licences", []).extend(granted)
+            if not granted:
+                problems.append(
+                    f"adopted candidate {index} ({row_shape}) with no strong "
+                    f"identity; narrowed={narrowed} identified={identified}")
+            if unasserted and not (already_holds or identified):
+                problems.append(f"adopted LABELLED row {index} the payload never asserted")
+            if index not in narrowed and not already_holds:
+                problems.append(f"adopted candidate {index} its own domain contradicts")
+        return problems
+
+    @staticmethod
+    def _check_no_move_and_fulfilled(cell, outcome, verdict):
+        """NO-MOVE and FULFILLED, plus the census flag for a yanked master."""
+        _shapes, _mastered, master_state, _domain, _shape, _cross_site = cell
+        problems = []
+
+        # NO-MOVE: nothing that already had a chassis lost or swapped it.
+        # The master counts: a dcim.virtualchassis payload naming a master is
+        # not authority to pull that device out of the chassis it is in -- which
+        # is exactly what the IN_OTHER_CHASSIS conflict exists to say. Recorded
+        # rather than asserted here, because the create path (NetBox's own
+        # dcim.signals.assign_virtualchassis_master) does it in cells adoption
+        # declined, and the census below is the measurement of how many.
+        for pk in outcome["moved"]:
+            if pk != outcome["master_pk"]:
+                problems.append(f"relocated device {pk}")
+            elif master_state == "in_other":
+                verdict["master_yanked"] = True
+
+        # FULFILLED: a usable master masters a chassis of that name afterwards.
+        if not outcome["error"]:
+            if master_state == "masters_other":
+                if outcome["masters"] != [outcome["extras"]["owned"]]:
+                    problems.append("the unique-master row is no longer the answer")
+            elif master_state != "missing":
+                if not outcome["masters"]:
+                    problems.append("the request left the named master mastering nothing")
+                else:
+                    mastered_row = outcome["after_rows"][outcome["masters"][0]]
+                    if mastered_row[0] != NAME:
+                        problems.append("the master was attached to a differently named row")
+        return problems
+
+    # ---- the two error cells converge after their remedy -------------------
+
+    def test_the_conflict_cell_converges_once_the_device_moves(self):
+        """
+        The only refusal adoption's caller raises, and it is not permanent.
+
+        The master is a plain member of another chassis. The message names the
+        holder and the move; making that move in NetBox is something an operator
+        can do without the producer changing a byte, and the identical payload
+        then applies.
+        """
+        candidate = VirtualChassis.objects.create(name=NAME)  # empty: rule 3 adopts
+        elsewhere = VirtualChassis.objects.create(name="mx-elsewhere")
+        self._place(self.master, elsewhere, 2)
+
+        with self.assertRaises(ChangeSetException) as caught:
+            apply_changeset(ChangeSet(changes=[Change(
+                change_type=ChangeType.CREATE, object_type="dcim.virtualchassis",
+                ref_id="vc1", data={"name": NAME, "master": self.master.pk},
+            )]), SimpleNamespace(user=None))
+        message = caught.exception.errors["dcim.virtualchassis"]["master"][0]
+        self.assertIn("mx-elsewhere", message)
+        self.assertIn("Move the device in NetBox", message)
+        self.assertNotIn("Supply domain", message)
+        self.assertNotIn("virtual_chassis entity", message)
+
+        # the remedy, taken in NetBox rather than in the payload
+        Device.objects.filter(pk=self.master.pk).update(
+            virtual_chassis=candidate, vc_position=1)
+        apply_changeset(ChangeSet(changes=[Change(
+            change_type=ChangeType.CREATE, object_type="dcim.virtualchassis",
+            ref_id="vc1", data={"name": NAME, "master": self.master.pk},
+        )]), SimpleNamespace(user=None))
+        candidate.refresh_from_db()
+        self.assertEqual(candidate.master_id, self.master.pk)
+        self.assertEqual(VirtualChassis.objects.filter(name=NAME).count(), 1)
+
+    def test_the_conflict_is_only_reported_where_adoption_was_chosen(self):
+        """
+        MEASURED HOLE: decline-and-create routes past the IN_OTHER_CHASSIS conflict.
+
+        Same payload, same master, same "the master is a plain member of another
+        chassis" fact. The only difference between the two halves below is
+        whether the same-named masterless candidate is EMPTY or POPULATED:
+
+          - empty  -> adoption takes it (rule 3), the attach reports
+            IN_OTHER_CHASSIS, and the apply is a structured conflict. Nothing
+            moves.
+          - populated -> adoption DECLINES (no strong identity), the ordinary
+            create path inserts the payload's own chassis, and NetBox's own
+            dcim.signals.assign_virtualchassis_master then pulls the master OUT
+            of the chassis it was in. 200, no error, a device relocated by a
+            dcim.virtualchassis payload -- the precise act the conflict message
+            says a dcim.virtualchassis payload is not authority to perform.
+
+        Both halves are asserted so the asymmetry is a fact in the suite rather
+        than an inference. It is not a regression against develop (which has no
+        adoption and relocates in every cell) but it is a hole in what
+        _MasterAttach's docstring claims, and it widened when the ambiguous cells
+        stopped adopting.
+        """
+        elsewhere = VirtualChassis.objects.create(name="mx-elsewhere")
+        self._place(self.master, elsewhere, 2)
+        create = ChangeSet(changes=[Change(
+            change_type=ChangeType.CREATE, object_type="dcim.virtualchassis",
+            ref_id="vc1", data={"name": NAME, "master": self.master.pk})])
+
+        empty = VirtualChassis.objects.create(name=NAME)
+        with self.assertRaises(ChangeSetException):
+            apply_changeset(create, SimpleNamespace(user=None))
+        self.master.refresh_from_db()
+        self.assertEqual(self.master.virtual_chassis_id, elsewhere.pk)
+
+        self._place(self.occupants["c0"], empty, 9)  # the SAME row, now populated
+        apply_changeset(create, SimpleNamespace(user=None))
+        self.master.refresh_from_db()
+        self.assertNotEqual(
+            self.master.virtual_chassis_id, elsewhere.pk,
+            "the create path left the master where it was")
+        self.assertEqual(
+            VirtualChassis.objects.filter(name=NAME).count(), 2,
+            "the payload got its own row")
+
+    def test_the_dangling_master_cell_converges_once_the_device_exists(self):
+        """A master pk with no device is a hard error, and the next plan fixes it."""
+        VirtualChassis.objects.create(name=NAME)
+        gone = Device.objects.create(
+            name="mx-gone", site=self.site, device_type=self.dt, role=self.role)
+        pk = gone.pk
+        gone.delete()
+
+        with self.assertRaises(ChangeSetException):
+            apply_changeset(ChangeSet(changes=[Change(
+                change_type=ChangeType.CREATE, object_type="dcim.virtualchassis",
+                ref_id="vc1", data={"name": NAME, "master": pk},
+            )]), SimpleNamespace(user=None))
+
+        apply_changeset(ChangeSet(changes=[Change(
+            change_type=ChangeType.CREATE, object_type="dcim.virtualchassis",
+            ref_id="vc1", data={"name": NAME, "master": self.master.pk},
+        )]), SimpleNamespace(user=None))
+        self.assertEqual(VirtualChassis.objects.filter(name=NAME).count(), 1)
+        self.assertEqual(
+            VirtualChassis.objects.get(name=NAME).master_id, self.master.pk)
+
+
+class VirtualChassisMatcherRefusalMatrixTests(TestCase):
+    """The other door: what a MASTERLESS reference resolves to, over the same rows."""
+
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        """One site, one device pool: the matcher reads rows and a member hint."""
+        cls.site = Site.objects.create(name="mm-site", slug="mm-site")
+        mfr = Manufacturer.objects.create(name="mm-mfr", slug="mm-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="mm-dt", slug="mm-dt")
+        cls.role = DeviceRole.objects.create(name="mm-role", slug="mm-role")
+        cls.devices = {
+            key: Device.objects.create(
+                name=f"mm-{key}", site=cls.site, device_type=cls.dt, role=cls.role)
+            for key in ("h", "o0", "o1", "o2")
+        }
+
+    def _build(self, shapes):
+        rows = []
+        for index, shape in enumerate(shapes):
+            vc = VirtualChassis.objects.create(
+                name=NAME, domain=LABEL if shape in ("L", "ML") else "")
+            if shape in ("P", "L", "M", "ML"):
+                Device.objects.filter(pk=self.devices[f"o{index}"].pk).update(
+                    virtual_chassis=vc, vc_position=9)
+                if shape in ("M", "ML"):
+                    vc.refresh_from_db()
+                    vc.master = self.devices[f"o{index}"]
+                    vc.save()
+            rows.append(vc)
+        return rows
+
+    def _audit_refusal(self, cell, message):
+        """A refusal must name a remedy, and none that the producer cannot take."""
+        shapes, domain, _hint = cell
+        problems = []
+        if len(shapes) < 2:
+            problems.append(f"{cell}: refused with {len(shapes)} row(s)")
+        for banned in ("Supply domain", "Supply a domain", "on the virtual_chassis entity"):
+            if banned in message:
+                problems.append(f"{cell}: refusal says {banned!r}")
+        if not any(p in message for p in ("in NetBox", "separate requests")):
+            problems.append(f"{cell}: refusal names no actionable remedy")
+        if domain is None and "separate requests" not in message:
+            # A payload asserting no discriminator is narrowed by none, so a
+            # refusal must not offer labelling the rows as the NetBox-side fix
+            # without saying so. Match the disclaimer's intent, not one phrasing.
+            disclaimers = ("does NOT settle it", "cannot settle it on its own")
+            if not any(d in message for d in disclaimers):
+                problems.append(
+                    f"{cell}: refusal offers labelling to a payload that asserts nothing")
+        return problems
+
+    def _matcher_cell(self, shapes, domain, hint):
+        """One cell: build the rows, resolve the reference, classify the answer."""
+        rows = self._build(shapes)
+        if hint == "in_0" and rows:
+            Device.objects.filter(pk=self.devices["h"].pk).update(
+                virtual_chassis=rows[0], vc_position=8)
+        data = {"name": NAME, "master": None}
+        if domain is not None:
+            data["domain"] = domain
+        if hint != "none":
+            data[VC_MEMBER_HINT] = [self.devices["h"].pk]
+        cell = (shapes, domain, hint)
+        try:
+            found = find_existing_object(data, "dcim.virtualchassis")
+        except AmbiguousObjectMatch as exc:
+            return "ambiguous", self._audit_refusal(cell, str(exc))
+        if found is None:
+            return "none", []
+        return "resolved", ([] if found.name == NAME else [f"{cell}: wrong row"])
+
+    def test_every_matcher_cell_either_resolves_creates_or_names_a_remedy(self):
+        """No cell refuses without a remedy, and no refusal asks for a payload field."""
+        failures = []
+        kinds = set()
+        counted = 0
+        # 0/1/2 rows, for the same reason as the applier matrix above, and here
+        # even the oracle cannot see a third: build_queryset filters on name
+        # alone while _build names every row NAME, so `found.name == NAME` is
+        # vacuously true. A cell observes resolved / none / ambiguous plus the
+        # refusal text. Every branch any cell here can reach is reachable with
+        # two rows -- not every branch resolve HAS: the "referencing members
+        # already belong to DIFFERENT candidates" refusal needs two hinted
+        # members and this enumeration hints one, so it is unreachable at any
+        # row count and is covered by its own scenario test instead.
+        for length in range(3):
+            for shapes in itertools.product("EPLM", repeat=length):
+                for domain in (None, "", LABEL, OTHER_LABEL):
+                    for hint in ("none", "free", "in_0"):
+                        sid = transaction.savepoint()
+                        try:
+                            kind, problems = self._matcher_cell(shapes, domain, hint)
+                            kinds.add(kind)
+                            failures.extend(problems)
+                            counted += 1
+                        finally:
+                            transaction.savepoint_rollback(sid)
+        # Exact, not a floor: a later edit that narrows an axis has to say so
+        # here rather than quietly enumerating less.
+        self.assertEqual(counted, 252, "the matcher enumeration changed size")
+        self.assertEqual(kinds, {"resolved", "none", "ambiguous"}, kinds)
+        self.assertEqual(failures, [], "\n".join(failures[:40]))
+
+    def test_labelling_one_row_does_not_settle_a_payload_that_asserts_nothing(self):
+        """
+        MEASURED: the refusal's first remedy does not work for this payload.
+
+        The message reads "Settle it in NetBox, which needs no change to what the
+        producer sends: give one of those rows a domain the others do not have,
+        or merge the duplicates into one row." The middle clause is false as
+        stated. narrow_vc_candidates only narrows by what the PAYLOAD asserts,
+        so labelling a row changes nothing for a payload that asserts no domain
+        -- and the sentence immediately before it has just said "The payload
+        asserts nothing that tells them apart".
+
+        Measured both ways here: labelling one row leaves the identical payload
+        refused, and labelling it only helps once the PRODUCER also sends the
+        domain -- which is a change to what the producer sends, and one
+        orb-agent cannot make (its device_name builder emits name + master).
+        The other two remedies in the same sentence do work and are pinned by
+        the sibling tests.
+        """
+        rows = self._build(("P", "P"))
+        payload = {"name": NAME, "master": None}
+        with self.assertRaises(AmbiguousObjectMatch):
+            find_existing_object(dict(payload), "dcim.virtualchassis")
+
+        rows[0].domain = LABEL
+        rows[0].save()
+        with self.assertRaises(AmbiguousObjectMatch):
+            find_existing_object(dict(payload), "dcim.virtualchassis")
+
+        found = find_existing_object(
+            {"name": NAME, "master": None, "domain": LABEL}, "dcim.virtualchassis")
+        self.assertEqual(found.pk, rows[0].pk)
+
+    def test_an_ambiguous_reference_converges_once_the_duplicates_are_merged(self):
+        """The remedy that does work with no producer change: one row, one answer."""
+        rows = self._build(("P", "P"))
+        with self.assertRaises(AmbiguousObjectMatch):
+            find_existing_object({"name": NAME, "master": None}, "dcim.virtualchassis")
+
+        Device.objects.filter(virtual_chassis=rows[1]).update(
+            virtual_chassis=rows[0], vc_position=7)
+        rows[1].delete()
+        found = find_existing_object(
+            {"name": NAME, "master": None}, "dcim.virtualchassis")
+        self.assertEqual(found.pk, rows[0].pk)
+
+    def test_an_ambiguous_reference_converges_once_the_device_is_placed(self):
+        """The other remedy the message names: put the device in the right row."""
+        rows = self._build(("P", "P"))
+        data = {"name": NAME, "master": None, VC_MEMBER_HINT: [self.devices["h"].pk]}
+        with self.assertRaises(AmbiguousObjectMatch):
+            find_existing_object(dict(data), "dcim.virtualchassis")
+
+        Device.objects.filter(pk=self.devices["h"].pk).update(
+            virtual_chassis=rows[1], vc_position=8)
+        found = find_existing_object(dict(data), "dcim.virtualchassis")
+        self.assertEqual(found.pk, rows[1].pk)
+
+
+class CrossSiteMemberFirstConvergenceTests(APITestCase):
+    """
+    A VirtualChassis spanning two sites must never be REFUSED, in either order.
+
+    This is the case a site veto broke -- refusing to adopt a candidate holding
+    members from outside the master's site made the apply answer 400 on every
+    pass, forever. The veto was reverted, and that half is still pinned here at
+    the DOOR the producer uses, in both request orders and through both entry
+    points, which the unit-level test of the same cell does not reach: no site
+    of anybody's may turn into an error or move.
+
+    What these tests no longer assert is a single row. A populated row matched
+    on the name alone is not adopted any more (see
+    applier._choose_adoption_candidate), so member-first leaves the member's
+    row and the master's row side by side. Measured, and the reason this is
+    shippable where the veto was not: the pair is STABLE -- re-ingesting either
+    payload plans nothing, because the member reference resolves to the row it
+    is already in and the master-bearing one resolves through unique_master.
+    Two visible rows an operator can merge, not a plan that never settles.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.bulk_url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        patcher = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        Site.objects.create(name="xs-site-a", slug="xs-site-a")
+        Site.objects.create(name="xs-site-b", slug="xs-site-b")
+        Manufacturer.objects.create(name="xs-mfr", slug="xs-mfr")
+        DeviceType.objects.create(
+            manufacturer=Manufacturer.objects.get(name="xs-mfr"),
+            model="xs-dt", slug="xs-dt")
+        DeviceRole.objects.create(name="xs-role", slug="xs-role")
+
+    def _device(self, name, site, extra):
+        entity = {
+            "name": name,
+            "site": {"name": site},
+            "role": {"name": "xs-role"},
+            "device_type": {"manufacturer": {"name": "xs-mfr"}, "model": "xs-dt"},
+        }
+        entity.update(extra)
+        return {"timestamp": 1, "object_type": "dcim.device", "entity": {"device": entity}}
+
+    def _payloads(self, vc_name, master, member):
+        master_payload = self._device(master, "xs-site-a", {
+            "vc_position": 1,
+            "virtual_chassis": {
+                "name": vc_name,
+                "master": {"name": master, "site": {"name": "xs-site-a"}},
+            },
+        })
+        member_payload = self._device(member, "xs-site-b", {
+            "vc_position": 2, "virtual_chassis": {"name": vc_name},
+        })
+        return master_payload, member_payload
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        return r.json().get("change_set", {})
+
+    def _diff_apply(self, payload):
+        cs = self._diff(payload)
+        if not cs.get("changes"):
+            return
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"), r.content)
+
+    def _assert_one_row(self, vc_name, master, member):
+        rows = VirtualChassis.objects.filter(name=vc_name)
+        self.assertEqual(rows.count(), 1, list(rows.values_list("pk", "domain")))
+        row = rows.first()
+        self.assertEqual(row.master.name, master)
+        self.assertEqual(
+            sorted(row.members.values_list("name", "vc_position")),
+            [(master, 1), (member, 2)])
+        self.assertEqual(row.member_count, row.members.count())
+        for payload in self._payloads(vc_name, master, member):
+            changes = [c for c in self._diff(payload).get("changes", [])
+                       if c["change_type"] != "noop"]
+            self.assertEqual(changes, [], changes)
+
+    def _assert_split_rows(self, vc_name, master, member):
+        """Member-first leaves two rows, and the pair must be stable."""
+        rows = VirtualChassis.objects.filter(name=vc_name)
+        self.assertEqual(rows.count(), 2, list(rows.values_list("pk", "domain")))
+        mastered = rows.exclude(master__isnull=True)
+        self.assertEqual(mastered.count(), 1, "no row ended up mastered")
+        self.assertEqual(mastered.first().master.name, master)
+        self.assertEqual(
+            sorted(mastered.first().members.values_list("name", "vc_position")),
+            [(master, 1)])
+        orphan = rows.filter(master__isnull=True).first()
+        self.assertEqual(
+            sorted(orphan.members.values_list("name", "vc_position")),
+            [(member, 2)], "the member left the row its own reference created")
+        # The property that makes a split acceptable at all: nothing re-plans.
+        for payload in self._payloads(vc_name, master, member):
+            changes = [c for c in self._diff(payload).get("changes", [])
+                       if c["change_type"] != "noop"]
+            self.assertEqual(changes, [], changes)
+
+    def test_two_requests_both_orders_are_stable_across_sites(self):
+        """Master-first still lands one row; member-first lands two stable ones."""
+        for order in ("master_first", "member_first"):
+            vc_name = f"xs-{order}"
+            master, member = f"xs-m-{order}", f"xs-n-{order}"
+            master_payload, member_payload = self._payloads(vc_name, master, member)
+            first, second = (
+                (master_payload, member_payload) if order == "master_first"
+                else (member_payload, master_payload))
+            self._diff_apply(first)
+            self._diff_apply(second)
+            if order == "master_first":
+                # The chassis exists before the member names it, so the member's
+                # name-only reference resolves to the one row that is there.
+                self._assert_one_row(vc_name, master, member)
+            else:
+                self._assert_split_rows(vc_name, master, member)
+    def test_bulk_both_orders_are_stable_across_sites(self):
+        """The same two orders inside one /bulk-plan-apply/ request."""
+        for order in ("master_first", "member_first"):
+            vc_name = f"xsb-{order}"
+            master, member = f"xsb-m-{order}", f"xsb-n-{order}"
+            master_payload, member_payload = self._payloads(vc_name, master, member)
+            first, second = (
+                (master_payload, member_payload) if order == "master_first"
+                else (member_payload, master_payload))
+            entities = [
+                {"id": "first", "object_type": "dcim.device", "entity": first["entity"]},
+                {"id": "second", "object_type": "dcim.device", "entity": second["entity"]},
+            ]
+            r = self.client.post(self.bulk_url, data={"entities": entities},
+                                 format="json", **self.auth)
+            self.assertEqual(r.status_code, 200, r.content)
+            for result in r.json()["results"]:
+                self.assertIsNone(result.get("errors"), result)
+            if order == "master_first":
+                self._assert_one_row(vc_name, master, member)
+            else:
+                self._assert_split_rows(vc_name, master, member)
+
+    def test_the_cross_site_member_keeps_its_own_site(self):
+        """Neither the split nor a convergence may move anybody's site to fit."""
+        vc_name, master, member = "xs-keep", "xs-m-keep", "xs-n-keep"
+        master_payload, member_payload = self._payloads(vc_name, master, member)
+        self._diff_apply(member_payload)
+        self._diff_apply(master_payload)
+        self.assertEqual(Device.objects.get(name=master).site.name, "xs-site-a")
+        self.assertEqual(Device.objects.get(name=member).site.name, "xs-site-b")
+        self._assert_split_rows(vc_name, master, member)
+class AmbiguityRemedyTruthTests(TestCase):
+    """
+    Does each remedy the ambiguity refusal names actually settle it?
+
+    A refusal a producer cannot act on never converges, so the sentence the
+    refusal ends with is part of the behaviour. Each clause is executed here
+    rather than read.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Two same-named populated rows and a device to place."""
+        cls.site = Site.objects.create(name="ar-site", slug="ar-site")
+        mfr = Manufacturer.objects.create(name="ar-mfr", slug="ar-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="ar-dt", slug="ar-dt")
+        cls.role = DeviceRole.objects.create(name="ar-role", slug="ar-role")
+
+    def _row(self, domain, member):
+        row = VirtualChassis.objects.create(name="ar-stack", domain=domain)
+        device = Device.objects.create(
+            name=member, site=self.site, device_type=self.dt, role=self.role)
+        Device.objects.filter(pk=device.pk).update(virtual_chassis=row, vc_position=9)
+        return row
+
+    def _resolve(self, **extra):
+        data = {"name": "ar-stack", "master": None}
+        data.update(extra)
+        return find_existing_object(data, "dcim.virtualchassis")
+
+    def test_two_rows_that_already_carry_different_domains_still_refuse(self):
+        """
+        MEASURED: the "give one of those rows a domain" clause is false as scoped.
+
+        The refusal's closing sentence reads "Settle it in NetBox, which needs no
+        change to what the producer sends: give one of those rows a domain the
+        others do not have ...". Here the two rows ALREADY carry different
+        domains -- there is nothing left to give -- and the identical payload is
+        refused all the same, because narrow_vc_candidates narrows by what the
+        PAYLOAD asserts and this payload asserts nothing.
+
+        This is the exact state the E2E test
+        test_two_same_named_stacks_make_a_member_reference_ambiguous sets up, so
+        the clause is being shown to a producer for whom it cannot work. The
+        remedy that does work with no producer change is measured below.
+        """
+        self._row("building-a", "ar-a1")
+        self._row("building-b", "ar-b1")
+        with self.assertRaises(AmbiguousObjectMatch):
+            self._resolve()
+
+    def test_the_domain_clause_works_only_once_the_producer_asserts_one(self):
+        """The same lever, held by the producer: asserting domain resolves it."""
+        row_a = self._row("building-a", "ar-a2")
+        self._row("building-b", "ar-b2")
+        self.assertEqual(self._resolve(domain="building-a").pk, row_a.pk)
+
+    def test_labelling_helps_when_the_payload_already_asserts_a_shared_domain(self):
+        """
+        And it is a real remedy in the OTHER branch of the same message.
+
+        When the payload asserts a domain that every row carries, giving one row
+        a different one narrows the rest away -- no producer change needed. So
+        the clause belongs to that branch of the message, not to both.
+        """
+        row_a = self._row("shared", "ar-a3")
+        row_b = self._row("shared", "ar-b3")
+        with self.assertRaises(AmbiguousObjectMatch):
+            self._resolve(domain="shared")
+        row_a.domain = "moved-out"
+        row_a.save()
+        self.assertEqual(self._resolve(domain="shared").pk, row_b.pk)
+
+    def test_merging_the_duplicates_settles_it_with_no_producer_change(self):
+        """The clause that does work for a payload asserting nothing."""
+        row_a = self._row("building-a", "ar-a4")
+        row_b = self._row("building-b", "ar-b4")
+        with self.assertRaises(AmbiguousObjectMatch):
+            self._resolve()
+        Device.objects.filter(virtual_chassis=row_b).update(
+            virtual_chassis=row_a, vc_position=7)
+        row_b.delete()
+        self.assertEqual(self._resolve().pk, row_a.pk)
+
+    def test_placing_the_device_settles_it_with_no_producer_change(self):
+        """The other clause that works: the member's own chassis answers."""
+        self._row("building-a", "ar-a5")
+        row_b = self._row("building-b", "ar-b5")
+        joiner = Device.objects.create(
+            name="ar-join", site=self.site, device_type=self.dt, role=self.role)
+        with self.assertRaises(AmbiguousObjectMatch):
+            self._resolve(**{VC_MEMBER_HINT: [joiner.pk]})
+        Device.objects.filter(pk=joiner.pk).update(
+            virtual_chassis=row_b, vc_position=8)
+        self.assertEqual(
+            self._resolve(**{VC_MEMBER_HINT: [joiner.pk]}).pk, row_b.pk)
+
+    def test_separate_requests_settle_the_disagreeing_hints_refusal(self):
+        """
+        The other refusal's remedy, executed: one device per request.
+
+        Two member devices already in DIFFERENT same-named rows make one payload
+        describe a merge, and the matcher refuses rather than move either. Its
+        message says to ingest those devices in separate requests; a single hint
+        per request resolves to that device's own chassis, so it does.
+        """
+        row_a = self._row("building-a", "ar-a6")
+        row_b = self._row("building-b", "ar-b6")
+        a_member = Device.objects.get(name="ar-a6")
+        b_member = Device.objects.get(name="ar-b6")
+        with self.assertRaises(AmbiguousObjectMatch) as caught:
+            self._resolve(**{VC_MEMBER_HINT: [a_member.pk, b_member.pk]})
+        self.assertIn("separate requests", str(caught.exception))
+        self.assertEqual(self._resolve(**{VC_MEMBER_HINT: [a_member.pk]}).pk, row_a.pk)
+        self.assertEqual(self._resolve(**{VC_MEMBER_HINT: [b_member.pk]}).pk, row_b.pk)
+
+
+class AmbiguityAtTheBulkDoorTests(APITestCase):
+    """
+    The third door for the name-ambiguity refusal: /bulk-plan-apply/.
+
+    generate-diff and apply-change-set are both pinned elsewhere. bulk-plan-apply
+    plans and applies each entity itself, so a refusal that only rendered at the
+    other two doors would surface here as a 500 or, worse, as a whole-request
+    failure that discards the entities that were fine. It has to be PER ENTITY.
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.bulk_url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        patcher = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.site = Site.objects.create(name="bd-site", slug="bd-site")
+        mfr = Manufacturer.objects.create(name="bd-mfr", slug="bd-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="bd-dt", slug="bd-dt")
+        self.role = DeviceRole.objects.create(name="bd-role", slug="bd-role")
+
+    def _seed(self, domain, member):
+        row = VirtualChassis.objects.create(name="bd-shared", domain=domain)
+        device = Device.objects.create(
+            name=member, site=self.site, device_type=self.dt, role=self.role)
+        Device.objects.filter(pk=device.pk).update(virtual_chassis=row, vc_position=1)
+        row.refresh_from_db()
+        row.master = device
+        row.save()
+        return row
+
+    def _entity(self, name, extra):
+        entity = {
+            "name": name,
+            "site": {"name": "bd-site"},
+            "role": {"name": "bd-role"},
+            "device_type": {"manufacturer": {"name": "bd-mfr"}, "model": "bd-dt"},
+        }
+        entity.update(extra)
+        return {"object_type": "dcim.device", "entity": {"device": entity}}
+
+    def test_the_refusal_is_per_entity_and_the_others_still_apply(self):
+        """
+        One entity is refused, the other is applied, and neither row is touched.
+
+        The ambiguous entity must carry the structured error under its own id --
+        naming both rows -- while the unrelated entity in the same request
+        succeeds. A whole-request 400 would be a different contract and would
+        make one bad reference cost a batch. Measured shape: HTTP 207
+        Multi-Status, the refusal under the entity's ``errors["plan"]`` because
+        it is raised while that entity is being planned.
+        """
+        row_a = self._seed("building-a", "bd-a1")
+        row_b = self._seed("building-b", "bd-b1")
+        before = {
+            row.pk: (row.domain, row.master_id, row.last_updated, row.members.count())
+            for row in (row_a, row_b)
+        }
+
+        entities = [
+            {"id": "fine", **self._entity("bd-plain", {})},
+            {"id": "ambiguous", **self._entity("bd-joiner", {
+                "vc_position": 3, "virtual_chassis": {"name": "bd-shared"}})},
+        ]
+        response = self.client.post(
+            self.bulk_url, data={"entities": entities}, format="json", **self.auth)
+        self.assertEqual(response.status_code, 207, response.content)
+        results = {item["id"]: item for item in response.json()["results"]}
+
+        self.assertIsNone(results["fine"].get("errors"), results["fine"])
+        self.assertTrue(Device.objects.filter(name="bd-plain").exists())
+
+        errors = results["ambiguous"].get("errors")
+        self.assertIsNotNone(errors, results["ambiguous"])
+        message = errors["plan"]["dcim.virtualchassis"]["name"][0]
+        self.assertIn(f"id {row_a.pk}", message)
+        self.assertIn(f"id {row_b.pk}", message)
+        self.assertIn("Settle it in NetBox", message)
+        self.assertNotIn("Supply domain", message)
+
+        self.assertFalse(Device.objects.filter(name="bd-joiner").exists())
+        for row in (row_a, row_b):
+            row.refresh_from_db()
+            self.assertEqual(
+                (row.domain, row.master_id, row.last_updated, row.members.count()),
+                before[row.pk], f"row {row.pk} was written by a refused entity")
+
+    def test_a_domain_on_the_same_entity_resolves_it_at_this_door_too(self):
+        """The escape hatch works at the bulk door as well, and moves nobody else."""
+        row_a = self._seed("building-a", "bd-a2")
+        row_b = self._seed("building-b", "bd-b2")
+        entities = [{"id": "joiner", **self._entity("bd-joiner2", {
+            "vc_position": 3,
+            "virtual_chassis": {"name": "bd-shared", "domain": "building-b"}})}]
+        response = self.client.post(
+            self.bulk_url, data={"entities": entities}, format="json", **self.auth)
+        self.assertEqual(response.status_code, 200, response.content)
+        result = response.json()["results"][0]
+        self.assertIsNone(result.get("errors"), result)
+        self.assertEqual(
+            Device.objects.get(name="bd-joiner2").virtual_chassis_id, row_b.pk)
+        self.assertEqual(row_a.members.count(), 1)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_vc_identity_partition.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_vc_identity_partition.py
@@ -1,0 +1,908 @@
+"""Two same-named VirtualChassis nodes in ONE entity graph: merged, or kept apart."""
+from itertools import permutations
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site, VirtualChassis
+from django.test import SimpleTestCase, TestCase
+from rest_framework import serializers
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api import transformer
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.matcher import (
+    asserted_vc_identity,
+    partition_vc_identities,
+    vc_identities_conflict,
+)
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class VirtualChassisIdentityPartitionTests(APITestCase):
+    """
+    Same name, one graph: what the payload asserts decides one chassis or two.
+
+    VirtualChassisNameMatcher.fingerprint is keyed on the name ALONE, and
+    deliberately, so that a member's name-only chassis node and the
+    master-bearing one merge into a single create (issue #183). The cost, not
+    measured until this file existed, is that two same-named nodes asserting
+    DIFFERENT identity merged too -- and _merge_nodes then rejected the whole
+    entity, identically on every retry, so the payload could never be ingested
+    at all.
+
+    Scope, measured rather than assumed: it only ever happened INSIDE one entity
+    graph. Separate entities of one bulk request are transformed separately and
+    were never affected (test_separate_entities_were_never_affected).
+
+    The cross-device graphs here are built with a CABLE between two switches,
+    which is how two unrelated stacks legitimately end up in one entity graph
+    and is the one device-to-device edge NetBox does not second-guess. (A device
+    reaching another through primary_ip4 plans fine and then fails NetBox's own
+    "the specified IP address is not assigned to this device" on apply, so it
+    cannot show what happens after the plan.)
+    """
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.bulk_plan_apply_url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.site = Site.objects.create(name="fp-site", slug="fp-site")
+        mfr = Manufacturer.objects.create(name="fp-mfr", slug="fp-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="fp-dt", slug="fp-dt")
+        self.role = DeviceRole.objects.create(name="fp-role", slug="fp-role")
+
+    # ---- payload builders -------------------------------------------------
+
+    def _device(self, name, **extra):
+        """A complete dcim.device entity, so every nested device can be created."""
+        return dict({
+            "name": name,
+            "site": {"name": "fp-site"},
+            "role": {"name": "fp-role"},
+            "device_type": {"manufacturer": {"name": "fp-mfr"}, "model": "fp-dt"},
+        }, **extra)
+
+    def _cabled(self, a, b, iface="Gi0/1"):
+        """One dcim.cable entity whose two ends land on two different devices."""
+        def termination(device):
+            return [{"object_interface": {
+                "device": device, "name": iface, "type": "1000base-t",
+            }}]
+
+        return {"timestamp": 1, "object_type": "dcim.cable", "entity": {"cable": {
+            "a_terminations": termination(a),
+            "b_terminations": termination(b),
+            "status": "connected", "type": "cat6",
+        }}}
+
+    def _seed_labelled_stack(self, name, domain, member):
+        """ORM-seed a converged one-member stack carrying a domain."""
+        vc = VirtualChassis.objects.create(name=name, domain=domain)
+        device = Device.objects.create(
+            name=member, site=self.site, device_type=self.dt, role=self.role
+        )
+        Device.objects.filter(pk=device.pk).update(virtual_chassis=vc, vc_position=2)
+        vc.refresh_from_db()
+        vc.master = device
+        vc.save()
+        return vc
+
+    # ---- helpers ----------------------------------------------------------
+
+    def _plan(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        return r.json()["change_set"]
+
+    def _apply(self, change_set):
+        r = self.client.post(self.apply_url, data=change_set, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+
+    def _refused(self, payload):
+        """The whole entity rejected, with the merge conflict as the reason."""
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        return str(r.json()["errors"])
+
+    def _vc_changes(self, change_set):
+        return [c for c in change_set["changes"]
+                if c["object_type"] == "dcim.virtualchassis"]
+
+    def _non_noop(self, payload):
+        return [c for c in self._plan(payload)["changes"] if c["change_type"] != "noop"]
+
+    def _assert_noop_rediff(self, payload):
+        self.assertEqual(self._non_noop(payload), [])
+
+    # ---- the payload that could never be ingested -------------------------
+
+    def test_different_masters_in_one_graph_plan_two_chassis_and_apply(self):
+        """
+        The strong case: two switches in different stacks that share a chassis name.
+
+        VirtualChassis.master is a DB UNIQUE constraint, so two nodes naming
+        DIFFERENT masters cannot be one row: they are two stacks, and since
+        VirtualChassis.name is not unique in NetBox, two rows is a state NetBox
+        permits and an operator can already be in. Merging them produced
+        "Conflicting values for 'master' merging duplicate dcim.virtualchassis"
+        and rejected the entity -- cable, interfaces, devices and all -- on
+        every attempt.
+
+        Measured here end to end: two creates planned, applied, each member in
+        the stack its OWN reference named, and an empty re-diff. A merge would
+        have put both members in one stack; a fingerprint keyed on master
+        instead of name would have split the intended merge below.
+        """
+        near = self._device("fpm-d1", vc_position=2, virtual_chassis={
+            "name": "fpm-stack", "master": self._device("fpm-a1"),
+        })
+        far = self._device("fpm-d2", vc_position=2, virtual_chassis={
+            "name": "fpm-stack", "master": self._device("fpm-b1"),
+        })
+        payload = self._cabled(near, far)
+
+        cs = self._plan(payload)
+        chassis = self._vc_changes(cs)
+        self.assertEqual([c["change_type"] for c in chassis], ["create", "create"], cs)
+        self.assertEqual({c["data"]["name"] for c in chassis}, {"fpm-stack"})
+        self._apply(cs)
+
+        rows = VirtualChassis.objects.filter(name="fpm-stack")
+        self.assertEqual(rows.count(), 2)
+        by_master = {row.master.name: row for row in rows}
+        self.assertEqual(set(by_master), {"fpm-a1", "fpm-b1"},
+                         "the two stacks did not keep their own masters")
+        self.assertEqual(
+            {d.name for d in by_master["fpm-a1"].members.all()}, {"fpm-a1", "fpm-d1"})
+        self.assertEqual(
+            {d.name for d in by_master["fpm-b1"].members.all()}, {"fpm-b1", "fpm-d2"})
+        self._assert_noop_rediff(payload)
+
+    def test_two_labelled_stacks_that_exist_are_each_matched_to_their_own_row(self):
+        """
+        Same name, different domains, both rows already in NetBox: two noops.
+
+        What this pins is the PARTITION, not the domain narrowing. Merging the
+        two nodes denied the matcher any chance to answer: the entity was
+        rejected with "Conflicting values for 'domain'" before a lookup ran,
+        even though NetBox held an unambiguous answer for each node. Now each
+        node reaches the matcher and lands on its own row.
+
+        Be precise about WHICH rule answers here, because the name this test
+        used to carry credited the wrong one: each referencing device is already
+        a member of the row it names, so resolve rule 1 (a referencing member
+        already belongs to one candidate) answers before the domain is
+        consulted at all. The domain is what makes the two nodes two identities
+        in the transformer; it is not what picks the rows here.
+        test_a_new_member_is_narrowed_by_the_domain_it_asserts isolates the
+        narrowing, with a device that belongs to neither row.
+        """
+        row_a = self._seed_labelled_stack("fpl-stack", "building-a", "fpl-a1")
+        row_b = self._seed_labelled_stack("fpl-stack", "building-b", "fpl-b1")
+        near = self._device("fpl-a1", vc_position=2, virtual_chassis={
+            "name": "fpl-stack", "domain": "building-a",
+        })
+        far = self._device("fpl-b1", vc_position=2, virtual_chassis={
+            "name": "fpl-stack", "domain": "building-b",
+        })
+        payload = self._cabled(near, far, iface="Gi0/2")
+
+        cs = self._plan(payload)
+        planned = {c["object_id"] for c in self._vc_changes(cs)}
+        self.assertEqual(planned, {row_a.pk, row_b.pk},
+                         "each node must match its own row")
+        self.assertEqual(
+            [c["change_type"] for c in self._vc_changes(cs)], ["noop", "noop"], cs)
+        self._apply(cs)
+        self._assert_noop_rediff(payload)
+        for row, domain, member in ((row_a, "building-a", "fpl-a1"),
+                                    (row_b, "building-b", "fpl-b1")):
+            row.refresh_from_db()
+            self.assertEqual(row.domain, domain)
+            self.assertEqual([d.name for d in row.members.all()], [member])
+
+    def test_a_new_member_is_narrowed_by_the_domain_it_asserts(self):
+        """
+        Domain narrowing on its own, with rule 1 unable to answer.
+
+        Two same-named rows carry different domains, and the device referencing
+        the chassis belongs to NEITHER -- so the member-ownership rule that
+        answers in the test above has nothing to say, and the asserted domain is
+        the only thing that can choose. It picks the row that carries it, and
+        the device joins that row rather than the older one.
+
+        This is the assertion the sibling test was miscredited with, and the
+        thing _VC_DISCRIMINATORS commits to: narrow_vc_candidates keeps only the
+        candidates carrying an asserted value.
+        """
+        row_a = self._seed_labelled_stack("fpn-stack", "building-a", "fpn-a1")
+        row_b = self._seed_labelled_stack("fpn-stack", "building-b", "fpn-b1")
+        payload = {"timestamp": 1, "object_type": "dcim.device", "entity": {"device":
+            self._device("fpn-new", vc_position=7, virtual_chassis={
+                "name": "fpn-stack", "domain": "building-b",
+            })}}
+
+        cs = self._plan(payload)
+        self.assertEqual(
+            {c["object_id"] for c in self._vc_changes(cs)}, {row_b.pk},
+            "the asserted domain did not choose the row carrying it",
+        )
+        self._apply(cs)
+
+        joined = Device.objects.get(name="fpn-new")
+        self.assertEqual(joined.virtual_chassis_id, row_b.pk)
+        self.assertEqual(
+            sorted(row_a.members.values_list("name", flat=True)), ["fpn-a1"],
+            "the row whose domain was NOT asserted gained a member",
+        )
+        self._assert_noop_rediff(payload)
+
+    def test_the_reported_domain_payload_is_rejected_not_half_applied(self):
+        """
+        The reported repro: planned in full, then refused, and nothing written.
+
+        Shape: a member names its chassis with a domain and a master, and the
+        MASTER's own chassis reference names the same chassis with a DIFFERENT
+        domain. The partition does its job -- two nodes, two groups, two creates
+        previewed, where the whole entity used to be rejected at the merge.
+
+        The apply then refuses, and it should. The payload asserts both "fpd-m1
+        masters the building-a stack" and "fpd-m1 belongs to the building-b
+        stack of the same name", and a device is in one chassis at a time, so
+        there is no state that satisfies it. Contradictory input may be
+        rejected; what may NOT happen -- and what happened here before -- is a
+        200 that reports success while re-planning the same domain change on
+        every later pass, forever. That is the whole of the second requirement
+        this change exists to meet: a discriminator is identity, so a payload
+        contradicting the row it names is told so instead of being applied to it
+        and quietly re-proposed.
+
+        Nothing is left behind: the apply is one transaction, so the two rows it
+        planned are rolled back and a producer that fixes its payload starts
+        clean.
+
+        The rough edge, recorded rather than hidden: the message is NetBox's own
+        constraint ("currently designated as its master") rather than a
+        statement about the identity contradiction, so it names a symptom and
+        not the cause. A structured per-entity conflict naming both domains
+        would be the better error; this test pins the refusal, not the wording.
+        """
+        payload = {"timestamp": 1, "object_type": "dcim.device", "entity": {"device":
+            self._device("fpd-d1", vc_position=2, virtual_chassis={
+                "name": "fpd-stack",
+                "domain": "building-a",
+                "master": self._device("fpd-m1", virtual_chassis={
+                    "name": "fpd-stack", "domain": "building-b",
+                }),
+            })}}
+
+        cs = self._plan(payload)
+        self.assertEqual([c["change_type"] for c in self._vc_changes(cs)],
+                         ["create", "create"], cs)
+
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        self.assertIn("master", str(r.json().get("errors")).lower())
+        self.assertEqual(
+            VirtualChassis.objects.filter(name="fpd-stack").count(), 0,
+            "a refused apply left rows behind",
+        )
+
+    def test_two_domains_arriving_in_sequence_end_as_two_stable_rows(self):
+        """
+        A then B, in separate requests, and BOTH plan nothing afterwards.
+
+        This is the sequential case the domain contract has to answer, and the
+        one the old rule-0 exemption got wrong. Step 1 ingests fps-stack /
+        building-a. Step 2 ingests the same NAME with building-b. A non-empty
+        domain is identity, so step 2 does not bind step 1's row on the strength
+        of the name; it describes a chassis that does not exist yet and gets it.
+
+        Step 3 is the part that used to fail: re-ingesting either payload plans
+        NOTHING. Before, step 2 bound the single existing row and then proposed
+        `domain: building-b` on it again on every pass -- a successful apply that
+        never converged, which is not a contract worth having. Two rows, each
+        holding its own domain and its own master, is.
+        """
+        def stack(device, domain):
+            return {"timestamp": 1, "object_type": "dcim.device", "entity": {"device":
+                self._device(device, vc_position=1, virtual_chassis={
+                    "name": "fps-stack",
+                    "domain": domain,
+                    "master": self._device(device),
+                })}}
+
+        first, second = stack("fps-a1", "building-a"), stack("fps-b1", "building-b")
+        for payload in (first, second):
+            self._apply(self._plan(payload))
+
+        rows = VirtualChassis.objects.filter(name="fps-stack")
+        self.assertEqual(rows.count(), 2, list(rows.values_list("pk", "domain")))
+        self.assertEqual({r.domain for r in rows}, {"building-a", "building-b"})
+        self.assertEqual({r.master.name for r in rows}, {"fps-a1", "fps-b1"})
+        for row in rows:
+            self.assertEqual([d.name for d in row.members.all()], [row.master.name])
+
+        self._assert_noop_rediff(first)
+        self._assert_noop_rediff(second)
+
+    # ---- what must keep merging -------------------------------------------
+
+    def test_the_name_only_node_still_merges_into_the_master_bearing_one(self):
+        """Issue #183's merge, inside one graph: one chassis, not a split one."""
+        payload = {"timestamp": 1, "object_type": "dcim.device", "entity": {"device":
+            self._device("fpi-d1", vc_position=2, virtual_chassis={
+                "name": "fpi-stack",
+                "master": self._device("fpi-m1", virtual_chassis={"name": "fpi-stack"}),
+            })}}
+
+        cs = self._plan(payload)
+        self.assertEqual(len(self._vc_changes(cs)), 1, cs)
+        self._apply(cs)
+        rows = VirtualChassis.objects.filter(name="fpi-stack")
+        self.assertEqual(rows.count(), 1)
+        self.assertEqual(rows.first().master.name, "fpi-m1")
+        self._assert_noop_rediff(payload)
+
+    def test_the_same_master_stub_twice_still_plans_one_chassis(self):
+        """
+        The orb shape: every reference carries the SAME master stub, one create.
+
+        This is what forces the partition to compare CANONICAL references
+        (transformer._canonical_uuids). One device mentioned twice in a graph is
+        two nodes with two uuids until dedupe merges them, so comparing the
+        references as they arrive would read two identical stubs as two
+        different masters and split the very chassis this branch exists to keep
+        whole.
+        """
+        stub = self._device("fpo-m1")
+        near = self._device("fpo-d1", vc_position=2, virtual_chassis={
+            "name": "fpo-stack", "master": dict(stub),
+        })
+        far = self._device("fpo-d2", vc_position=3, virtual_chassis={
+            "name": "fpo-stack", "master": dict(stub),
+        })
+        payload = self._cabled(near, far, iface="Gi0/3")
+
+        cs = self._plan(payload)
+        self.assertEqual(len(self._vc_changes(cs)), 1, cs)
+        self._apply(cs)
+        rows = VirtualChassis.objects.filter(name="fpo-stack")
+        self.assertEqual(rows.count(), 1)
+        row = rows.first()
+        self.assertEqual(row.master.name, "fpo-m1")
+        self.assertEqual(
+            {d.name for d in row.members.all()}, {"fpo-m1", "fpo-d1", "fpo-d2"},
+            "the one stack lost a member",
+        )
+        self._assert_noop_rediff(payload)
+
+    # ---- conflicts that are still conflicts -------------------------------
+
+    def test_one_master_and_two_domains_is_a_conflict_not_two_rows(self):
+        """
+        The unique key outranks the discriminator, in BOTH directions.
+
+        Two nodes naming the SAME master are one row -- the constraint says so
+        -- so their disagreement about domain is a field conflict to report,
+        not licence to plan a second row whose insert could not succeed.
+        """
+        stub = self._device("fpc-m1")
+        near = self._device("fpc-d1", vc_position=2, virtual_chassis={
+            "name": "fpc-stack", "domain": "building-a", "master": dict(stub),
+        })
+        far = self._device("fpc-d2", vc_position=3, virtual_chassis={
+            "name": "fpc-stack", "domain": "building-b", "master": dict(stub),
+        })
+
+        errors = self._refused(self._cabled(near, far, iface="Gi0/4"))
+        self.assertIn("Conflicting values for 'domain'", errors)
+        # No row-count assertion here: _refused only posts to /generate-diff/,
+        # which never writes, so "count == 0" could not fail and proved nothing.
+        # What matters is that the refusal names the field, above.
+
+    def test_a_non_identity_field_disagreement_is_still_a_conflict(self):
+        """
+        The control: the partition splits on IDENTITY, never on disagreement.
+
+        Neither node asserts a master or a domain, so both describe the one
+        unidentified chassis, and their descriptions genuinely disagree. That is
+        two sources contradicting each other about real data, which nothing can
+        discard -- it must stay a reported conflict rather than quietly becoming
+        two rows.
+        """
+        near = self._device("fpn-d1", vc_position=2, virtual_chassis={
+            "name": "fpn-stack", "description": "from the near device",
+        })
+        far = self._device("fpn-d2", vc_position=3, virtual_chassis={
+            "name": "fpn-stack", "description": "from the far device",
+        })
+
+        errors = self._refused(self._cabled(near, far, iface="Gi0/5"))
+        self.assertIn("Conflicting values for 'description'", errors)
+        # See above: planning writes nothing, so a row count here is vacuous.
+
+    # ---- the bound of the finding ------------------------------------------
+
+    def test_separate_entities_were_never_affected(self):
+        """
+        Two entities, same chassis name, different masters: always planned fine.
+
+        Each entity of a bulk request is transformed on its own, so these two
+        nodes never met in one graph and neither plan ever saw a conflict. It is
+        pinned so the fix is not read as having rescued this, and so the
+        single-entity and bulk paths cannot silently diverge.
+        """
+        bulk = {"entities": [
+            {"id": "a", "object_type": "dcim.device", "entity": {"device": self._device(
+                "fps-d1", vc_position=2, virtual_chassis={
+                    "name": "fps-stack", "master": self._device("fps-a1")})}},
+            {"id": "b", "object_type": "dcim.device", "entity": {"device": self._device(
+                "fps-d2", vc_position=2, virtual_chassis={
+                    "name": "fps-stack", "master": self._device("fps-b1")})}},
+        ]}
+        r = self.client.post(self.bulk_plan_apply_url, data=bulk, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        for result in r.json()["results"]:
+            self.assertIsNone(result.get("errors"), result)
+        self.assertEqual(
+            {row.master.name for row in VirtualChassis.objects.filter(name="fps-stack")},
+            {"fps-a1", "fps-b1"},
+        )
+
+
+class VCIdentityPartitionRuleTests(SimpleTestCase):
+    """
+    The partitioning rule itself, as a table. No database, no graph.
+
+    Written against payload dicts rather than identity dicts so
+    asserted_vc_identity's own reading of "asserts" is covered too: an explicit
+    ``domain: ""`` is a claim, and ``master: None`` -- what the transformer
+    emits for a member-only payload -- is not.
+    """
+
+    M1 = UnresolvedReference("dcim.device", "u-m1")
+    M2 = UnresolvedReference("dcim.device", "u-m2")
+
+    def _partition(self, *payloads):
+        return partition_vc_identities([asserted_vc_identity(p) for p in payloads])
+
+    def test_the_rule_table(self):
+        """One row per shape, each with the reason it answers what it answers."""
+        cases = [
+            (
+                "a node asserting nothing joins the one asserting group (issue #183)",
+                [{"name": "s"}, {"name": "s", "master": self.M1}],
+                [0, 0],
+            ),
+            (
+                "an explicit master null asserts nothing, so it joins too",
+                [{"name": "s", "master": None}, {"name": "s", "master": self.M1}],
+                [0, 0],
+            ),
+            (
+                "different masters are different stacks: master is a unique key",
+                [{"name": "s", "master": self.M1}, {"name": "s", "master": self.M2}],
+                [0, 1],
+            ),
+            (
+                "the same master is one stack however many nodes name it",
+                [{"name": "s", "master": self.M1}, {"name": "s", "master": self.M1},
+                 {"name": "s"}],
+                [0, 0, 0],
+            ),
+            (
+                "one master and two domains is ONE group: the unique key outranks "
+                "the discriminator, and the domains are then a field conflict",
+                [{"name": "s", "master": self.M1, "domain": "a"},
+                 {"name": "s", "master": self.M1, "domain": "b"}],
+                [0, 0],
+            ),
+            (
+                "asserting nothing with SEVERAL groups to choose from stays its own: "
+                "guessing would put a member device in a stack nothing identified",
+                [{"name": "s", "master": self.M1}, {"name": "s", "master": self.M2},
+                 {"name": "s"}],
+                [0, 1, 2],
+            ),
+            (
+                "...but two such nodes asserting the SAME nothing stay together, so "
+                "one unidentifiable chassis named twice is still planned once",
+                [{"name": "s", "master": self.M1}, {"name": "s", "master": self.M2},
+                 {"name": "s"}, {"name": "s"}],
+                [0, 1, 2, 2],
+            ),
+            (
+                "a domain places a masterless node onto the one stack that matches",
+                [{"name": "s", "master": self.M1, "domain": "a"},
+                 {"name": "s", "master": self.M2, "domain": "b"},
+                 {"name": "s", "domain": "b"}, {"name": "s", "domain": "a"}],
+                [0, 1, 1, 0],
+            ),
+            (
+                "a domain no group carries places nothing, and stands alone",
+                [{"name": "s", "master": self.M1, "domain": "a"},
+                 {"name": "s", "master": self.M2, "domain": "b"},
+                 {"name": "s", "domain": "c"}],
+                [0, 1, 2],
+            ),
+            (
+                "with no master anywhere the domains seed the groups themselves",
+                [{"name": "s", "domain": "a"}, {"name": "s", "domain": "b"},
+                 {"name": "s", "domain": "a"}],
+                [0, 1, 0],
+            ),
+            (
+                "one domain and a silent node, no master: one stack, that somebody "
+                "labelled",
+                [{"name": "s", "domain": "a"}, {"name": "s"}],
+                [0, 0],
+            ),
+            (
+                "an explicitly EMPTY domain is an assertion like any other",
+                [{"name": "s", "domain": ""}, {"name": "s", "domain": "a"}],
+                [0, 1],
+            ),
+            (
+                "nodes asserting nothing at all are one stack, always",
+                [{"name": "s"}, {"name": "s"}, {"name": "s"}],
+                [0, 0, 0],
+            ),
+            (
+                "a field a group's own members contradict tells nothing apart any "
+                "more, so it cannot attract a node by whichever value came first",
+                [{"name": "s", "master": self.M1, "domain": "a"},
+                 {"name": "s", "master": self.M1, "domain": "b"},
+                 {"name": "s", "domain": "a"}],
+                [0, 0, 1],
+            ),
+        ]
+        for reason, payloads, expected in cases:
+            with self.subTest(reason):
+                self.assertEqual(self._partition(*payloads), expected, reason)
+
+    def test_the_partition_does_not_depend_on_arrival_order(self):
+        """
+        Every ordering of the same nodes groups them the same way.
+
+        Order independence is why this is a bucket-wide partition resolved in
+        one go rather than a first-fit merge taken as each duplicate arrives:
+        which stack a member device ends up in must not depend on which
+        reference the producer happened to emit first. All 24 orderings are
+        checked, not just the reverse, because first-fit only misbehaves for
+        SOME of them.
+        """
+        payloads = [
+            {"name": "s", "master": self.M1, "domain": "a"},
+            {"name": "s", "master": self.M2, "domain": "b"},
+            {"name": "s", "domain": "b"},
+            {"name": "s"},
+        ]
+
+        def grouping(order):
+            """Who is with whom, in ORIGINAL positions, group numbering dropped."""
+            groups = self._partition(*(payloads[i] for i in order))
+            return sorted(
+                sorted(order[i] for i, g in enumerate(groups) if g == group)
+                for group in set(groups)
+            )
+
+        # 0 is a stack, 1 is another, 2's domain places it on 1, and 3 identifies
+        # neither so it stands alone.
+        self.assertEqual(grouping([0, 1, 2, 3]), [[0], [1, 2], [3]])
+        for order in permutations(range(len(payloads))):
+            with self.subTest(order=order):
+                self.assertEqual(grouping(list(order)), [[0], [1, 2], [3]])
+
+    def test_two_different_claims_on_one_silent_group_are_both_refused(self):
+        """
+        The price of order independence, stated rather than discovered later.
+
+        One group, asserting only its master, and two nodes claiming different
+        domains: nothing says which of them is that stack, so both stand alone.
+        Placing whichever arrived first is precisely the order-dependence the
+        one-pass placement exists to avoid.
+        """
+        self.assertEqual(
+            self._partition(
+                {"name": "s", "master": self.M1},
+                {"name": "s", "domain": "a"},
+                {"name": "s", "domain": "b"},
+            ),
+            [0, 1, 2],
+        )
+        # A silent node alongside them is still placed: it contradicts neither,
+        # so the refusal above is about the contradiction, not about company.
+        self.assertEqual(
+            self._partition(
+                {"name": "s", "master": self.M1},
+                {"name": "s", "domain": "a"},
+                {"name": "s"},
+            ),
+            [0, 0, 0],
+        )
+        # And still placed when BOTH contradicting claimants are present. This
+        # is the one the collective reading got wrong: it asked whether the
+        # claimants agreed with each other, so "a" disagreeing with "b" refused
+        # the silent node too -- a member's name-only chassis reference pushed
+        # into a chassis of its own that nothing identified. "a" and "b" are
+        # each refused and never join group 0, so the silent claim on it was
+        # unambiguous all along.
+        self.assertEqual(
+            self._partition(
+                {"name": "s", "master": self.M1},
+                {"name": "s", "domain": "a"},
+                {"name": "s", "domain": "b"},
+                {"name": "s"},
+            ),
+            [0, 1, 2, 0],
+        )
+
+    def test_conflict_is_symmetric_and_silence_conflicts_with_nothing(self):
+        """vc_identities_conflict's own contract, which the partition rests on."""
+        pairs = [
+            ({}, {"master": self.M1}, False),
+            ({}, {"domain": "a"}, False),
+            ({"master": self.M1}, {"master": self.M2}, True),
+            ({"master": self.M1}, {"master": self.M1}, False),
+            # master decides alone when both carry one, in both directions...
+            ({"master": self.M1, "domain": "a"}, {"master": self.M1, "domain": "b"}, False),
+            ({"master": self.M1, "domain": "a"}, {"master": self.M2, "domain": "a"}, True),
+            # ...and when only one carries a master, the discriminator answers.
+            ({"master": self.M1, "domain": "a"}, {"domain": "b"}, True),
+            ({"master": self.M1, "domain": "a"}, {"domain": "a"}, False),
+            ({"domain": ""}, {"domain": "a"}, True),
+        ]
+        for a, b, expected in pairs:
+            with self.subTest(f"{a} vs {b}"):
+                self.assertEqual(vc_identities_conflict(a, b), expected)
+                self.assertEqual(vc_identities_conflict(b, a), expected, "not symmetric")
+
+
+class VCPartitionKeyScopeTests(TestCase):
+    """The group qualifier must not reach the keys that are not the name."""
+
+    @staticmethod
+    def _distinct(result):
+        """
+        How many distinct nodes survived, which is NOT len(result).
+
+        _fingerprint_dedupe appends to its output once per INPUT entity, and a
+        merge appends the survivor's uuid again -- so a merged pair comes back
+        as a two-element list holding the same node twice. Counting the list
+        was the vacuous assertion this helper exists to stop: it reports the
+        input count either way.
+        """
+        return len({entity["_uuid"] for entity in result})
+
+    @staticmethod
+    def _vc(uuid, name, master_uuid):
+        return {
+            "_uuid": uuid,
+            "_object_type": "dcim.virtualchassis",
+            "_refs": set(),
+            "name": name,
+            "master": UnresolvedReference(object_type="dcim.device", uuid=master_uuid),
+        }
+
+    def test_two_names_one_master_still_meet_on_the_unique_master_key(self):
+        """
+        A partitioned node must still dedupe against an UNPARTITIONED one.
+
+        The group qualifier is bucket-local: a node is given one only inside a
+        name bucket that actually splits. Qualifying EVERY fingerprint with it
+        therefore put partitioned nodes in a different key space from every
+        other node, and two chassis nodes naming ONE master under DIFFERENT
+        names stopped meeting on the auto-derived unique_master key -- two
+        creates, both claiming a master the database holds unique, so the
+        second bound the first row instead of reporting anything.
+
+        Here "fpr-stack" splits (two masters) so its nodes carry a qualifier,
+        while "fpr-other" is alone and carries none. It names the same master
+        as one of them, so the two are the same row by the unique constraint
+        and must meet. Meeting them surfaces the real disagreement -- one row
+        cannot be called two things -- which is a diagnosable refusal rather
+        than a silent wrong write. Measured with the qualifier on every key:
+        three entities out, no error.
+        """
+        nodes = [
+            self._vc("vc-a", "fpr-stack", "dev-m1"),
+            self._vc("vc-b", "fpr-stack", "dev-m2"),
+            self._vc("vc-c", "fpr-other", "dev-m1"),
+        ]
+        with self.assertRaises(serializers.ValidationError) as caught:
+            transformer._fingerprint_dedupe(nodes)
+        message = str(caught.exception)
+        self.assertIn("Conflicting values for 'name'", message)
+        self.assertIn("fpr-stack", message)
+        self.assertIn("fpr-other", message)
+
+    @staticmethod
+    def _addressed(uuid, name, netbox_id):
+        return {
+            "_uuid": uuid,
+            "_object_type": "dcim.virtualchassis",
+            "_refs": set(),
+            "name": name,
+            "_netbox_id": netbox_id,
+        }
+
+    def test_two_nodes_addressing_different_rows_do_not_merge(self):
+        """
+        An explicit row id is identity, and dedupe is where it has to be read.
+
+        _resolve_existing_references is the only other place that consults
+        _netbox_id, and it runs AFTER _fingerprint_dedupe. So two same-named
+        nodes explicitly addressing two DIFFERENT rows were merged into one
+        before anything looked at their ids, and one addressed row was silently
+        dropped. An id outranks even master here: it names the row itself.
+        """
+        nodes = [
+            self._addressed("vc-1", "fpi-stack", 4001),
+            self._addressed("vc-2", "fpi-stack", 4002),
+        ]
+        result, _ = transformer._fingerprint_dedupe(nodes)
+        self.assertEqual(self._distinct(result), 2, "two separately addressed rows merged")
+        self.assertEqual({e["_netbox_id"] for e in result}, {4001, 4002})
+
+    def test_a_merge_keeps_the_addressed_row_whichever_node_arrived_first(self):
+        """
+        An explicit row id must survive a merge, and not depend on arrival order.
+
+        A silent node and a node addressing row 12 carry the same name and do
+        not conflict -- silence conflicts with nothing -- so they are one group
+        and merge, which is correct. But _merge_nodes prefers a's value for
+        every key beginning with an underscore, so the id survived only when the
+        addressed node happened to be first.
+
+        Measured before the fix: silent first gave a survivor with no id at all,
+        so the row the producer explicitly named was dropped and the node fell
+        back to matching by name; addressed first kept it. Same inputs, two
+        answers -- the order dependence the partition exists to remove.
+        """
+        for label, order in (
+            ("silent first", ["silent", "addressed"]),
+            ("addressed first", ["addressed", "silent"]),
+        ):
+            with self.subTest(label):
+                built = {
+                    "silent": {"_uuid": f"s-{label}", "_object_type": "dcim.virtualchassis",
+                               "_refs": set(), "name": "fpo-order"},
+                    "addressed": self._addressed(f"a-{label}", "fpo-order", 12),
+                }
+                result, _ = transformer._fingerprint_dedupe([built[k] for k in order])
+                self.assertEqual(self._distinct(result), 1, "the pair stopped merging")
+                self.assertEqual(
+                    result[0].get("_netbox_id"), 12,
+                    "the addressed row was dropped by arrival order",
+                )
+
+    def test_an_addressed_node_still_meets_an_unaddressed_one_on_their_master(self):
+        """
+        Only two CLAIMS on one master may keep it apart, not one claim and silence.
+
+        unique_master is a DB unique constraint, so two nodes naming one master
+        are one row and the key is left bare so they meet. The exception is two
+        nodes ADDRESSING DIFFERENT rows while naming that master -- merging
+        those drops an addressed row silently.
+
+        Withholding the exemption from any node carrying a _netbox_id was too
+        broad a reading of that exception. Here the addressed node (row 41,
+        master M, in a name bucket that splits) and an UNADDRESSED node naming M
+        under another name never met either, though the unaddressed one
+        contradicts nothing: both resolve to row 41 through unique_master, the
+        differ emits two updates, and the later name silently wins. Measured
+        before the fix: three survivors where the first and third are one row.
+
+        They meet now, and meeting surfaces the real disagreement -- one row
+        cannot be called two things -- which is a report rather than a silent
+        write. The contest is decided over the MASTER, across names: only a
+        master claimed by more than one distinct id qualifies its key.
+        """
+        nodes = [
+            dict(self._addressed("vc-a", "fpk-x", 41),
+                 master=UnresolvedReference(object_type="dcim.device", uuid="dev-m")),
+            # splits the "fpk-x" bucket, so vc-a is partitioned
+            {"_uuid": "vc-c", "_object_type": "dcim.virtualchassis", "_refs": set(),
+             "name": "fpk-x",
+             "master": UnresolvedReference(object_type="dcim.device", uuid="dev-m2")},
+            # another name, same master as vc-a, addresses nothing
+            {"_uuid": "vc-b", "_object_type": "dcim.virtualchassis", "_refs": set(),
+             "name": "fpk-y",
+             "master": UnresolvedReference(object_type="dcim.device", uuid="dev-m")},
+        ]
+        with self.assertRaises(serializers.ValidationError) as caught:
+            transformer._fingerprint_dedupe(nodes)
+        message = str(caught.exception)
+        self.assertIn("Conflicting values for 'name'", message)
+        self.assertIn("fpk-x", message)
+        self.assertIn("fpk-y", message)
+
+    def test_two_addressed_rows_are_not_remerged_by_a_shared_master(self):
+        """
+        The unique_master exemption must not undo the partition's own answer.
+
+        Exempting unique_master from qualification is what lets two nodes naming
+        one master meet across different names. That reasoning holds only while
+        neither node has said WHICH row it is: here both carry an explicit
+        _netbox_id, they address DIFFERENT rows, and they happen to submit the
+        same master. The partition separates them correctly, and the bare master
+        fingerprint then merged them straight back -- silently, because
+        _merge_nodes ignores conflicts in private fields, so nothing reported
+        the _netbox_id disagreement and one addressed row simply disappeared
+        (measured: two nodes in, one out, both carrying 5001).
+
+        A shared master here is contradictory input, not evidence of sameness:
+        VirtualChassis.master is unique, so one master cannot be on two rows.
+        Keeping the nodes apart lets the constraint that owns that rule refuse
+        it, instead of the dedupe quietly picking a winner.
+        """
+        nodes = [
+            dict(self._addressed("vc-1", "fpm-stack", 5001),
+                 master=UnresolvedReference(object_type="dcim.device", uuid="dev-m")),
+            dict(self._addressed("vc-2", "fpm-stack", 5002),
+                 master=UnresolvedReference(object_type="dcim.device", uuid="dev-m")),
+        ]
+        result, _ = transformer._fingerprint_dedupe(nodes)
+        self.assertEqual(self._distinct(result), 2,
+                         "a shared master re-merged two separately addressed rows")
+        self.assertEqual({e["_netbox_id"] for e in result}, {5001, 5002})
+
+    def test_an_addressed_node_still_merges_with_a_silent_one_naming_its_master(self):
+        """
+        The boundary the fix above could have broken, so it is pinned.
+
+        One node addresses a row and names a master; the other names only the
+        same master. Withholding the unique_master exemption from the addressed
+        node must not separate them: the silent node has said nothing about
+        WHICH row, so it does not contradict the addressed one -- they are one
+        group, share a qualifier, and meet on the qualified name key instead.
+        """
+        nodes = [
+            dict(self._addressed("vc-1", "fpx-stack", 6001),
+                 master=UnresolvedReference(object_type="dcim.device", uuid="dev-m")),
+            {"_uuid": "vc-2", "_object_type": "dcim.virtualchassis", "_refs": set(),
+             "name": "fpx-stack",
+             "master": UnresolvedReference(object_type="dcim.device", uuid="dev-m")},
+        ]
+        result, _ = transformer._fingerprint_dedupe(nodes)
+        self.assertEqual(self._distinct(result), 1,
+                         "a silent node was separated from the row it agrees with")
+        self.assertEqual(result[0]["_netbox_id"], 6001)
+
+    def test_two_nodes_addressing_the_same_row_still_merge(self):
+        """The other direction: one id named twice is one node, as before."""
+        nodes = [
+            self._addressed("vc-1", "fpi-same", 4003),
+            self._addressed("vc-2", "fpi-same", 4003),
+        ]
+        result, _ = transformer._fingerprint_dedupe(nodes)
+        self.assertEqual(self._distinct(result), 1, "one addressed row became two nodes")
+        self.assertEqual(result[0]["_netbox_id"], 4003)
+
+    def test_the_split_itself_still_holds_under_the_narrowed_qualifier(self):
+        """Narrowing the qualifier to the name key must not un-split a bucket."""
+        nodes = [
+            self._vc("vc-a", "fpr-two", "dev-m1"),
+            self._vc("vc-b", "fpr-two", "dev-m2"),
+        ]
+        result, _ = transformer._fingerprint_dedupe(nodes)
+        self.assertEqual(self._distinct(result), 2,
+                         "the two masters were merged into one chassis")
+        self.assertEqual({e["name"] for e in result}, {"fpr-two"})

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_vc_name_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_vc_name_matcher.py
@@ -1,0 +1,1360 @@
+"""Unit tests for masterless VirtualChassis name matching."""
+from types import SimpleNamespace
+from unittest import mock
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site, VirtualChassis
+from django.db.models import QuerySet
+from django.test import SimpleTestCase, TestCase
+
+from netbox_diode_plugin.api.applier import (
+    _is_auto_created_component,
+    _locked_adoption_candidates,
+    apply_changeset,
+)
+from netbox_diode_plugin.api.common import (
+    VC_MEMBER_HINT,
+    Change,
+    ChangeSet,
+    ChangeSetException,
+    ChangeType,
+    UnresolvedReference,
+)
+from netbox_diode_plugin.api.matcher import (
+    _REQUIRES_PRE_SAVE_MATCH,
+    AmbiguousObjectMatch,
+    find_existing_object,
+    fingerprints,
+    get_model_matchers,
+    pre_save_match_binds_only,
+    requires_pre_save_match,
+    vc_hint_pks,
+)
+
+
+def _apply_vc_create(data, extra_changes=()):
+    """Apply a single dcim.virtualchassis CREATE, exactly as a changeset would."""
+    cs = ChangeSet(changes=[Change(
+        change_type=ChangeType.CREATE,
+        object_type="dcim.virtualchassis",
+        ref_id="vc1",
+        data=data,
+    ), *extra_changes])
+    return apply_changeset(cs, SimpleNamespace(user=None))
+
+
+class VirtualChassisNameMatcherTests(TestCase):
+    """Name-only VC payloads must bind existing VCs; master-bearing ones must not."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed two same-named VCs (older mastered, newer empty) plus a distinct one."""
+        site = Site.objects.create(name="vcm-site", slug="vcm-site")
+        mfr = Manufacturer.objects.create(name="vcm-mfr", slug="vcm-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="vcm-dt", slug="vcm-dt")
+        role = DeviceRole.objects.create(name="vcm-role", slug="vcm-role")
+        cls.master = Device.objects.create(
+            name="vcm-sw1", site=site, device_type=dt, role=role
+        )
+        cls.vc_old = VirtualChassis.objects.create(name="vcm-stack", master=cls.master)
+        Device.objects.filter(pk=cls.master.pk).update(
+            virtual_chassis=cls.vc_old, vc_position=1
+        )
+        cls.vc_dup = VirtualChassis.objects.create(name="vcm-stack")  # newer, masterless
+        cls.vc_other = VirtualChassis.objects.create(name="vcm-other")
+
+    def test_matcher_registration_and_order(self):
+        """The logical name matcher precedes the auto-derived unique_master."""
+        names = [m.name for m in get_model_matchers(VirtualChassis)]
+        self.assertEqual(names[0], "logical_vc_name_no_master")
+        self.assertIn("unique_master", names)
+
+    def test_name_only_payload_matches_mastered_vc(self):
+        """A masterless payload binds by name even when the DB row HAS a master."""
+        found = find_existing_object({"name": "vcm-other"}, "dcim.virtualchassis")
+        self.assertEqual(found, self.vc_other)
+
+    def test_a_populated_row_beats_an_empty_same_named_duplicate(self):
+        """
+        Two rows, one real: resolve the real one -- NOT because it is older.
+
+        THE OLD EXPECTATION HERE WAS UNSAFE: this assertion used to read
+        "oldest pk wins over the newer duplicate", which is the policy, not the
+        reason. The seed happens to make the mastered row the older one, so the
+        two rules were indistinguishable in this fixture and the assertion
+        passed under a rule that also picks an arbitrary row when BOTH
+        candidates are real stacks (see
+        VirtualChassisAmbiguityTests.test_two_populated_rows_refuse_to_resolve).
+
+        What holds now is a fact about the rows: vc_dup has no master and no
+        members, so it is not a stack anyone owns, and exactly one candidate is.
+        """
+        found = find_existing_object({"name": "vcm-stack"}, "dcim.virtualchassis")
+        self.assertEqual(found, self.vc_old)
+        self.assertIsNone(self.vc_dup.master_id)
+        self.assertEqual(self.vc_dup.members.count(), 0)
+
+    def test_explicit_null_master_counts_as_masterless(self):
+        """master: None gates the same as an absent master key."""
+        found = find_existing_object(
+            {"name": "vcm-other", "master": None}, "dcim.virtualchassis"
+        )
+        self.assertEqual(found, self.vc_other)
+
+    def test_master_bearing_payload_ignores_name_matcher(self):
+        """With master present, unique_master is authoritative."""
+        found = find_existing_object(
+            {"name": "totally-different-name", "master": self.master.pk},
+            "dcim.virtualchassis",
+        )
+        self.assertEqual(found, self.vc_old)
+
+    def test_no_hit_returns_none(self):
+        """Unknown name with no master creates (returns None)."""
+        self.assertIsNone(
+            find_existing_object({"name": "vcm-missing"}, "dcim.virtualchassis")
+        )
+
+    def test_non_string_name_never_reaches_filter(self):
+        """A malformed name is ignored by the matcher, not raised."""
+        self.assertIsNone(
+            find_existing_object({"name": ["vcm-other"]}, "dcim.virtualchassis")
+        )
+
+    def test_fingerprint_emitted_regardless_of_master(self):
+        """Name-only and master-bearing entities share the name fingerprint."""
+        fp_no_master = fingerprints({"name": "x-stack"}, "dcim.virtualchassis")
+        fp_master = fingerprints(
+            {"name": "x-stack", "master": 1}, "dcim.virtualchassis"
+        )
+        shared = set(fp_no_master) & set(fp_master)
+        self.assertTrue(shared, "expected a shared name-keyed fingerprint")
+
+
+class VirtualChassisHintPkTests(SimpleTestCase):
+    """
+    The member-hint type filter, pinned without a database.
+
+    Through find_existing_object this guard is invisible: a hint of [True] means
+    pk 1, and whether pk 1 happens to be a member of one of the candidates
+    depends on a sequence the test cannot control -- so the behavioural test
+    passes either way and the guard is unpinned. Asserting the extraction
+    directly is the only way to fail when the bool exclusion is removed.
+    """
+
+    def test_only_real_pks_survive(self):
+        """Every non-pk form the wire or the transformer can put in the hint."""
+        self.assertEqual(vc_hint_pks([3, 7]), [3, 7])
+        self.assertEqual(vc_hint_pks([True, False]), [], "bool read as pk 1/0")
+        self.assertEqual(vc_hint_pks([3, True, None, "4", [5], 7.5]), [3])
+        self.assertEqual(vc_hint_pks(UnresolvedReference("dcim.device", "u")), [])
+        self.assertEqual(
+            vc_hint_pks([UnresolvedReference("dcim.device", "u"), 9]), [9],
+            "a device this batch is still creating carries no evidence",
+        )
+
+    def test_absent_and_scalar_forms(self):
+        """None means no hint; a bare pk is accepted as a one-item hint."""
+        self.assertEqual(vc_hint_pks(None), [])
+        self.assertEqual(vc_hint_pks([]), [])
+        self.assertEqual(vc_hint_pks(5), [5])
+
+
+class VirtualChassisAmbiguityTests(TestCase):
+    """
+    What a name that matches SEVERAL real chassis resolves to: nothing.
+
+    find_existing_object's framework default is order_by('pk').first(), and for
+    a name-keyed match on a model with no uniqueness on name that is a policy
+    rather than a lookup. The rows here are two legitimately distinct stacks
+    that happen to share a name -- the state the default silently picks a winner
+    from, and (because the reference being resolved is usually a member device's
+    virtual_chassis) plans a device move out of.
+
+    These are unit tests on find_existing_object because that is the single door
+    both the plan path and the direct-apply path go through; the end-to-end
+    consequences are in test_virtualchassis_ingest.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Two same-named, differently-domained, both-populated chassis."""
+        site = Site.objects.create(name="vcx-site", slug="vcx-site")
+        mfr = Manufacturer.objects.create(name="vcx-mfr", slug="vcx-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="vcx-dt", slug="vcx-dt")
+        role = DeviceRole.objects.create(name="vcx-role", slug="vcx-role")
+        cls.kw = {"site": site, "device_type": dt, "role": role}
+
+        cls.a1 = Device.objects.create(name="vcx-a1", **cls.kw)
+        cls.vc_a = VirtualChassis.objects.create(name="vcx-shared", domain="building-a")
+        Device.objects.filter(pk=cls.a1.pk).update(virtual_chassis=cls.vc_a, vc_position=1)
+        cls.vc_a.refresh_from_db()
+        cls.vc_a.master = cls.a1
+        cls.vc_a.save()
+
+        cls.b1 = Device.objects.create(name="vcx-b1", **cls.kw)
+        cls.vc_b = VirtualChassis.objects.create(name="vcx-shared", domain="building-b")
+        Device.objects.filter(pk=cls.b1.pk).update(virtual_chassis=cls.vc_b, vc_position=1)
+        cls.vc_b.refresh_from_db()
+        cls.vc_b.master = cls.b1
+        cls.vc_b.save()
+
+        cls.loose = Device.objects.create(name="vcx-loose", **cls.kw)
+
+    def test_an_asserted_domain_outranks_the_member_hint(self):
+        """
+        A move the payload asks for must not become a rewrite of the row it left.
+
+        vcx-a1 is already a member of the building-a row, and its payload names
+        the chassis with domain building-b. Membership used to answer first, so
+        this resolved to the building-a row -- and the plan then UPDATED that
+        row's domain to "building-b" and left the device where it was,
+        overwriting the discriminator that identifies somebody's stack instead
+        of performing the move. Measured before the fix: resolved to the
+        building-a row in both cases below.
+
+        A non-empty discriminator is identity, so it excludes rows before any
+        other rule looks at them; membership then chooses among what is left,
+        which is what membership is good for.
+        """
+        self.assertEqual(
+            find_existing_object(
+                {"name": "vcx-shared", "domain": "building-b",
+                 VC_MEMBER_HINT: [self.a1.pk]},
+                "dcim.virtualchassis"),
+            self.vc_b,
+            "the member hint overrode an explicit domain",
+        )
+
+    def test_a_domain_no_row_carries_creates_rather_than_rewriting_one(self):
+        """
+        The same failure with nothing to move to: create, do not overwrite.
+
+        The payload asserts a domain neither row carries, so it describes a
+        chassis that does not exist yet. Returning None creates it. Answering
+        with the row the device happens to sit in would rewrite that row's
+        domain on every pass and never move anything.
+        """
+        self.assertIsNone(
+            find_existing_object(
+                {"name": "vcx-shared", "domain": "building-nowhere",
+                 VC_MEMBER_HINT: [self.a1.pk]},
+                "dcim.virtualchassis"),
+        )
+
+    def test_the_member_hint_still_decides_when_no_domain_is_asserted(self):
+        """The control: with nothing asserted, existing membership answers."""
+        self.assertEqual(
+            find_existing_object(
+                {"name": "vcx-shared", VC_MEMBER_HINT: [self.a1.pk]},
+                "dcim.virtualchassis"),
+            self.vc_a,
+        )
+
+    def test_two_populated_rows_refuse_to_resolve(self):
+        """
+        The core refusal, with an error that names both rows and the way out.
+
+        The way out has to be one somebody can take. This refusal is reached by
+        a payload that carries a name and nothing else, so "supply a domain on
+        the reference" is advice for a producer that has a domain to supply --
+        orb-agent does not emit one at all. Every remedy here is therefore a
+        NetBox-side action that leaves the payload untouched.
+
+        And it must not offer a NetBox-side action that does not work either.
+        These two rows already carry DIFFERENT domains, and the payload still
+        cannot be resolved, because narrowing looks at the values the PAYLOAD
+        asserts: labelling rows changes nothing while it asserts none. The
+        message used to end "give one of those rows a domain the others do not
+        have", under the heading "needs no change to what the producer sends" --
+        advice already satisfied by this very fixture. It now says so, and the
+        domain appears only as the pair it really is (producer sends it, row
+        carries it). test_the_remedy_the_refusal_names_actually_resolves_it
+        walks the remedies it does name.
+        """
+        self.assertNotEqual(self.vc_a.domain, self.vc_b.domain)
+        with self.assertRaises(AmbiguousObjectMatch) as caught:
+            find_existing_object({"name": "vcx-shared"}, "dcim.virtualchassis")
+        message = str(caught.exception)
+        self.assertIn("vcx-shared", message)
+        self.assertIn(f"id {self.vc_a.pk}", message)
+        self.assertIn(f"id {self.vc_b.pk}", message)
+        self.assertIn("Settle it in NetBox", message)
+        self.assertIn("merge the duplicates", message)
+        self.assertNotIn("Supply domain", message)
+        self.assertIn("labelling these rows cannot settle it on its own", message)
+        self.assertNotIn("the others do not have", message)
+
+    def test_the_remedy_the_refusal_names_actually_resolves_it(self):
+        """
+        Every remedy in the message, taken literally, and the outcome measured.
+
+        A structured error is only worth its space if following it changes the
+        answer. Three states, one payload ({"name": ...} and nothing else):
+
+          - label one row: STILL ambiguous. This is the advice the message used
+            to lead with, and it is inert here -- narrow_vc_candidates iterates
+            the discriminators the payload asserts, and this payload asserts
+            none, so no labelling of any row narrows anything.
+          - place the referencing device in one of them: resolves, to that row,
+            through rule 1 (the member hint).
+          - merge the duplicates (here: delete the row nobody meant, the
+            operator's other lever): resolves, because one candidate is left.
+        """
+        VirtualChassis.objects.filter(pk=self.vc_a.pk).update(domain="vcx-relabelled")
+        with self.assertRaises(AmbiguousObjectMatch):
+            find_existing_object({"name": "vcx-shared"}, "dcim.virtualchassis")
+
+        Device.objects.filter(pk=self.loose.pk).update(
+            virtual_chassis=self.vc_b, vc_position=9)
+        self.assertEqual(
+            find_existing_object(
+                {"name": "vcx-shared", VC_MEMBER_HINT: [self.loose.pk]},
+                "dcim.virtualchassis"),
+            self.vc_b,
+        )
+
+        Device.objects.filter(pk=self.loose.pk).update(
+            virtual_chassis=None, vc_position=None)
+        Device.objects.filter(pk=self.a1.pk).update(
+            virtual_chassis=None, vc_position=None)
+        VirtualChassis.objects.filter(pk=self.vc_a.pk).update(master=None)
+        VirtualChassis.objects.filter(pk=self.vc_a.pk).delete()
+        self.assertEqual(
+            find_existing_object({"name": "vcx-shared"}, "dcim.virtualchassis"),
+            self.vc_b,
+        )
+
+    def test_the_refusal_carries_the_per_entity_error_shape(self):
+        """
+        It has to be reportable, not just raised.
+
+        Both API boundaries render a ChangeSetException's ``errors`` dict
+        directly, so the shape is the contract: {object_type: {field: [msg]}}.
+        A bare exception here would surface as a 500 at one door or the other.
+        """
+        with self.assertRaises(ChangeSetException) as caught:
+            find_existing_object({"name": "vcx-shared"}, "dcim.virtualchassis")
+        errors = caught.exception.errors
+        self.assertIn("dcim.virtualchassis", errors)
+        self.assertIn("name", errors["dcim.virtualchassis"])
+        self.assertEqual(len(errors["dcim.virtualchassis"]["name"]), 1)
+
+    def test_the_refusal_is_not_a_malformed_reference(self):
+        """
+        It must not be a ValueError or TypeError, and this is not pedantry.
+
+        Three call sites swallow those two to turn a payload the ORM cannot
+        query into "no match" (applier._find_existing_object_or_none,
+        _try_find_and_update_existing_instance, and apply_changeset's own
+        handler chain). An ambiguity that inherited from either would be
+        swallowed the same way -- and "no match" for a name that matched twice
+        means INSERT A THIRD ROW.
+        """
+        self.assertFalse(issubclass(AmbiguousObjectMatch, ValueError))
+        self.assertFalse(issubclass(AmbiguousObjectMatch, TypeError))
+        self.assertTrue(issubclass(AmbiguousObjectMatch, ChangeSetException))
+
+    def test_a_discriminator_resolves_one_row(self):
+        """A domain is a claim about which row, so it resolves -- to the named one."""
+        self.assertEqual(
+            find_existing_object(
+                {"name": "vcx-shared", "domain": "building-b"}, "dcim.virtualchassis"),
+            self.vc_b,
+        )
+        self.assertEqual(
+            find_existing_object(
+                {"name": "vcx-shared", "domain": "building-a"}, "dcim.virtualchassis"),
+            self.vc_a,
+        )
+
+    def test_a_discriminator_no_row_carries_is_a_create_not_an_ambiguity(self):
+        """
+        A domain no candidate has means "not one of these rows".
+
+        Returning None here is the difference between creating the chassis the
+        payload describes and binding one whose own discriminator contradicts
+        it. Raising instead would make a legitimate third stack unrepresentable.
+        """
+        self.assertIsNone(
+            find_existing_object(
+                {"name": "vcx-shared", "domain": "building-c"}, "dcim.virtualchassis")
+        )
+
+    def test_an_empty_domain_excludes_every_row_that_carries_one(self):
+        """
+        An explicitly submitted empty domain is a value, not an absence.
+
+        Both rows here carry a domain, so a payload declaring the chassis has
+        none describes NEITHER of them -- which is the create case, not the
+        ambiguous one. The "" used to be dropped as if the key were missing, so
+        this call refused as ambiguous and, wherever it did resolve, the ""
+        was then written over the matched row's domain: the discriminator the
+        refusal message asks the operator to set, destroyed by the payload that
+        should have been excluded by it.
+        """
+        self.assertIsNone(
+            find_existing_object(
+                {"name": "vcx-shared", "domain": ""}, "dcim.virtualchassis")
+        )
+
+    def test_an_empty_domain_narrows_to_the_row_that_carries_none(self):
+        """
+        Exclusion is all "" does, and it is enough to resolve a third row.
+
+        It excludes building-a and building-b and leaves one candidate, which
+        resolves like any other single candidate. It never IDENTIFIES a row --
+        every chassis that never set a domain carries "" -- which is why
+        applier._choose_adoption_candidate will not let it authorise adopting a
+        populated row the way a real domain does.
+        """
+        plain = VirtualChassis.objects.create(name="vcx-shared")
+        member = Device.objects.create(name="vcx-c1", **self.kw)
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=plain, vc_position=1)
+        self.assertEqual(
+            find_existing_object(
+                {"name": "vcx-shared", "domain": ""}, "dcim.virtualchassis"),
+            plain,
+        )
+
+    def test_a_refusal_does_not_ask_for_what_the_payload_already_supplied(self):
+        """
+        The remedy has to be actionable, and this one used to be a loop.
+
+        Two rows share the name AND the domain, so the payload's discriminator
+        is asserted, matched, and still does not tell them apart. Every one of
+        these refusals used to end "Supply domain ... to identify it" -- telling
+        the operator to do the thing they just did, which is how a structured
+        error stops being a way out and becomes noise.
+        """
+        twin_a = VirtualChassis.objects.create(name="vcx-twin", domain="vcx-both")
+        twin_b = VirtualChassis.objects.create(name="vcx-twin", domain="vcx-both")
+        for row, name in ((twin_a, "vcx-t1"), (twin_b, "vcx-t2")):
+            member = Device.objects.create(name=name, **self.kw)
+            Device.objects.filter(pk=member.pk).update(virtual_chassis=row, vc_position=1)
+
+        with self.assertRaises(AmbiguousObjectMatch) as caught:
+            find_existing_object(
+                {"name": "vcx-twin", "domain": "vcx-both"}, "dcim.virtualchassis")
+        message = str(caught.exception)
+        self.assertIn(f"id {twin_a.pk}", message)
+        self.assertIn(f"id {twin_b.pk}", message)
+        self.assertIn("asserts domain 'vcx-both'", message)
+        self.assertNotIn("Supply domain", message)
+        self.assertIn("Settle it in NetBox", message)
+
+    def test_the_member_a_device_is_already_in_wins(self):
+        """
+        The rule that guarantees no relocation, and it needs the member hint.
+
+        The hint is what the transformer pushes onto a nested chassis node from
+        the device that referenced it (common.VC_MEMBER_HINT); the matcher
+        cannot see the device any other way. With it, a device already in the
+        NEWER duplicate resolves to that one -- against creation order, which is
+        the point.
+        """
+        Device.objects.filter(pk=self.loose.pk).update(
+            virtual_chassis=self.vc_b, vc_position=2)
+        found = find_existing_object(
+            {"name": "vcx-shared", VC_MEMBER_HINT: [self.loose.pk]},
+            "dcim.virtualchassis",
+        )
+        self.assertEqual(found, self.vc_b)
+
+    def test_a_hint_for_a_chassis_less_device_carries_no_evidence(self):
+        """A device in no chassis cannot break the tie, so the refusal stands."""
+        with self.assertRaises(AmbiguousObjectMatch):
+            find_existing_object(
+                {"name": "vcx-shared", VC_MEMBER_HINT: [self.loose.pk]},
+                "dcim.virtualchassis",
+            )
+
+    def test_hints_that_disagree_refuse_rather_than_pick_a_side(self):
+        """
+        Two referencing members already in DIFFERENT same-named chassis.
+
+        Whichever row were chosen, the other member would be moved out of the
+        stack it is in, so there is no answer to give. (Several members of one
+        chassis in one batch dedupe into a single chassis node whose hint is the
+        union -- transformer._merge_nodes -- which is how both pks arrive here.)
+        """
+        with self.assertRaises(AmbiguousObjectMatch) as caught:
+            find_existing_object(
+                {"name": "vcx-shared", VC_MEMBER_HINT: [self.a1.pk, self.b1.pk]},
+                "dcim.virtualchassis",
+            )
+        self.assertIn("DIFFERENT", str(caught.exception))
+
+    def test_a_bogus_hint_value_is_a_refusal_not_a_valueerror(self):
+        """
+        A malformed hint must not reach the ORM as a pk.
+
+        Every form here carries no evidence, so the refusal is the right answer.
+        What this pins is that it IS a refusal and not a ValueError/TypeError
+        out of query construction -- the applier turns those into "no match",
+        which for a name that matched twice means inserting a third row.
+
+        It does NOT pin the bool exclusion: [True] would mean pk 1, and whether
+        pk 1 is a member of one of these candidates depends on a sequence no
+        test controls. VirtualChassisHintPkTests pins that directly.
+        """
+        for hint in ([True], [None], ["abc"], [[1]], [], None, self.loose.pk):
+            with self.subTest(hint=hint):
+                with self.assertRaises(AmbiguousObjectMatch):
+                    find_existing_object(
+                        {"name": "vcx-shared", VC_MEMBER_HINT: hint},
+                        "dcim.virtualchassis",
+                    )
+
+    def test_a_row_resolved_before_the_duplicate_appeared_is_not_served_from_cache(self):
+        """
+        The find-object cache must not be able to answer this question at all.
+
+        find_obj_cache_ttl defaults to 30s and the key is built from SCALAR
+        fields only, so a name-keyed VirtualChassis lookup would cache one row
+        under a key that cannot see the member hint OR the appearance of a
+        second same-named row. Two consequences, both silent: a payload naming
+        the chassis on behalf of a DIFFERENT member device would be served the
+        first device's answer, and an ambiguity that must be reported would be
+        answered with whatever row was cached before the duplicate existed.
+        A cache hit also skips resolve() entirely, so the whole policy would be
+        bypassed rather than merely stale.
+
+        _find_obj_cache_key therefore declines to key dcim.virtualchassis at
+        all, which disables both the django cache and the request-scoped one.
+        """
+        with mock.patch(
+            "netbox_diode_plugin.api.matcher._get_find_obj_cache_ttl", return_value=30
+        ):
+            self.assertEqual(
+                find_existing_object(
+                    {"name": "vcx-cached", "domain": "building-a"}, "dcim.virtualchassis"),
+                None,
+            )
+            first = VirtualChassis.objects.create(name="vcx-cached", domain="building-a")
+            Device.objects.filter(pk=self.loose.pk).update(
+                virtual_chassis=first, vc_position=1)
+            self.assertEqual(
+                find_existing_object({"name": "vcx-cached"}, "dcim.virtualchassis"), first)
+
+            second = VirtualChassis.objects.create(name="vcx-cached", domain="building-b")
+            other = Device.objects.create(name="vcx-cached-b1", **self.kw)
+            Device.objects.filter(pk=other.pk).update(
+                virtual_chassis=second, vc_position=1)
+
+            with self.assertRaises(AmbiguousObjectMatch):
+                find_existing_object({"name": "vcx-cached"}, "dcim.virtualchassis")
+
+    def test_a_unique_candidate_still_resolves(self):
+        """
+        The floor: none of the above may cost the ordinary case.
+
+        One row with the name, no hint, no discriminator -- this is what the
+        whole feature is for, and every rule above is scoped to the multi-row
+        case so that it stays a plain resolution.
+        """
+        only = VirtualChassis.objects.create(name="vcx-only", domain="building-z")
+        self.assertEqual(
+            find_existing_object({"name": "vcx-only"}, "dcim.virtualchassis"), only)
+        self.assertIsNone(
+            find_existing_object({"name": "vcx-nothing"}, "dcim.virtualchassis"))
+
+
+class VirtualChassisPreSaveMatchScopeTests(TestCase):
+    """
+    What the find-first CREATE route does, and to which payloads it applies.
+
+    For dcim.virtualchassis the route RESOLVES a CREATE onto an existing row
+    and writes nothing to it (matcher._PRE_SAVE_MATCH_BIND_ONLY); for every
+    other entry in matcher._REQUIRES_PRE_SAVE_MATCH it is an UPDATE path that
+    applies the CREATE's payload to whatever find_existing_object returns. The
+    scope of the routing is a behavioural contract with two halves either way,
+    and both are asserted here through a real apply. (The test this replaced
+    asserted only that "dcim.virtualchassis" was a member of the set literal
+    that defines the route, which is true by construction and cannot fail for
+    any reason a reader would care about.)
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A chassis-less device, plus a device that already masters a chassis."""
+        site = Site.objects.create(name="vcs-site", slug="vcs-site")
+        mfr = Manufacturer.objects.create(name="vcs-mfr", slug="vcs-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="vcs-dt", slug="vcs-dt")
+        role = DeviceRole.objects.create(name="vcs-role", slug="vcs-role")
+        cls.free = Device.objects.create(
+            name="vcs-free", site=site, device_type=dt, role=role
+        )
+        cls.owner = Device.objects.create(
+            name="vcs-owner", site=site, device_type=dt, role=role
+        )
+        cls.owned = VirtualChassis.objects.create(name="vcs-owned", master=cls.owner)
+        Device.objects.filter(pk=cls.owner.pk).update(
+            virtual_chassis=cls.owned, vc_position=1
+        )
+
+    def test_masterless_create_binds_the_existing_row_without_writing_it(self):
+        """
+        The half the route exists for: a masterless CREATE binds the row by name.
+
+        This is the plan-ahead race in miniature. VirtualChassis has no unique
+        constraint on name, so without the pre-save lookup this CREATE inserts
+        a second row and the chassis is split across two, half its members
+        orphaned on each.
+
+        Binding is the whole of what the race needs, and the payload is
+        deliberately NOT applied. The same absent uniqueness that makes the
+        lookup necessary also makes it insufficient as an identity claim: the
+        row matched by name may be a different stack another source owns (see
+        matcher._PRE_SAVE_MATCH_BIND_ONLY). last_updated carries the no-write
+        assertion, because on a row that was already blank "untouched" and
+        "saved with the payload minus its description" look alike.
+        """
+        existing = VirtualChassis.objects.create(name="vcs-race")
+        before = existing.last_updated
+
+        _apply_vc_create({"name": "vcs-race", "description": "from the second plan"})
+
+        self.assertEqual(VirtualChassis.objects.filter(name="vcs-race").count(), 1)
+        existing.refresh_from_db()
+        self.assertEqual(existing.description, "")
+        self.assertEqual(existing.last_updated, before, "the bound row was saved")
+
+    def test_master_bearing_create_does_not_become_an_update(self):
+        """
+        The half the route must NOT cover: a CREATE may not rewrite another chassis.
+
+        With master present the matcher that answers find_existing_object is
+        the auto-derived unique_master one, so a master-bearing CREATE on the
+        pre-save path resolves "the chassis named vcs-renamed, mastered by
+        vcs-owner" onto the chassis vcs-owner already masters.
+
+        What that resolution would DO depends on the other seam: before
+        _PRE_SAVE_MATCH_BIND_ONLY it renamed that converged, unrelated row on a
+        create; with bind-only in force it would bind to it silently instead,
+        so the named chassis is never created and later references resolve to
+        the wrong row. Both are worth excluding, but only the first was a
+        write, and the assertions below now hold for either reason -- see
+        test_route_is_scoped_to_masterless_payloads for what actually pins the
+        gate.
+        """
+        _apply_vc_create({
+            "name": "vcs-renamed",
+            "master": self.owner.pk,
+            "description": "must not land anywhere",
+        })
+
+        self.owned.refresh_from_db()
+        self.assertEqual(self.owned.name, "vcs-owned")
+        self.assertEqual(self.owned.description, "")
+        self.assertFalse(VirtualChassis.objects.filter(name="vcs-renamed").exists())
+
+    def test_route_is_scoped_to_masterless_payloads(self):
+        """
+        The seam itself: master present in any form keeps a CREATE off the UPDATE path.
+
+        The malformed forms matter as much as the well-formed one. A matcher
+        interpolates the payload value straight into an ORM pk filter, where
+        bool and non-integral float coerce SILENTLY (True -> 1, 7.5 -> 7)
+        instead of declining, so they would select an unrelated row. Excluding
+        master-bearing payloads keeps that filter out of reach rather than
+        guarding it -- a seam pin, not a claim about row state: with bind-only
+        in force the gate changes no row's contents, so this test is the only
+        thing that fails if the gate is removed.
+        """
+        self.assertTrue(requires_pre_save_match("dcim.virtualchassis", {"name": "x"}))
+        self.assertTrue(
+            requires_pre_save_match("dcim.virtualchassis", {"name": "x", "master": None}),
+            "explicit null must gate as masterless, like VirtualChassisNameMatcher",
+        )
+        for master in (self.owner.pk, str(self.owner.pk), True, False, 7.5, 7.0, "abc", [1]):
+            with self.subTest(master=master):
+                self.assertFalse(
+                    requires_pre_save_match(
+                        "dcim.virtualchassis", {"name": "x", "master": master}
+                    )
+                )
+
+    def test_ungated_types_are_unaffected_by_the_scoping(self):
+        """Only dcim.virtualchassis is payload-scoped; the other entries are not."""
+        for object_type in ("dcim.macaddress", "dcim.cable", "ipam.prefix"):
+            with self.subTest(object_type=object_type):
+                self.assertTrue(requires_pre_save_match(object_type, {"master": 1}))
+        self.assertFalse(requires_pre_save_match("dcim.site", {}))
+
+
+class PreSaveMatchBindOnlyTests(TestCase):
+    """
+    The second seam: what a pre-save-matched CREATE may do to the row it found.
+
+    requires_pre_save_match decides whether to LOOK; this decides whether to
+    WRITE. They are separate questions because the find-first path serves two
+    populations with opposite needs. An auto-created component was instantiated
+    by NetBox from the very device or module the payload names, so the match is
+    an identity and the payload is the authority that must overwrite the
+    template's defaults. A dcim.virtualchassis match is by name alone against a
+    model with no uniqueness on name, so it is a guess -- good enough to dedupe
+    an insert, not good enough to write another source's row.
+    """
+
+    #: applier._is_auto_created_component's own list, asserted against it below.
+    AUTO_CREATED = (
+        "dcim.consoleport",
+        "dcim.consoleserverport",
+        "dcim.powerport",
+        "dcim.poweroutlet",
+        "dcim.interface",
+        "dcim.rearport",
+        "dcim.frontport",
+        "dcim.modulebay",
+        "dcim.devicebay",
+        "dcim.inventoryitem",
+    )
+
+    def test_virtualchassis_binds_without_writing(self):
+        """The one bind-only type, and the reason the seam exists at all."""
+        self.assertTrue(pre_save_match_binds_only("dcim.virtualchassis"))
+
+    def test_every_other_pre_save_matched_type_still_applies_its_payload(self):
+        """
+        Naming them all: this is a behavioural change nobody else may inherit.
+
+        dcim.module's find-first, for one, exists precisely to APPLY a payload
+        that the IntegrityError recovery it replaced used to discard.
+        """
+        for object_type in sorted(_REQUIRES_PRE_SAVE_MATCH - {"dcim.virtualchassis"}):
+            with self.subTest(object_type=object_type):
+                self.assertFalse(pre_save_match_binds_only(object_type))
+
+    def test_no_auto_created_component_is_bind_only(self):
+        """
+        The overlap that would be silent: both populations share one dispatch.
+
+        applier._try_pre_save_match routes auto-created components through this
+        same seam, so a component type added to _PRE_SAVE_MATCH_BIND_ONLY would
+        stop ingest overwriting template defaults with no test failing for that
+        reason -- the row would still be bound and no duplicate created.
+        """
+        for object_type in self.AUTO_CREATED:
+            with self.subTest(object_type=object_type):
+                self.assertTrue(
+                    _is_auto_created_component(object_type),
+                    "the list under test has drifted from the applier's",
+                )
+                self.assertFalse(pre_save_match_binds_only(object_type))
+
+    def test_a_type_with_no_pre_save_match_at_all_is_not_bind_only(self):
+        """Bind-only narrows the find-first route; it is not a route of its own."""
+        for object_type in ("dcim.site", "dcim.device", "dcim.rack"):
+            with self.subTest(object_type=object_type):
+                self.assertFalse(pre_save_match_binds_only(object_type))
+                self.assertFalse(requires_pre_save_match(object_type, {}))
+
+
+class VirtualChassisAdoptionTests(TestCase):
+    """Master-bearing VC creates must adopt same-named masterless VCs."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Seed a masterless VC (bulk member-first aftermath) and its master-to-be."""
+        site = Site.objects.create(name="vca-site", slug="vca-site")
+        mfr = Manufacturer.objects.create(name="vca-mfr", slug="vca-mfr")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="vca-dt", slug="vca-dt")
+        role = DeviceRole.objects.create(name="vca-role", slug="vca-role")
+        cls.vc = VirtualChassis.objects.create(name="vca-stack")
+        cls.master = Device.objects.create(
+            name="vca-sw1", site=site, device_type=dt, role=role
+        )
+
+    def _apply_create(self, data, extra_changes=()):
+        return _apply_vc_create(data, extra_changes=extra_changes)
+
+    def test_master_bearing_create_adopts_masterless_vc(self):
+        """No duplicate VC; adoption attaches the chassis-less master and sets it."""
+        self._apply_create({"name": "vca-stack", "master": self.master.pk})
+        self.assertEqual(VirtualChassis.objects.filter(name="vca-stack").count(), 1)
+        self.vc.refresh_from_db()
+        self.assertEqual(self.vc.master_id, self.master.pk)
+        self.master.refresh_from_db()
+        self.assertEqual(self.master.virtual_chassis_id, self.vc.pk)
+        self.assertEqual(self.master.vc_position, 1)  # NetBox's own choice for a VC master
+
+    def test_adoption_sets_master_once_member(self):
+        """When the master device already belongs to the VC, adoption sets master."""
+        Device.objects.filter(pk=self.master.pk).update(
+            virtual_chassis=self.vc, vc_position=1
+        )
+        self._apply_create({"name": "vca-stack", "master": self.master.pk})
+        self.assertEqual(VirtualChassis.objects.filter(name="vca-stack").count(), 1)
+        self.vc.refresh_from_db()
+        self.assertEqual(self.vc.master_id, self.master.pk)
+
+    def test_master_already_owning_a_chassis_declines_adoption_of_a_decoy(self):
+        """
+        A same-named masterless decoy must not receive a CREATE aimed at the owned row.
+
+        The decoy is the row the adopter's own queryset picks (same name,
+        master__isnull=True), and the master named by the payload cannot be
+        attached to it -- VirtualChassis.master is unique and another chassis
+        already holds it. Deferring master and saving the rest, which is how
+        the adopter treats a master that merely sits in another chassis, writes
+        the payload onto a row the payload never referred to and leaves the
+        real one untouched, with nothing to converge it. So the adopter must
+        decline outright, and the CREATE settles on the unique-master row
+        without rewriting it.
+
+        Applying the payload is the plan path's job, not a create's: an ingest
+        of this entity plans an UPDATE of the unique-master row, because
+        find_existing_object resolves master-bearing payloads to it at plan
+        time. A create that also rewrote it is what let a create rename a
+        chassis it did not name.
+        """
+        mastered = VirtualChassis.objects.create(name="vca-mastered", master=self.master)
+        Device.objects.filter(pk=self.master.pk).update(
+            virtual_chassis=mastered, vc_position=1
+        )
+        decoy = VirtualChassis.objects.create(name="vca-mastered")  # masterless, same name
+        mastered.refresh_from_db()
+        before = mastered.last_updated
+
+        self._apply_create({
+            "name": "vca-mastered",
+            "master": self.master.pk,
+            "description": "must not land anywhere",
+        })
+
+        self.assertEqual(VirtualChassis.objects.filter(name="vca-mastered").count(), 2)
+        decoy.refresh_from_db()
+        self.assertEqual(decoy.description, "")
+        self.assertIsNone(decoy.master)
+        mastered.refresh_from_db()
+        self.assertEqual(mastered.description, "")
+        self.assertEqual(mastered.master_id, self.master.pk)
+        self.assertEqual(mastered.last_updated, before, "the CREATE wrote the owned row")
+
+    def test_adoption_reports_a_conflict_for_a_device_in_another_chassis(self):
+        """
+        A master already in ANOTHER chassis is a reported conflict, then converges.
+
+        THE OLD EXPECTATION HERE WAS UNSAFE: it asserted that the apply
+        SUCCEEDS with master silently dropped. Not relocating the device was and
+        is right; answering 200 was not. The payload asked for
+        VirtualChassis(name=X, master=Y) and got a chassis without a master,
+        reported as applied -- and since a standalone chassis payload carries
+        nothing else, an identical re-ingest re-plans the identical CREATE
+        forever. A reconciler cannot tell that apart from success.
+
+        The second half of the test is unchanged and is what makes the conflict
+        a conflict rather than a wall: once something else (the device's own
+        payload) makes the device a member, the identical apply binds master.
+        """
+        elsewhere = VirtualChassis.objects.create(name="vca-elsewhere")
+        Device.objects.filter(pk=self.master.pk).update(
+            virtual_chassis=elsewhere, vc_position=2
+        )
+        with self.assertRaises(ChangeSetException) as caught:
+            self._apply_create({"name": "vca-stack", "master": self.master.pk})
+        errors = caught.exception.errors["dcim.virtualchassis"]
+        self.assertIn("master", errors)
+        self.assertIn("vca-elsewhere", errors["master"][0])
+
+        self.vc.refresh_from_db()
+        self.assertIsNone(self.vc.master)  # not forced
+        self.master.refresh_from_db()
+        self.assertEqual(self.master.virtual_chassis_id, elsewhere.pk)  # not relocated
+        self.assertEqual(self.master.vc_position, 2)
+
+        Device.objects.filter(pk=self.master.pk).update(
+            virtual_chassis=self.vc, vc_position=1
+        )
+        self._apply_create({"name": "vca-stack", "master": self.master.pk})
+        self.assertEqual(VirtualChassis.objects.filter(name="vca-stack").count(), 1)
+        self.vc.refresh_from_db()
+        self.assertEqual(self.vc.master_id, self.master.pk)  # second pass converges
+
+    def test_adoption_prefers_row_with_membership_over_oldest(self):
+        """Among several same-named masterless rows, adopt the one the master already belongs to."""
+        older = self.vc  # from setUpTestData: masterless, empty, lowest pk
+        newer = VirtualChassis.objects.create(name="vca-stack")  # masterless, higher pk
+        Device.objects.filter(pk=self.master.pk).update(
+            virtual_chassis=newer, vc_position=1
+        )
+        self._apply_create({"name": "vca-stack", "master": self.master.pk})
+        self.assertEqual(VirtualChassis.objects.filter(name="vca-stack").count(), 2)
+        newer.refresh_from_db()
+        self.assertEqual(newer.master_id, self.master.pk)
+        older.refresh_from_db()
+        self.assertIsNone(older.master)
+
+    def test_a_populated_row_matched_only_by_name_is_left_alone_and_a_new_one_created(self):
+        """
+        The measured hazard, at the adopter's own door, and the answer to it.
+
+        The candidate holds another device and does not hold the requested
+        master, so binding it would designate this payload's device the master
+        of somebody else's stack and drag it in. Nothing in the payload says
+        that row is meant -- and nothing in the changeset asks for the
+        membership either, because a standalone dcim.virtualchassis entity plans
+        no device change at all. So adoption declines.
+
+        Declining is not refusing. The payload's own CREATE is still applied, on
+        a row of its own, which is the only answer that both leaves the foreign
+        row alone AND converges: a refusal here repeats on every identical pass,
+        and the entity that provokes it (orb-agent's standalone virtual_chassis
+        entity) carries nothing that could be changed to satisfy it.
+        """
+        squatter = Device.objects.create(
+            name="vca-squatter", site=self.master.site,
+            device_type=self.master.device_type, role=self.master.role,
+        )
+        Device.objects.filter(pk=squatter.pk).update(
+            virtual_chassis=self.vc, vc_position=4)
+        self.vc.refresh_from_db()
+        before = self.vc.last_updated
+
+        self._apply_create({"name": "vca-stack", "master": self.master.pk})
+
+        self.vc.refresh_from_db()
+        self.assertIsNone(self.vc.master_id, "the foreign row was mastered")
+        self.assertEqual(self.vc.last_updated, before, "the foreign row was written")
+        self.assertEqual(list(self.vc.members.values_list("name", flat=True)),
+                         ["vca-squatter"], "a device was moved into the foreign row")
+
+        mine = VirtualChassis.objects.exclude(pk=self.vc.pk).get(name="vca-stack")
+        self.assertEqual(mine.master_id, self.master.pk)
+        self.master.refresh_from_db()
+        self.assertEqual(self.master.virtual_chassis_id, mine.pk)
+        self.assertEqual(self.master.vc_position, 1)
+
+    def test_several_masterless_rows_sharing_the_name_are_neither_adopted_nor_written(self):
+        """
+        Two empty candidates are indistinguishable, so neither may be chosen.
+
+        A single empty row IS adopted (test_master_bearing_create_adopts_
+        masterless_vc): nothing is relocated and no duplicate is left. Two of
+        them are a different question -- picking either is creation order
+        wearing a disguise. What follows from "cannot choose" is create, not
+        refuse: the payload gets its own row, both duplicates are left exactly
+        as they were, and the operator can still delete them. A refusal would
+        have blocked the ingest on a mess the producer cannot clean up.
+        """
+        second = VirtualChassis.objects.create(name="vca-stack")  # a second empty duplicate
+        self._apply_create({"name": "vca-stack", "master": self.master.pk})
+
+        self.assertEqual(VirtualChassis.objects.filter(name="vca-stack").count(), 3)
+        for row in (self.vc, second):
+            row.refresh_from_db()
+            self.assertIsNone(row.master_id)
+            self.assertEqual(row.members.count(), 0)
+        mine = VirtualChassis.objects.get(name="vca-stack", master=self.master)
+        self.assertNotIn(mine.pk, {self.vc.pk, second.pk})
+
+    def test_two_rows_sharing_the_asserted_domain_are_left_alone_and_a_third_created(self):
+        """
+        A discriminator that narrows to TWO rows identifies neither.
+
+        Both masterless rows carry domain "vca-twin" and the payload asserts it,
+        so narrowing keeps both and rule 2 does not fire (it needs exactly one).
+        The old behaviour raised here and told the operator to "supply domain" --
+        the value they had just supplied. There is nothing to add to this
+        payload, so there is nothing to refuse it for: the chassis it describes
+        is created, both twins are left byte-identical, and the duplicate names
+        stay visible in NetBox where they can be merged.
+        """
+        VirtualChassis.objects.filter(pk=self.vc.pk).update(domain="vca-twin")
+        twin = VirtualChassis.objects.create(name="vca-stack", domain="vca-twin")
+        self.vc.refresh_from_db()
+        before = self.vc.last_updated
+
+        self._apply_create(
+            {"name": "vca-stack", "domain": "vca-twin", "master": self.master.pk})
+
+        self.vc.refresh_from_db()
+        self.assertIsNone(self.vc.master_id)
+        self.assertEqual(self.vc.last_updated, before)
+        twin.refresh_from_db()
+        self.assertIsNone(twin.master_id)
+        self.assertEqual(VirtualChassis.objects.filter(name="vca-stack").count(), 3)
+        mine = VirtualChassis.objects.get(name="vca-stack", master=self.master)
+        self.assertEqual(mine.domain, "vca-twin")
+
+    def test_adoption_accepts_a_domain_identified_populated_row(self):
+        """A domain turns the refusal above into an identification, and it adopts."""
+        squatter = Device.objects.create(
+            name="vca-squatter2", site=self.master.site,
+            device_type=self.master.device_type, role=self.master.role,
+        )
+        VirtualChassis.objects.filter(pk=self.vc.pk).update(domain="vca-dom")
+        Device.objects.filter(pk=squatter.pk).update(
+            virtual_chassis=self.vc, vc_position=4)
+
+        self._apply_create({
+            "name": "vca-stack", "domain": "vca-dom", "master": self.master.pk})
+        self.vc.refresh_from_db()
+        self.assertEqual(self.vc.master_id, self.master.pk)
+        self.master.refresh_from_db()
+        self.assertEqual(self.master.virtual_chassis_id, self.vc.pk)
+        self.assertEqual(VirtualChassis.objects.filter(name="vca-stack").count(), 1)
+
+    def _move_licence_case(self, change_type, name):
+        """One adoption where a device in ANOTHER chassis is the requested master."""
+        foreign = VirtualChassis.objects.create(name=f"{name}-foreign")
+        Device.objects.filter(pk=self.master.pk).update(
+            virtual_chassis=foreign, vc_position=2)
+        empty = VirtualChassis.objects.create(name=name)
+        raised = None
+        try:
+            self._apply_create(
+                {"name": name, "master": self.master.pk},
+                extra_changes=[Change(
+                    change_type=change_type,
+                    object_type="dcim.device",
+                    object_id=self.master.pk,
+                    data={"virtual_chassis": "vc1", "vc_position": 1},
+                    new_refs=["virtual_chassis"],
+                )],
+            )
+        except ChangeSetException as exc:
+            raised = exc
+        self.master.refresh_from_db()
+        empty.refresh_from_db()
+        return raised, empty
+
+    def test_a_noop_device_change_does_not_authorize_a_move(self):
+        """
+        Only a change that will actually WRITE the membership may license a move.
+
+        apply_changeset skips NOOP outright, so a NOOP device change asserting
+        this chassis promises a membership that never lands -- but the licence
+        it bought was spent anyway. Measured before the fix, on a hand-built
+        changeset (reachable through apply-change-set and bulk-apply, not
+        through generate-diff): the master was relocated out of another
+        producer's chassis into the adopted row and made its master, 200,
+        errors null, with the IN_OTHER_CHASSIS conflict a standalone payload
+        gets bypassed entirely.
+
+        Nothing legitimate is lost. A device that really is already a member
+        never reaches _attach_master_to_virtualchassis at all, because the
+        caller checks existing.members first.
+        """
+        raised, empty = self._move_licence_case(ChangeType.NOOP, "vca-noop")
+        self.assertIsNotNone(raised, "a NOOP authorized the move")
+        self.assertIn("member of", str(raised))
+        self.assertNotEqual(
+            self.master.virtual_chassis_id, empty.pk,
+            "the device was relocated on the strength of a change that never runs",
+        )
+        self.assertIsNone(empty.master_id)
+
+    def test_an_update_device_change_still_authorizes_the_move(self):
+        """The control: a change that does write the membership still licenses it."""
+        raised, empty = self._move_licence_case(ChangeType.UPDATE, "vca-update")
+        self.assertIsNone(raised, f"the move was refused: {raised}")
+        self.assertEqual(self.master.virtual_chassis_id, empty.pk)
+        self.assertEqual(empty.master_id, self.master.pk)
+
+    def test_adoption_locks_its_candidates_before_deciding(self):
+        """
+        The candidate rows are locked, and the decision reads state after the lock.
+
+        Adoption reads a row, decides it is adoptable, then writes it. Unlocked,
+        two workers applying master-bearing CREATEs for one name both read the
+        same EMPTY row as adoptable, both attach their own device, and the later
+        save overwrites the first master -- two stacks merged into one row, both
+        told 200, one master gone.
+
+        Asserted on the SQL because that is what can be checked deterministically
+        here: a FOR UPDATE against the candidate pks, and the annotated re-read
+        issued after it rather than before. A genuine two-connection race needs
+        a TransactionTestCase and threads, which this suite has none of; what is
+        pinned is that the lock is taken and that nothing decides on state read
+        before it.
+
+        The lock is two statements because Postgres refuses FOR UPDATE beside a
+        DISTINCT -- "FOR UPDATE is not allowed with DISTINCT clause" -- and
+        beside the member-count aggregate, so a single locked query is not
+        available.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        VirtualChassis.objects.create(name="vca-locked")
+        with CaptureQueriesContext(connection) as captured:
+            _locked_adoption_candidates(
+                VirtualChassis, "vca-locked", self.master.pk)
+
+        sql = [q["sql"] for q in captured.captured_queries]
+        locking = [i for i, s in enumerate(sql) if "FOR UPDATE" in s.upper()]
+        self.assertEqual(len(locking), 1, sql)
+        self.assertIn("ORDER BY", sql[locking[0]].upper(),
+                      "candidates must be locked in a deterministic order")
+
+        after = [s for s in sql[locking[0] + 1:] if "COUNT(" in s.upper()]
+        self.assertTrue(
+            after, "the annotated re-read must run AFTER the lock, not before")
+
+    def test_a_row_renamed_under_the_lock_is_no_longer_a_candidate(self):
+        """
+        The locked re-read decides; the unlocked scan only says what to lock.
+
+        The pks are fixed by the time the lock is taken, so a re-read filtered on
+        pk and eligibility alone still returns a row that another transaction
+        RENAMED while this one waited -- masterless and empty, therefore still
+        "eligible", but no longer the chassis this payload names. Adopting it
+        writes this payload's name over a row that had become somebody else's:
+        silent wrong-row mutation, which the lock alone does not prevent.
+
+        The interleaving is simulated rather than raced, deterministically: the
+        rename happens during the lock acquisition, which is exactly the window
+        a second worker committing in would occupy. A genuine two-connection
+        race would need a TransactionTestCase and threads; what matters here is
+        that the re-read repeats the NAME predicate, and that is what this pins.
+        """
+        row = VirtualChassis.objects.create(name="vca-renamed")
+        original = QuerySet.select_for_update
+
+        def rename_then_lock(queryset, *args, **kwargs):
+            # Another worker renames this row and commits while we wait.
+            VirtualChassis.objects.filter(pk=row.pk).update(name="vca-moved-on")
+            return original(queryset, *args, **kwargs)
+
+        with mock.patch.object(QuerySet, "select_for_update", rename_then_lock):
+            candidates = _locked_adoption_candidates(
+                VirtualChassis, "vca-renamed", self.master.pk)
+
+        self.assertEqual(
+            candidates, [],
+            "adopted a row whose name changed while the lock was being taken",
+        )
+        row.refresh_from_db()
+        self.assertEqual(row.name, "vca-moved-on", "the renamed row was written")
+
+    def test_adoption_declines_a_row_whose_domain_the_payload_contradicts(self):
+        """
+        Rule 1 does not outrank an asserted discriminator. Adoption WRITES.
+
+        The requested master already sits in this row, so rule 1 ("the database
+        has already agreed") would take it -- but the row carries domain
+        "vca-dom-a" and the payload asserts "vca-dom-b". A device can sit in a
+        chassis the payload is not talking about, so membership is not licence
+        to write a payload that describes a different one.
+
+        Measured before the fix: the row came back labelled "vca-dom-b", 200,
+        errors null -- somebody's stack silently relabelled. That is worse here
+        than in the matcher, which binds without writing: adoption applies its
+        payload through serializer.save(), so choosing the wrong row rewrites
+        it. matcher.resolve excludes contradicted rows before its own member
+        hint for the same reason; these two must not disagree.
+        """
+        row = VirtualChassis.objects.create(name="vca-labelled", domain="vca-dom-a")
+        Device.objects.filter(pk=self.master.pk).update(
+            virtual_chassis=row, vc_position=2)
+
+        self._apply_create(
+            {"name": "vca-labelled", "domain": "vca-dom-b", "master": self.master.pk})
+
+        row.refresh_from_db()
+        self.assertEqual(row.domain, "vca-dom-a", "the contradicted row was relabelled")
+        self.assertIsNone(row.master_id, "the contradicted row was mastered")
+        own = VirtualChassis.objects.filter(name="vca-labelled").exclude(pk=row.pk)
+        self.assertEqual(own.count(), 1, "the payload did not get its own row")
+        self.assertEqual(own.first().domain, "vca-dom-b")
+
+    def test_adoption_declines_a_populated_row_a_planned_device_change_names(self):
+        """
+        A planned Device change says WHICH CHASSIS, never WHICH ROW, so it licenses nothing.
+
+        This cell used to adopt. The Device change asserts
+        virtual_chassis = <the CREATE's own ref>, which is the row the preview
+        names, and asserts nothing about the pre-existing row that adoption
+        would redirect that create onto. Within the member-first shape it
+        therefore could not tell this producer's own earlier pass from another
+        producer's identically named stack, and it took the row in both cases.
+
+        Now it declines: the row nobody identified is left exactly as it was and
+        the payload gets its own. The cost is real and is not hidden -- a
+        name-only member-first producer no longer converges by itself, and
+        accumulates a duplicate until an operator merges the rows or the
+        producer starts sending identity. The gain is that a populated stack
+        nobody identified is never written, and a duplicate is visible where a
+        silent merge of two stacks is not.
+        """
+        squatter = Device.objects.create(
+            name="vca-squatter3", site=self.master.site,
+            device_type=self.master.device_type, role=self.master.role,
+        )
+        Device.objects.filter(pk=squatter.pk).update(
+            virtual_chassis=self.vc, vc_position=4)
+
+        self._apply_create(
+            {"name": "vca-stack", "master": self.master.pk},
+            extra_changes=[Change(
+                change_type=ChangeType.UPDATE,
+                object_type="dcim.device",
+                object_id=self.master.pk,
+                data={"virtual_chassis": "vc1", "vc_position": 1},
+                new_refs=["virtual_chassis"],
+            )],
+        )
+
+        self.vc.refresh_from_db()
+        self.assertIsNone(self.vc.master_id, "adopted a row nothing identified")
+        self.assertEqual(
+            {d.pk for d in self.vc.members.all()}, {squatter.pk},
+            "the untouched row gained or lost a member",
+        )
+        own = VirtualChassis.objects.filter(name="vca-stack").exclude(pk=self.vc.pk)
+        self.assertEqual(own.count(), 1, "the payload did not get its own row")
+        self.assertEqual(own.first().master_id, self.master.pk)
+        self.master.refresh_from_db()
+        self.assertEqual(self.master.virtual_chassis_id, own.first().pk)
+    def test_an_empty_domain_payload_creates_its_own_row_and_keeps_the_labelled_one(self):
+        """
+        Adoption declines where the matcher binds, and the asymmetry is the point.
+
+        The single same-named masterless row carries domain "vca-dom" and the
+        payload asserts "": an assertion that contradicts the row. Dropping it
+        (the old behaviour) adopted that row and wrote "" over its domain --
+        a discriminator destroyed by a payload it should have excluded. Adoption
+        has a lossless alternative the matcher does not have, namely the CREATE
+        its own plan already asked for, so it takes it.
+        """
+        VirtualChassis.objects.filter(pk=self.vc.pk).update(domain="vca-dom")
+        self.vc.refresh_from_db()
+        before = self.vc.last_updated
+
+        self._apply_create(
+            {"name": "vca-stack", "domain": "", "master": self.master.pk})
+
+        self.vc.refresh_from_db()
+        self.assertEqual(self.vc.domain, "vca-dom", "the payload's '' was written over it")
+        self.assertIsNone(self.vc.master_id)
+        self.assertEqual(self.vc.last_updated, before)
+        fresh = VirtualChassis.objects.exclude(pk=self.vc.pk).get(name="vca-stack")
+        self.assertEqual(fresh.domain, "")
+        self.assertEqual(fresh.master_id, self.master.pk)
+
+    def test_a_cross_site_member_first_row_is_declined_but_never_refused(self):
+        """
+        A VirtualChassis legitimately spans sites, so member sites are not identity.
+
+        The device already in the row lives at another site. That fact was
+        briefly a veto -- refuse to adopt a row holding members from outside the
+        master's site -- and the veto had to be reverted because it made this
+        apply answer 400 on every pass and never converge. This test still pins
+        that half: whatever else happens here, it must not be an error, and it
+        must not depend on anybody's site.
+
+        The other half changed. This row is populated and identified by nothing
+        but its name, so it is no longer adopted either -- the payload gets its
+        own row. Declining is not refusing: the apply succeeds, the cross-site
+        row is untouched, and nothing is permanent. The honest fix for the
+        convergence this gives up is source-owned VirtualChassis identity, not
+        a guess about sites.
+        """
+        other_site = Site.objects.create(name="vca-site-b", slug="vca-site-b")
+        stranger = Device.objects.create(
+            name="vca-elsewhere", site=other_site,
+            device_type=self.master.device_type, role=self.master.role,
+        )
+        Device.objects.filter(pk=stranger.pk).update(
+            virtual_chassis=self.vc, vc_position=4)
+
+        self._apply_create(
+            {"name": "vca-stack", "master": self.master.pk},
+            extra_changes=[Change(
+                change_type=ChangeType.UPDATE,
+                object_type="dcim.device",
+                object_id=self.master.pk,
+                data={"virtual_chassis": "vc1", "vc_position": 1},
+                new_refs=["virtual_chassis"],
+            )],
+        )
+
+        self.vc.refresh_from_db()
+        self.assertIsNone(self.vc.master_id)
+        self.assertEqual({d.pk for d in self.vc.members.all()}, {stranger.pk})
+        own = VirtualChassis.objects.filter(name="vca-stack").exclude(pk=self.vc.pk)
+        self.assertEqual(own.count(), 1)
+        self.assertEqual(own.first().master_id, self.master.pk)
+        self.master.refresh_from_db()
+        self.assertEqual(self.master.virtual_chassis_id, own.first().pk)
+    def test_an_empty_domain_is_not_an_identification_that_licenses_adoption(self):
+        """
+        "" narrows, and must not IDENTIFY -- tested at the door where it survives.
+
+        apply-change-set applies changes nobody planned, so a domain of ""
+        reaches _choose_adoption_candidate here, where the differ drops it from
+        a planned CREATE (test_an_empty_domain_in_the_payload_is_not_a_licence_
+        to_join measures that). The row carries no domain either, so "" is
+        consistent with it and narrows to it -- and if that counted as an
+        IDENTIFICATION it would collect rule 2's permission, which is the one
+        rule that adopts a POPULATED row with no companion device change at all.
+        Every chassis that never set a domain carries "", so it tells no two rows
+        apart and identifies none: this standalone payload gets its own row.
+        """
+        squatter = Device.objects.create(
+            name="vca-empty-dom", site=self.master.site,
+            device_type=self.master.device_type, role=self.master.role,
+        )
+        Device.objects.filter(pk=squatter.pk).update(
+            virtual_chassis=self.vc, vc_position=4)
+        self.vc.refresh_from_db()
+        before = self.vc.last_updated
+
+        self._apply_create(
+            {"name": "vca-stack", "domain": "", "master": self.master.pk})
+
+        self.vc.refresh_from_db()
+        self.assertIsNone(self.vc.master_id, "'' identified the row and adopted it")
+        self.assertEqual(self.vc.last_updated, before)
+        self.assertEqual(list(self.vc.members.values_list("name", flat=True)),
+                         ["vca-empty-dom"])
+        mine = VirtualChassis.objects.exclude(pk=self.vc.pk).get(name="vca-stack")
+        self.assertEqual(mine.master_id, self.master.pk)
+
+    def test_a_row_whose_domain_the_payload_never_asserts_is_left_for_its_owner(self):
+        """
+        Somebody labelled that stack and this payload never mentions the label.
+
+        The row carries domain "vca-dom"; the payload asserts no domain at all,
+        so name plus a planned device change is all it has -- and a row bearing a
+        discriminator the payload is silent about is a row the payload has not
+        identified. Contrast test_adoption_accepts_a_domain_identified_populated_
+        row, where the same value IS asserted and the same row is adopted.
+
+        This steers between adopting and creating; it never rejects the payload.
+        The labelled row keeps its label, its master slot and its members, and
+        the payload lands on a row of its own.
+        """
+        labelled = Device.objects.create(
+            name="vca-labelled", site=self.master.site,
+            device_type=self.master.device_type, role=self.master.role,
+        )
+        VirtualChassis.objects.filter(pk=self.vc.pk).update(domain="vca-dom")
+        Device.objects.filter(pk=labelled.pk).update(
+            virtual_chassis=self.vc, vc_position=4)
+        self.vc.refresh_from_db()
+        before = self.vc.last_updated
+
+        self._apply_create(
+            {"name": "vca-stack", "master": self.master.pk},
+            extra_changes=[Change(
+                change_type=ChangeType.UPDATE,
+                object_type="dcim.device",
+                object_id=self.master.pk,
+                data={"virtual_chassis": "vc1", "vc_position": 1},
+                new_refs=["virtual_chassis"],
+            )],
+        )
+
+        self.vc.refresh_from_db()
+        self.assertIsNone(self.vc.master_id)
+        self.assertEqual(self.vc.domain, "vca-dom")
+        self.assertEqual(self.vc.last_updated, before)
+        self.assertEqual(list(self.vc.members.values_list("name", flat=True)),
+                         ["vca-labelled"])
+        mine = VirtualChassis.objects.exclude(pk=self.vc.pk).get(name="vca-stack")
+        self.assertEqual(mine.domain, "")
+        self.assertEqual(mine.master_id, self.master.pk)
+        self.master.refresh_from_db()
+        self.assertEqual(self.master.virtual_chassis_id, mine.pk)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_version.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_version.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+
+from django.test import TestCase
+
+from netbox_diode_plugin.version import version_display, version_semver
+
+
+class VersionTestCase(TestCase):
+    """Test case for the version module."""
+
+    def test_version(self):
+        """Check the injected semver."""
+        assert version_semver() == "0.0.0"
+
+    def test_version_display(self):
+        """Check the injected display."""
+        assert version_display() == "v0.0.0-dev-unknown"

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_views.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_views.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests."""
+from unittest import mock
+
+from django.contrib import messages
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+from django.test import TestCase as _TestCase
+from django.urls import reverse
+from rest_framework import status
+from users.models import ObjectPermission
+from utilities.permissions import resolve_permission_type
+
+from netbox_diode_plugin.models import Setting
+from netbox_diode_plugin.views import SettingsEditView, SettingsView
+
+User = get_user_model()
+
+
+class TestCase(_TestCase):
+    """Base test case class for NetBox Diode plugin tests."""
+
+    def add_permissions(self, user, *names):
+        """Assign a set of permissions to the test user. Accepts permission names in the form <app>.<action>_<model>."""
+        for name in names:
+            object_type, action = resolve_permission_type(name)
+            obj_perm = ObjectPermission(name=name, actions=[action])
+            obj_perm.save()
+            obj_perm.users.add(user)
+            obj_perm.object_types.add(object_type)
+
+
+class SettingsViewTestCase(TestCase):
+    """Test case for the SettingsView."""
+
+    def setUp(self):
+        """Setup the test case."""
+        self.path = reverse("plugins:netbox_diode_plugin:settings")
+        self.request = RequestFactory().get(self.path)
+        self.view = SettingsView()
+        self.view.setup(self.request)
+
+    def test_returns_200_for_authenticated(self):
+        """Test that the view returns 200 for an authenticated user."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        response = self.view.get(self.request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_redirects_to_login_page_for_unauthenticated_user(self):
+        """Test that the view returns 200 for an authenticated user."""
+        self.request.user = AnonymousUser()
+        self.view.setup(self.request)
+
+        response = SettingsView.as_view()(self.request)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, f"/netbox/login/?next={self.path}")
+
+    def test_settings_created_if_not_found(self):
+        """Test that the settings are created with placeholder data if not found."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        with mock.patch("netbox_diode_plugin.models.Setting.objects.get") as mock_get:
+            mock_get.side_effect = Setting.DoesNotExist
+
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpc://localhost:8080/diode", str(response.content))
+
+
+    def test_settings_display_with_diode_target_display(self):
+        """Test that diode_target_display overrides the displayed target."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        def mock_get_plugin_config(plugin, key):
+            if key == "diode_target_display":
+                return "grpcs://external.example.com/diode"
+            if key == "diode_target_override":
+                return None
+            if key == "diode_target":
+                return "grpc://localhost:8080/diode"
+            return None
+
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config",
+            side_effect=mock_get_plugin_config,
+        ):
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpcs://external.example.com/diode", str(response.content))
+            self.assertNotIn("grpc://localhost:8080/diode", str(response.content))
+
+    def test_diode_target_display_takes_precedence_over_override(self):
+        """Test that diode_target_display takes precedence over diode_target_override for display."""
+        self.request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(self.request.user, "netbox_diode_plugin.view_setting")
+
+        def mock_get_plugin_config(plugin, key):
+            if key == "diode_target_display":
+                return "grpcs://external.example.com/diode"
+            if key == "diode_target_override":
+                return "grpc://internal-override:8080/diode"
+            if key == "diode_target":
+                return "grpc://localhost:8080/diode"
+            return None
+
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config",
+            side_effect=mock_get_plugin_config,
+        ):
+            response = self.view.get(self.request)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn("grpcs://external.example.com/diode", str(response.content))
+            self.assertNotIn("grpc://internal-override:8080/diode", str(response.content))
+
+
+class SettingsEditViewTestCase(TestCase):
+    """Test case for the SettingsEditView."""
+
+    def setUp(self):
+        """Setup the test case."""
+        self.path = reverse("plugins:netbox_diode_plugin:settings_edit")
+        self.request_factory = RequestFactory()
+        self.view = SettingsEditView()
+
+    def test_returns_200_for_authenticated(self):
+        """Test that the view returns 200 for an authenticated user."""
+        request = self.request_factory.get(self.path)
+        request.user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(request.user, "netbox_diode_plugin.view_setting", "netbox_diode_plugin.change_setting")
+        request.htmx = None
+        self.view.setup(request)
+
+        response = self.view.get(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_redirects_to_login_page_for_unauthenticated_user(self):
+        """Test that the view redirects an authenticated user to login page."""
+        request = self.request_factory.get(self.path)
+        request.user = AnonymousUser()
+        self.view.setup(request)
+
+        response = self.view.get(request)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, f"/netbox/login/?next={self.path}")
+
+    def test_settings_updated(self):
+        """Test that the settings are updated."""
+        user = User.objects.create_user("foo", password="pass")
+        self.add_permissions(user, "netbox_diode_plugin.view_setting", "netbox_diode_plugin.change_setting")
+
+        request = self.request_factory.get(self.path)
+        request.user = user
+        request.htmx = None
+        self.view.setup(request)
+
+        response = self.view.get(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("grpc://localhost:8080/diode", str(response.content))
+
+        request = self.request_factory.post(self.path)
+        request.user = user
+        request.htmx = None
+        request.POST = {"diode_target": "grpc://localhost:8090/diode"}
+
+        middleware = SessionMiddleware(get_response=lambda request: None)
+        middleware.process_request(request)
+        request.session.save()
+
+        middleware = MessageMiddleware(get_response=lambda request: None)
+        middleware.process_request(request)
+        request.session.save()
+
+        response = self.view.post(request)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, reverse("plugins:netbox_diode_plugin:settings"))
+
+        request = self.request_factory.get(self.path)
+        request.user = user
+        request.htmx = None
+        self.view.setup(request)
+
+        response = self.view.get(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("grpc://localhost:8090/diode", str(response.content))
+
+    def test_settings_update_post_redirects_to_login_page_for_unauthenticated_user(
+        self,
+    ):
+        """Test that the view redirects an authenticated user to login page."""
+        request = self.request_factory.post(self.path)
+        request.user = AnonymousUser()
+        request.htmx = None
+        request.POST = {"diode_target": "grpc://localhost:8090/diode"}
+
+        response = self.view.post(request)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, f"/netbox/login/?next={self.path}")
+
+    def test_settings_update_allowed_on_get_method_with_override(self):
+        """Test that accessing settings edit shows info message when diode target is overridden."""
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config"
+        ) as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
+
+            user = User.objects.create_user("foo", password="pass")
+            self.add_permissions(
+                user,
+                "netbox_diode_plugin.view_setting",
+                "netbox_diode_plugin.add_setting",
+                "netbox_diode_plugin.change_setting",
+            )
+
+            request = self.request_factory.get(self.path)
+            request.user = user
+            request.htmx = None
+
+            middleware = SessionMiddleware(get_response=lambda request: None)
+            middleware.process_request(request)
+            request.session.save()
+
+            middleware = MessageMiddleware(get_response=lambda request: None)
+            middleware.process_request(request)
+            request.session.save()
+
+            self.view.setup(request)
+            response = self.view.get(request)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            # Check that the message was added
+            storage = messages.get_messages(request)
+            message_list = list(storage)
+            self.assertEqual(len(message_list), 1)
+            self.assertEqual(
+                str(message_list[0]),
+                "The Diode target field is disabled because it is overridden in the plugin configuration.",
+            )
+
+    def test_settings_update_allowed_on_post_method_with_override(self):
+        """Test that updating settings succeeds when diode target is overridden (field is disabled in form)."""
+        with mock.patch(
+            "netbox_diode_plugin.views.get_plugin_config"
+        ) as mock_get_plugin_config:
+            mock_get_plugin_config.return_value = "grpc://localhost:8080/diode"
+
+            user = User.objects.create_user("foo", password="pass")
+            self.add_permissions(
+                user,
+                "netbox_diode_plugin.view_setting",
+                "netbox_diode_plugin.add_setting",
+                "netbox_diode_plugin.change_setting",
+            )
+
+            request = self.request_factory.post(self.path)
+            request.user = user
+            request.htmx = None
+            request.POST = {"diode_target": "grpc://localhost:8090/diode"}
+
+            middleware = SessionMiddleware(get_response=lambda request: None)
+            middleware.process_request(request)
+            request.session.save()
+
+            middleware = MessageMiddleware(get_response=lambda request: None)
+            middleware.process_request(request)
+            request.session.save()
+
+            setattr(request, "session", "session")
+            messages = FallbackStorage(request)
+            request._messages = messages
+
+            self.view.setup(request)
+            response = self.view.post(request)
+
+            # Should succeed and redirect to settings view
+            self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+            self.assertEqual(
+                response.url, reverse("plugins:netbox_diode_plugin:settings")
+            )

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_virtualchassis_ingest.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_virtualchassis_ingest.py
@@ -1,0 +1,2938 @@
+"""E2E: VirtualChassis natural-shape ingest, convergence, and regressions."""
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from core.models import ObjectChange
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site, VirtualChassis
+from django.test import SimpleTestCase
+from utilities.testing import APITestCase
+
+from netbox_diode_plugin.api import matcher
+from netbox_diode_plugin.api.applier import _coerce_pk
+from netbox_diode_plugin.api.authentication import DiodeOAuth2Authentication
+from netbox_diode_plugin.api.matcher import _PRE_SAVE_MATCH_BIND_ONLY
+from netbox_diode_plugin.api.transformer import _IS_CIRCULAR_REFERENCE
+from netbox_diode_plugin.plugin_config import get_diode_user
+
+
+class VirtualChassisIngestE2ETests(APITestCase):
+    """Natural VC shapes must converge to one VC with master and members."""
+
+    def setUp(self):
+        """Mock OAuth2 introspection so the Diode API endpoints accept requests."""
+        super().setUp()
+        self.diff_url = "/netbox/api/plugins/diode/generate-diff/"
+        self.apply_url = "/netbox/api/plugins/diode/apply-change-set/"
+        self.bulk_plan_apply_url = "/netbox/api/plugins/diode/bulk-plan-apply/"
+        self.auth = {"HTTP_AUTHORIZATION": "Bearer mocked_oauth_token"}
+        diode_user = SimpleNamespace(
+            user=get_diode_user(),
+            token_scopes=["netbox:read", "netbox:write"],
+            token_data={"scope": "netbox:read netbox:write"},
+        )
+        p = mock.patch.object(
+            DiodeOAuth2Authentication, "_introspect_token", return_value=diode_user
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+        self.site = Site.objects.create(name="vce-site", slug="vce-site")
+        mfr = Manufacturer.objects.create(name="vce-mfr", slug="vce-mfr")
+        self.dt = DeviceType.objects.create(manufacturer=mfr, model="vce-dt", slug="vce-dt")
+        self.role = DeviceRole.objects.create(name="vce-role", slug="vce-role")
+
+    # ---- payload builders -------------------------------------------------
+
+    def _device_payload(self, name, extra=None, asset_tag=None):
+        entity = {
+            "name": name,
+            "site": {"name": "vce-site"},
+            "role": {"name": "vce-role"},
+            "device_type": {"manufacturer": {"name": "vce-mfr"}, "model": "vce-dt"},
+        }
+        if asset_tag:
+            entity["asset_tag"] = asset_tag
+        entity.update(extra or {})
+        return {"timestamp": 1, "object_type": "dcim.device", "entity": {"device": entity}}
+
+    def _vc_payload(self, name, master_name, domain=None):
+        vc = {
+            "name": name,
+            "master": {"name": master_name, "site": {"name": "vce-site"}},
+        }
+        if domain is not None:
+            vc["domain"] = domain
+        return {"timestamp": 1, "object_type": "dcim.virtualchassis",
+                "entity": {"virtual_chassis": vc}}
+
+    def _seed_named_stack(self, vc_name, domain, members):
+        """
+        ORM-seed a converged stack: ``members`` is {device_name: position}, first is master.
+
+        Two of these with the SAME name and different domains are the review's
+        scenario: two legitimately distinct stacks that a name cannot tell apart.
+        """
+        devices = {}
+        vc = VirtualChassis.objects.create(name=vc_name, domain=domain)
+        for name, position in members.items():
+            d = Device.objects.create(
+                name=name, site=self.site, device_type=self.dt, role=self.role
+            )
+            Device.objects.filter(pk=d.pk).update(virtual_chassis=vc, vc_position=position)
+            devices[name] = d
+        vc.refresh_from_db()
+        vc.master = devices[next(iter(members))]
+        vc.save()
+        return vc, devices
+
+    def _diff(self, payload):
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        return r.json().get("change_set", {})
+
+    def _diff_apply(self, payload, allow_empty=False):
+        cs = self._diff(payload)
+        if allow_empty and not cs.get("changes"):
+            # Already fully converged: generate-diff legitimately returns an
+            # empty changes list (this codebase's established idempotency
+            # signal, see test_updates.py's post-create re-diff assertion),
+            # and apply-change-set intentionally 400s on an empty changeset
+            # (applier._validate_change_set: "Changes are required"). A real
+            # reconciler client would not call apply here either -- skip it.
+            return cs
+        self.assertTrue(cs.get("changes"), cs)
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+        return cs
+
+    def _assert_noop_rediff(self, payload):
+        cs = self._diff(payload)
+        non_noop = [c for c in cs.get("changes", []) if c["change_type"] != "noop"]
+        self.assertEqual(non_noop, [], non_noop)
+
+    def _assert_split_vc(self, name, master_name, mastered_members, orphan_members):
+        """
+        Two same-named rows: the one this payload made, and the one it declined.
+
+        A populated row matched on the name alone is not adopted, so a
+        member-first pass leaves the member's masterless row where it is and the
+        master-bearing pass gets its own. Both halves are asserted, because the
+        property that makes the split shippable is that NOTHING MOVED: the row
+        the payload did not identify has to be byte-identical afterwards.
+        """
+        rows = VirtualChassis.objects.filter(name=name)
+        self.assertEqual(rows.count(), 2, list(rows.values_list("pk", "master_id")))
+        mastered = rows.exclude(master__isnull=True)
+        self.assertEqual(mastered.count(), 1, "no row ended up mastered")
+        mastered = mastered.first()
+        self.assertEqual(mastered.master.name, master_name)
+        self.assertEqual(
+            dict(mastered.members.values_list("name", "vc_position")), mastered_members)
+        orphan = rows.filter(master__isnull=True).first()
+        self.assertIsNone(orphan.master_id, "the declined row acquired a master")
+        self.assertEqual(
+            dict(orphan.members.values_list("name", "vc_position")), orphan_members,
+            "the declined row's membership changed")
+        return mastered, orphan
+
+    def _assert_single_vc(self, name, master_name=None, members=None):
+        vcs = VirtualChassis.objects.filter(name=name)
+        self.assertEqual(vcs.count(), 1)
+        vc = vcs.first()
+        if master_name is not None:
+            self.assertIsNotNone(vc.master, "master not set")
+            self.assertEqual(vc.master.name, master_name)
+        if members:
+            self.assertEqual(vc.members.count(), len(members), members)
+        for member_name, position in (members or {}).items():
+            d = Device.objects.get(name=member_name)
+            self.assertEqual(d.virtual_chassis_id, vc.pk, member_name)
+            self.assertEqual(d.vc_position, position, member_name)
+        return vc
+
+    # ---- scenarios --------------------------------------------------------
+
+    def _seed_stack(self, vc_name="vce-stack", master="vce-sw1", position=1):
+        """ORM-seed a converged one-member stack (master at position)."""
+        dev = Device.objects.create(
+            name=master, site=self.site, device_type=self.dt, role=self.role
+        )
+        vc = VirtualChassis.objects.create(name=vc_name, master=dev)
+        Device.objects.filter(pk=dev.pk).update(virtual_chassis=vc, vc_position=position)
+        return vc, dev
+
+    def test_member_reingest_name_only_binds_existing_vc(self):
+        """The silent-duplicate generator: name-only VC ref must not duplicate."""
+        vc, _ = self._seed_stack()
+        payload = self._device_payload("vce-sw2", {
+            "vc_position": 2, "virtual_chassis": {"name": "vce-stack"},
+        })
+        self._diff_apply(payload)
+        self._assert_single_vc("vce-stack", master_name="vce-sw1",
+                               members={"vce-sw2": 2, "vce-sw1": 1})
+        self._assert_noop_rediff(payload)
+
+    def test_master_reingest_natural_shape_idempotent(self):
+        """A master carrying its own VC ref: no cycle, no detach error."""
+        self._seed_stack()
+        payload = self._device_payload("vce-sw1", {
+            "vc_position": 1,
+            "virtual_chassis": {
+                "name": "vce-stack",
+                "master": {"name": "vce-sw1", "site": {"name": "vce-site"}},
+            },
+        })
+        cs = self._diff_apply(payload, allow_empty=True)
+        self.assertEqual(cs.get("changes"), [], cs)
+        self._assert_single_vc("vce-stack", master_name="vce-sw1", members={"vce-sw1": 1})
+        self._assert_noop_rediff(payload)
+
+    def test_fresh_stack_single_batch_master_position_and_priority(self):
+        """First ingest of a natural master with position != 1 and priority."""
+        payload = self._device_payload("vce-sw1", {
+            "vc_position": 3, "vc_priority": 128,
+            "virtual_chassis": {
+                "name": "vce-stack",
+                "master": {"name": "vce-sw1", "site": {"name": "vce-site"}},
+            },
+        })
+        self._diff_apply(payload)
+        vc = self._assert_single_vc("vce-stack", master_name="vce-sw1", members={"vce-sw1": 3})
+        self.assertEqual(vc.master.vc_priority, 128)
+        self._assert_noop_rediff(payload)
+
+    def test_natural_shape_leaves_member_count_equal_to_actual_members(self):
+        """
+        The counter must not be double-incremented by the deferred device update.
+
+        This is the PR's headline shape and it plans three changes: create the
+        device (ref R), create the chassis mastered by R, then update R with its
+        position. Between changes two and three NetBox's own
+        dcim.signals.assign_virtualchassis_master has already written
+        virtual_chassis onto the device ROW -- through a different Python object
+        -- and utilities.counters has already counted that membership.
+
+        Applying change three to the instance the CREATE returned therefore
+        replays the assignment from a stale baseline:
+        utilities.counters.post_save_receiver reads TrackingModelMixin's
+        tracker, sees virtual_chassis_id go None -> chassis, and increments
+        VirtualChassis.member_count a second time for the one membership that
+        exists. member_count is not a field ingest diffs, so the re-diff below
+        is empty and nothing ever repairs it -- the stored count stays one
+        above the truth for the life of the row.
+
+        The two assertions are deliberately paired: member_count on its own
+        would also be satisfied by a chassis that ended up with two members.
+        """
+        payload = self._device_payload("vce-sw1", {
+            "vc_position": 3, "vc_priority": 128,
+            "virtual_chassis": {
+                "name": "vce-stack",
+                "master": {"name": "vce-sw1", "site": {"name": "vce-site"}},
+            },
+        })
+        cs = self._diff_apply(payload)
+
+        # Pin the shape: the third change is an UPDATE addressed by ref_id, so
+        # it is the branch that reuses the CREATE's in-memory instance.
+        deferred = [c for c in cs["changes"]
+                    if c["object_type"] == "dcim.device" and c["change_type"] == "update"]
+        self.assertEqual(len(deferred), 1, cs)
+        self.assertIsNone(deferred[0]["object_id"], deferred[0])
+        self.assertIsNotNone(deferred[0]["ref_id"], deferred[0])
+
+        vc = self._assert_single_vc("vce-stack", master_name="vce-sw1",
+                                   members={"vce-sw1": 3})
+        self.assertEqual(vc.members.count(), 1)
+        self.assertEqual(vc.member_count, 1, "stored member_count diverged from reality")
+
+        # ...and it never self-heals, so the divergence would be permanent.
+        self._assert_noop_rediff(payload)
+        self.assertEqual(VirtualChassis.objects.get(pk=vc.pk).member_count, 1)
+
+        # Re-reading the row must not change what the deferred update records.
+        # A fresh read makes a prechange snapshot cheap to take, and taking one
+        # would alter the changelog in two ways at once -- adding
+        # prechange_data, and (through NetBox's ObjectChange.has_changes gate)
+        # deciding whether the row is recorded at all. Neither belongs in a
+        # counter fix, so the shipped behaviour is the one from before the
+        # re-read: an 'update' row, with no prechange.
+        # test_module_adoption pins the same branch on the shape where that
+        # gate actually drops the row.
+        dev = Device.objects.get(name="vce-sw1")
+        dev_change = ObjectChange.objects.filter(
+            changed_object_type__app_label="dcim",
+            changed_object_type__model="device",
+            changed_object_id=dev.pk,
+        ).order_by("pk").last()
+        self.assertIsNotNone(dev_change, "the deferred update recorded no change at all")
+        self.assertEqual(dev_change.action, "update", dev_change)
+        self.assertIsNone(dev_change.prechange_data, dev_change)
+        self.assertEqual(
+            dev_change.postchange_data.get("virtual_chassis"), vc.pk,
+            dev_change.postchange_data,
+        )
+
+    def test_custom_position_on_preexisting_master_device(self):
+        """The signal-clobber case: pre-existing device, position must survive ingest 1."""
+        Device.objects.create(name="vce-sw1", site=self.site, device_type=self.dt, role=self.role)
+        payload = self._device_payload("vce-sw1", {
+            "vc_position": 2, "vc_priority": 255,
+            "virtual_chassis": {
+                "name": "vce-stack",
+                "master": {"name": "vce-sw1", "site": {"name": "vce-site"}},
+            },
+        })
+        self._diff_apply(payload)
+        dev = Device.objects.get(name="vce-sw1")
+        self.assertEqual(dev.vc_position, 2)   # NOT the signal's forced 1
+        self.assertEqual(dev.vc_priority, 255)
+        self._assert_noop_rediff(payload)
+
+    def test_chassis_move_into_position_taken_in_the_old_chassis(self):
+        """
+        A legal cross-chassis move whose target position is taken in the OLD chassis.
+
+        vce-sw2 sits at position 2 of vce-stack-a, where position 3 belongs to
+        vce-sw3; the payload promotes it to master of vce-stack-b at position
+        3, which is free there. The position must travel WITH the chassis:
+        asserting vc_position=3 on the device while it is still a member of
+        vce-stack-a trips NetBox's (virtual_chassis, vc_position) uniqueness
+        constraint -- "Device with this Virtual chassis and VC position
+        already exists" -- and rejects a valid move.
+
+        Naming the moving device as the new chassis's master is what makes the
+        reproduction deterministic: it forces the VirtualChassis change to
+        sort after the device change, so _handle_post_creates cannot merge the
+        deferred step back into the device change (which would reunite chassis
+        and position and mask the bug).
+        """
+        vc_a, _ = self._seed_stack(vc_name="vce-stack-a", master="vce-sw1")
+        for name, position in (("vce-sw2", 2), ("vce-sw3", 3)):
+            d = Device.objects.create(
+                name=name, site=self.site, device_type=self.dt, role=self.role
+            )
+            Device.objects.filter(pk=d.pk).update(virtual_chassis=vc_a, vc_position=position)
+
+        payload = self._device_payload("vce-sw2", {
+            "vc_position": 3,
+            "virtual_chassis": {
+                "name": "vce-stack-b",
+                "master": {"name": "vce-sw2", "site": {"name": "vce-site"}},
+            },
+        })
+        self._diff_apply(payload)
+
+        self._assert_single_vc("vce-stack-b", master_name="vce-sw2", members={"vce-sw2": 3})
+        # the old chassis keeps its own occupant of that position
+        stayed = Device.objects.get(name="vce-sw3")
+        self.assertEqual(stayed.virtual_chassis_id, vc_a.pk)
+        self.assertEqual(stayed.vc_position, 3)
+        self._assert_noop_rediff(payload)
+
+    def test_inline_master_position_rides_only_on_the_deferred_update(self):
+        """
+        Pin the split: the main device change carries no position, the deferred one does.
+
+        NetBox's assign_virtualchassis_master signal forces the inline
+        master's vc_position to 1 when the VirtualChassis row is created, so
+        the submitted position can only survive on the deferred update that
+        runs after it. A second copy on the main change buys nothing here (the
+        signal overwrites it) and is exactly what rejects a cross-chassis
+        move, so the position must appear on the deferred change ONLY.
+        """
+        payload = self._device_payload("vce-sw1", {
+            "vc_position": 3, "vc_priority": 128,
+            "virtual_chassis": {
+                "name": "vce-stack",
+                "master": {"name": "vce-sw1", "site": {"name": "vce-site"}},
+            },
+        })
+        cs = self._diff(payload)
+        device_changes = [c for c in cs.get("changes", []) if c["object_type"] == "dcim.device"]
+        creates = [c for c in device_changes if c["change_type"] == "create"]
+        deferred = [c for c in device_changes if c["change_type"] == "update"]
+        self.assertEqual(len(creates), 1, cs)
+        self.assertEqual(len(deferred), 1, cs)
+        self.assertNotIn("vc_position", creates[0]["data"], creates[0])
+        self.assertNotIn("vc_priority", creates[0]["data"], creates[0])
+        self.assertIn("virtual_chassis", deferred[0]["data"], deferred[0])
+        self.assertEqual(deferred[0]["data"]["vc_position"], 3, deferred[0])
+        self.assertEqual(deferred[0]["data"]["vc_priority"], 128, deferred[0])
+
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+        dev = Device.objects.get(name="vce-sw1")
+        self.assertEqual(dev.vc_position, 3)   # NOT the signal's forced 1
+        self.assertEqual(dev.vc_priority, 128)
+        self._assert_noop_rediff(payload)
+
+    def test_master_rename_via_asset_tag_natural_shape(self):
+        """Master renamed while matched by asset_tag; natural shape must converge."""
+        vc, dev = self._seed_stack()
+        Device.objects.filter(pk=dev.pk).update(asset_tag="vce-at-1")
+        payload = self._device_payload("vce-sw1-renamed", {
+            "vc_position": 1,
+            "virtual_chassis": {"name": "vce-stack"},
+        }, asset_tag="vce-at-1")
+        self._diff_apply(payload)
+        self._assert_single_vc("vce-stack", master_name="vce-sw1-renamed",
+                               members={"vce-sw1-renamed": 1})
+        self._assert_noop_rediff(payload)
+
+    def test_duplicate_field_state_member_keeps_the_chassis_it_is_in(self):
+        """
+        Bug aftermath: the member sits in a duplicate, and ingest must NOT move it.
+
+        THE OLD EXPECTATION HERE WAS UNSAFE and this test used to assert it:
+        "vce-sw2 migrates back to the oldest same-named chassis". It passed
+        because the name matcher resolved a name-only reference with
+        order_by('pk').first(), so a name that matches two rows always chose the
+        older one -- and since this reference is a MEMBER DEVICE's
+        virtual_chassis, choosing meant RELOCATING that device. Determinism is
+        not identity: run the same shape with two legitimately distinct stacks
+        sharing a name (see the ambiguity tests below) and the identical rule
+        moves a device into another building's stack.
+
+        The rule now is "prefer the chassis this device already belongs to",
+        which is the one preference the database itself answers, so nothing
+        moves and the second pass plans nothing at all. Recovering from
+        duplicates is still possible where the evidence is real -- see
+        test_empty_duplicate_loses_to_the_populated_chassis, where the member is
+        NOT already placed -- but a name is not evidence enough to move a device
+        that is.
+        """
+        vc_old, master = self._seed_stack()
+        vc_dup = VirtualChassis.objects.create(name="vce-stack")
+        member = Device.objects.create(
+            name="vce-sw2", site=self.site, device_type=self.dt, role=self.role
+        )
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=vc_dup, vc_position=2)
+
+        payload = self._device_payload("vce-sw2", {
+            "vc_position": 2, "virtual_chassis": {"name": "vce-stack"},
+        })
+        # Fully converged already: the device is where the payload says it is.
+        self.assertEqual(self._diff(payload).get("changes"), [])
+        member.refresh_from_db()
+        self.assertEqual(member.virtual_chassis_id, vc_dup.pk, "the member was relocated")
+        self.assertEqual(member.vc_position, 2)
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-stack").count(), 2)
+        self._assert_noop_rediff(payload)
+
+    def test_empty_duplicate_loses_to_the_populated_chassis(self):
+        """
+        Recovery that IS safe: an empty same-named row is not a stack anyone owns.
+
+        A bug-created duplicate is empty and masterless; the real chassis has a
+        master and members. A new member's name-only reference resolves to the
+        real one -- not because it is older (it is, and that is irrelevant: the
+        assertions below hold for the POPULATED row whichever order the rows
+        were created in) but because exactly one candidate is a stack at all.
+        No device is moved: vce-sw2 is not in either row to begin with.
+        """
+        vc_dup = VirtualChassis.objects.create(name="vce-stack")  # created FIRST, empty
+        vc_real, master = self._seed_stack()                      # newer, populated
+        self.assertLess(vc_dup.pk, vc_real.pk, "the empty duplicate must be the older row")
+
+        payload = self._device_payload("vce-sw2", {
+            "vc_position": 2, "virtual_chassis": {"name": "vce-stack"},
+        })
+        self._diff_apply(payload)
+        member = Device.objects.get(name="vce-sw2")
+        self.assertEqual(member.virtual_chassis_id, vc_real.pk)
+        self.assertEqual(vc_dup.members.count(), 0)
+        self._assert_noop_rediff(payload)
+
+    def test_two_same_named_stacks_make_a_member_reference_ambiguous(self):
+        """
+        The review's scenario, and the failure mode this whole policy exists for.
+
+        Two legitimately distinct stacks are both called "vce-shared": one in
+        building-a with vce-a1/vce-a2, one in building-b with vce-b1/vce-b2.
+        Ingesting a new member vce-b3 whose virtual_chassis reference carries
+        the name and nothing else USED to bind the older row and place vce-b3
+        into the building-A stack -- silently, with no later diff mentioning it.
+
+        It must now fail, at PLAN time, with an error that names both rows and
+        says what would resolve them. Failing at plan is what makes it a
+        deviation the producer sees rather than a write it has to detect
+        afterwards.
+        """
+        vc_a, _ = self._seed_named_stack(
+            "vce-shared", "building-a", {"vce-a1": 1, "vce-a2": 2})
+        vc_b, _ = self._seed_named_stack(
+            "vce-shared", "building-b", {"vce-b1": 1, "vce-b2": 2})
+        self.assertLess(vc_a.pk, vc_b.pk)
+
+        r = self.client.post(
+            self.diff_url,
+            data=self._device_payload("vce-b3", {
+                "vc_position": 3, "virtual_chassis": {"name": "vce-shared"},
+            }),
+            format="json", **self.auth,
+        )
+        self.assertEqual(r.status_code, 400, r.content)
+        error = r.json()["errors"]["dcim.virtualchassis"]["name"][0]
+        self.assertIn("vce-shared", error)
+        self.assertIn(f"id {vc_a.pk}", error)
+        self.assertIn(f"id {vc_b.pk}", error)
+        # The message names domain, but only as what it is for a payload that
+        # asserts none: half of a two-part fix (the producer sends it, the row
+        # carries it). These two rows already carry different domains, so
+        # labelling alone cannot resolve this -- see
+        # test_the_remedy_the_refusal_names_actually_resolves_it.
+        self.assertIn("domain", error)
+        self.assertIn("labelling these rows cannot settle it on its own", error)
+
+        # nothing planned means nothing applied: no device, no membership change
+        self.assertFalse(Device.objects.filter(name="vce-b3").exists())
+        self.assertEqual(vc_a.members.count(), 2)
+        self.assertEqual(vc_b.members.count(), 2)
+
+    def test_domain_resolves_a_reference_two_stacks_would_otherwise_share(self):
+        """
+        The discriminator does the work the name cannot: vce-b3 lands in building-b.
+
+        Same two stacks as above. The only difference is that the member's
+        virtual_chassis reference carries domain, which is a claim about WHICH
+        row rather than a guess between rows -- so it resolves, and it resolves
+        to the row the producer named, not the older one.
+        """
+        vc_a, _ = self._seed_named_stack(
+            "vce-shared", "building-a", {"vce-a1": 1, "vce-a2": 2})
+        vc_b, _ = self._seed_named_stack(
+            "vce-shared", "building-b", {"vce-b1": 1, "vce-b2": 2})
+
+        payload = self._device_payload("vce-b3", {
+            "vc_position": 3,
+            "virtual_chassis": {"name": "vce-shared", "domain": "building-b"},
+        })
+        self._diff_apply(payload)
+
+        member = Device.objects.get(name="vce-b3")
+        self.assertEqual(member.virtual_chassis_id, vc_b.pk)
+        self.assertEqual(member.vc_position, 3)
+        self.assertEqual(vc_a.members.count(), 2, "the building-A stack was touched")
+        vc_a.refresh_from_db()
+        self.assertEqual(vc_a.domain, "building-a", "the building-A domain was overwritten")
+        self._assert_noop_rediff(payload)
+
+    def test_an_existing_member_keeps_its_own_stack_when_the_name_is_shared(self):
+        """
+        The member's own membership outranks everything, including the older row.
+
+        vce-b3 is already in the building-B stack, which is the NEWER of the two
+        same-named rows. A name-only reference must resolve to the chassis it is
+        in -- the previous policy resolved to the older row and MOVED it, which
+        is the same defect as the ambiguity above wearing a converged disguise:
+        it looks idempotent and is a relocation.
+        """
+        vc_a, _ = self._seed_named_stack(
+            "vce-shared", "building-a", {"vce-a1": 1, "vce-a2": 2})
+        vc_b, _ = self._seed_named_stack(
+            "vce-shared", "building-b", {"vce-b1": 1, "vce-b2": 2})
+        member = Device.objects.create(
+            name="vce-b3", site=self.site, device_type=self.dt, role=self.role
+        )
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=vc_b, vc_position=3)
+
+        payload = self._device_payload("vce-b3", {
+            "vc_position": 3, "virtual_chassis": {"name": "vce-shared"},
+        })
+        self.assertEqual(self._diff(payload).get("changes"), [])
+        member.refresh_from_db()
+        self.assertEqual(member.virtual_chassis_id, vc_b.pk)
+        self.assertEqual(vc_a.members.count(), 2)
+
+    def test_workaround_shape_still_resolves(self):
+        """Orb's shipped shape: plain master, top-level VC, member with inline VC."""
+        self._diff_apply(self._device_payload("vce-sw1"))
+        self._diff_apply(self._vc_payload("vce-stack", "vce-sw1"))
+        payload = self._device_payload("vce-sw2", {
+            "vc_position": 2,
+            "virtual_chassis": {
+                "name": "vce-stack",
+                "master": {"name": "vce-sw1", "site": {"name": "vce-site"}},
+            },
+        })
+        self._diff_apply(payload)
+        self._assert_single_vc("vce-stack", master_name="vce-sw1",
+                               members={"vce-sw1": 1, "vce-sw2": 2})
+        self._assert_noop_rediff(payload)
+
+    def test_vc_detach_member_clears_and_master_deviates(self):
+        """
+        virtual_chassis: {} detaches a member; a master detach is a deviation.
+
+        Empirically probed: generate-diff happily
+        plans the master's virtual_chassis: null UPDATE -- NetBox's
+        Device.clean() master-detach guard only runs at save() time, so
+        the rejection surfaces as a per-entity APPLY error, not at plan.
+        """
+        vc, master = self._seed_stack()
+        member = Device.objects.create(
+            name="vce-sw2", site=self.site, device_type=self.dt, role=self.role
+        )
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=vc, vc_position=2)
+
+        cs = self._diff(self._device_payload("vce-sw2", {"virtual_chassis": {}}))
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        member.refresh_from_db()
+        self.assertIsNone(member.virtual_chassis_id)
+
+        # Plan-time: NetBox validation for master-detach only runs at save(),
+        # so generate-diff succeeds and plans a plain UPDATE.
+        cs2 = self._diff(self._device_payload("vce-sw1", {"virtual_chassis": {}}))
+        device_changes = [c for c in cs2.get("changes", []) if c["object_type"] == "dcim.device"]
+        self.assertTrue(device_changes, cs2)
+        self.assertEqual(device_changes[0]["change_type"], "update")
+
+        # Apply-time: NetBox's Device.clean() rejects the master detach as a
+        # per-entity error.
+        r2 = self.client.post(self.apply_url, data=cs2, format="json", **self.auth)
+        self.assertEqual(r2.status_code, 400, r2.content)
+        self.assertIn("virtual chassis", str(r2.json()).lower())
+        master.refresh_from_db()
+        self.assertEqual(master.virtual_chassis_id, vc.pk)  # rejected apply leaves DB untouched
+
+    def test_positionless_member_yields_position_deviation(self):
+        """
+        A VC ref without vc_position surfaces a position error at APPLY, not a 500.
+
+        Plan-time validate runs clean_fields only; Device.clean's
+        position-required rule fires in the serializer during apply.
+        Empirically confirmed at APPLY.
+        """
+        self._seed_stack()
+        cs = self._diff(self._device_payload("vce-sw3", {"virtual_chassis": {"name": "vce-stack"}}))
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        body = str(r.json())
+        self.assertIn("position", body.lower(), body)
+        self.assertFalse(Device.objects.filter(name="vce-sw3").exists())
+
+    def test_fresh_stack_two_requests_both_orders_are_stable(self):
+        """
+        Master-first and member-first request orders both end at ONE VC.
+
+        Member-first exercises the adoption fallback end-to-end: the member's
+        name-only ref creates a masterless VC, and the master's later
+        master-bearing node must adopt it instead of duplicating.
+        """
+        for order, (vc_name, m, s2) in {
+            "master_first": ("vce-ord1", "vce-m1", "vce-n1"),
+            "member_first": ("vce-ord2", "vce-m2", "vce-n2"),
+        }.items():
+            master_payload = self._device_payload(m, {
+                "vc_position": 1,
+                "virtual_chassis": {
+                    "name": vc_name,
+                    "master": {"name": m, "site": {"name": "vce-site"}},
+                },
+            })
+            member_payload = self._device_payload(s2, {
+                "vc_position": 2, "virtual_chassis": {"name": vc_name},
+            })
+            first, second = (
+                (master_payload, member_payload) if order == "master_first"
+                else (member_payload, master_payload)
+            )
+            self._diff_apply(first)
+            self._diff_apply(second)
+            # Both orders are fully converged by now, so this third pass
+            # legitimately plans empty: member-first no longer defers VC.master
+            # for an ingest, because adoption attaches the chassis-less master
+            # itself. It stays here as a re-ingest safety net.
+            self._diff_apply(master_payload, allow_empty=True)
+            if order == "master_first":
+                # The chassis exists before the member names it, so the
+                # member's name-only reference resolves to the one row there.
+                self._assert_single_vc(
+                    vc_name, master_name=m, members={m: 1, s2: 2})
+            else:
+                # Member-first builds the row before any master exists, so
+                # the master-bearing pass declines it and takes its own.
+                self._assert_split_vc(vc_name, master_name=m,
+                                      mastered_members={m: 1},
+                                      orphan_members={s2: 2})
+            self._assert_noop_rediff(master_payload)
+            self._assert_noop_rediff(member_payload)
+
+    def test_bulk_plan_apply_member_first_ordering_is_stable(self):
+        """
+        Member-first ordering within ONE bulk-plan-apply request.
+
+        /bulk-plan-apply/ plans-then-applies each entity in the submitted
+        order, sharing the request-scoped obj/prechange caches across
+        entities (see BulkPlanApplyView docstring in api/views.py). This
+        makes it a real single-request analogue of the two-request
+        member-first case above: entity 1 (member, name-only VC ref) applies
+        before entity 2 (master, master-bearing VC ref) is even planned.
+        """
+        vc_name, m, s2 = "vce-bulk1", "vce-bm1", "vce-bn1"
+        member_payload = self._device_payload(s2, {
+            "vc_position": 2, "virtual_chassis": {"name": vc_name},
+        })
+        master_payload = self._device_payload(m, {
+            "vc_position": 1,
+            "virtual_chassis": {
+                "name": vc_name,
+                "master": {"name": m, "site": {"name": "vce-site"}},
+            },
+        })
+        bulk_payload = {
+            "entities": [
+                {"id": "member", "object_type": "dcim.device", "entity": member_payload["entity"]},
+                {"id": "master", "object_type": "dcim.device", "entity": master_payload["entity"]},
+            ]
+        }
+        r = self.client.post(self.bulk_plan_apply_url, data=bulk_payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        results = {res["id"]: res for res in r.json()["results"]}
+        self.assertIsNone(results["member"].get("errors"), results["member"])
+        self.assertIsNone(results["master"].get("errors"), results["master"])
+
+        # The member entity creates a masterless row and the master-bearing
+        # entity declines to adopt it, so the request ends with two rows. The
+        # decline does not care that both entities arrived together: sharing the
+        # request-scoped caches does not make a populated row identifiable.
+        rows = VirtualChassis.objects.filter(name=vc_name)
+        self.assertEqual(rows.count(), 2, list(rows.values_list("pk", "master_id")))
+
+        # Pin the bulk request's own outcome: each device sits in the row its
+        # OWN entity produced, before any follow-up re-ingest happens.
+        orphan = rows.filter(master__isnull=True).get()
+        mastered = rows.exclude(master__isnull=True).get()
+        self.assertEqual(Device.objects.get(name=s2).virtual_chassis_id, orphan.pk)
+        self.assertEqual(mastered.master.name, m)
+        self._diff_apply(master_payload, allow_empty=True)
+        self._assert_split_vc(vc_name, master_name=m,
+                              mastered_members={m: 1}, orphan_members={s2: 2})
+        self._assert_noop_rediff(master_payload)
+        self._assert_noop_rediff(member_payload)
+
+    def _second_producer_payload(self, domain=None):
+        """A site-B device claiming the same chassis NAME, with its own master."""
+        vc = {
+            "name": "vce-shared",
+            "master": {"name": "vce-b3", "site": {"name": "vce-site-b"}},
+        }
+        if domain is not None:
+            vc["domain"] = domain
+        return self._device_payload("vce-b3", {
+            "site": {"name": "vce-site-b"},
+            "vc_position": 3,
+            "virtual_chassis": vc,
+        })
+
+    def _seed_a_producers_member_first_stack(self):
+        """
+        Producer A ingests two members, name-only VC ref: the shape of this PR.
+
+        Leaves exactly the state the member-first convergence tests rely on -- a
+        masterless row nobody has mastered yet -- and it is the same state a
+        SECOND producer's identically named stack presents to adoption. That is
+        the point: the row cannot tell the two apart, so the guard has to.
+        """
+        Site.objects.create(name="vce-site-b", slug="vce-site-b")
+        for name, position in (("vce-a1", 1), ("vce-a2", 2)):
+            self._diff_apply(self._device_payload(name, {
+                "vc_position": position,
+                "virtual_chassis": {"name": "vce-shared"},
+            }))
+        row = VirtualChassis.objects.get(name="vce-shared")
+        self.assertIsNone(row.master_id)
+        self.assertEqual(row.members.count(), 2)
+        return row
+
+    def _assert_producer_a_row_untouched(self, row, before, extra_rows=0):
+        """
+        Producer A's row is byte-identical, and the decline left no mess.
+
+        ``extra_rows`` is how many same-named rows the declining payload created
+        for itself: 0 where the payload was not applied at all, 1 where it
+        declined the adoption and created its own. Asserted rather than left
+        open, because "declined" and "silently did nothing" look alike from
+        producer A's side and only one of them converges.
+        """
+        row.refresh_from_db()
+        self.assertIsNone(row.master_id, "the declined adoption mastered the row anyway")
+        self.assertEqual(row.members.count(), 2, "a device was moved into the row")
+        self.assertEqual(row.last_updated, before, "the declined adoption saved the row")
+        self.assertEqual(
+            VirtualChassis.objects.filter(name=row.name).count(), 1 + extra_rows)
+
+    # ---- the real producer, transcribed ------------------------------------
+
+    # The chassis-relevant entities of a real orb-agent snmp-discovery capture
+    # of a three-member Cisco 2960X stack, in the order the agent emitted them.
+    # The full run is 154 entities; the 145 interface entities, the two
+    # ip_address and two prefix entities, the master's primary_ip4 sub-tree, the
+    # platform nodes and the free-text descriptions are dropped here because
+    # none of them reaches a VirtualChassis. Everything that does is verbatim,
+    # including two details that matter: the standalone virtual_chassis entity
+    # carries a name and a master stub and NOTHING else (no domain -- orb's
+    # device_name builder emits none, at all, for any device), and vc_position
+    # arrives as a string. The device and the chassis share the name because the
+    # capture's own redaction wrote "<private>" into both.
+    _ORB_MASTER_STUB = {
+        "name": "<private>",
+        "device_type": {"manufacturer": {"name": "Cisco"}, "model": "WS-C2960X-48FPS-L"},
+        "role": {"name": "switch"},
+        "serial": "FCW1929B68S",
+        "site": {"name": "orbvc-lab"},
+    }
+
+    def _orb_capture_payloads(self):
+        """The four entities above, as ingest payloads in producer order."""
+        def device(name, model, serial, extra=None):
+            entity = {
+                "name": name,
+                "device_type": {"manufacturer": {"name": "Cisco"}, "model": model},
+                "role": {"name": "switch"},
+                "serial": serial,
+                "site": {"name": "orbvc-lab"},
+            }
+            entity.update(extra or {})
+            return {"timestamp": 1, "object_type": "dcim.device",
+                    "entity": {"device": entity}}
+
+        return [
+            device("<private>", "WS-C2960X-48FPS-L", "FCW1929B68S"),
+            {"timestamp": 1, "object_type": "dcim.virtualchassis",
+             "entity": {"virtual_chassis": {
+                 "name": "<private>", "master": dict(self._ORB_MASTER_STUB)}}},
+            device("<private>-2", "WS-C2960X-24PS-L", "FCW1931A06Z", {
+                "vc_position": "2",
+                "virtual_chassis": {
+                    "name": "<private>", "master": dict(self._ORB_MASTER_STUB)},
+            }),
+            device("<private>-3", "WS-C2960X-48FPS-L", "FCW1929B6BP", {
+                "vc_position": "3",
+                "virtual_chassis": {
+                    "name": "<private>", "master": dict(self._ORB_MASTER_STUB)},
+            }),
+        ]
+
+    def test_the_real_orb_agent_capture_gets_its_own_chassis_beside_a_same_named_row(self):
+        """
+        THE headline case, and the one that chose decline-and-create over refuse.
+
+        A masterless, populated, same-named VirtualChassis is already in NetBox
+        -- somebody else's stack, or this producer's own earlier member-first
+        pass, indistinguishable from the payload's side. The capture above is
+        then replayed in producer order. Three behaviours were measured on
+        v4.5.5 with the full 154-entity run:
+
+          - develop (08af3fb, no adoption at all): 200, the stack gets its own
+            chassis, members at 1/2/3, empty re-diff.
+          - the branch before this series: adoption took the oldest masterless
+            same-named row, so the master was hijacked into the foreign row --
+            dragged in at position 3, with the row's cached member_count left at
+            1 against 3 real members. Because that row is not the one the
+            members' own payloads resolve to, their two device entities were
+            REJECTED (400 at apply-change-set, aggregated to 207 at
+            bulk-plan-apply: "Device with this Virtual chassis and VC position
+            already exists"), on that pass and on every later one; the two
+            switches then reach NetBox only through their interface entities,
+            which create them with virtual_chassis NULL and vc_position NULL.
+            The rejection is loud and repeats; the hijack next to it is silent.
+            Measured on the full 154-entity run, whose interface entities are
+            what create those two devices at all -- the four entities
+            transcribed below would leave them absent.
+          - refusing the ambiguous adoption: 207 on every pass, forever. The
+            standalone virtual_chassis entity carries name + master and nothing
+            else, so no remedy naming a payload field is one this producer can
+            take, and the identical bytes arrive again every run.
+
+        Declining the adoption and letting the CREATE proceed reproduces
+        develop's outcome exactly, which is the point: this is a branch that
+        adds a mechanism, and the mechanism must not make the branch worse than
+        its own base on its own producer's data.
+
+        Asserted here: the payload's stack ends up in a chassis of its OWN with
+        all three members at 1/2/3, the cached member_count agrees with the real
+        one, the foreign row is byte-identical (last_updated, master, members),
+        and every entity re-diffs empty.
+        """
+        other = Site.objects.create(name="orbvc-other", slug="orbvc-other")
+        foreign = VirtualChassis.objects.create(name="<private>")
+        for name, position in (("orbvc-decoy-1", 1), ("orbvc-decoy-2", 2)):
+            d = Device.objects.create(
+                name=name, site=other, device_type=self.dt, role=self.role)
+            Device.objects.filter(pk=d.pk).update(
+                virtual_chassis=foreign, vc_position=position)
+        foreign.refresh_from_db()
+        before = foreign.last_updated
+        foreign_members = sorted(foreign.members.values_list("name", "vc_position"))
+
+        payloads = self._orb_capture_payloads()
+        for payload in payloads:
+            self._diff_apply(payload, allow_empty=True)
+
+        mine = VirtualChassis.objects.exclude(pk=foreign.pk).get(name="<private>")
+        self.assertEqual(mine.master.name, "<private>")
+        self.assertEqual(
+            sorted(mine.members.values_list("name", "vc_position")),
+            [("<private>", 1), ("<private>-2", 2), ("<private>-3", 3)],
+        )
+        self.assertEqual(mine.member_count, mine.members.count())
+        self.assertEqual(mine.member_count, 3)
+
+        foreign.refresh_from_db()
+        self.assertIsNone(foreign.master_id, "the master was hijacked into the foreign row")
+        self.assertEqual(foreign.last_updated, before, "the foreign row was written")
+        self.assertEqual(
+            sorted(foreign.members.values_list("name", "vc_position")), foreign_members)
+
+        for payload in payloads:
+            self._assert_noop_rediff(payload)
+
+    def test_the_capture_reconverges_after_an_operator_re_elects_the_master(self):
+        """
+        An operator re-elects the master in NetBox; the next ingest must find the row.
+
+        Measured on v4.5.5 and v4.4.10 with the full 154-entity capture replayed
+        through bulk-plan-apply, after ``vc.master`` was moved to the member at
+        position 2:
+
+          - without the member-holding candidate below: the standalone
+            virtual_chassis entity resolves to nothing (the name matcher is
+            gated off by its master stub, unique_master looks for a row mastered
+            by a device that no longer masters one, and the adopter only
+            considered masterless rows), so it CREATES a second chassis. The
+            three-member stack ends up split 1 + 2 across two rows and the
+            member that is still the old row's master fails forever with
+            NetBox's "Device cannot be removed from virtual chassis ... because
+            it is currently designated as its master" -- 207 on every pass.
+          - with it: 200, one row, the master restored, the members untouched.
+
+        The candidate is admitted on the strongest identity evidence there is
+        (rule 1: the requested master is ALREADY a member of that row, so
+        nothing is moved on the strength of a name) and only when the row does
+        not already carry that master -- a row that does is resolved by
+        unique_master at plan time, and a CREATE that reached the adopter for it
+        is a stale plan the create path must settle without rewriting the row
+        (test_master_already_owning_a_chassis_declines_adoption_of_a_decoy).
+
+        The find-obj lookup cache is disabled for the second pass on purpose.
+        With it warm, develop and the pre-identity branch head appear to
+        converge here -- but only because a 30-second cached pk is served for a
+        payload that no matcher resolves any more, so the apparent convergence
+        expires with the cache and orb-agent's re-run interval is longer than
+        that. The behaviour has to hold without it.
+        """
+        payloads = self._orb_capture_payloads()
+        for payload in payloads:
+            self._diff_apply(payload, allow_empty=True)
+
+        vc = VirtualChassis.objects.get(name="<private>")
+        successor = vc.members.exclude(pk=vc.master_id).order_by("vc_position").first()
+        vc.master = successor
+        vc.save()
+        self.assertEqual(vc.master.name, "<private>-2")
+
+        with mock.patch.object(matcher, "_get_find_obj_cache_ttl", return_value=0):
+            for payload in payloads:
+                self._diff_apply(payload, allow_empty=True)
+
+            self.assertEqual(VirtualChassis.objects.filter(name="<private>").count(), 1)
+            reconverged = self._assert_single_vc(
+                "<private>", master_name="<private>",
+                members={"<private>": 1, "<private>-2": 2, "<private>-3": 3},
+            )
+            self.assertEqual(reconverged.pk, vc.pk, "the stack was split into a second row")
+            self.assertEqual(reconverged.member_count, reconverged.members.count())
+
+            for payload in payloads:
+                self._assert_noop_rediff(payload)
+
+    def test_a_second_producers_member_first_stack_gets_its_own_row(self):
+        """
+        Producer B never lands in producer A's stack. This is the data-integrity line.
+
+        Producer A ingests two site-A devices member-first, leaving a masterless
+        "vce-shared" holding both. Producer B then ingests one site-B device
+        whose nested virtual_chassis carries the same name, its own master, and
+        no domain. It gets its OWN row: producer A's row keeps exactly its two
+        members and stays masterless, and nothing of B's is written into it.
+
+        This used to adopt, and what it did was the worst outcome reachable on
+        this path -- B's device joined A's stack and became its master, reported
+        200, and left no duplicate and no ambiguity for anyone to notice. The
+        licence was that this changeset plans B's membership of the chassis it
+        is creating; but that Device change names the CREATE's own reference,
+        not A's row, and adoption is the step that would redirect it, so the
+        reference could never be evidence about which row to take.
+
+        The payload is byte-for-byte the shape of a legitimate member-first
+        second pass by ONE producer (test_fresh_stack_two_requests_both_orders_
+        are_stable, member_first), which is exactly why no rule over these rows
+        can separate them: same name, masterless, populated, unlabelled either
+        way. So both now decline, and the cost lands on the honest case as a
+        duplicate rather than on the dishonest one as a silent merge. Closing it
+        properly needs identity the source owns.
+
+        What is held down here: the split CONVERGES -- the re-diff is empty, so
+        no pass re-plans -- and it is visible, two rows an operator can merge.
+        The sibling test below is the escape hatch: a domain makes producer B's
+        payload describe its own chassis and it gets one.
+        """
+        self._seed_a_producers_member_first_stack()
+
+        payload = self._second_producer_payload()
+        cs = self._diff(payload)
+        vc_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.virtualchassis"]
+        self.assertEqual([c["change_type"] for c in vc_changes], ["create"], cs)
+
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+
+        self._assert_split_vc(
+            "vce-shared", master_name="vce-b3",
+            mastered_members={"vce-b3": 3},
+            orphan_members={"vce-a1": 1, "vce-a2": 2},
+        )
+        self._assert_noop_rediff(payload)
+
+    def test_the_row_a_decline_leaves_behind_refuses_a_later_name_only_member(self):
+        """
+        What declining COSTS, measured, one producer and no foreign row anywhere.
+
+        Nothing here is another source's stack. One producer sends two members
+        with name-only virtual_chassis references, which builds a single
+        masterless row; then a STANDALONE dcim.virtualchassis entity naming a
+        master for the same name. That entity plans no device change, so
+        adoption declines it (_choose_adoption_candidate: a populated candidate,
+        no membership planned) and the create gives it a row of its own. Two
+        populated rows now share the name.
+
+        From there:
+          - an EXISTING member re-ingests clean, because the member hint puts it
+            in the row it is already in (VirtualChassisNameMatcher rule 1);
+          - a NEW member with the same name-only reference is a 400 at
+            generate-diff -- on that pass and every later one -- and its device
+            is not created at all.
+
+        That is the residual cost of decline-and-create, and it is asserted here
+        rather than described in a docstring: the refusal is loud, it names the
+        two rows and remedies that work, and no row was written -- but a
+        producer in this shape is blocked on this name until an operator merges
+        the rows or places the device. The alternative measured against it was
+        adopting the populated row on the strength of the name, which is the
+        hijack this series removed.
+        """
+        for name, position in (("vce-m1", 1), ("vce-m2", 2)):
+            self._diff_apply(self._device_payload(name, {
+                "vc_position": position,
+                "virtual_chassis": {"name": "vce-solo"},
+            }))
+        row = VirtualChassis.objects.get(name="vce-solo")
+        self.assertIsNone(row.master_id)
+        self.assertEqual(row.members.count(), 2)
+
+        # The master arrives as a plain device entity first and then as the
+        # standalone chassis entity's master stub -- orb-agent's own shape.
+        self._diff_apply(self._device_payload("vce-m3"))
+        self._diff_apply(self._vc_payload("vce-solo", "vce-m3"))
+        rows = VirtualChassis.objects.filter(name="vce-solo").order_by("pk")
+        self.assertEqual(rows.count(), 2)
+        row.refresh_from_db()
+        self.assertIsNone(row.master_id, "the decline mastered the row anyway")
+        self.assertEqual(row.members.count(), 2)
+        self.assertEqual(rows.last().master.name, "vce-m3")
+
+        # An existing member is unaffected: the hint answers for it.
+        self._assert_noop_rediff(self._device_payload("vce-m1", {
+            "vc_position": 1, "virtual_chassis": {"name": "vce-solo"}}))
+
+        # A new member is not: two populated rows, nothing to tell them apart.
+        r = self.client.post(
+            self.diff_url,
+            data=self._device_payload("vce-m4", {
+                "vc_position": 4, "virtual_chassis": {"name": "vce-solo"}}),
+            format="json", **self.auth,
+        )
+        self.assertEqual(r.status_code, 400, r.content)
+        error = r.json()["errors"]["dcim.virtualchassis"]["name"][0]
+        self.assertIn("merge the duplicates", error)
+        self.assertFalse(Device.objects.filter(name="vce-m4").exists())
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-solo").count(), 2)
+
+    def test_the_second_producer_gets_its_own_row_once_it_says_which(self):
+        """
+        The escape hatch from the bound above, and it does not touch A's row.
+
+        A domain makes the payload describe ITS chassis rather than share a name
+        with one, and no candidate carries that value -- which is not ambiguity
+        but "a chassis that does not exist yet", so it is created. Two rows share
+        the name afterwards and that is the correct answer: they are two stacks.
+        This is the one lever a producer has over the bound, and it is why the
+        bound is a bound rather than a defect: the ambiguity is in the data.
+        """
+        row = self._seed_a_producers_member_first_stack()
+        before = row.last_updated
+
+        payload = self._second_producer_payload(domain="vce-site-b")
+        self._diff_apply(payload)
+        self._assert_noop_rediff(payload)
+
+        self._assert_producer_a_row_untouched(row, before, extra_rows=1)
+        mine = VirtualChassis.objects.exclude(pk=row.pk).get(name="vce-shared")
+        self.assertEqual(mine.domain, "vce-site-b")
+        self.assertEqual(mine.master.name, "vce-b3")
+        self.assertEqual(
+            list(mine.members.values_list("name", flat=True)), ["vce-b3"])
+
+    def test_bulk_plan_apply_reaches_the_same_answer_for_a_second_producer(self):
+        """
+        Same bound through the other door, and the reason to test it twice.
+
+        /bulk-plan-apply/ plans and applies each entity in turn, sharing the
+        request-scoped caches, so entity 3 is planned against a database that
+        already holds entities 1 and 2 -- a real single-request analogue of the
+        cross-producer sequence. The point of testing it here is that the two
+        doors must not disagree: a 207 at one and a 200 at the other would mean
+        the same three payloads reconcile differently depending on how the
+        reconciler batched them.
+        """
+        Site.objects.create(name="vce-site-b", slug="vce-site-b")
+        entities = [
+            {"id": "a1", "object_type": "dcim.device",
+             "entity": self._device_payload("vce-a1", {
+                 "vc_position": 1, "virtual_chassis": {"name": "vce-shared"}})["entity"]},
+            {"id": "a2", "object_type": "dcim.device",
+             "entity": self._device_payload("vce-a2", {
+                 "vc_position": 2, "virtual_chassis": {"name": "vce-shared"}})["entity"]},
+            {"id": "b3", "object_type": "dcim.device",
+             "entity": self._second_producer_payload()["entity"]},
+        ]
+        r = self.client.post(self.bulk_plan_apply_url, data={"entities": entities},
+                             format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        results = {res["id"]: res for res in r.json()["results"]}
+        for key in ("a1", "a2", "b3"):
+            self.assertIsNone(results[key].get("errors"), results[key])
+
+        self._assert_split_vc(
+            "vce-shared", master_name="vce-b3",
+            mastered_members={"vce-b3": 3},
+            orphan_members={"vce-a1": 1, "vce-a2": 2},
+        )
+
+    def test_the_differ_drops_an_empty_domain_from_a_planned_create(self):
+        """
+        A producer that sends domain "" is, by the time apply reads it, silent.
+
+        Measured here rather than assumed: the differ DROPS ``domain: ""`` from
+        the CREATE it plans, because it equals the column default for a row that
+        does not exist yet -- so whatever the producer sent, adoption sees no
+        assertion at all and this payload gets exactly the treatment of one that
+        omitted the field. If that ever changes, this test is what notices.
+
+        The other half -- that "" could not IDENTIFY a row even where it does
+        survive, because every chassis that never set a domain carries it -- is
+        pinned at the door where it survives, apply-change-set, whose changes no
+        differ built: test_an_empty_domain_is_not_an_identification_that_
+        licenses_adoption in the matcher suite.
+        """
+        self._seed_a_producers_member_first_stack()
+
+        cs = self._diff(self._second_producer_payload(domain=""))
+        vc_create = [c for c in cs["changes"]
+                     if c["object_type"] == "dcim.virtualchassis"][0]
+        self.assertEqual(vc_create["change_type"], "create")
+        self.assertNotIn("domain", vc_create["data"], vc_create)
+
+    def test_a_labelled_row_survives_a_payload_that_asserts_no_domain(self):
+        """
+        An explicitly empty domain is a value, and it excludes the labelled row.
+
+        Two same-named populated stacks, one labelled "vce-dom" and one not. A
+        member payload carrying domain "" used to have that value DROPPED as if
+        absent: the reference was then ambiguous between both rows, and where it
+        did resolve, "" was written over the matched row's domain -- destroying
+        the one field the ambiguity refusal tells the operator to set. Now ""
+        narrows to the row that carries no domain, and the labelled row is not
+        read, not bound and not written.
+        """
+        labelled, _ = self._seed_named_stack("vce-dup", "vce-dom", {"vce-d1": 1})
+        plain, _ = self._seed_named_stack("vce-dup", "", {"vce-p1": 1})
+        before = labelled.last_updated
+
+        payload = self._device_payload("vce-p2", {
+            "vc_position": 2,
+            "virtual_chassis": {"name": "vce-dup", "domain": ""},
+        })
+        self._diff_apply(payload)
+
+        self.assertEqual(Device.objects.get(name="vce-p2").virtual_chassis_id, plain.pk)
+        labelled.refresh_from_db()
+        self.assertEqual(labelled.domain, "vce-dom", "the payload's '' was written over it")
+        self.assertEqual(labelled.last_updated, before)
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-dup").count(), 2)
+
+    def test_standalone_vc_payload_adopts_a_domain_identified_row_and_attaches_master(self):
+        """
+        FIRST ingest must converge: adoption has to establish membership itself.
+
+        A member-first ingest leaves a masterless VC; the standalone VC payload
+        that names the master IS the whole payload, so there is no "later
+        ingest" of it that would ever attach the master device. Dropping master
+        here leaves the row masterless forever and re-plans the same CREATE on
+        every pass.
+
+        THE OLD EXPECTATION HERE WAS UNSAFE in one respect, and the payload is
+        what changed: this test used to adopt a POPULATED masterless row on the
+        strength of its NAME alone, which is exactly the shape that attaches
+        this payload's master to another producer's stack and drags the device
+        into it (see test_standalone_vc_payload_creates_its_own_row_rather_than_
+        taking_one, which now pins the decline). The payload therefore carries
+        domain, so the row is identified rather than guessed -- and every
+        assertion about what adoption then DOES is unchanged, because none of
+        them was the problem.
+
+        The master lands at position 1 -- the position NetBox itself assigns
+        when it attaches a new chassis's master (dcim.signals.
+        assign_virtualchassis_master) -- because the payload carries none.
+        """
+        member = Device.objects.create(
+            name="vce-sw2", site=self.site, device_type=self.dt, role=self.role
+        )
+        vc = VirtualChassis.objects.create(name="vce-stack", domain="vce-dom")
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=vc, vc_position=2)
+        Device.objects.create(
+            name="vce-sw1", site=self.site, device_type=self.dt, role=self.role
+        )
+        count_before = VirtualChassis.objects.get(pk=vc.pk).member_count
+
+        payload = self._vc_payload("vce-stack", "vce-sw1", domain="vce-dom")
+        self._diff_apply(payload)
+
+        adopted = self._assert_single_vc("vce-stack", master_name="vce-sw1",
+                                        members={"vce-sw1": 1, "vce-sw2": 2})
+        self.assertEqual(adopted.pk, vc.pk)  # adopted, not duplicated
+        # The attach bumps member_count through a direct UPDATE the adopted
+        # instance cannot see, so the adoption save must not write its stale
+        # in-memory counter back over it. Asserted as a delta because the
+        # queryset .update() seeding above never fires the counter signal.
+        self.assertEqual(adopted.member_count, count_before + 1)
+        # ...and the re-read must not cost the changelog its prechange snapshot.
+        # member_count is what pins the ORDERING: the attach bumps it, so a
+        # snapshot taken AFTER the attach would record count_before + 1. master
+        # alone proves nothing here, because the attach never touches it -- that
+        # assertion holds whichever side of the attach the snapshot is taken on.
+        vc_change = ObjectChange.objects.filter(
+            changed_object_type__app_label="dcim",
+            changed_object_type__model="virtualchassis",
+            changed_object_id=adopted.pk,
+        ).latest("time")
+        self.assertIsNotNone(vc_change.prechange_data, vc_change)
+        self.assertIsNone(vc_change.prechange_data.get("master"), vc_change.prechange_data)
+        self.assertEqual(
+            vc_change.prechange_data.get("member_count"), count_before, vc_change.prechange_data
+        )
+        self.assertEqual(vc_change.postchange_data.get("master"), adopted.master_id)
+        self._assert_noop_rediff(payload)
+
+    def test_standalone_vc_payload_creates_its_own_row_rather_than_taking_one(self):
+        """
+        The measured hazard, and the answer that both avoids it and converges.
+
+        Identical to the adoption test above except that the payload carries no
+        discriminator. The row named "vce-stack" already holds vce-sw2; the
+        payload asks for vce-sw1 to master a chassis of that name. Adopting on
+        the name alone attached vce-sw1 to THAT row -- measured 200, master set,
+        the device dragged into a stack it was never in, and no later diff
+        mentioning the join, because a VirtualChassis payload names no members.
+
+        It now creates its own row, and the pre-existing one is left
+        byte-identical: last_updated is the assertion that proves it, because
+        "untouched" and "saved with the same two fields" look alike in name and
+        master.
+
+        This shape is the one that decided the design. It is orb-agent's
+        standalone virtual_chassis entity -- the second of the 154 entities its
+        snmp-discovery run emits (see test_the_real_orb_agent_stack_capture_...).
+        A refusal here is permanent for that producer: the entity carries a name
+        and a master and nothing else, orb emits no domain at all, and every
+        subsequent run re-sends the identical bytes. Measured against the real
+        capture with a masterless same-named row present: refusing gave 207 on
+        every pass forever; declining gives 200, the stack's own chassis, and an
+        empty re-diff -- which is also what develop does with the same input.
+        """
+        member = Device.objects.create(
+            name="vce-sw2", site=self.site, device_type=self.dt, role=self.role
+        )
+        vc = VirtualChassis.objects.create(name="vce-stack")
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=vc, vc_position=2)
+        master = Device.objects.create(
+            name="vce-sw1", site=self.site, device_type=self.dt, role=self.role
+        )
+        vc.refresh_from_db()
+        before = vc.last_updated
+
+        payload = self._vc_payload("vce-stack", "vce-sw1")
+        self._diff_apply(payload)
+
+        vc.refresh_from_db()
+        self.assertIsNone(vc.master_id)
+        self.assertEqual(vc.last_updated, before, "the declined adoption saved the row")
+        self.assertEqual(list(vc.members.values_list("name", flat=True)), ["vce-sw2"])
+
+        mine = VirtualChassis.objects.exclude(pk=vc.pk).get(name="vce-stack")
+        self.assertEqual(mine.master_id, master.pk)
+        master.refresh_from_db()
+        self.assertEqual(master.virtual_chassis_id, mine.pk)
+        self.assertEqual(master.vc_position, 1)
+        self._assert_noop_rediff(payload)
+
+    def test_standalone_vc_payload_reingest_is_a_noop(self):
+        """
+        The property the drop-master path violated: identical re-ingest settles.
+
+        Before adoption attached the master, every pass re-planned the same
+        CREATE against a row that stayed masterless -- an ingest pipeline that
+        never converges, which for a reconciler is the sharp end of it.
+        """
+        vc = VirtualChassis.objects.create(name="vce-stack")
+        Device.objects.create(
+            name="vce-sw1", site=self.site, device_type=self.dt, role=self.role
+        )
+        payload = self._vc_payload("vce-stack", "vce-sw1")
+
+        self._diff_apply(payload)
+        first = self._assert_single_vc("vce-stack", master_name="vce-sw1",
+                                      members={"vce-sw1": 1})
+        self.assertEqual(first.pk, vc.pk)
+
+        self._assert_noop_rediff(payload)
+        self._diff_apply(payload, allow_empty=True)
+        again = self._assert_single_vc("vce-stack", master_name="vce-sw1",
+                                      members={"vce-sw1": 1})
+        self.assertEqual(again.pk, vc.pk)
+
+    def test_standalone_vc_adoption_takes_the_lowest_free_position(self):
+        """
+        The provisional position steps past positions the adopted row already uses.
+
+        Positions 1 and 3 are taken, so the master gets 2 -- lowest free, not
+        highest+1. It is provisional either way: the device's own payload
+        asserts the real position, and Device.clean simply refuses a member
+        without one, so adoption has to pick something.
+        """
+        vc = VirtualChassis.objects.create(name="vce-stack", domain="vce-dom")
+        for name, position in (("vce-sw2", 1), ("vce-sw3", 3)):
+            d = Device.objects.create(
+                name=name, site=self.site, device_type=self.dt, role=self.role
+            )
+            Device.objects.filter(pk=d.pk).update(virtual_chassis=vc, vc_position=position)
+        Device.objects.create(
+            name="vce-sw1", site=self.site, device_type=self.dt, role=self.role
+        )
+
+        # domain identifies the row: a POPULATED chassis is not adopted on its
+        # name alone any more, so the position rule is exercised through the
+        # discriminated path (see test_standalone_vc_payload_creates_its_own_
+        # row_rather_than_taking_one).
+        self._diff_apply(self._vc_payload("vce-stack", "vce-sw1", domain="vce-dom"))
+        self._assert_single_vc("vce-stack", master_name="vce-sw1",
+                              members={"vce-sw1": 2, "vce-sw2": 1, "vce-sw3": 3})
+
+    def test_a_device_payload_may_move_itself_into_the_chassis_it_names(self):
+        """A device that carries its own membership change IS authority for the move."""
+        # The sibling test above refuses this move for a STANDALONE chassis payload,
+        # and that refusal was right. Applied to a device payload it was wrong: the
+        # plan contains `update dcim.device` asserting this chassis, ordered after the
+        # create it names, so the move is the producer's request and is in the preview.
+        # Refusing it rejected the apply before that update ran, rolled it back, and
+        # every identical re-ingest failed the same way -- a permanent 400 on the
+        # member-first shape this feature exists for.
+        old = VirtualChassis.objects.create(name="vcm-old")
+        mover = Device.objects.create(
+            name="vcm-d1", site=self.site, device_type=self.dt, role=self.role
+        )
+        Device.objects.filter(pk=mover.pk).update(virtual_chassis=old, vc_position=1)
+        target = VirtualChassis.objects.create(name="vcm-new")
+
+        payload = self._device_payload("vcm-d1", extra={
+            "virtual_chassis": {
+                "name": "vcm-new",
+                "master": self._device_payload("vcm-d1")["entity"]["device"],
+            },
+            "vc_position": 1,
+        })
+        self._diff_apply(payload)
+
+        mover.refresh_from_db()
+        target.refresh_from_db()
+        self.assertEqual(mover.virtual_chassis_id, target.pk)
+        self.assertEqual(target.master_id, mover.pk)
+        self.assertEqual(VirtualChassis.objects.filter(name="vcm-new").count(), 1)
+        self.assertEqual(target.member_count, target.members.count())
+        self._assert_noop_rediff(payload)
+
+    def test_standalone_vc_payload_will_not_move_master_out_of_another_chassis(self):
+        """
+        Adoption attaches a chassis-less device; it does not relocate one -- and says so.
+
+        Membership is asserted by the DEVICE payload (Device.virtual_chassis).
+        A VC payload naming a master is not authority to pull that device out
+        of a chassis it already belongs to. That part is unchanged.
+
+        THE OLD EXPECTATION HERE WAS UNSAFE in the answer it accepted, not in
+        the refusal: this test used to assert 200 with master silently dropped.
+        A payload requesting VirtualChassis(name=X, master=Y) was reported as
+        successfully applied while Y was not made master of anything, and
+        because a standalone VC payload carries nothing else, an identical
+        re-ingest re-planned the identical CREATE forever -- three plan+apply
+        cycles measured, each 200 with errors null, master never set. "The
+        deviation stays visible because the CREATE keeps re-planning" is not
+        visibility; it asks the producer to infer a conflict from a plan that
+        never empties. It is now a per-entity conflict on field master, and the
+        DB is left exactly as it was.
+
+        The remedy had to be rewritten too. It used to read "ingest the device's
+        own payload with virtual_chassis and vc_position to move it", which is
+        advice orb-agent cannot follow: it sends the stack master as a plain
+        device entity with no chassis fields at all (that is what the standalone
+        virtual_chassis entity is for), so there is no payload of its it could
+        change. The move it names now is one an operator can make in NetBox, and
+        the message says the payload then applies unchanged.
+        """
+        other, _ = self._seed_stack(vc_name="vce-other", master="vce-sw9")
+        member = Device.objects.create(
+            name="vce-sw1", site=self.site, device_type=self.dt, role=self.role
+        )
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=other, vc_position=2)
+        vc = VirtualChassis.objects.create(name="vce-stack")
+        vc.refresh_from_db()
+        before = vc.last_updated
+
+        cs = self._diff(self._vc_payload("vce-stack", "vce-sw1"))
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        error = r.json()["errors"]["dcim.virtualchassis"]["master"][0]
+        self.assertIn("vce-sw1", error)
+        self.assertIn("vce-other", error)
+        self.assertIn("Move the device in NetBox", error,
+                      "the error must name a move somebody can actually make")
+        self.assertIn("applies unchanged on the next pass", error)
+        self.assertNotIn(
+            "vc_position", error,
+            "orb-agent sends the master with no chassis fields; asking it for "
+            "virtual_chassis + vc_position on that device is advice it cannot take",
+        )
+
+        member.refresh_from_db()
+        self.assertEqual(member.virtual_chassis_id, other.pk)  # not relocated
+        self.assertEqual(member.vc_position, 2)
+        vc.refresh_from_db()
+        self.assertIsNone(vc.master_id)
+        self.assertEqual(vc.members.count(), 0)
+        self.assertEqual(vc.last_updated, before, "the refused apply saved the chassis anyway")
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-stack").count(), 1)
+
+    def test_a_conflicted_master_converges_once_the_device_moves_itself(self):
+        """
+        The conflict is a conflict, not a dead end: the device's own payload clears it.
+
+        This is what makes the refusal above the right answer rather than merely
+        a louder one. The device payload owns membership, so ingesting IT moves
+        vce-sw1 into vce-stack; the identical VirtualChassis payload then adopts
+        the row (its master is now a member -- the strongest identity there is)
+        and sets master. Two ingests, no guess, no relocation performed by a
+        chassis payload.
+        """
+        other, _ = self._seed_stack(vc_name="vce-other", master="vce-sw9")
+        member = Device.objects.create(
+            name="vce-sw1", site=self.site, device_type=self.dt, role=self.role
+        )
+        Device.objects.filter(pk=member.pk).update(virtual_chassis=other, vc_position=2)
+        vc = VirtualChassis.objects.create(name="vce-stack")
+
+        vc_payload = self._vc_payload("vce-stack", "vce-sw1")
+        cs = self._diff(vc_payload)
+        self.assertEqual(
+            self.client.post(self.apply_url, data=cs, format="json", **self.auth).status_code,
+            400,
+        )
+
+        # the device asserts its own membership
+        self._diff_apply(self._device_payload("vce-sw1", {
+            "vc_position": 1, "virtual_chassis": {"name": "vce-stack"},
+        }))
+        # ...and now the same chassis payload lands
+        self._diff_apply(vc_payload)
+        adopted = self._assert_single_vc("vce-stack", master_name="vce-sw1",
+                                        members={"vce-sw1": 1})
+        self.assertEqual(adopted.pk, vc.pk)
+        self._assert_noop_rediff(vc_payload)
+
+    def _plan_vc_create_then_delete_master(self, vc_name, master_name):
+        """Plan a master-bearing VC CREATE against an adoptable row, then delete the master."""
+        vc = VirtualChassis.objects.create(name=vc_name)
+        master = Device.objects.create(
+            name=master_name, site=self.site, device_type=self.dt, role=self.role
+        )
+        cs = self._diff(self._vc_payload(vc_name, master_name))
+        master.delete()
+        return vc, cs
+
+    def test_master_deleted_between_plan_and_apply_is_rejected(self):
+        """
+        A planned master pk with no device behind it must fail the apply.
+
+        Plan-then-apply is two round trips, so nothing stops the master
+        resolved at plan time from being deleted before the apply lands. The
+        payload then references an object that is not there, and adoption must
+        not "converge" that by dropping master: the CREATE would be reported as
+        successfully applied, the chassis would be saved masterless, and the
+        dangling reference -- a hard serializer error on every other applied
+        change -- would leave no trace at all.
+        """
+        vc, cs = self._plan_vc_create_then_delete_master("vce-stack", "vce-sw1")
+
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, (cs, r.content))
+        errors = r.json()["errors"]
+        # NetBox's own dangling-reference error, on the field that carried it
+        self.assertIn("dcim.virtualchassis", errors, errors)
+        self.assertIn("master", errors["dcim.virtualchassis"], errors)
+
+        # The rejected apply leaves the adoptable row exactly as it was.
+        #
+        # These three alone would ALSO have held under the silent success this
+        # test exists to catch: the adoptable row was already masterless with no
+        # members, and the payload carried nothing but name and master, so
+        # "unchanged" and "wrongly saved without its master" look identical in
+        # those fields. The status assertion above was carrying the whole test.
+        # last_updated is what separates them -- a save would have moved it --
+        # and the absence of an ObjectChange proves the row was never written.
+        before = vc.last_updated
+        vc.refresh_from_db()
+        self.assertIsNone(vc.master_id)
+        self.assertEqual(vc.members.count(), 0)
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-stack").count(), 1)
+        self.assertEqual(vc.last_updated, before, "the rejected apply saved the chassis anyway")
+        self.assertFalse(
+            ObjectChange.objects.filter(
+                changed_object_type__app_label="dcim",
+                changed_object_type__model="virtualchassis",
+                changed_object_id=vc.pk,
+            ).exists(),
+            "a rolled-back apply must leave no changelog entry for the chassis",
+        )
+
+    def test_missing_master_and_conflicted_master_are_not_the_same_outcome(self):
+        """
+        Adoption's two "cannot attach" cases must not collapse into one branch.
+
+        THE OLD EXPECTATION HERE WAS UNSAFE for the first half: it asserted 200
+        with master dropped when the named master lived in another chassis. Both
+        halves are 400 now, so the point of the test moves -- but it does not
+        disappear, because the two are still different answers and collapsing
+        them still costs a property:
+
+        - the named master is a MEMBER of a different chassis: a CONFLICT the
+          producer can act on, reported on field master, naming the chassis
+          that holds the device and how to move it. It is recoverable by
+          ingesting the device (test_a_conflicted_master_converges_once_the_
+          device_moves_itself).
+        - the named master DOES NOT EXIST: a dangling reference, reported by
+          NetBox's own serializer on the same field. Nothing can converge a pk
+          that resolves to nothing -- the producer's fix is a different payload,
+          not a different order.
+
+        The shared field is deliberate (both are about master) and it is why
+        the MESSAGES are asserted rather than just the status: a single branch
+        handling both would still produce two 400s, and only the text would
+        reveal that the reconciler had been told the wrong thing.
+        """
+        # conflict: the master is real, but it lives in another chassis
+        other, _ = self._seed_stack(vc_name="vce-other", master="vce-sw9")
+        held = Device.objects.create(
+            name="vce-held", site=self.site, device_type=self.dt, role=self.role
+        )
+        Device.objects.filter(pk=held.pk).update(virtual_chassis=other, vc_position=2)
+        conflicted_vc = VirtualChassis.objects.create(name="vce-conflicted")
+
+        cs = self._diff(self._vc_payload("vce-conflicted", "vce-held"))
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        conflict = r.json()["errors"]["dcim.virtualchassis"]["master"][0]
+        self.assertIn("member of", conflict, conflict)
+        self.assertIn("vce-other", conflict, conflict)
+        conflicted_vc.refresh_from_db()
+        self.assertIsNone(conflicted_vc.master_id)
+        held.refresh_from_db()
+        self.assertEqual(held.virtual_chassis_id, other.pk)
+
+        # missing: same inability to attach, different reason and different error
+        missing_vc, cs = self._plan_vc_create_then_delete_master("vce-missing", "vce-ghost")
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, (cs, r.content))
+        dangling = r.json()["errors"]["dcim.virtualchassis"]["master"][0]
+        self.assertNotIn("member of", dangling, dangling)
+        missing_vc.refresh_from_db()
+        self.assertIsNone(missing_vc.master_id)
+
+    def test_name_only_master_stub_yields_required_fields_deviation(self):
+        """A VC whose inline master stub lacks matcher keys fails loudly, not silently."""
+        r = self.client.post(
+            self.diff_url,
+            data={"timestamp": 1, "object_type": "dcim.virtualchassis",
+                  "entity": {"virtual_chassis": {
+                      "name": "vce-badstub",
+                      "master": {"name": "vce-ghost"},
+                  }}},
+            format="json", **self.auth,
+        )
+        self.assertEqual(r.status_code, 400, r.content)
+        # the standalone device CREATE lacks device_type/role/site
+        self.assertIn("required", str(r.json()).lower())
+
+    def test_explicit_master_null_plans_master_clearing_update(self):
+        """Pin the clear-FK contract: name-matched VC with master:{} plans master=None."""
+        self._seed_stack()
+        cs = self._diff({
+            "timestamp": 1, "object_type": "dcim.virtualchassis",
+            "entity": {"virtual_chassis": {"name": "vce-stack", "master": {}}},
+        })
+        updates = [c for c in cs.get("changes", [])
+                   if c["object_type"] == "dcim.virtualchassis"
+                   and "master" in (c.get("data") or {})]
+        self.assertTrue(updates, cs)
+        self.assertIsNone(updates[0]["data"]["master"])
+
+    # ---- direct apply-change-set: master arrives exactly as posted ---------
+
+    def _vc_create_changeset(self, name, master):
+        """A minimal apply-change-set body carrying master exactly as given."""
+        return {
+            "id": str(uuid.uuid4()),
+            "changes": [{
+                "change_id": str(uuid.uuid4()),
+                "change_type": "create",
+                "object_version": None,
+                "object_type": "dcim.virtualchassis",
+                "object_id": None,
+                "ref_id": "1",
+                "data": {"name": name, "master": master},
+            }],
+        }
+
+    def _seed_adoptable(self, vc_name="vce-stack", master_name="vce-sw1"):
+        """A masterless VC to adopt, plus a chassis-less device to become its master."""
+        vc = VirtualChassis.objects.create(name=vc_name)
+        master = Device.objects.create(
+            name=master_name, site=self.site, device_type=self.dt, role=self.role
+        )
+        return vc, master
+
+    def test_direct_apply_integer_master_adopts(self):
+        """The well-formed direct-POST shape: an int pk adopts the masterless row."""
+        vc, master = self._seed_adoptable()
+
+        r = self.client.post(self.apply_url, data=self._vc_create_changeset("vce-stack", master.pk),
+                             format="json", **self.auth)
+
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+        adopted = self._assert_single_vc("vce-stack", master_name="vce-sw1", members={"vce-sw1": 1})
+        self.assertEqual(adopted.pk, vc.pk)
+
+    def test_direct_apply_numeric_string_master_adopts(self):
+        """
+        A numeric-string pk is a legal wire form and must keep adopting.
+
+        The malformed-value guard has to COERCE this, not decline it: declining
+        falls through to the create path, which would leave a second chassis of
+        the same name beside the masterless row this is supposed to bind.
+        """
+        vc, master = self._seed_adoptable()
+
+        r = self.client.post(self.apply_url,
+                             data=self._vc_create_changeset("vce-stack", str(master.pk)),
+                             format="json", **self.auth)
+
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+        adopted = self._assert_single_vc("vce-stack", master_name="vce-sw1", members={"vce-sw1": 1})
+        self.assertEqual(adopted.pk, vc.pk)
+
+    def test_direct_apply_malformed_master_is_a_structured_400(self):
+        """
+        A non-numeric master must be reported as an error, not crash the apply.
+
+        The plan path always resolves master to a pk, so this shape reaches the
+        applier only through a direct POST to apply-change-set (or bulk-apply)
+        -- a first-class entry point, and nothing between the wire and the
+        applier coerces the field: ChangeSet.validate pops relation fields
+        before instantiating the model. Carried into an ORM filter it raises
+        ValueError, which apply_changeset's handler chain does not catch
+        (ValidationError, ObjectDoesNotExist, TypeError, IntegrityError,
+        KeyError), so it escapes as a 500 -- burying the structured 400 the VC
+        serializer already produces for this exact value.
+
+        TWO lookups on this path carried it into the ORM: the adoption pass,
+        and the match lookup _create_or_find_instance falls back to once the
+        serializer has rejected the payload. Either one alone still 500s, so
+        this test goes green only when both decline a malformed reference.
+        """
+        vc, _ = self._seed_adoptable()
+        before = vc.last_updated
+
+        r = self.client.post(self.apply_url, data=self._vc_create_changeset("vce-stack", "abc"),
+                             format="json", **self.auth)
+
+        self.assertEqual(r.status_code, 400, r.content)
+        errors = r.json()["errors"]
+        self.assertIn("dcim.virtualchassis", errors, errors)
+        self.assertIn("master", errors["dcim.virtualchassis"], errors)
+
+        # Declining the adoption must not half-apply it either. On a row that
+        # was already masterless and memberless, "untouched" and "saved without
+        # its master" look identical in those two fields -- last_updated is
+        # what separates them, so it carries the no-write assertion.
+        vc.refresh_from_db()
+        self.assertIsNone(vc.master_id)
+        self.assertEqual(vc.members.count(), 0)
+        self.assertEqual(vc.last_updated, before, "the rejected apply saved the chassis anyway")
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-stack").count(), 1)
+
+
+    def test_direct_apply_master_bearing_create_never_rewrites_another_chassis(self):
+        """
+        A CREATE must not be able to rename or otherwise write an existing chassis.
+
+        With master present the matcher that answers find_existing_object is
+        the auto-derived unique_master one, so a master-bearing CREATE routed
+        onto the pre-save path resolves "create the chassis named NEW, mastered
+        by D" onto whichever chassis D already masters -- an unrelated,
+        already-converged row.
+
+        Read the mechanism carefully, because it changed inside this series and
+        the earlier wording here was wrong. It is NOT the payload gate
+        (matcher._virtualchassis_pre_save_match_applies) that keeps this green
+        today: bind-only does (matcher._PRE_SAVE_MATCH_BIND_ONLY), because a
+        pre-save-matched dcim.virtualchassis CREATE no longer writes the row it
+        resolves onto at all. Removing the gate leaves this test -- and every
+        other test in this file -- passing; only the gate's own seam test,
+        test_route_is_scoped_to_masterless_payloads, fails. The gate still
+        earns its place as a seam pin: it keeps master out of an ORM pk filter,
+        where the malformed forms below coerce silently rather than declining
+        (True -> pk 1, 7.5 -> pk 7, 7.0 -> pk 7), and it stops a master-bearing
+        CREATE binding to the wrong row so that later references in the
+        changeset resolve to it. Neither of those is a WRITE, which is why
+        mutating the gate away does not fail this assertion.
+
+        The invariant is asserted over every pre-existing row rather than over
+        the outcome of the apply, because the outcome legitimately varies with
+        the value: what must never vary is that no row that existed before the
+        request comes out of it changed.
+        """
+        vc, master = self._seed_stack(vc_name="vce-owned", master="vce-sw1")
+
+        for label, master_value in (
+            ("well_formed_pk", master.pk),
+            ("numeric_string", str(master.pk)),
+            ("bool_true", True),
+            ("bool_false", False),
+            ("non_integral_float", 7.5),
+            ("integral_float", 7.0),
+        ):
+            with self.subTest(master=label):
+                before = {
+                    row.pk: (row.name, row.description, row.master_id, row.last_updated)
+                    for row in VirtualChassis.objects.all()
+                }
+                r = self.client.post(
+                    self.apply_url,
+                    data=self._vc_create_changeset("vce-renamed", master_value),
+                    format="json", **self.auth,
+                )
+                self.assertIn(r.status_code, (200, 400), r.content)
+                after = {
+                    row.pk: (row.name, row.description, row.master_id, row.last_updated)
+                    for row in VirtualChassis.objects.filter(pk__in=before)
+                }
+                self.assertEqual(after, before, f"{label}: a pre-existing chassis was written")
+                self.assertEqual(
+                    VirtualChassis.objects.get(pk=vc.pk).name, "vce-owned",
+                    f"{label}: the chassis this master already owns was renamed",
+                )
+
+
+    # ---- bind, do not overwrite -------------------------------------------
+
+    def _row_fields(self, pks):
+        """
+        The chassis fields a CREATE must never write, per row.
+
+        member_count is deliberately NOT here: binding a member legitimately
+        changes it, and _assert_member_count_is_honest checks that instead.
+        last_updated IS here, because it is the only witness that separates
+        "untouched" from "saved with values identical to its own".
+        """
+        return {
+            row.pk: (row.name, row.description, row.domain, row.master_id, row.last_updated)
+            for row in VirtualChassis.objects.filter(pk__in=pks)
+        }
+
+    def _assert_member_count_is_honest(self, *vcs):
+        """Stored member_count against the membership that actually exists."""
+        for vc in vcs:
+            fresh = VirtualChassis.objects.get(pk=vc.pk)
+            self.assertEqual(
+                fresh.member_count, fresh.members.count(),
+                f"{fresh.name}: stored member_count diverged from reality",
+            )
+
+    #: Every shape a name-only match can land on. Not variations on a theme --
+    #: three distinct ways that criterion can be wrong about identity, and the
+    #: two that are not "masterless and empty" are the two it was never
+    #: verified against.
+    ROW_KINDS = (
+        # A converged stack another source owns. VirtualChassis.name has no
+        # unique constraint, so a same-named plan is no evidence of sameness.
+        "mastered",
+        # The row the plan-ahead race actually means: inserted moments earlier
+        # by a sibling plan built from the same masterless payload.
+        "masterless_empty",
+        # What a member-first ingest leaves, and what this PR's own
+        # IN_OTHER_CHASSIS branch deliberately leaves: real members, no master.
+        # A guard keyed on master__isnull calls this one fresh and writes it.
+        "masterless_populated",
+    )
+
+    def _seed_row_kind(self, kind, name):
+        """One chassis of the given shape, owned by another site, with fields set."""
+        vc = VirtualChassis.objects.create(
+            name=name, domain="dom-b", description="OWNED-BY-B"
+        )
+        if kind == "masterless_empty":
+            return vc
+        site_b = Site.objects.filter(slug="vce-site-b").first() or Site.objects.create(
+            name="vce-site-b", slug="vce-site-b"
+        )
+        members = []
+        for position in (1, 2):
+            d = Device.objects.create(
+                name=f"{name}-b{position}", site=site_b,
+                device_type=self.dt, role=self.role,
+            )
+            d.virtual_chassis = vc
+            d.vc_position = position
+            d.save()
+            members.append(d)
+        if kind == "mastered":
+            # Re-read before saving: the membership signals have since bumped
+            # member_count by direct UPDATE, and a full save() through this
+            # instance would write its own stale 0 back over them. (The applier
+            # guards the same hazard in _try_adopt_masterless_virtualchassis.)
+            vc.refresh_from_db()
+            vc.master = members[0]
+            vc.save()
+        vc.refresh_from_db()
+        return vc
+
+    def test_a_masterless_create_never_writes_the_row_it_matched(self):
+        """
+        The contract, at the applier's own door: bind the row, write nothing.
+
+        The pre-save match (matcher._REQUIRES_PRE_SAVE_MATCH) exists to stop a
+        duplicate INSERT, and for dcim.virtualchassis that is ALL it may do.
+        Applying the CREATE's payload to the matched row is a separate act and
+        an unsafe one: the criterion is the name alone, VirtualChassis.name has
+        no unique constraint, so the row may be a converged stack another
+        source owns. Measured before this change -- a stale plan's description
+        and domain landed on another site's live chassis, 200, no error, and
+        nothing in any later diff to repair it, after which the two sources
+        flapped those fields indefinitely.
+
+        Both masterless wire forms are covered because a client changeset
+        reaches the applier without the transformer, so master may be absent or
+        explicitly null; the payload gate treats them alike and so must this.
+        The explicit-null form is the more destructive, and it is where this
+        change FIXES a bug rather than merely declining to introduce one: an
+        explicit master: null on a matched row set that row's master_id to NULL
+        while every member stayed attached -- measured on the parent commit AND
+        on the first draft of this branch, which is why the "master_null" arms
+        below are assertions about a repair, not a regression guard.
+
+        The row-count assertion is the other half, and it is why this refuses
+        the WRITE rather than the MATCH: exactly one row, so no duplicate is
+        left behind for nothing to clean up.
+        """
+        for kind in self.ROW_KINDS:
+            for label, extra in (("master_absent", {}), ("master_null", {"master": None})):
+                with self.subTest(row=kind, master=label):
+                    name = f"vce-{kind.replace('_', '-')}-{label.replace('_', '-')}"
+                    vc = self._seed_row_kind(kind, name)
+                    before = self._row_fields([vc.pk])
+                    # No domain asserted on purpose: this payload must stay
+                    # INDISTINGUISHABLE from the row it races, which is what
+                    # makes the bind-only contract the thing under test. A
+                    # payload asserting a domain the row does not carry is a
+                    # different case entirely -- it identifies a different
+                    # chassis and gets its own row (see
+                    # test_a_contradicting_domain_takes_its_own_row).
+                    data = {"name": name, "description": "FROM-A"}
+                    data.update(extra)
+
+                    r = self.client.post(
+                        self.apply_url,
+                        data={
+                            "id": str(uuid.uuid4()),
+                            "changes": [{
+                                "change_id": str(uuid.uuid4()),
+                                "change_type": "create",
+                                "object_version": None,
+                                "object_type": "dcim.virtualchassis",
+                                "object_id": None,
+                                "ref_id": "1",
+                                "data": data,
+                            }],
+                        },
+                        format="json", **self.auth,
+                    )
+
+                    self.assertEqual(r.status_code, 200, r.content)
+                    self.assertIsNone(r.json().get("errors"))
+                    self.assertEqual(self._row_fields([vc.pk]), before,
+                                     f"{kind}/{label}: the matched chassis was written")
+                    self.assertEqual(
+                        VirtualChassis.objects.filter(name=name).count(), 1,
+                        f"{kind}/{label}: the CREATE left a duplicate row behind",
+                    )
+                    self._assert_member_count_is_honest(vc)
+
+    def test_a_bind_says_which_submitted_values_it_discarded(self):
+        """
+        A bind answers 200 having written nothing, so it has to say so.
+
+        Refusing the write is right -- the criteria carry no database uniqueness,
+        so the row may be a different object that merely matches -- but a caller
+        told only "200, errors null" has been told its change applied when its
+        payload was dropped. A producer that replays its whole state converges
+        on the next pass, through the object-id UPDATE the row's existence now
+        makes plannable; a one-shot or push-on-change producer never sends that
+        pass and would never learn.
+
+        The warning names only what was actually dropped. `name` was submitted
+        too and is NOT named, because the row already carries it -- proof that
+        this reports discarded writes rather than every field in the payload.
+        """
+        name = "vce-warns"
+        vc = self._seed_row_kind("masterless_populated", name)
+
+        r = self.client.post(
+            self.apply_url,
+            data={
+                "id": str(uuid.uuid4()),
+                "changes": [{
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.virtualchassis",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {"name": name, "description": "FROM-A"},
+                }],
+            },
+            format="json", **self.auth,
+        )
+        self.assertEqual(r.status_code, 200, r.content)
+        body = r.json()
+        self.assertIsNone(body.get("errors"))
+
+        warnings = body.get("warnings")
+        self.assertEqual(len(warnings or []), 1, body)
+        warning = warnings[0]
+        self.assertEqual(warning["object_type"], "dcim.virtualchassis")
+        self.assertEqual(warning["object_id"], vc.pk)
+        self.assertIn("description", warning["fields"])
+        self.assertNotIn(
+            "name", warning["fields"],
+            "reported a field the row already carried, so this is not a discard report",
+        )
+        self.assertIn("object_id", warning["message"])
+
+    def test_a_colliding_create_says_it_stored_nothing(self):
+        """
+        A create resolved onto an existing row must not report a silent success.
+
+        Two payload nodes can reference ONE existing object through DISJOINT
+        selectors -- an asset_tag in one, a (name, site) in another. Those share
+        no fingerprint, so dedupe cannot merge them and nothing upstream knows
+        they are one object; the second only meets the first at this lookup,
+        where the create collides and is resolved onto the existing row with its
+        payload dropped. Before this, that answered 200 with nothing stored and
+        nothing said, so which node's values survived was decided by arrival
+        order and invisible either way.
+
+        Seeded here with a plain unique collision, because the shape above needs
+        no special machinery to produce the same fall-through: what is pinned is
+        that the fall-through reports itself.
+        """
+        existing = VirtualChassis.objects.create(
+            name="vce-collide", domain="owned-by-someone")
+        master = Device.objects.create(
+            name="vce-collide-m", site=self.site,
+            device_type=self.dt, role=self.role)
+        Device.objects.filter(pk=master.pk).update(
+            virtual_chassis=existing, vc_position=1)
+        existing.refresh_from_db()
+        existing.master = master
+        existing.save()
+
+        r = self.client.post(
+            self.apply_url,
+            data={
+                "id": str(uuid.uuid4()),
+                "changes": [{
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.virtualchassis",
+                    "object_id": None,
+                    "ref_id": "vc1",
+                    # same master, so the unique_master constraint collides
+                    "data": {"name": "vce-other-name", "domain": "mine",
+                             "master": master.pk},
+                }],
+            },
+            format="json", **self.auth,
+        )
+        self.assertEqual(r.status_code, 200, r.content)
+        body = r.json()
+        self.assertIsNone(body.get("errors"))
+
+        warnings = body.get("warnings") or []
+        self.assertEqual(len(warnings), 1, body)
+        warning = warnings[0]
+        self.assertEqual(warning["object_type"], "dcim.virtualchassis")
+        self.assertEqual(warning["object_id"], existing.pk)
+        self.assertIn("domain", warning["fields"])
+        self.assertIn("object_id", warning["message"])
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.domain, "owned-by-someone",
+                         "the colliding payload was written after all")
+
+    def _bind_then_update_changeset(self, name, update_change):
+        """A masterless CREATE that binds by name, plus an UPDATE on its ref."""
+        return {
+            "id": str(uuid.uuid4()),
+            "changes": [
+                {
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.virtualchassis",
+                    "object_id": None,
+                    "ref_id": "vcb",
+                    # masterless, so the pre-save match binds it by name alone
+                    "data": {"name": name},
+                },
+                update_change,
+            ],
+        }
+
+    def test_a_ref_only_update_after_a_bind_only_create_is_refused(self):
+        """
+        A bind writes nothing, so no later change may write through its ref.
+
+        _try_bind_existing_instance resolves a masterless CREATE onto a
+        same-named existing row and deliberately writes nothing to it: the name
+        carries no DB uniqueness, so the row may be a different stack that
+        merely matches. The ref_id UPDATE branch is an ordinary
+        serializer.save(), so a changeset pairing the two lands the update's
+        payload on exactly the row the create refused to touch -- one change
+        later, and past the guarantee.
+
+        Measured before this guard: 200 with errors null, and a stranger's
+        chassis domain rewritten.
+
+        generate-diff cannot plan the shape -- dcim.virtualchassis is absent
+        from _IS_CIRCULAR_REFERENCE, pinned by
+        test_bind_only_types_are_not_circular_references -- but
+        apply-change-set and bulk-apply take the changeset from the client, and
+        the same pairing arrives from a changeset planned before another worker
+        created the row this bind now finds.
+        """
+        existing = VirtualChassis.objects.create(
+            name="vce-bound", domain="owned-by-someone")
+
+        r = self.client.post(
+            self.apply_url,
+            data=self._bind_then_update_changeset("vce-bound", {
+                "change_id": str(uuid.uuid4()),
+                "change_type": "update",
+                "object_version": None,
+                "object_type": "dcim.virtualchassis",
+                "object_id": None,
+                "ref_id": "vcb",
+                "data": {"domain": "stolen"},
+            }),
+            format="json", **self.auth,
+        )
+
+        self.assertEqual(r.status_code, 400, r.content)
+        # the error must say what to send instead, not merely refuse
+        self.assertIn("object_id", r.content.decode())
+        existing.refresh_from_db()
+        self.assertEqual(existing.domain, "owned-by-someone",
+                         "the update wrote through a bind-only ref")
+        self.assertEqual(
+            VirtualChassis.objects.filter(name="vce-bound").count(), 1,
+            "the refused changeset left a duplicate behind")
+
+    def test_an_update_with_an_explicit_object_id_still_writes_the_bound_row(self):
+        """
+        The guard refuses the ref-only form, not the deliberate one.
+
+        Naming the row by object_id is a caller saying which row it means,
+        which is exactly what the bind declined to guess. That still applies.
+        """
+        existing = VirtualChassis.objects.create(
+            name="vce-explicit", domain="before")
+
+        r = self.client.post(
+            self.apply_url,
+            data=self._bind_then_update_changeset("vce-explicit", {
+                "change_id": str(uuid.uuid4()),
+                "change_type": "update",
+                "object_version": None,
+                "object_type": "dcim.virtualchassis",
+                "object_id": existing.pk,
+                "ref_id": None,
+                "data": {"domain": "after"},
+            }),
+            format="json", **self.auth,
+        )
+
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+        existing.refresh_from_db()
+        self.assertEqual(existing.domain, "after")
+
+    def test_a_ref_only_update_after_an_ordinary_create_still_writes(self):
+        """
+        Only a BOUND ref is refused; a ref that really created a row is not.
+
+        Without this, the guard would look like it works while actually
+        refusing every ref_id update -- including the deferred writes the
+        differ plans for dcim.device and dcim.modulebay.
+        """
+        r = self.client.post(
+            self.apply_url,
+            data=self._bind_then_update_changeset("vce-fresh-name", {
+                "change_id": str(uuid.uuid4()),
+                "change_type": "update",
+                "object_version": None,
+                "object_type": "dcim.virtualchassis",
+                "object_id": None,
+                "ref_id": "vcb",
+                "data": {"domain": "written"},
+            }),
+            format="json", **self.auth,
+        )
+
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+        created = VirtualChassis.objects.get(name="vce-fresh-name")
+        self.assertEqual(created.domain, "written")
+
+    def test_an_ordinary_apply_carries_no_warnings_key(self):
+        """The key is absent unless something happened, so a clean apply is unchanged."""
+        payload = self._device_payload("vce-nowarn", {
+            "vc_position": 1,
+            "virtual_chassis": {
+                "name": "vce-nowarn-stack",
+                "master": {"name": "vce-nowarn", "site": {"name": "vce-site"}},
+            },
+        })
+        cs = self._diff(payload)
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertNotIn("warnings", r.json())
+
+    def _chassis_with_master(self, vc_name, dev_name, position=None):
+        """A dcim.virtualchassis payload nesting its master, optionally with a position."""
+        master = {
+            "name": dev_name,
+            "site": {"name": "vce-site"},
+            "role": {"name": "vce-role"},
+            "device_type": {"manufacturer": {"name": "vce-mfr"}, "model": "vce-dt"},
+        }
+        if position is not None:
+            master["vc_position"] = position
+        return {"timestamp": 1, "object_type": "dcim.virtualchassis",
+                "entity": {"virtual_chassis": {"name": vc_name, "master": master}}}
+
+    def test_a_position_on_a_nested_master_survives_the_chassis_signal(self):
+        """
+        A position supplied on the chassis's own master must not be overwritten.
+
+        A device that nests virtual_chassis itself has its position moved onto a
+        deferred step, because the position only means anything once the chassis
+        exists. A device nested the OTHER way -- as the chassis payload's master,
+        with no virtual_chassis nested back -- had no such step, so the position
+        stayed on the device's change, which is ordered BEFORE the chassis.
+
+        Measured before the fix: both a new and an existing device applied 200
+        and ended at vc_position 1, because NetBox's signal sets the master's
+        position when the chassis attaches and overwrote the submitted 5.
+        Silently -- nothing errored, the value was just gone.
+        """
+        for label, seed in (("new", False), ("existing", True)):
+            with self.subTest(label):
+                vc_name, dev_name = f"vce-npos-{label}", f"vce-nposd-{label}"
+                if seed:
+                    Device.objects.create(
+                        name=dev_name, site=self.site,
+                        device_type=self.dt, role=self.role)
+                payload = self._chassis_with_master(vc_name, dev_name, position=5)
+                self._diff_apply(payload)
+                self.assertEqual(Device.objects.get(name=dev_name).vc_position, 5)
+                self._assert_noop_rediff(payload)
+
+    def _two_members_naming_one_master(self, vc_name, master, near_pos, far_pos,
+                                       master_pos_a, master_pos_b):
+        """One graph naming the same master twice, through two member devices."""
+        def member(name, position, master_position):
+            return self._device_payload(name, {
+                "vc_position": position,
+                "virtual_chassis": {
+                    "name": vc_name,
+                    "master": self._device_payload(
+                        master, {"vc_position": master_position})["entity"]["device"],
+                },
+            })["entity"]["device"]
+
+        def termination(device):
+            return [{"object_interface": {
+                "device": device, "name": "Gi0/9", "type": "1000base-t"}}]
+
+        return {"timestamp": 1, "object_type": "dcim.cable", "entity": {"cable": {
+            "a_terminations": termination(member(f"{master}-n1", near_pos, master_pos_a)),
+            "b_terminations": termination(member(f"{master}-n2", far_pos, master_pos_b)),
+            "status": "connected", "type": "cat6",
+        }}}
+
+    def test_duplicate_master_stubs_that_disagree_are_a_conflict(self):
+        """
+        A companion moved onto a deferred step must still be able to conflict.
+
+        Post-create steps are deliberately never dedupe candidates, but their
+        _instance IS canonicalised through the dedupe -- so two duplicate nodes
+        that merge into one device leave TWO deferred steps pointing at it. That
+        is invisible rather than merely redundant when they disagree, because
+        moving the companions onto those steps takes the disagreement off the
+        main nodes BEFORE they merge, which is where it would have been caught.
+
+        Measured before the fix, one graph naming the same master with
+        vc_position 5 and 7: both updates planned, apply 200 with no conflict,
+        and the stored position alternated 5, 7, 5 over three identical
+        ingests. A successful apply that never converges.
+
+        Now it is the same conflict the main nodes would have raised.
+        """
+        payload = self._two_members_naming_one_master(
+            "vce-dupm", "vce-dupmm", near_pos=2, far_pos=3,
+            master_pos_a=5, master_pos_b=7)
+        r = self.client.post(self.diff_url, data=payload, format="json", **self.auth)
+        self.assertEqual(r.status_code, 400, r.content)
+        message = str(r.json()["errors"])
+        self.assertIn("Conflicting values for 'vc_position'", message)
+        self.assertIn("dcim.device", message)
+
+    def test_duplicate_master_stubs_that_agree_plan_one_step(self):
+        """
+        The other half: agreeing steps collapse rather than writing twice.
+
+        Two deferred updates for one device were emitted even when they said
+        the same thing -- harmless, but a duplicate write and a duplicate
+        changelog row. They are one step now, and the ingest converges.
+        """
+        payload = self._two_members_naming_one_master(
+            "vce-agrm", "vce-agrmm", near_pos=2, far_pos=3,
+            master_pos_a=5, master_pos_b=5)
+        cs = self._diff(payload)
+        master_steps = [
+            c for c in cs["changes"]
+            if c["object_type"] == "dcim.device"
+            and (c.get("data") or {}).get("vc_position") == 5
+        ]
+        self.assertEqual(len(master_steps), 1, master_steps)
+        self._diff_apply(payload)
+        self.assertEqual(Device.objects.get(name="vce-agrmm").vc_position, 5)
+        self._assert_noop_rediff(payload)
+
+    def test_a_position_survives_an_unrelated_deferred_field_on_the_master(self):
+        """
+        An existing post-create step must be EXTENDED, not read as job done.
+
+        dcim.device has four circular references -- primary_ip4, primary_ip6,
+        oob_ip and virtual_chassis -- so a nested master can already own a
+        post-create step for a reason that has nothing to do with the chassis.
+        Keying on "a step exists" rather than "this relationship is deferred"
+        let the position stay behind:
+
+          master {vc_position: 5, oob_ip: ...}, no virtual_chassis nested back
+          -> the oob_ip step exists, so _move_deferred_companions leaves the
+             position alone (that step carries no virtual_chassis) and the
+             deferral bailed on seeing the step at all
+          -> plan: create device WITH vc_position=5 and no virtual_chassis
+          -> the signal attaches the master and overwrites it with 1
+
+        The same silent loss the deferral was added to stop, one field away.
+        Both the position and the unrelated reference now ride the one step.
+        """
+        for label, seed in (("new", False), ("existing", True)):
+            with self.subTest(label):
+                vc_name, dev_name = f"vce-pcx-{label}", f"vce-pcxd-{label}"
+                if seed:
+                    Device.objects.create(
+                        name=dev_name, site=self.site,
+                        device_type=self.dt, role=self.role)
+                master = {
+                    "name": dev_name,
+                    "site": {"name": "vce-site"},
+                    "role": {"name": "vce-role"},
+                    "device_type": {"manufacturer": {"name": "vce-mfr"}, "model": "vce-dt"},
+                    "vc_position": 5,
+                    # Assigned through an interface on the device itself, which
+                    # is what NetBox requires of an oob_ip -- and it is also the
+                    # realistic shape, since a bare address is rejected.
+                    "oob_ip": {
+                        "address": f"10.99.{1 if seed else 2}.1/24",
+                        "assigned_object_interface": {
+                            "device": {
+                                "name": dev_name,
+                                "site": {"name": "vce-site"},
+                                "role": {"name": "vce-role"},
+                                "device_type": {
+                                    "manufacturer": {"name": "vce-mfr"},
+                                    "model": "vce-dt",
+                                },
+                            },
+                            "name": "mgmt0",
+                            "type": "1000base-t",
+                        },
+                    },
+                }
+                payload = {"timestamp": 1, "object_type": "dcim.virtualchassis",
+                           "entity": {"virtual_chassis": {"name": vc_name, "master": master}}}
+                self._diff_apply(payload)
+
+                device = Device.objects.get(name=dev_name)
+                self.assertEqual(device.vc_position, 5, "the position was overwritten")
+                self.assertIsNotNone(device.virtual_chassis_id)
+                self.assertIsNotNone(
+                    device.oob_ip_id, "the unrelated deferred field was dropped")
+                self._assert_noop_rediff(payload)
+
+    def test_a_master_with_no_position_gains_no_deferred_step(self):
+        """
+        The deferral fires only when a position is actually there.
+
+        This is the real orb-agent shape -- its master stub carries a name, a
+        device_type, a role, a serial and a site, and no position at all -- so an
+        unconditional deferred step would change the plan for that producer to no
+        purpose. The plan here is the device and the chassis, nothing else, and
+        the master still ends up at NetBox's own choice of position 1.
+        """
+        payload = self._chassis_with_master("vce-nopos", "vce-noposd")
+        cs = self._diff(payload)
+        planned = [(c["change_type"], c["object_type"]) for c in cs["changes"]
+                   if c["change_type"] != "noop"]
+        self.assertEqual(
+            planned,
+            [("create", "dcim.device"), ("create", "dcim.virtualchassis")],
+            "a deferred step was planned for a master carrying no position",
+        )
+        self._diff_apply(payload)
+        device = Device.objects.get(name="vce-noposd")
+        self.assertEqual(device.vc_position, 1)
+        self.assertIsNotNone(device.virtual_chassis_id)
+
+    def test_a_contradicting_domain_takes_its_own_row(self):
+        """
+        The other half of the bind-only contract: a domain the row lacks is identity.
+
+        The same race as the tests above -- a same-named row already exists,
+        owned by another source, carrying domain "dom-b" -- except this payload
+        asserts "dom-a". A NON-EMPTY discriminator the row does not carry means
+        "not this row" (matcher.contradicting_vc_discriminator), so the pre-save
+        match does not bind it. The payload gets its own row and the other is
+        byte-identical afterwards, last_updated included.
+
+        This is the price of making domain mean ONE thing, and it is a real
+        price: a plan-ahead race with a domain in it now ends in two rows where
+        the name-only race still ends in one, because the match can no longer
+        de-duplicate against a row the payload has just contradicted. It is
+        the better half of the trade -- the alternative bound the row and then
+        re-proposed the contradicted domain onto it on every later pass, forever
+        -- and this one converges: the next pass narrows the two rows by the
+        asserted domain and finds its own.
+        """
+        name = "vce-contradict"
+        vc = self._seed_row_kind("masterless_populated", name)
+        before = self._row_fields([vc.pk])
+
+        r = self.client.post(
+            self.apply_url,
+            data={
+                "id": str(uuid.uuid4()),
+                "changes": [{
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.virtualchassis",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {"name": name, "description": "FROM-A", "domain": "dom-a"},
+                }],
+            },
+            format="json", **self.auth,
+        )
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+
+        self.assertEqual(self._row_fields([vc.pk]), before,
+                         "the contradicted row was written after all")
+        rows = VirtualChassis.objects.filter(name=name)
+        self.assertEqual(rows.count(), 2, list(rows.values_list("pk", "domain")))
+        own = rows.exclude(pk=vc.pk).get()
+        self.assertEqual(own.domain, "dom-a")
+        self.assertEqual(own.description, "FROM-A")
+
+    def test_a_masterless_create_on_an_ambiguous_name_is_a_structured_400(self):
+        """
+        The APPLY boundary for ambiguity, reached without the transformer.
+
+        apply-change-set and bulk-apply take a client-supplied changeset
+        straight to the applier, so any ambiguity guard that lived only in the
+        plan path would be a guard with a documented bypass. This is the same
+        two-stacks-one-name state as the plan-time test, driven through the
+        pre-save match instead: it calls find_existing_object, which is where
+        the refusal lives, so one raise covers both doors.
+
+        Neither row may be written and no third row may be inserted -- the two
+        wrong answers here are opposite (bind one, or create a duplicate) and
+        both are silent, which is why the row snapshot and the count are
+        asserted together.
+        """
+        vc_a, _ = self._seed_named_stack(
+            "vce-shared", "building-a", {"vce-a1": 1, "vce-a2": 2})
+        vc_b, _ = self._seed_named_stack(
+            "vce-shared", "building-b", {"vce-b1": 1, "vce-b2": 2})
+        before = self._row_fields([vc_a.pk, vc_b.pk])
+
+        r = self.client.post(
+            self.apply_url,
+            data={
+                "id": str(uuid.uuid4()),
+                "changes": [{
+                    "change_id": str(uuid.uuid4()),
+                    "change_type": "create",
+                    "object_version": None,
+                    "object_type": "dcim.virtualchassis",
+                    "object_id": None,
+                    "ref_id": "1",
+                    "data": {"name": "vce-shared", "description": "FROM-A"},
+                }],
+            },
+            format="json", **self.auth,
+        )
+
+        self.assertEqual(r.status_code, 400, r.content)
+        error = r.json()["errors"]["dcim.virtualchassis"]["name"][0]
+        self.assertIn(f"id {vc_a.pk}", error)
+        self.assertIn(f"id {vc_b.pk}", error)
+        self.assertEqual(self._row_fields([vc_a.pk, vc_b.pk]), before)
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-shared").count(), 2)
+
+    def test_a_stale_plan_applied_never_writes_the_row_it_matched(self):
+        """
+        The same contract through the real plan path, which is how it happens.
+
+        The pre-save match exists for plans that went stale: a worker plans a
+        member device whose chassis is named but not yet present, so its plan
+        holds a masterless create dcim.virtualchassis carrying whatever the
+        source says about the chassis. Between plan and apply, the row appears.
+
+        The membership DOES bind -- the device joins the matched chassis -- and
+        that is the point rather than a concession: binding is what keeps a
+        second, permanently orphaned row out of the table. What must not travel
+        with it is the payload's opinion of that row's own fields.
+        """
+        for kind in self.ROW_KINDS:
+            with self.subTest(row=kind):
+                name = f"vce-plan-{kind.replace('_', '-')}"
+                dev_name = f"vce-a-{kind.replace('_', '-')}"
+                payload = self._device_payload(dev_name, {
+                    "vc_position": 9,
+                    "virtual_chassis": {
+                        # see the note above: no domain, so the row is not
+                        # contradicted and the bind is what gets exercised
+                        "name": name, "description": "FROM-A",
+                    },
+                })
+
+                cs = self._diff(payload)
+                vc_creates = [c for c in cs["changes"]
+                              if c["object_type"] == "dcim.virtualchassis"
+                              and c["change_type"] == "create"]
+                self.assertEqual(len(vc_creates), 1, cs)
+                self.assertIsNone(vc_creates[0]["data"].get("master"), vc_creates[0])
+
+                # ...and only now does the chassis appear.
+                vc = self._seed_row_kind(kind, name)
+                before = self._row_fields([vc.pk])
+
+                r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+                self.assertEqual(r.status_code, 200, r.content)
+                self.assertIsNone(r.json().get("errors"))
+
+                self.assertEqual(self._row_fields([vc.pk]), before,
+                                 f"{kind}: a plan that never named this row wrote it")
+                self.assertEqual(VirtualChassis.objects.filter(name=name).count(), 1,
+                                 f"{kind}: the stale plan left a duplicate row")
+                self.assertEqual(Device.objects.get(name=dev_name).virtual_chassis_id, vc.pk)
+                self._assert_member_count_is_honest(vc)
+
+    def test_a_stale_member_only_plan_leaves_no_orphan_chassis(self):
+        """
+        The routing's own headline case: a name-only plan, applied late.
+
+        This is the shape the pre-save match was added for, and the one a
+        row-level refusal breaks. A member device whose payload names the
+        chassis and nothing else plans exactly
+        create dcim.virtualchassis {"name": X} -- no master, no fields. Refuse
+        that match and the apply inserts a SECOND masterless X, binds the
+        member to it, and leaves it behind forever once a later round rebinds
+        the member: same name, no master, no members, and no diff that ever
+        mentions it, because ingest does not delete rows.
+
+        Binding gives the parent commit's behaviour back exactly: one row, the
+        member joins the converged chassis, its fields untouched, member_count
+        truthful, and the immediate re-diff empty -- converged in one apply.
+        """
+        payload = self._device_payload("vce-late", {
+            "vc_position": 2, "virtual_chassis": {"name": "vce-stack"},
+        })
+        cs = self._diff(payload)
+        vc_creates = [c for c in cs["changes"]
+                      if c["object_type"] == "dcim.virtualchassis"
+                      and c["change_type"] == "create"]
+        self.assertEqual(len(vc_creates), 1, cs)
+        self.assertEqual(vc_creates[0]["data"].get("name"), "vce-stack")
+        self.assertIsNone(vc_creates[0]["data"].get("master"), vc_creates[0])
+        self.assertNotIn("description", vc_creates[0]["data"], vc_creates[0])
+
+        # ...and only now does a converged, MASTERED vce-stack appear.
+        vc, master = self._seed_stack()
+        VirtualChassis.objects.filter(pk=vc.pk).update(
+            description="CONVERGED-B", domain="dom-b"
+        )
+        vc.refresh_from_db()
+        before = self._row_fields([vc.pk])
+
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-stack").count(), 1,
+                         "a second, permanently orphaned chassis was inserted")
+        self.assertEqual(self._row_fields([vc.pk]), before)
+        self.assertEqual(Device.objects.get(name="vce-late").virtual_chassis_id, vc.pk)
+        self.assertEqual(VirtualChassis.objects.get(pk=vc.pk).member_count, 2)
+        self._assert_member_count_is_honest(vc)
+        self._assert_noop_rediff(payload)
+
+    def test_three_stale_member_only_plans_leave_no_orphan_chassis(self):
+        """
+        Orphans accumulate one per stale plan, so more than one must be shown.
+
+        A single stale plan hides the shape of the defect: refusing the match
+        yields ONE extra row, which reads like a duplicate some later pass
+        tidies up. Nothing tidies it up, and every additional planner adds
+        another. Three plans, all built before the chassis existed, must still
+        converge on one row.
+        """
+        plans = []
+        for position, dev_name in enumerate(("vce-l1", "vce-l2", "vce-l3"), start=2):
+            plans.append(self._diff(self._device_payload(dev_name, {
+                "vc_position": position, "virtual_chassis": {"name": "vce-stack"},
+            })))
+
+        vc, _ = self._seed_stack()
+
+        for cs in plans:
+            r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+            self.assertEqual(r.status_code, 200, r.content)
+            self.assertIsNone(r.json().get("errors"))
+
+        rows = VirtualChassis.objects.filter(name="vce-stack")
+        self.assertEqual(rows.count(), 1,
+                         list(rows.values("pk", "master_id", "member_count")))
+        for dev_name in ("vce-l1", "vce-l2", "vce-l3"):
+            self.assertEqual(
+                Device.objects.get(name=dev_name).virtual_chassis_id, vc.pk, dev_name
+            )
+        self.assertEqual(VirtualChassis.objects.get(pk=vc.pk).member_count, 4)
+        self._assert_member_count_is_honest(vc)
+
+    def test_a_bound_chassis_converges_its_fields_on_the_next_pass(self):
+        """
+        Refusing the write is a DEFERRAL, and the design is wrong unless it is.
+
+        The fields a bound CREATE declines to write have to land eventually, or
+        binding is just data loss. They do, and by the ordinary route: the row
+        now exists, so the next generate-diff matches it and plans an UPDATE
+        addressed by object_id -- the path that is entitled to write, because
+        that plan was built against the row rather than guessing at it. One
+        further round is all it takes.
+        """
+        payload = self._device_payload("vce-sw2", {
+            "vc_position": 2,
+            "virtual_chassis": {
+                "name": "vce-stack", "description": "FROM-A",
+            },
+        })
+
+        # Planned while no such chassis exists, so the plan holds a masterless
+        # CREATE. Seeding the row first would have the matcher find it at PLAN
+        # time and plan an UPDATE, which never exercises the bind.
+        cs = self._diff(payload)
+        vc_creates = [c for c in cs["changes"]
+                      if c["object_type"] == "dcim.virtualchassis"
+                      and c["change_type"] == "create"]
+        self.assertEqual(len(vc_creates), 1, cs)
+        vc = VirtualChassis.objects.create(name="vce-stack")
+
+        # pass 1: the CREATE binds the row and declines its fields
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+        fresh = VirtualChassis.objects.get(pk=vc.pk)
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-stack").count(), 1)
+        self.assertEqual(fresh.description, "")
+        self.assertEqual(fresh.domain, "")
+        self.assertEqual(Device.objects.get(name="vce-sw2").virtual_chassis_id, vc.pk)
+
+        # pass 2: the matcher finds the row, so this is an UPDATE naming it
+        cs = self._diff(payload)
+        vc_changes = [c for c in cs["changes"] if c["object_type"] == "dcim.virtualchassis"]
+        self.assertEqual(len(vc_changes), 1, cs)
+        self.assertEqual(vc_changes[0]["change_type"], "update", vc_changes[0])
+        self.assertEqual(vc_changes[0]["object_id"], vc.pk, vc_changes[0])
+        r = self.client.post(self.apply_url, data=cs, format="json", **self.auth)
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+
+        fresh = VirtualChassis.objects.get(pk=vc.pk)
+        self.assertEqual(fresh.description, "FROM-A")
+        # Still empty because this payload never asserted a domain -- it must
+        # not, or it would identify a different chassis and never bind at all.
+        self.assertEqual(fresh.domain, "")
+
+        # ...and that is convergence, not a flap: nothing left to plan.
+        self._assert_noop_rediff(payload)
+
+    def test_a_bound_chassis_is_referenceable_later_in_the_same_changeset(self):
+        """
+        A bound row must reach created[ref_id], or the changeset breaks.
+
+        The find-first path returns the row it settled on and _apply_change
+        stores it under the change's ref_id; every later change resolves its
+        new_object references out of that dict. Binding returns an instance
+        this request never saved, which is exactly the case where an
+        implementation could plausibly return None ("nothing happened") and
+        turn the next change into a KeyError -- surfaced as "unresolved
+        reference", a 400 for a changeset that is perfectly valid.
+        """
+        vc = VirtualChassis.objects.create(name="vce-stack")
+
+        r = self.client.post(
+            self.apply_url,
+            data={
+                "id": str(uuid.uuid4()),
+                "changes": [
+                    {
+                        "change_id": str(uuid.uuid4()),
+                        "change_type": "create",
+                        "object_version": None,
+                        "object_type": "dcim.virtualchassis",
+                        "object_id": None,
+                        "ref_id": "vc-1",
+                        "data": {"name": "vce-stack", "description": "FROM-A"},
+                    },
+                    {
+                        "change_id": str(uuid.uuid4()),
+                        "change_type": "create",
+                        "object_version": None,
+                        "object_type": "dcim.device",
+                        "object_id": None,
+                        "ref_id": "dev-1",
+                        "new_refs": ["virtual_chassis"],
+                        "data": {
+                            "name": "vce-sw2",
+                            "site": self.site.pk,
+                            "role": self.role.pk,
+                            "device_type": self.dt.pk,
+                            "vc_position": 2,
+                            "virtual_chassis": "vc-1",
+                        },
+                    },
+                ],
+            },
+            format="json", **self.auth,
+        )
+
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertIsNone(r.json().get("errors"))
+        self.assertEqual(Device.objects.get(name="vce-sw2").virtual_chassis_id, vc.pk)
+        self.assertEqual(VirtualChassis.objects.filter(name="vce-stack").count(), 1)
+        # ...and the reference did not smuggle the payload in either
+        self.assertEqual(VirtualChassis.objects.get(pk=vc.pk).description, "")
+
+
+    # ---- bind, but still report the payload's errors ----------------------
+
+    #: Over-length values for two VirtualChassis CharFields. Any serializer at
+    #: all rejects these, which is the point: the question under test is
+    #: whether a serializer runs, not which error it produces.
+    TOO_LONG = (("description", "d" * 400), ("domain", "x" * 300))
+
+    def test_an_invalid_masterless_create_on_a_matched_row_is_still_a_400(self):
+        """
+        Binding declines the WRITE. It must not also swallow the payload error.
+
+        _try_bind_existing_instance hands the matched row back without saving,
+        and the first draft of it ran no serializer at all -- so
+        is_valid(raise_exception=True), the only thing that reports a bad
+        payload, never fired. An INVALID masterless CREATE that matched an
+        existing row therefore answered 200 with errors null while storing
+        nothing, where the parent commit answered 400. Two harms, both real:
+        the reconciler is told a change applied when nothing was stored, and
+        the change no longer aborts its own changeset, so companion changes the
+        parent rolled back are left half-landed. It is not permanent silence --
+        the next generate-diff plans an UPDATE carrying the same invalid value
+        and that 400s -- but it is a misreport, and a regression against base.
+
+        The fix validates against the matched instance and discards the save,
+        so both halves have to hold at once: the 400 comes back (here) and the
+        row is still untouched (asserted here too, and across the full matrix
+        in test_a_masterless_create_never_writes_the_row_it_matched).
+
+        Every row kind and both masterless wire forms are covered, because the
+        bind is reached identically for all six and a fix that only restored
+        the error for one of them would be worse than useless.
+        """
+        for field, value in self.TOO_LONG:
+            for kind in self.ROW_KINDS:
+                for label, extra in (("master_absent", {}), ("master_null", {"master": None})):
+                    with self.subTest(field=field, row=kind, master=label):
+                        name = f"vce-inv-{field[:3]}-{kind.replace('_', '-')}-{label.replace('_', '-')}"
+                        vc = self._seed_row_kind(kind, name)
+                        before = self._row_fields([vc.pk])
+                        data = {"name": name, field: value}
+                        data.update(extra)
+
+                        r = self.client.post(
+                            self.apply_url,
+                            data={
+                                "id": str(uuid.uuid4()),
+                                "changes": [{
+                                    "change_id": str(uuid.uuid4()),
+                                    "change_type": "create",
+                                    "object_version": None,
+                                    "object_type": "dcim.virtualchassis",
+                                    "object_id": None,
+                                    "ref_id": "1",
+                                    "data": data,
+                                }],
+                            },
+                            format="json", **self.auth,
+                        )
+
+                        self.assertEqual(r.status_code, 400, r.content)
+                        errors = r.json()["errors"]
+                        self.assertIn("dcim.virtualchassis", errors, errors)
+                        self.assertIn(field, errors["dcim.virtualchassis"], errors)
+
+                        # ...and rejecting it wrote nothing either.
+                        self.assertEqual(self._row_fields([vc.pk]), before,
+                                         f"{field}/{kind}/{label}: the rejected create wrote the row")
+                        self.assertEqual(
+                            VirtualChassis.objects.filter(name=name).count(), 1,
+                            f"{field}/{kind}/{label}: the rejected create inserted a row",
+                        )
+                        self._assert_member_count_is_honest(vc)
+
+    def test_a_valid_masterless_create_on_a_matched_row_is_200_and_writes_nothing(self):
+        """
+        The other half of the same seam, stated next to it.
+
+        Restoring the serializer must not turn a legal payload into an error,
+        and running the serializer must not turn a bind into a write. The
+        values here are well inside both columns' limits and are DIFFERENT from
+        the seeded row's, so a save of any kind would show up in _row_fields --
+        last_updated included, which is what separates "untouched" from "saved
+        with values identical to its own".
+        """
+        for kind in self.ROW_KINDS:
+            for label, extra in (("master_absent", {}), ("master_null", {"master": None})):
+                with self.subTest(row=kind, master=label):
+                    name = f"vce-val-{kind.replace('_', '-')}-{label.replace('_', '-')}"
+                    vc = self._seed_row_kind(kind, name)
+                    before = self._row_fields([vc.pk])
+                    # No domain asserted on purpose: this payload must stay
+                    # INDISTINGUISHABLE from the row it races, which is what
+                    # makes the bind-only contract the thing under test. A
+                    # payload asserting a domain the row does not carry is a
+                    # different case entirely -- it identifies a different
+                    # chassis and gets its own row (see
+                    # test_a_contradicting_domain_takes_its_own_row).
+                    data = {"name": name, "description": "FROM-A"}
+                    data.update(extra)
+
+                    r = self.client.post(
+                        self.apply_url,
+                        data={
+                            "id": str(uuid.uuid4()),
+                            "changes": [{
+                                "change_id": str(uuid.uuid4()),
+                                "change_type": "create",
+                                "object_version": None,
+                                "object_type": "dcim.virtualchassis",
+                                "object_id": None,
+                                "ref_id": "1",
+                                "data": data,
+                            }],
+                        },
+                        format="json", **self.auth,
+                    )
+
+                    self.assertEqual(r.status_code, 200, r.content)
+                    self.assertIsNone(r.json().get("errors"))
+                    self.assertEqual(self._row_fields([vc.pk]), before,
+                                     f"{kind}/{label}: validating the payload also saved it")
+                    self.assertEqual(VirtualChassis.objects.filter(name=name).count(), 1,
+                                     f"{kind}/{label}: the CREATE left a duplicate row behind")
+                    self._assert_member_count_is_honest(vc)
+
+    def test_an_invalid_masterless_create_with_no_matching_row_is_still_a_400(self):
+        """
+        The control: with nothing to bind, the error was never in question.
+
+        This is the arm that localises the bug to the bind. It 400s on the
+        parent commit, on the first draft of this branch, and here, because it
+        goes through _create_or_find_instance's own serializer. If it ever
+        diverged from the matched-row arms above, the difference would be
+        somewhere other than the seam this fix touches.
+        """
+        for field, value in self.TOO_LONG:
+            with self.subTest(field=field):
+                name = f"vce-nomatch-{field[:3]}"
+                r = self.client.post(
+                    self.apply_url,
+                    data={
+                        "id": str(uuid.uuid4()),
+                        "changes": [{
+                            "change_id": str(uuid.uuid4()),
+                            "change_type": "create",
+                            "object_version": None,
+                            "object_type": "dcim.virtualchassis",
+                            "object_id": None,
+                            "ref_id": "1",
+                            "data": {"name": name, field: value},
+                        }],
+                    },
+                    format="json", **self.auth,
+                )
+                self.assertEqual(r.status_code, 400, r.content)
+                self.assertIn(field, r.json()["errors"]["dcim.virtualchassis"], r.content)
+                self.assertFalse(VirtualChassis.objects.filter(name=name).exists())
+
+
+class BindOnlyReachabilityTests(SimpleTestCase):
+    """
+    The no-write guarantee covers the CREATE path. This pins its edge.
+
+    _try_bind_existing_instance writes nothing to the row it binds. The UPDATE
+    branch of _apply_change that resolves through created[ref_id] is an
+    ordinary serializer.save(), so a changeset pairing a create with a
+    ref_id-only update of the SAME object_type (object_id null) writes that
+    update's payload onto the bound row. The parent commit does the same;
+    origin/develop does not, because it inserts a duplicate and writes to that
+    instead -- so it is a divergence from develop in the destructive direction,
+    and the only reason it is a documentation item rather than a defect is that
+    nothing plannable emits that shape.
+
+    The same-type scoping is load-bearing. A ref_id-only update of a DIFFERENT
+    object_type also matches the parent, but that is a property of
+    applier._instance_for_deferred_update rather than of this branch, and
+    DeferredUpdateRefTypeTests is what pins it.
+
+    That reachability rests on ONE fact: transformer._IS_CIRCULAR_REFERENCE is
+    what makes generate-diff split a create from a ref_id-only update, and no
+    bind-only type is in it (measured: 0 of 960 planned changes across three
+    matrix runs was a VC update with no object_id). Adding one there would make
+    the gap reachable from ordinary ingest, silently.
+
+    A runtime guard was considered and rejected: silently skipping a write a
+    client changeset explicitly asked for is a new, undocumented behaviour, and
+    it would mask the intent instead of surfacing it. A seam test costs nothing
+    at runtime and fails loudly the moment the assumption stops holding, which
+    is the behaviour that is actually wanted here.
+    """
+
+    def test_bind_only_types_are_not_circular_references(self):
+        """No bind-only type may be split into a create plus a ref_id update."""
+        overlap = _PRE_SAVE_MATCH_BIND_ONLY & set(_IS_CIRCULAR_REFERENCE)
+        self.assertEqual(
+            overlap, set(),
+            "A bind-only type gained a deferred reference. _apply_change's "
+            "ref_id UPDATE branch saves, so generate-diff can now write the "
+            "row a CREATE only bound. Decide that deliberately before "
+            "relaxing this test.",
+        )
+
+
+class CoercePkTests(SimpleTestCase):
+    """
+    What may reach an ORM pk filter, for every shape a payload FK can carry.
+
+    Declining is never merely defensive: an unusable value passed through
+    raises ValueError/TypeError out of the ORM, and apply_changeset does not
+    catch either, so it lands as a 500 instead of the serializer's 400.
+    """
+
+    def test_usable_pk_forms_are_coerced(self):
+        """A resolved instance, an int, and a numeric string all yield the pk."""
+        self.assertEqual(_coerce_pk(SimpleNamespace(pk=7)), 7)
+        self.assertEqual(_coerce_pk(7), 7)
+        self.assertEqual(_coerce_pk("7"), 7)
+
+    def test_unusable_pk_forms_are_declined(self):
+        """Nothing the ORM would choke on gets through -- including an unsaved instance."""
+        for value in (None, "", "abc", "7.5", 7.5, [7], (7,), {"pk": 7}, SimpleNamespace(pk=None)):
+            with self.subTest(value=value):
+                self.assertIsNone(_coerce_pk(value))
+
+    def test_bool_is_not_a_pk(self):
+        """A bool is an int subclass, so True would otherwise silently mean pk 1."""
+        self.assertIsNone(_coerce_pk(True))
+        self.assertIsNone(_coerce_pk(False))


### PR DESCRIPTION
## Summary

Full NetBox 4.7.x support (ASUR-963): schema map sync, compatibility fixes for 4.7's behavior changes, `max_version` bump to `4.7.99`, fixture/CI/test-tree scaffolding, and regression cases for the new 4.7 entity types. Cloud delivery is waiting on the released `max_version` bump for NBC's 4.7.x rollout.

## Compatibility fixes (things NetBox 4.7 changed)

Running the mirrored test suite against 4.7 initially produced **1446 failing blocks**; these four fixes take it to **811 tests, OK**:

1. **`CustomField.objects.get_for_model()` returns a list now** (and queries eagerly). The matcher chained `.filter(unique=True)` onto it — crashed nearly everything. Now filters by iteration (QuerySet- and list-compatible).
2. **Device/VM name-uniqueness became a single `nulls_distinct=False` constraint** (the partial tenant-isnull twin is gone). The matcher treated absent constraint fields as unmatchable, so every tenant-less device fell to the create path (duplicates / 400s). `ObjectMatchCriteria` now treats absent/None fields as IS NULL for such constraints.
3. **`Service.protocol`/`ports` are no longer model-backed.** A new diode migration synthesizes `port_mappings` (`"tcp/53"`-style) from the legacy pair, so existing producers keep working unchanged on 4.7.
4. **Attribute-based related-object resolution is now permission-scoped** (`get_related_object_by_attrs(user=...)`, the enforcement side of NetBox security fix #21988), and — found during review — **interface MAC writes now require `dcim.add_macaddress`** (`MACAddressShortcutMixin`). An earlier revision of this PR made the service user a superuser; an adversarial security review rejected that (it reverted migration `0005_revoke_superuser_status` shipped for cause in #37, would have retroactively promoted never-deleted legacy diode API tokens on upgraded deployments, disabled a NetBox security control, and made operator revocation impossible while conflicting with SSO/REMOTE_AUTH). **Shipped instead**: a `post_migrate` receiver provisions two explicit ObjectPermissions for the service user — an unconstrained **view** grant across all object types (zero per-lookup SQL: `restrict()` short-circuits unconstrained grants; matches the matcher's existing unrestricted read posture) and an **add** grant on `dcim.macaddress` only. Re-synced on every `manage.py migrate`, so new object types are covered by the same command that installs them. The service user keeps an unusable password, and deactivating it or disabling the permissions in the UI is respected as a kill switch. Follow-up filed for the longer-term ideal (applier-side pre-resolution to IDs, NetBox's documented exempt path) and for auditing legacy pre-squash diode API tokens.

## Support scaffolding

- `max_version = "4.7.99"`; README compatibility row (`>= 4.7.0` / `1.17.0`). (The `netbox-plugin.yaml` manifest entry from an earlier revision is gone — develop deleted the manifest as unused in #208, and the rebase adopts that.)
- `docker/v4.7.x/` fixture (NetBox v4.7.0 GA on netbox-docker 5.1.0; `netboxlabs-netbox-branching` pinned to `1.2.0` GA, the first 4.7-compatible release)
- CI matrix gains `v4.7.0`
- `tests/v4.7.x/` mirrored from v4.6.x, plus five new 4.7 cases: ModuleBayType / CoolingSource / CoolingFeed / CoolingIntake round-trips and a native `port_mappings` service case
- Regenerated `plugin_utils.py` synced at 4.7.0 GA

5. **Counter buffering (#207) was 4.7-incompatible**: NetBox 4.7 passes `using=` through the counter signal handlers and the buffered wrapper's fixed signature raised TypeError on every counted write. Fixed with conditional forwarding (older NetBox originals reject the kwarg) and non-default-database deltas now delegate instead of buffering; `test_counter_buffer.py` mirrored into the v4.7.x tree.

Also adds compatibility guard tests: the declared min/max version range must cover the NetBox version the suite runs against (a stale `max_version` breaks field upgrades, never the suite itself), plus the service user's active-superuser invariant including lazy upgrade.

## End-to-end validation

The full pipeline was exercised against a live stack — diode-sdk-python (#109) → diode server built from netboxlabs/diode#577 → this branch → NetBox 4.7: **26/26 e2e checks pass**, covering name-based reference resolution (permission gate 1), interface MAC ingest (gate 2), channelized breakout (parent `channels` + subinterface `parent`/`channel_id`), `port_mappings` native and legacy forms, all five new 4.7 entities, and re-ingest idempotency. The e2e run surfaced two additional gaps, both fixed here: the flat `mac_address` write-shortcut (serializer-only field) was silently rejected by the diffable-field gate — now translated to the modeled `primary_mac_address` form via compat migrations — and lazily-created ObjectTypes drifted outside the provisioned view grant — now extended via ContentType post_save receivers.

## Verification

- Suite on **v4.7.0 GA: 842 tests, OK** (from 1446 failing blocks pre-fix), rebased onto current develop (#207/#208)
- 4.6/4.5/4.4 regression coverage via the CI matrix on this PR (the compat fixes are version-agnostic by construction)

Validated against **NetBox 4.7.0 GA** (fresh test database required when upgrading local keepdb databases from pre-release runs - GA renumbered the ipam migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)






