### PR TITLE
feat: match rack reservations by unit overlap so re-ingest converges (MON-325)

### DIFF
--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -94,7 +94,7 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| logical_cable_termination_set | 1 | logical |  | N/A | Custom matcher | All versions |
+| logical_cable_termination_set | 1 | logical | a_terminations, b_terminations | N/A | Match a Cable by its canonical set of terminations. | All versions |
 
 ## dcim.cablebundle
 
@@ -288,7 +288,7 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| logical_rackreservation_unit_overlap | 1 | logical |  | N/A | Custom matcher | All versions |
+| logical_rackreservation_unit_overlap | 1 | logical | rack, units | N/A | Match a RackReservation by unit overlap within its rack. | All versions |
 
 ## dcim.rackrole
 
@@ -345,7 +345,7 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| logical_vc_name_no_master | 1 | logical |  | N/A | Custom matcher | All versions |
+| logical_vc_name_no_master | 1 | logical | name | N/A | Best-effort VirtualChassis matcher: by name, only when the payload has no master. | All versions |
 | unique_master | 2 | builtin | master | N/A | Matches on unique field(s): master | All versions |
 
 ## dcim.virtualdevicecontext
@@ -426,15 +426,15 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| logical_ip_address_global_no_vrf | 1 | logical |  | N/A | Matches IP address address in global namespace (no VRF) | All versions |
-| logical_ip_address_within_vrf | 2 | logical |  | N/A | Matches IP address address within VRF | All versions |
+| logical_ip_address_global_no_vrf | 1 | logical | address | N/A | Matches IP address address in global namespace (no VRF) | All versions |
+| logical_ip_address_within_vrf | 2 | logical | address | N/A | Matches IP address address within VRF | All versions |
 
 ## ipam.iprange
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| logical_ip_range_start_end_global_no_vrf | 1 | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
-| logical_ip_range_start_end_within_vrf | 2 | logical |  | N/A | Matches IP range start_address, end_address within VRF context | All versions |
+| logical_ip_range_start_end_global_no_vrf | 1 | logical | start_address, end_address | N/A | Matches IP range start_address, end_address in global namespace (no VRF) | All versions |
+| logical_ip_range_start_end_within_vrf | 2 | logical | start_address, end_address | N/A | Matches IP range start_address, end_address within VRF context | All versions |
 
 ## ipam.prefix
 

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -284,6 +284,12 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
 | unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
+## dcim.rackreservation
+
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|---------------------|------|--------|-----------|-------------|---------------------|
+| logical_rackreservation_unit_overlap | 1 | logical |  | N/A | Custom matcher | All versions |
+
 ## dcim.rackrole
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -1935,7 +1935,7 @@ class RackReservationUnitOverlapMatcher:
         listing = "; ".join(
             f"pk={r.pk} units={sorted(r.units)} user_id={r.user_id}" for r in rows
         )
-        units = sorted({u for u in data.get("units", []) if isinstance(u, int)})
+        units = sorted({u for u in data.get("units", []) if self._real_int(u)})
         raise AmbiguousObjectMatch(
             f"dcim.rackreservation payload units {units} overlap "
             f"{len(rows)} existing reservations on rack {data.get('rack')}: "

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -936,6 +936,12 @@ _LOGICAL_MATCHERS = {
             condition=Q(assigned_object_id__isnull=True),
         ),
     ],
+    "dcim.rackreservation": lambda: [
+        RackReservationUnitOverlapMatcher(
+            model_class=get_object_type_model("dcim.rackreservation"),
+            name="logical_rackreservation_unit_overlap",
+        )
+    ],
     "ipam.aggregate": lambda: [
         ObjectMatchCriteria(
             fields=("prefix",),
@@ -1821,6 +1827,125 @@ class CableTerminationSetMatcher:
 
 
 @dataclass
+class RackReservationUnitOverlapMatcher:
+    """
+    Match a RackReservation by unit overlap within its rack.
+
+    RackReservation has no unique constraint; identity is chosen as "same
+    rack, sharing at least one unit". Exact-set equality would never
+    converge a payload whose unit set grew or shrank between cycles;
+    overlap does, with the submitted units replacing the stored set.
+    ObjectMatchCriteria is scalar-field-only and cannot express an
+    ArrayField overlap.
+
+    A payload overlapping SEVERAL reservations has no single-row answer
+    (binding any one still conflicts with the others at validation), so
+    resolve() refuses to choose rather than guessing -- see resolve().
+    """
+
+    model_class: type[models.Model]
+    name: str
+
+    min_version: str | None = None
+    max_version: str | None = None
+
+    def has_required_fields(self, data: dict) -> bool:
+        """A rack ref and a non-empty units list are present."""
+        units = data.get("units")
+        return (
+            data.get("rack") is not None
+            and isinstance(units, list)
+            and len(units) > 0
+        )
+
+    @staticmethod
+    def _real_int(value) -> bool:
+        """int excluding bool: True would otherwise mean pk/unit 1."""
+        return isinstance(value, int) and not isinstance(value, bool)
+
+    def _clean_units(self, data: dict) -> list | None:
+        """The units list when every element is a real int, else None."""
+        units = data.get("units")
+        if not isinstance(units, list) or not units:
+            return None
+        if not all(self._real_int(u) for u in units):
+            return None
+        return units
+
+    def fingerprint(self, data: dict) -> int | None:
+        """
+        In-batch dedupe key: rack ref + exact unit set, order-insensitive.
+
+        Overlap is not hashable, so only IDENTICAL unit sets merge here.
+        Overlapping-but-different in-batch payloads plan separately and
+        converge onto one row at apply through the pre-save re-match (last
+        writer wins) -- the same end state they reach when sent in separate
+        batches. Authoritative matching is build_queryset.
+        """
+        rack = data.get("rack")
+        units = self._clean_units(data)
+        if rack is None or units is None:
+            return None
+        if isinstance(rack, UnresolvedReference):
+            rack_key = ("__uuid__", rack.uuid)
+        elif self._real_int(rack):
+            rack_key = rack
+        else:
+            rack_key = ("__str__", str(rack))
+        return hash((
+            self.model_class.__name__,
+            self.name,
+            rack_key,
+            tuple(sorted(set(units))),
+        ))
+
+    def build_queryset(self, data: dict) -> models.QuerySet | None:
+        """
+        Overlap query, only when the rack is a resolved int pk.
+
+        Resolved references arrive as plain ints; an UnresolvedReference
+        means the rack is either being created in this batch or exists but
+        failed to match -- either way there is no pk to query, so abstain
+        and let the CREATE stand. bool is rejected explicitly: on the
+        direct apply path rack=true would otherwise coerce to rack_id=1
+        and hand the payload to rack 1's overlapping reservation.
+        """
+        rack = data.get("rack")
+        units = self._clean_units(data)
+        if units is None or not self._real_int(rack):
+            return None
+        return self.model_class.objects.filter(rack_id=rack, units__overlap=units)
+
+    def resolve(self, queryset: models.QuerySet, data: dict):
+        """
+        Bind a single overlapping reservation, or refuse to choose.
+
+        Zero rows: create. One row: that reservation, whatever its user --
+        every submitted field, user included, is last-writer-wins on a
+        match. Two or more rows: raise rather than guess; the message
+        names the rows and the remedies, and the same refusal covers rows
+        left behind by the residual concurrent-apply race.
+        """
+        rows = list(queryset.order_by("pk"))
+        if not rows:
+            return None
+        if len(rows) == 1:
+            return rows[0]
+        listing = "; ".join(
+            f"pk={r.pk} units={sorted(r.units)} user_id={r.user_id}" for r in rows
+        )
+        units = sorted({u for u in data.get("units", []) if isinstance(u, int)})
+        raise AmbiguousObjectMatch(
+            f"dcim.rackreservation payload units {units} overlap "
+            f"{len(rows)} existing reservations on rack {data.get('rack')}: "
+            f"{listing}. Split the payload to align with the existing "
+            "reservations, or merge/delete the overlapping reservations in "
+            "NetBox.",
+            "dcim.rackreservation",
+        )
+
+
+@dataclass
 class VRFIPNetworkIPMatcher:
     """Matches ip in a vrf, ignores mask."""
 
@@ -2143,6 +2268,13 @@ def _find_obj_cache_key(data: dict, object_type: str) -> str | None:
     if object_type == "dcim.cable":
         # Cable identity lives entirely in list fields skipped by the scalar-only
         # cache key; always run the authoritative build_queryset matcher loop.
+        return None
+
+    if object_type == "dcim.rackreservation":
+        # Reservation identity lives in the units ArrayField, which the
+        # scalar-only key below skips -- two different reservations on one
+        # rack could share a key and serve each other's cached answer.
+        # Returning None disables both the django and request-scoped caches.
         return None
 
     if object_type == "dcim.virtualchassis":

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -1861,7 +1861,7 @@ class RackReservationUnitOverlapMatcher:
 
     @staticmethod
     def _real_int(value) -> bool:
-        """int excluding bool: True would otherwise mean pk/unit 1."""
+        """Accept only real ints: bool would otherwise mean pk/unit 1."""
         return isinstance(value, int) and not isinstance(value, bool)
 
     def _clean_units(self, data: dict) -> list | None:

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -156,6 +156,7 @@ _REQUIRES_PRE_SAVE_MATCH = frozenset({
     "dcim.macaddress",
     "dcim.module",
     "dcim.modulebay",
+    "dcim.rackreservation",
     "dcim.virtualchassis",
     "ipam.prefix",
     "ipam.vlan",

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -7,7 +7,11 @@ from typing import Optional
 from django.core.management.base import BaseCommand
 
 from netbox_diode_plugin.api.differ import extract_supported_models
-from netbox_diode_plugin.api.matcher import _LOGICAL_MATCHERS, get_model_matchers
+from netbox_diode_plugin.api.matcher import (
+    _LOGICAL_MATCHERS,
+    ObjectMatchCriteria,
+    get_model_matchers,
+)
 
 
 @dataclass
@@ -64,7 +68,9 @@ class Command(BaseCommand):
                 return f"Matches IP address {ip_fields_str} in global namespace (no VRF)"
             if matcher.name.startswith('logical_ip_address_within_vrf'):
                 return f"Matches IP address {ip_fields_str} within VRF"
-            if matcher.name.startswith('logical_ip_range'):
+            if 'global_no_vrf' in matcher.name:
+                return f"Matches IP range {ip_fields_str} in global namespace (no VRF)"
+            if 'within_vrf' in matcher.name:
                 return f"Matches IP range {ip_fields_str} within VRF context"
 
         # Handle CustomFieldMatcher
@@ -97,7 +103,41 @@ class Command(BaseCommand):
                 return f"Matches on fields: {fields_str} where {condition_desc}"
             return f"Matches on fields: {fields_str}"
 
+        # Fall back to the matcher class's own docstring for custom matcher
+        # classes that have nothing functional to describe them by.
+        if type(matcher) is not ObjectMatchCriteria:
+            doc = matcher.__class__.__doc__
+            if doc:
+                first_line = doc.strip().splitlines()[0].strip()
+                if first_line:
+                    return first_line
+
         return "Custom matcher"
+
+    def get_matcher_fields(self, matcher) -> list[str] | None:
+        """Derive the Fields column value for a matcher, in priority order."""
+        fields = getattr(matcher, "fields", None)
+        if fields:
+            return list(fields)
+
+        ip_fields = getattr(matcher, "ip_fields", None)
+        if ip_fields:
+            return list(ip_fields)
+
+        a_field = getattr(matcher, "a_field", None)
+        b_field = getattr(matcher, "b_field", None)
+        if a_field and b_field:
+            return [a_field, b_field]
+
+        class_field_map = {
+            "VirtualChassisNameMatcher": ["name"],
+            "RackReservationUnitOverlapMatcher": ["rack", "units"],
+        }
+        mapped_fields = class_field_map.get(matcher.__class__.__name__)
+        if mapped_fields:
+            return mapped_fields
+
+        return None
 
     def get_version_constraints(self, matcher) -> str | None:
         """Get version constraints as a string."""
@@ -120,7 +160,7 @@ class Command(BaseCommand):
             for matcher in matchers:
                 info = MatcherInfo(
                     name=matcher.name,
-                    fields=list(matcher.fields) if hasattr(matcher, 'fields') and matcher.fields else None,
+                    fields=self.get_matcher_fields(matcher),
                     condition=self.extract_condition_description(matcher.condition) if hasattr(matcher, 'condition') else None,
                     description=self.get_matcher_description(matcher),
                     matcher_type=matcher.__class__.__name__,

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_generate_matching_docs.py
@@ -12,7 +12,14 @@ from django.core.management.base import CommandError
 from django.db.models import Q
 from django.test import TestCase
 
-from netbox_diode_plugin.api.matcher import AutoSlugMatcher, ObjectMatchCriteria
+from netbox_diode_plugin.api.matcher import (
+    AutoSlugMatcher,
+    CableTerminationSetMatcher,
+    GlobalIPNetworkIPMatcher,
+    ObjectMatchCriteria,
+    RackReservationUnitOverlapMatcher,
+    VirtualChassisNameMatcher,
+)
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
     Command,
     MatcherInfo,
@@ -128,6 +135,73 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         result = self.command.get_matcher_description(mock_matcher)
         self.assertEqual(result, "Matches IP range start_address, end_address within VRF context")
+
+    def test_get_matcher_description_ip_range_global_no_vrf(self):
+        """Test getting matcher description for IP range global-no-VRF matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_range_start_end_global_no_vrf"
+        mock_matcher.ip_fields = ["start_address", "end_address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertIn("no VRF", result)
+        self.assertEqual(
+            result, "Matches IP range start_address, end_address in global namespace (no VRF)"
+        )
+
+    def test_get_matcher_fields_cable_termination_set(self):
+        """Test deriving Fields for a real CableTerminationSetMatcher via a/b field names."""
+        matcher = CableTerminationSetMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["a_terminations", "b_terminations"])
+
+    def test_get_matcher_fields_virtual_chassis_name(self):
+        """Test deriving Fields for a real VirtualChassisNameMatcher via the class-name map."""
+        matcher = VirtualChassisNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["name"])
+
+    def test_get_matcher_fields_rackreservation_unit_overlap(self):
+        """Test deriving Fields for a real RackReservationUnitOverlapMatcher via the class-name map."""
+        matcher = RackReservationUnitOverlapMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["rack", "units"])
+
+    def test_get_matcher_fields_global_ip_network(self):
+        """Test deriving Fields for a real GlobalIPNetworkIPMatcher via ip_fields."""
+        matcher = GlobalIPNetworkIPMatcher(
+            ip_fields=["address"], vrf_field="vrf", model_class=None, name="x"
+        )
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["address"])
+
+    def test_get_matcher_description_cable_termination_set_docstring(self):
+        """Test that CableTerminationSetMatcher's description derives from its docstring."""
+        matcher = CableTerminationSetMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = CableTerminationSetMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
+
+    def test_get_matcher_description_virtual_chassis_name_docstring(self):
+        """Test that VirtualChassisNameMatcher's description derives from its docstring."""
+        matcher = VirtualChassisNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = VirtualChassisNameMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
+
+    def test_get_matcher_description_rackreservation_unit_overlap_docstring(self):
+        """Test that RackReservationUnitOverlapMatcher's description derives from its docstring."""
+        matcher = RackReservationUnitOverlapMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = RackReservationUnitOverlapMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
 
     def test_get_matcher_description_standard_fields(self):
         """Test getting matcher description for standard field-based matcher."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_ingest_convergence.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""RackReservation ingest convergence: overlap identity end-to-end.
+
+All rack payloads here carry a location and the rack is pre-seeded with it,
+so the rack ref re-matches on every cycle; the location-less rack shape has
+a separate, known matching gap and is deliberately not used.
+"""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import ChangeSetException
+from netbox_diode_plugin.api.differ import generate_changeset
+
+
+class RackReservationConvergenceTestCase(TestCase):
+    """Diff+apply round-trips for the unit-overlap identity."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Location-bearing rack and the reservation's user, pre-seeded."""
+        cls.site = Site.objects.create(name="rrc-site", slug="rrc-site")
+        cls.location = Location.objects.create(
+            name="rrc-loc", slug="rrc-loc", site=cls.site
+        )
+        cls.rack = Rack.objects.create(
+            name="rrc-rack", site=cls.site, location=cls.location
+        )
+        cls.user = User.objects.create(username="rrc-owner")
+        cls.user2 = User.objects.create(username="rrc-owner2")
+
+    def _entity(self, units, description="reserved", username="rrc-owner"):
+        return {
+            "rack": {
+                "name": "rrc-rack",
+                "site": {"name": "rrc-site"},
+                "location": {"name": "rrc-loc", "site": {"name": "rrc-site"}},
+            },
+            "units": units,
+            "description": description,
+            "user": {"username": username},
+        }
+
+    def _plan(self, entity):
+        return generate_changeset(entity, "dcim.rackreservation").change_set
+
+    def _apply(self, change_set):
+        return apply_changeset(change_set, request=None)
+
+    def _ingest(self, entity):
+        self._apply(self._plan(entity))
+
+    def test_identical_reingest_is_all_noop(self):
+        """The convergence bug: a second identical ingest must plan nothing."""
+        self._ingest(self._entity([1, 2, 3]))
+        cs = self._plan(self._entity([1, 2, 3]))
+        non_noop = [c for c in cs.changes if c.change_type.value != "noop"]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+        # and the rack itself re-matched (guards the test's own premise)
+        self.assertEqual(Rack.objects.filter(name="rrc-rack").count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_grow_units_updates_in_place(self):
+        """[1, 2] -> [1, 2, 3] is an UPDATE of the same row."""
+        self._ingest(self._entity([1, 2]))
+        rr = RackReservation.objects.get()
+        cs = self._plan(self._entity([1, 2, 3]))
+        updates = [c for c in cs.changes
+                   if c.object_type == "dcim.rackreservation"]
+        self.assertEqual(len(updates), 1, [c.to_dict() for c in cs.changes])
+        self.assertEqual(updates[0].change_type.value, "update")
+        self.assertEqual(updates[0].object_id, rr.pk)
+        self._apply(cs)
+        rr.refresh_from_db()
+        self.assertEqual(sorted(rr.units), [1, 2, 3])
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_shrink_units_updates_in_place(self):
+        """[1, 2, 3] -> [1, 2] shrinks the stored set (last writer wins)."""
+        self._ingest(self._entity([1, 2, 3]))
+        rr = RackReservation.objects.get()
+        cs = self._plan(self._entity([1, 2]))
+        updates = [c for c in cs.changes
+                   if c.object_type == "dcim.rackreservation"]
+        self.assertEqual(len(updates), 1, [c.to_dict() for c in cs.changes])
+        self.assertEqual(updates[0].change_type.value, "update")
+        self.assertEqual(updates[0].object_id, rr.pk)
+        self._apply(cs)
+        rr.refresh_from_db()
+        self.assertEqual(sorted(rr.units), [1, 2])
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_disjoint_units_create_second_reservation(self):
+        """No shared unit means a different reservation, any user."""
+        self._ingest(self._entity([1, 2]))
+        self._ingest(self._entity([5, 6], username="rrc-owner2"))
+        self.assertEqual(RackReservation.objects.count(), 2)
+        by_units = {tuple(sorted(r.units)): r for r in RackReservation.objects.all()}
+        self.assertEqual(by_units[(1, 2)].user_id, self.user.pk)
+        self.assertEqual(by_units[(5, 6)].user_id, self.user2.pk)
+
+    def test_field_changes_flow_through_on_match(self):
+        """description/user updates ride the overlap match."""
+        self._ingest(self._entity([1, 2], description="old"))
+        self._ingest(self._entity([1, 2], description="new", username="rrc-owner2"))
+        rr = RackReservation.objects.get()
+        self.assertEqual(rr.description, "new")
+        self.assertEqual(rr.user_id, self.user2.pk)
+
+    def test_multi_overlap_fails_at_plan_time(self):
+        """A payload spanning two reservations is refused loudly at plan."""
+        RackReservation.objects.create(
+            rack=self.rack, units=[1], user=self.user, description="a"
+        )
+        RackReservation.objects.create(
+            rack=self.rack, units=[2], user=self.user, description="b"
+        )
+        with self.assertRaises(ChangeSetException) as cm:
+            self._plan(self._entity([1, 2]))
+        self.assertIn("overlap", str(cm.exception))
+        self.assertEqual(RackReservation.objects.count(), 2)  # nothing changed
+
+    def test_batch_invariance_overlapping_plans_converge_to_one_row(self):
+        """Two overlapping CREATEs planned together adopt, last writer wins."""
+        cs_a = self._plan(self._entity([1, 2], description="first"))
+        cs_b = self._plan(self._entity([2, 3], description="second"))
+        self._apply(cs_a)
+        self._apply(cs_b)  # pre-save re-match adopts the row cs_a created
+        rr = RackReservation.objects.get()
+        self.assertEqual(sorted(rr.units), [2, 3])
+        self.assertEqual(rr.description, "second")
+
+    def test_stale_create_adopts_existing_reservation(self):
+        """A CREATE planned before the row existed applies onto it, not beside it."""
+        cs = self._plan(self._entity([1, 2], description="from-plan"))
+        RackReservation.objects.create(
+            rack=self.rack, units=[1, 2], user=self.user, description="raced-in"
+        )
+        self._apply(cs)
+        rr = RackReservation.objects.get()
+        self.assertEqual(rr.description, "from-plan")  # payload applied
+        self.assertEqual(sorted(rr.units), [1, 2])

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_ingest_convergence.py
@@ -9,6 +9,7 @@ a separate, known matching gap and is deliberately not used.
 
 from dcim.models import Location, Rack, RackReservation, Site
 from django.test import TestCase
+from tenancy.models import Tenant
 from users.models import User
 
 from netbox_diode_plugin.api.applier import apply_changeset
@@ -31,9 +32,10 @@ class RackReservationConvergenceTestCase(TestCase):
         )
         cls.user = User.objects.create(username="rrc-owner")
         cls.user2 = User.objects.create(username="rrc-owner2")
+        cls.tenant = Tenant.objects.create(name="rrc-tenant", slug="rrc-tenant")
 
-    def _entity(self, units, description="reserved", username="rrc-owner"):
-        return {
+    def _entity(self, units, description="reserved", username="rrc-owner", tenant=None, status=None):
+        entity = {
             "rack": {
                 "name": "rrc-rack",
                 "site": {"name": "rrc-site"},
@@ -43,6 +45,11 @@ class RackReservationConvergenceTestCase(TestCase):
             "description": description,
             "user": {"username": username},
         }
+        if tenant is not None:
+            entity["tenant"] = {"name": tenant}
+        if status is not None:
+            entity["status"] = status
+        return entity
 
     def _plan(self, entity):
         return generate_changeset(entity, "dcim.rackreservation").change_set
@@ -103,12 +110,20 @@ class RackReservationConvergenceTestCase(TestCase):
         self.assertEqual(by_units[(5, 6)].user_id, self.user2.pk)
 
     def test_field_changes_flow_through_on_match(self):
-        """description/user updates ride the overlap match."""
+        """description/user/tenant/status updates ride the overlap match."""
         self._ingest(self._entity([1, 2], description="old"))
-        self._ingest(self._entity([1, 2], description="new", username="rrc-owner2"))
+        self._ingest(self._entity(
+            [1, 2],
+            description="new",
+            username="rrc-owner2",
+            tenant="rrc-tenant",
+            status="pending"
+        ))
         rr = RackReservation.objects.get()
         self.assertEqual(rr.description, "new")
         self.assertEqual(rr.user_id, self.user2.pk)
+        self.assertEqual(rr.tenant_id, self.tenant.pk)
+        self.assertEqual(rr.status, "pending")
 
     def test_multi_overlap_fails_at_plan_time(self):
         """A payload spanning two reservations is refused loudly at plan."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_ingest_convergence.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2026 NetBox Labs, Inc.
-"""RackReservation ingest convergence: overlap identity end-to-end.
+"""
+RackReservation ingest convergence: overlap identity end-to-end.
 
 All rack payloads here carry a location and the rack is pre-seeded with it,
 so the rack ref re-matches on every cycle; the location-less rack shape has

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_matcher.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for RackReservationUnitOverlapMatcher and dcim.rackreservation routing."""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.matcher import (
+    AmbiguousObjectMatch,
+    RackReservationUnitOverlapMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+def _matcher():
+    return RackReservationUnitOverlapMatcher(
+        model_class=get_object_type_model("dcim.rackreservation"),
+        name="logical_rackreservation_unit_overlap",
+    )
+
+
+class RackReservationMatcherFieldsTestCase(TestCase):
+    """has_required_fields / build_queryset abstain rules (no DB rows needed)."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_has_required_fields_present(self):
+        """Rack ref plus non-empty units satisfies the gate."""
+        self.assertTrue(self.matcher.has_required_fields({"rack": 1, "units": [1]}))
+
+    def test_has_required_fields_missing_units(self):
+        """No units -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"rack": 1}))
+
+    def test_has_required_fields_empty_units(self):
+        """Empty units list -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"rack": 1, "units": []}))
+
+    def test_has_required_fields_missing_rack(self):
+        """No rack -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"units": [1]}))
+
+    def test_build_queryset_abstains_on_unresolved_rack(self):
+        """An in-batch rack ref has no pk to query -> abstain."""
+        ref = UnresolvedReference(object_type="dcim.rack", uuid="u-1")
+        self.assertIsNone(self.matcher.build_queryset({"rack": ref, "units": [1]}))
+
+    def test_build_queryset_abstains_on_bool_rack(self):
+        """rack=True must NOT be treated as pk 1."""
+        self.assertIsNone(self.matcher.build_queryset({"rack": True, "units": [1]}))
+
+    def test_build_queryset_abstains_on_non_int_unit(self):
+        """A non-int (or bool) unit element -> abstain, not a crash."""
+        self.assertIsNone(self.matcher.build_queryset({"rack": 1, "units": [1, "2"]}))
+        self.assertIsNone(self.matcher.build_queryset({"rack": 1, "units": [1, True]}))
+
+
+class RackReservationMatcherFingerprintTestCase(TestCase):
+    """In-batch dedupe fingerprint: exact unit set, order/duplicate-insensitive."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_fingerprint_equal_under_reorder_and_duplicates(self):
+        """Same rack + same unit set (any order, with dups) -> same key."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1, 2, 3]})
+        b = self.matcher.fingerprint({"rack": 7, "units": [3, 1, 2, 2]})
+        self.assertIsNotNone(a)
+        self.assertEqual(a, b)
+
+    def test_fingerprint_differs_on_unit_set(self):
+        """Overlapping-but-different unit sets do NOT dedupe-merge in batch."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1, 2]})
+        b = self.matcher.fingerprint({"rack": 7, "units": [2, 3]})
+        self.assertNotEqual(a, b)
+
+    def test_fingerprint_differs_on_rack(self):
+        """Same units on different racks are different reservations."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1]})
+        b = self.matcher.fingerprint({"rack": 8, "units": [1]})
+        self.assertNotEqual(a, b)
+
+    def test_fingerprint_unresolved_rack_keys_on_uuid(self):
+        """An unresolved rack ref still fingerprints (in-batch grouping)."""
+        ref = UnresolvedReference(object_type="dcim.rack", uuid="u-1")
+        a = self.matcher.fingerprint({"rack": ref, "units": [1]})
+        b = self.matcher.fingerprint({"rack": ref, "units": [1]})
+        self.assertIsNotNone(a)
+        self.assertEqual(a, b)
+
+    def test_fingerprint_none_when_units_missing(self):
+        """No units -> no fingerprint."""
+        self.assertIsNone(self.matcher.fingerprint({"rack": 7}))
+
+
+class RackReservationCacheKeyTestCase(TestCase):
+    """The scalar-only find-object cache must be disabled for this type.
+
+    Identity lives in the units ArrayField, which the scalar-only cache key
+    skips: without the carve-out, two different reservations on one rack
+    share a key and serve each other's cached answers -- including inside
+    this very test file (the lookup tests below differ only in units).
+    """
+
+    def test_find_obj_cache_key_disabled(self):
+        """No cache key for dcim.rackreservation, ever."""
+        data = {"rack": 1, "units": [1, 2], "description": "x", "status": "active"}
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.rackreservation"))
+
+
+class RackReservationMatcherLookupTestCase(TestCase):
+    """find_existing_object behavior against real rows (registration included)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """One rack with one existing reservation on units [1, 2]."""
+        cls.site = Site.objects.create(name="rrm-site", slug="rrm-site")
+        cls.location = Location.objects.create(
+            name="rrm-loc", slug="rrm-loc", site=cls.site
+        )
+        cls.rack = Rack.objects.create(
+            name="rrm-rack", site=cls.site, location=cls.location
+        )
+        cls.user = User.objects.create(username="rrm-user")
+        cls.existing = RackReservation.objects.create(
+            rack=cls.rack, units=[1, 2], user=cls.user, description="seed"
+        )
+
+    def _data(self, units):
+        return {"rack": self.rack.pk, "units": units, "description": "x"}
+
+    def test_identical_units_match(self):
+        """Same rack + same units -> the existing reservation."""
+        found = find_existing_object(self._data([1, 2]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_overlap_matches(self):
+        """Sharing one unit is identity: [2, 3] matches the [1, 2] row."""
+        found = find_existing_object(self._data([2, 3]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_order_and_duplicates_insensitive(self):
+        """[2, 2, 1] matches the [1, 2] row."""
+        found = find_existing_object(self._data([2, 2, 1]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_disjoint_units_no_match(self):
+        """[5, 6] shares nothing with [1, 2] -> create."""
+        self.assertIsNone(
+            find_existing_object(self._data([5, 6]), "dcim.rackreservation")
+        )
+
+    def test_other_rack_no_match(self):
+        """Same units on another rack -> create."""
+        rack2 = Rack.objects.create(
+            name="rrm-rack2", site=self.site, location=self.location
+        )
+        data = {"rack": rack2.pk, "units": [1, 2], "description": "x"}
+        self.assertIsNone(find_existing_object(data, "dcim.rackreservation"))
+
+    def test_multi_overlap_raises_ambiguous(self):
+        """A payload spanning two reservations refuses to pick one."""
+        other = RackReservation.objects.create(
+            rack=self.rack, units=[3], user=self.user, description="seed2"
+        )
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            find_existing_object(self._data([2, 3]), "dcim.rackreservation")
+        msg = str(cm.exception)
+        self.assertIn(str(self.existing.pk), msg)
+        self.assertIn(str(other.pk), msg)
+
+
+class RackReservationRoutingTestCase(TestCase):
+    """Pre-save routing for dcim.rackreservation."""
+
+    def test_requires_pre_save_match(self):
+        """No DB constraint means no IntegrityError backstop: pre-save match."""
+        self.assertTrue(requires_pre_save_match("dcim.rackreservation"))

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rackreservation_matcher.py
@@ -102,7 +102,8 @@ class RackReservationMatcherFingerprintTestCase(TestCase):
 
 
 class RackReservationCacheKeyTestCase(TestCase):
-    """The scalar-only find-object cache must be disabled for this type.
+    """
+    The scalar-only find-object cache must be disabled for this type.
 
     Identity lives in the units ArrayField, which the scalar-only cache key
     skips: without the carve-out, two different reservations on one rack

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_generate_matching_docs.py
@@ -12,7 +12,14 @@ from django.core.management.base import CommandError
 from django.db.models import Q
 from django.test import TestCase
 
-from netbox_diode_plugin.api.matcher import AutoSlugMatcher, ObjectMatchCriteria
+from netbox_diode_plugin.api.matcher import (
+    AutoSlugMatcher,
+    CableTerminationSetMatcher,
+    GlobalIPNetworkIPMatcher,
+    ObjectMatchCriteria,
+    RackReservationUnitOverlapMatcher,
+    VirtualChassisNameMatcher,
+)
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
     Command,
     MatcherInfo,
@@ -128,6 +135,73 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         result = self.command.get_matcher_description(mock_matcher)
         self.assertEqual(result, "Matches IP range start_address, end_address within VRF context")
+
+    def test_get_matcher_description_ip_range_global_no_vrf(self):
+        """Test getting matcher description for IP range global-no-VRF matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_range_start_end_global_no_vrf"
+        mock_matcher.ip_fields = ["start_address", "end_address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertIn("no VRF", result)
+        self.assertEqual(
+            result, "Matches IP range start_address, end_address in global namespace (no VRF)"
+        )
+
+    def test_get_matcher_fields_cable_termination_set(self):
+        """Test deriving Fields for a real CableTerminationSetMatcher via a/b field names."""
+        matcher = CableTerminationSetMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["a_terminations", "b_terminations"])
+
+    def test_get_matcher_fields_virtual_chassis_name(self):
+        """Test deriving Fields for a real VirtualChassisNameMatcher via the class-name map."""
+        matcher = VirtualChassisNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["name"])
+
+    def test_get_matcher_fields_rackreservation_unit_overlap(self):
+        """Test deriving Fields for a real RackReservationUnitOverlapMatcher via the class-name map."""
+        matcher = RackReservationUnitOverlapMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["rack", "units"])
+
+    def test_get_matcher_fields_global_ip_network(self):
+        """Test deriving Fields for a real GlobalIPNetworkIPMatcher via ip_fields."""
+        matcher = GlobalIPNetworkIPMatcher(
+            ip_fields=["address"], vrf_field="vrf", model_class=None, name="x"
+        )
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["address"])
+
+    def test_get_matcher_description_cable_termination_set_docstring(self):
+        """Test that CableTerminationSetMatcher's description derives from its docstring."""
+        matcher = CableTerminationSetMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = CableTerminationSetMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
+
+    def test_get_matcher_description_virtual_chassis_name_docstring(self):
+        """Test that VirtualChassisNameMatcher's description derives from its docstring."""
+        matcher = VirtualChassisNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = VirtualChassisNameMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
+
+    def test_get_matcher_description_rackreservation_unit_overlap_docstring(self):
+        """Test that RackReservationUnitOverlapMatcher's description derives from its docstring."""
+        matcher = RackReservationUnitOverlapMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = RackReservationUnitOverlapMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
 
     def test_get_matcher_description_standard_fields(self):
         """Test getting matcher description for standard field-based matcher."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_ingest_convergence.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""RackReservation ingest convergence: overlap identity end-to-end.
+
+All rack payloads here carry a location and the rack is pre-seeded with it,
+so the rack ref re-matches on every cycle; the location-less rack shape has
+a separate, known matching gap and is deliberately not used.
+"""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import ChangeSetException
+from netbox_diode_plugin.api.differ import generate_changeset
+
+
+class RackReservationConvergenceTestCase(TestCase):
+    """Diff+apply round-trips for the unit-overlap identity."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Location-bearing rack and the reservation's user, pre-seeded."""
+        cls.site = Site.objects.create(name="rrc-site", slug="rrc-site")
+        cls.location = Location.objects.create(
+            name="rrc-loc", slug="rrc-loc", site=cls.site
+        )
+        cls.rack = Rack.objects.create(
+            name="rrc-rack", site=cls.site, location=cls.location
+        )
+        cls.user = User.objects.create(username="rrc-owner")
+        cls.user2 = User.objects.create(username="rrc-owner2")
+
+    def _entity(self, units, description="reserved", username="rrc-owner"):
+        return {
+            "rack": {
+                "name": "rrc-rack",
+                "site": {"name": "rrc-site"},
+                "location": {"name": "rrc-loc", "site": {"name": "rrc-site"}},
+            },
+            "units": units,
+            "description": description,
+            "user": {"username": username},
+        }
+
+    def _plan(self, entity):
+        return generate_changeset(entity, "dcim.rackreservation").change_set
+
+    def _apply(self, change_set):
+        return apply_changeset(change_set, request=None)
+
+    def _ingest(self, entity):
+        self._apply(self._plan(entity))
+
+    def test_identical_reingest_is_all_noop(self):
+        """The convergence bug: a second identical ingest must plan nothing."""
+        self._ingest(self._entity([1, 2, 3]))
+        cs = self._plan(self._entity([1, 2, 3]))
+        non_noop = [c for c in cs.changes if c.change_type.value != "noop"]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+        # and the rack itself re-matched (guards the test's own premise)
+        self.assertEqual(Rack.objects.filter(name="rrc-rack").count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_grow_units_updates_in_place(self):
+        """[1, 2] -> [1, 2, 3] is an UPDATE of the same row."""
+        self._ingest(self._entity([1, 2]))
+        rr = RackReservation.objects.get()
+        cs = self._plan(self._entity([1, 2, 3]))
+        updates = [c for c in cs.changes
+                   if c.object_type == "dcim.rackreservation"]
+        self.assertEqual(len(updates), 1, [c.to_dict() for c in cs.changes])
+        self.assertEqual(updates[0].change_type.value, "update")
+        self.assertEqual(updates[0].object_id, rr.pk)
+        self._apply(cs)
+        rr.refresh_from_db()
+        self.assertEqual(sorted(rr.units), [1, 2, 3])
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_shrink_units_updates_in_place(self):
+        """[1, 2, 3] -> [1, 2] shrinks the stored set (last writer wins)."""
+        self._ingest(self._entity([1, 2, 3]))
+        rr = RackReservation.objects.get()
+        cs = self._plan(self._entity([1, 2]))
+        updates = [c for c in cs.changes
+                   if c.object_type == "dcim.rackreservation"]
+        self.assertEqual(len(updates), 1, [c.to_dict() for c in cs.changes])
+        self.assertEqual(updates[0].change_type.value, "update")
+        self.assertEqual(updates[0].object_id, rr.pk)
+        self._apply(cs)
+        rr.refresh_from_db()
+        self.assertEqual(sorted(rr.units), [1, 2])
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_disjoint_units_create_second_reservation(self):
+        """No shared unit means a different reservation, any user."""
+        self._ingest(self._entity([1, 2]))
+        self._ingest(self._entity([5, 6], username="rrc-owner2"))
+        self.assertEqual(RackReservation.objects.count(), 2)
+        by_units = {tuple(sorted(r.units)): r for r in RackReservation.objects.all()}
+        self.assertEqual(by_units[(1, 2)].user_id, self.user.pk)
+        self.assertEqual(by_units[(5, 6)].user_id, self.user2.pk)
+
+    def test_field_changes_flow_through_on_match(self):
+        """description/user updates ride the overlap match."""
+        self._ingest(self._entity([1, 2], description="old"))
+        self._ingest(self._entity([1, 2], description="new", username="rrc-owner2"))
+        rr = RackReservation.objects.get()
+        self.assertEqual(rr.description, "new")
+        self.assertEqual(rr.user_id, self.user2.pk)
+
+    def test_multi_overlap_fails_at_plan_time(self):
+        """A payload spanning two reservations is refused loudly at plan."""
+        RackReservation.objects.create(
+            rack=self.rack, units=[1], user=self.user, description="a"
+        )
+        RackReservation.objects.create(
+            rack=self.rack, units=[2], user=self.user, description="b"
+        )
+        with self.assertRaises(ChangeSetException) as cm:
+            self._plan(self._entity([1, 2]))
+        self.assertIn("overlap", str(cm.exception))
+        self.assertEqual(RackReservation.objects.count(), 2)  # nothing changed
+
+    def test_batch_invariance_overlapping_plans_converge_to_one_row(self):
+        """Two overlapping CREATEs planned together adopt, last writer wins."""
+        cs_a = self._plan(self._entity([1, 2], description="first"))
+        cs_b = self._plan(self._entity([2, 3], description="second"))
+        self._apply(cs_a)
+        self._apply(cs_b)  # pre-save re-match adopts the row cs_a created
+        rr = RackReservation.objects.get()
+        self.assertEqual(sorted(rr.units), [2, 3])
+        self.assertEqual(rr.description, "second")
+
+    def test_stale_create_adopts_existing_reservation(self):
+        """A CREATE planned before the row existed applies onto it, not beside it."""
+        cs = self._plan(self._entity([1, 2], description="from-plan"))
+        RackReservation.objects.create(
+            rack=self.rack, units=[1, 2], user=self.user, description="raced-in"
+        )
+        self._apply(cs)
+        rr = RackReservation.objects.get()
+        self.assertEqual(rr.description, "from-plan")  # payload applied
+        self.assertEqual(sorted(rr.units), [1, 2])

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_ingest_convergence.py
@@ -9,6 +9,7 @@ a separate, known matching gap and is deliberately not used.
 
 from dcim.models import Location, Rack, RackReservation, Site
 from django.test import TestCase
+from tenancy.models import Tenant
 from users.models import User
 
 from netbox_diode_plugin.api.applier import apply_changeset
@@ -31,9 +32,10 @@ class RackReservationConvergenceTestCase(TestCase):
         )
         cls.user = User.objects.create(username="rrc-owner")
         cls.user2 = User.objects.create(username="rrc-owner2")
+        cls.tenant = Tenant.objects.create(name="rrc-tenant", slug="rrc-tenant")
 
-    def _entity(self, units, description="reserved", username="rrc-owner"):
-        return {
+    def _entity(self, units, description="reserved", username="rrc-owner", tenant=None, status=None):
+        entity = {
             "rack": {
                 "name": "rrc-rack",
                 "site": {"name": "rrc-site"},
@@ -43,6 +45,11 @@ class RackReservationConvergenceTestCase(TestCase):
             "description": description,
             "user": {"username": username},
         }
+        if tenant is not None:
+            entity["tenant"] = {"name": tenant}
+        if status is not None:
+            entity["status"] = status
+        return entity
 
     def _plan(self, entity):
         return generate_changeset(entity, "dcim.rackreservation").change_set
@@ -103,12 +110,20 @@ class RackReservationConvergenceTestCase(TestCase):
         self.assertEqual(by_units[(5, 6)].user_id, self.user2.pk)
 
     def test_field_changes_flow_through_on_match(self):
-        """description/user updates ride the overlap match."""
+        """description/user/tenant/status updates ride the overlap match."""
         self._ingest(self._entity([1, 2], description="old"))
-        self._ingest(self._entity([1, 2], description="new", username="rrc-owner2"))
+        self._ingest(self._entity(
+            [1, 2],
+            description="new",
+            username="rrc-owner2",
+            tenant="rrc-tenant",
+            status="pending"
+        ))
         rr = RackReservation.objects.get()
         self.assertEqual(rr.description, "new")
         self.assertEqual(rr.user_id, self.user2.pk)
+        self.assertEqual(rr.tenant_id, self.tenant.pk)
+        self.assertEqual(rr.status, "pending")
 
     def test_multi_overlap_fails_at_plan_time(self):
         """A payload spanning two reservations is refused loudly at plan."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_ingest_convergence.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2026 NetBox Labs, Inc.
-"""RackReservation ingest convergence: overlap identity end-to-end.
+"""
+RackReservation ingest convergence: overlap identity end-to-end.
 
 All rack payloads here carry a location and the rack is pre-seeded with it,
 so the rack ref re-matches on every cycle; the location-less rack shape has

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_matcher.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for RackReservationUnitOverlapMatcher and dcim.rackreservation routing."""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.matcher import (
+    AmbiguousObjectMatch,
+    RackReservationUnitOverlapMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+def _matcher():
+    return RackReservationUnitOverlapMatcher(
+        model_class=get_object_type_model("dcim.rackreservation"),
+        name="logical_rackreservation_unit_overlap",
+    )
+
+
+class RackReservationMatcherFieldsTestCase(TestCase):
+    """has_required_fields / build_queryset abstain rules (no DB rows needed)."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_has_required_fields_present(self):
+        """Rack ref plus non-empty units satisfies the gate."""
+        self.assertTrue(self.matcher.has_required_fields({"rack": 1, "units": [1]}))
+
+    def test_has_required_fields_missing_units(self):
+        """No units -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"rack": 1}))
+
+    def test_has_required_fields_empty_units(self):
+        """Empty units list -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"rack": 1, "units": []}))
+
+    def test_has_required_fields_missing_rack(self):
+        """No rack -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"units": [1]}))
+
+    def test_build_queryset_abstains_on_unresolved_rack(self):
+        """An in-batch rack ref has no pk to query -> abstain."""
+        ref = UnresolvedReference(object_type="dcim.rack", uuid="u-1")
+        self.assertIsNone(self.matcher.build_queryset({"rack": ref, "units": [1]}))
+
+    def test_build_queryset_abstains_on_bool_rack(self):
+        """rack=True must NOT be treated as pk 1."""
+        self.assertIsNone(self.matcher.build_queryset({"rack": True, "units": [1]}))
+
+    def test_build_queryset_abstains_on_non_int_unit(self):
+        """A non-int (or bool) unit element -> abstain, not a crash."""
+        self.assertIsNone(self.matcher.build_queryset({"rack": 1, "units": [1, "2"]}))
+        self.assertIsNone(self.matcher.build_queryset({"rack": 1, "units": [1, True]}))
+
+
+class RackReservationMatcherFingerprintTestCase(TestCase):
+    """In-batch dedupe fingerprint: exact unit set, order/duplicate-insensitive."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_fingerprint_equal_under_reorder_and_duplicates(self):
+        """Same rack + same unit set (any order, with dups) -> same key."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1, 2, 3]})
+        b = self.matcher.fingerprint({"rack": 7, "units": [3, 1, 2, 2]})
+        self.assertIsNotNone(a)
+        self.assertEqual(a, b)
+
+    def test_fingerprint_differs_on_unit_set(self):
+        """Overlapping-but-different unit sets do NOT dedupe-merge in batch."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1, 2]})
+        b = self.matcher.fingerprint({"rack": 7, "units": [2, 3]})
+        self.assertNotEqual(a, b)
+
+    def test_fingerprint_differs_on_rack(self):
+        """Same units on different racks are different reservations."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1]})
+        b = self.matcher.fingerprint({"rack": 8, "units": [1]})
+        self.assertNotEqual(a, b)
+
+    def test_fingerprint_unresolved_rack_keys_on_uuid(self):
+        """An unresolved rack ref still fingerprints (in-batch grouping)."""
+        ref = UnresolvedReference(object_type="dcim.rack", uuid="u-1")
+        a = self.matcher.fingerprint({"rack": ref, "units": [1]})
+        b = self.matcher.fingerprint({"rack": ref, "units": [1]})
+        self.assertIsNotNone(a)
+        self.assertEqual(a, b)
+
+    def test_fingerprint_none_when_units_missing(self):
+        """No units -> no fingerprint."""
+        self.assertIsNone(self.matcher.fingerprint({"rack": 7}))
+
+
+class RackReservationCacheKeyTestCase(TestCase):
+    """The scalar-only find-object cache must be disabled for this type.
+
+    Identity lives in the units ArrayField, which the scalar-only cache key
+    skips: without the carve-out, two different reservations on one rack
+    share a key and serve each other's cached answers -- including inside
+    this very test file (the lookup tests below differ only in units).
+    """
+
+    def test_find_obj_cache_key_disabled(self):
+        """No cache key for dcim.rackreservation, ever."""
+        data = {"rack": 1, "units": [1, 2], "description": "x", "status": "active"}
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.rackreservation"))
+
+
+class RackReservationMatcherLookupTestCase(TestCase):
+    """find_existing_object behavior against real rows (registration included)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """One rack with one existing reservation on units [1, 2]."""
+        cls.site = Site.objects.create(name="rrm-site", slug="rrm-site")
+        cls.location = Location.objects.create(
+            name="rrm-loc", slug="rrm-loc", site=cls.site
+        )
+        cls.rack = Rack.objects.create(
+            name="rrm-rack", site=cls.site, location=cls.location
+        )
+        cls.user = User.objects.create(username="rrm-user")
+        cls.existing = RackReservation.objects.create(
+            rack=cls.rack, units=[1, 2], user=cls.user, description="seed"
+        )
+
+    def _data(self, units):
+        return {"rack": self.rack.pk, "units": units, "description": "x"}
+
+    def test_identical_units_match(self):
+        """Same rack + same units -> the existing reservation."""
+        found = find_existing_object(self._data([1, 2]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_overlap_matches(self):
+        """Sharing one unit is identity: [2, 3] matches the [1, 2] row."""
+        found = find_existing_object(self._data([2, 3]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_order_and_duplicates_insensitive(self):
+        """[2, 2, 1] matches the [1, 2] row."""
+        found = find_existing_object(self._data([2, 2, 1]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_disjoint_units_no_match(self):
+        """[5, 6] shares nothing with [1, 2] -> create."""
+        self.assertIsNone(
+            find_existing_object(self._data([5, 6]), "dcim.rackreservation")
+        )
+
+    def test_other_rack_no_match(self):
+        """Same units on another rack -> create."""
+        rack2 = Rack.objects.create(
+            name="rrm-rack2", site=self.site, location=self.location
+        )
+        data = {"rack": rack2.pk, "units": [1, 2], "description": "x"}
+        self.assertIsNone(find_existing_object(data, "dcim.rackreservation"))
+
+    def test_multi_overlap_raises_ambiguous(self):
+        """A payload spanning two reservations refuses to pick one."""
+        other = RackReservation.objects.create(
+            rack=self.rack, units=[3], user=self.user, description="seed2"
+        )
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            find_existing_object(self._data([2, 3]), "dcim.rackreservation")
+        msg = str(cm.exception)
+        self.assertIn(str(self.existing.pk), msg)
+        self.assertIn(str(other.pk), msg)
+
+
+class RackReservationRoutingTestCase(TestCase):
+    """Pre-save routing for dcim.rackreservation."""
+
+    def test_requires_pre_save_match(self):
+        """No DB constraint means no IntegrityError backstop: pre-save match."""
+        self.assertTrue(requires_pre_save_match("dcim.rackreservation"))

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rackreservation_matcher.py
@@ -102,7 +102,8 @@ class RackReservationMatcherFingerprintTestCase(TestCase):
 
 
 class RackReservationCacheKeyTestCase(TestCase):
-    """The scalar-only find-object cache must be disabled for this type.
+    """
+    The scalar-only find-object cache must be disabled for this type.
 
     Identity lives in the units ArrayField, which the scalar-only cache key
     skips: without the carve-out, two different reservations on one rack

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_generate_matching_docs.py
@@ -12,7 +12,14 @@ from django.core.management.base import CommandError
 from django.db.models import Q
 from django.test import TestCase
 
-from netbox_diode_plugin.api.matcher import AutoSlugMatcher, ObjectMatchCriteria
+from netbox_diode_plugin.api.matcher import (
+    AutoSlugMatcher,
+    CableTerminationSetMatcher,
+    GlobalIPNetworkIPMatcher,
+    ObjectMatchCriteria,
+    RackReservationUnitOverlapMatcher,
+    VirtualChassisNameMatcher,
+)
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
     Command,
     MatcherInfo,
@@ -128,6 +135,73 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         result = self.command.get_matcher_description(mock_matcher)
         self.assertEqual(result, "Matches IP range start_address, end_address within VRF context")
+
+    def test_get_matcher_description_ip_range_global_no_vrf(self):
+        """Test getting matcher description for IP range global-no-VRF matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_range_start_end_global_no_vrf"
+        mock_matcher.ip_fields = ["start_address", "end_address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertIn("no VRF", result)
+        self.assertEqual(
+            result, "Matches IP range start_address, end_address in global namespace (no VRF)"
+        )
+
+    def test_get_matcher_fields_cable_termination_set(self):
+        """Test deriving Fields for a real CableTerminationSetMatcher via a/b field names."""
+        matcher = CableTerminationSetMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["a_terminations", "b_terminations"])
+
+    def test_get_matcher_fields_virtual_chassis_name(self):
+        """Test deriving Fields for a real VirtualChassisNameMatcher via the class-name map."""
+        matcher = VirtualChassisNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["name"])
+
+    def test_get_matcher_fields_rackreservation_unit_overlap(self):
+        """Test deriving Fields for a real RackReservationUnitOverlapMatcher via the class-name map."""
+        matcher = RackReservationUnitOverlapMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["rack", "units"])
+
+    def test_get_matcher_fields_global_ip_network(self):
+        """Test deriving Fields for a real GlobalIPNetworkIPMatcher via ip_fields."""
+        matcher = GlobalIPNetworkIPMatcher(
+            ip_fields=["address"], vrf_field="vrf", model_class=None, name="x"
+        )
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["address"])
+
+    def test_get_matcher_description_cable_termination_set_docstring(self):
+        """Test that CableTerminationSetMatcher's description derives from its docstring."""
+        matcher = CableTerminationSetMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = CableTerminationSetMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
+
+    def test_get_matcher_description_virtual_chassis_name_docstring(self):
+        """Test that VirtualChassisNameMatcher's description derives from its docstring."""
+        matcher = VirtualChassisNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = VirtualChassisNameMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
+
+    def test_get_matcher_description_rackreservation_unit_overlap_docstring(self):
+        """Test that RackReservationUnitOverlapMatcher's description derives from its docstring."""
+        matcher = RackReservationUnitOverlapMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = RackReservationUnitOverlapMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
 
     def test_get_matcher_description_standard_fields(self):
         """Test getting matcher description for standard field-based matcher."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_ingest_convergence.py
@@ -9,6 +9,7 @@ a separate, known matching gap and is deliberately not used.
 
 from dcim.models import Location, Rack, RackReservation, Site
 from django.test import TestCase
+from tenancy.models import Tenant
 from users.models import User
 
 from netbox_diode_plugin.api.applier import apply_changeset
@@ -31,9 +32,10 @@ class RackReservationConvergenceTestCase(TestCase):
         )
         cls.user = User.objects.create(username="rrc-owner")
         cls.user2 = User.objects.create(username="rrc-owner2")
+        cls.tenant = Tenant.objects.create(name="rrc-tenant", slug="rrc-tenant")
 
-    def _entity(self, units, description="reserved", username="rrc-owner"):
-        return {
+    def _entity(self, units, description="reserved", username="rrc-owner", tenant=None, status=None):
+        entity = {
             "rack": {
                 "name": "rrc-rack",
                 "site": {"name": "rrc-site"},
@@ -43,6 +45,11 @@ class RackReservationConvergenceTestCase(TestCase):
             "description": description,
             "user": {"username": username},
         }
+        if tenant is not None:
+            entity["tenant"] = {"name": tenant}
+        if status is not None:
+            entity["status"] = status
+        return entity
 
     def _plan(self, entity):
         return generate_changeset(entity, "dcim.rackreservation").change_set
@@ -103,12 +110,20 @@ class RackReservationConvergenceTestCase(TestCase):
         self.assertEqual(by_units[(5, 6)].user_id, self.user2.pk)
 
     def test_field_changes_flow_through_on_match(self):
-        """description/user updates ride the overlap match."""
+        """description/user/tenant/status updates ride the overlap match."""
         self._ingest(self._entity([1, 2], description="old"))
-        self._ingest(self._entity([1, 2], description="new", username="rrc-owner2"))
+        self._ingest(self._entity(
+            [1, 2],
+            description="new",
+            username="rrc-owner2",
+            tenant="rrc-tenant",
+            status="pending"
+        ))
         rr = RackReservation.objects.get()
         self.assertEqual(rr.description, "new")
         self.assertEqual(rr.user_id, self.user2.pk)
+        self.assertEqual(rr.tenant_id, self.tenant.pk)
+        self.assertEqual(rr.status, "pending")
 
     def test_multi_overlap_fails_at_plan_time(self):
         """A payload spanning two reservations is refused loudly at plan."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_ingest_convergence.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""RackReservation ingest convergence: overlap identity end-to-end.
+
+All rack payloads here carry a location and the rack is pre-seeded with it,
+so the rack ref re-matches on every cycle; the location-less rack shape has
+a separate, known matching gap and is deliberately not used.
+"""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import ChangeSetException
+from netbox_diode_plugin.api.differ import generate_changeset
+
+
+class RackReservationConvergenceTestCase(TestCase):
+    """Diff+apply round-trips for the unit-overlap identity."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Location-bearing rack and the reservation's user, pre-seeded."""
+        cls.site = Site.objects.create(name="rrc-site", slug="rrc-site")
+        cls.location = Location.objects.create(
+            name="rrc-loc", slug="rrc-loc", site=cls.site
+        )
+        cls.rack = Rack.objects.create(
+            name="rrc-rack", site=cls.site, location=cls.location
+        )
+        cls.user = User.objects.create(username="rrc-owner")
+        cls.user2 = User.objects.create(username="rrc-owner2")
+
+    def _entity(self, units, description="reserved", username="rrc-owner"):
+        return {
+            "rack": {
+                "name": "rrc-rack",
+                "site": {"name": "rrc-site"},
+                "location": {"name": "rrc-loc", "site": {"name": "rrc-site"}},
+            },
+            "units": units,
+            "description": description,
+            "user": {"username": username},
+        }
+
+    def _plan(self, entity):
+        return generate_changeset(entity, "dcim.rackreservation").change_set
+
+    def _apply(self, change_set):
+        return apply_changeset(change_set, request=None)
+
+    def _ingest(self, entity):
+        self._apply(self._plan(entity))
+
+    def test_identical_reingest_is_all_noop(self):
+        """The convergence bug: a second identical ingest must plan nothing."""
+        self._ingest(self._entity([1, 2, 3]))
+        cs = self._plan(self._entity([1, 2, 3]))
+        non_noop = [c for c in cs.changes if c.change_type.value != "noop"]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+        # and the rack itself re-matched (guards the test's own premise)
+        self.assertEqual(Rack.objects.filter(name="rrc-rack").count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_grow_units_updates_in_place(self):
+        """[1, 2] -> [1, 2, 3] is an UPDATE of the same row."""
+        self._ingest(self._entity([1, 2]))
+        rr = RackReservation.objects.get()
+        cs = self._plan(self._entity([1, 2, 3]))
+        updates = [c for c in cs.changes
+                   if c.object_type == "dcim.rackreservation"]
+        self.assertEqual(len(updates), 1, [c.to_dict() for c in cs.changes])
+        self.assertEqual(updates[0].change_type.value, "update")
+        self.assertEqual(updates[0].object_id, rr.pk)
+        self._apply(cs)
+        rr.refresh_from_db()
+        self.assertEqual(sorted(rr.units), [1, 2, 3])
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_shrink_units_updates_in_place(self):
+        """[1, 2, 3] -> [1, 2] shrinks the stored set (last writer wins)."""
+        self._ingest(self._entity([1, 2, 3]))
+        self._ingest(self._entity([1, 2]))
+        rr = RackReservation.objects.get()
+        self.assertEqual(sorted(rr.units), [1, 2])
+
+    def test_disjoint_units_create_second_reservation(self):
+        """No shared unit means a different reservation, any user."""
+        self._ingest(self._entity([1, 2]))
+        self._ingest(self._entity([5, 6], username="rrc-owner2"))
+        self.assertEqual(RackReservation.objects.count(), 2)
+        by_units = {tuple(sorted(r.units)): r for r in RackReservation.objects.all()}
+        self.assertEqual(by_units[(1, 2)].user_id, self.user.pk)
+        self.assertEqual(by_units[(5, 6)].user_id, self.user2.pk)
+
+    def test_field_changes_flow_through_on_match(self):
+        """description/user updates ride the overlap match."""
+        self._ingest(self._entity([1, 2], description="old"))
+        self._ingest(self._entity([1, 2], description="new", username="rrc-owner2"))
+        rr = RackReservation.objects.get()
+        self.assertEqual(rr.description, "new")
+        self.assertEqual(rr.user_id, self.user2.pk)
+
+    def test_multi_overlap_fails_at_plan_time(self):
+        """A payload spanning two reservations is refused loudly at plan."""
+        RackReservation.objects.create(
+            rack=self.rack, units=[1], user=self.user, description="a"
+        )
+        RackReservation.objects.create(
+            rack=self.rack, units=[2], user=self.user, description="b"
+        )
+        with self.assertRaises(ChangeSetException) as cm:
+            self._plan(self._entity([1, 2]))
+        self.assertIn("overlap", str(cm.exception))
+        self.assertEqual(RackReservation.objects.count(), 2)  # nothing changed
+
+    def test_batch_invariance_overlapping_plans_converge_to_one_row(self):
+        """Two overlapping CREATEs planned together adopt, last writer wins."""
+        cs_a = self._plan(self._entity([1, 2], description="first"))
+        cs_b = self._plan(self._entity([2, 3], description="second"))
+        self._apply(cs_a)
+        self._apply(cs_b)  # pre-save re-match adopts the row cs_a created
+        rr = RackReservation.objects.get()
+        self.assertEqual(sorted(rr.units), [2, 3])
+        self.assertEqual(rr.description, "second")
+
+    def test_stale_create_adopts_existing_reservation(self):
+        """A CREATE planned before the row existed applies onto it, not beside it."""
+        cs = self._plan(self._entity([1, 2], description="from-plan"))
+        RackReservation.objects.create(
+            rack=self.rack, units=[1, 2], user=self.user, description="raced-in"
+        )
+        self._apply(cs)
+        rr = RackReservation.objects.get()
+        self.assertEqual(rr.description, "from-plan")  # payload applied
+        self.assertEqual(sorted(rr.units), [1, 2])

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_ingest_convergence.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2026 NetBox Labs, Inc.
-"""RackReservation ingest convergence: overlap identity end-to-end.
+"""
+RackReservation ingest convergence: overlap identity end-to-end.
 
 All rack payloads here carry a location and the rack is pre-seeded with it,
 so the rack ref re-matches on every cycle; the location-less rack shape has

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_ingest_convergence.py
@@ -81,9 +81,17 @@ class RackReservationConvergenceTestCase(TestCase):
     def test_shrink_units_updates_in_place(self):
         """[1, 2, 3] -> [1, 2] shrinks the stored set (last writer wins)."""
         self._ingest(self._entity([1, 2, 3]))
-        self._ingest(self._entity([1, 2]))
         rr = RackReservation.objects.get()
+        cs = self._plan(self._entity([1, 2]))
+        updates = [c for c in cs.changes
+                   if c.object_type == "dcim.rackreservation"]
+        self.assertEqual(len(updates), 1, [c.to_dict() for c in cs.changes])
+        self.assertEqual(updates[0].change_type.value, "update")
+        self.assertEqual(updates[0].object_id, rr.pk)
+        self._apply(cs)
+        rr.refresh_from_db()
         self.assertEqual(sorted(rr.units), [1, 2])
+        self.assertEqual(RackReservation.objects.count(), 1)
 
     def test_disjoint_units_create_second_reservation(self):
         """No shared unit means a different reservation, any user."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_matcher.py
@@ -12,6 +12,7 @@ from netbox_diode_plugin.api.matcher import (
     RackReservationUnitOverlapMatcher,
     _find_obj_cache_key,
     find_existing_object,
+    requires_pre_save_match,
 )
 from netbox_diode_plugin.api.plugin_utils import get_object_type_model
 
@@ -175,3 +176,11 @@ class RackReservationMatcherLookupTestCase(TestCase):
         msg = str(cm.exception)
         self.assertIn(str(self.existing.pk), msg)
         self.assertIn(str(other.pk), msg)
+
+
+class RackReservationRoutingTestCase(TestCase):
+    """Pre-save routing for dcim.rackreservation."""
+
+    def test_requires_pre_save_match(self):
+        """No DB constraint means no IntegrityError backstop: pre-save match."""
+        self.assertTrue(requires_pre_save_match("dcim.rackreservation"))

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_matcher.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for RackReservationUnitOverlapMatcher and dcim.rackreservation routing."""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.matcher import (
+    AmbiguousObjectMatch,
+    RackReservationUnitOverlapMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+def _matcher():
+    return RackReservationUnitOverlapMatcher(
+        model_class=get_object_type_model("dcim.rackreservation"),
+        name="logical_rackreservation_unit_overlap",
+    )
+
+
+class RackReservationMatcherFieldsTestCase(TestCase):
+    """has_required_fields / build_queryset abstain rules (no DB rows needed)."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_has_required_fields_present(self):
+        """Rack ref plus non-empty units satisfies the gate."""
+        self.assertTrue(self.matcher.has_required_fields({"rack": 1, "units": [1]}))
+
+    def test_has_required_fields_missing_units(self):
+        """No units -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"rack": 1}))
+
+    def test_has_required_fields_empty_units(self):
+        """Empty units list -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"rack": 1, "units": []}))
+
+    def test_has_required_fields_missing_rack(self):
+        """No rack -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"units": [1]}))
+
+    def test_build_queryset_abstains_on_unresolved_rack(self):
+        """An in-batch rack ref has no pk to query -> abstain."""
+        ref = UnresolvedReference(object_type="dcim.rack", uuid="u-1")
+        self.assertIsNone(self.matcher.build_queryset({"rack": ref, "units": [1]}))
+
+    def test_build_queryset_abstains_on_bool_rack(self):
+        """rack=True must NOT be treated as pk 1."""
+        self.assertIsNone(self.matcher.build_queryset({"rack": True, "units": [1]}))
+
+    def test_build_queryset_abstains_on_non_int_unit(self):
+        """A non-int (or bool) unit element -> abstain, not a crash."""
+        self.assertIsNone(self.matcher.build_queryset({"rack": 1, "units": [1, "2"]}))
+        self.assertIsNone(self.matcher.build_queryset({"rack": 1, "units": [1, True]}))
+
+
+class RackReservationMatcherFingerprintTestCase(TestCase):
+    """In-batch dedupe fingerprint: exact unit set, order/duplicate-insensitive."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_fingerprint_equal_under_reorder_and_duplicates(self):
+        """Same rack + same unit set (any order, with dups) -> same key."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1, 2, 3]})
+        b = self.matcher.fingerprint({"rack": 7, "units": [3, 1, 2, 2]})
+        self.assertIsNotNone(a)
+        self.assertEqual(a, b)
+
+    def test_fingerprint_differs_on_unit_set(self):
+        """Overlapping-but-different unit sets do NOT dedupe-merge in batch."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1, 2]})
+        b = self.matcher.fingerprint({"rack": 7, "units": [2, 3]})
+        self.assertNotEqual(a, b)
+
+    def test_fingerprint_differs_on_rack(self):
+        """Same units on different racks are different reservations."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1]})
+        b = self.matcher.fingerprint({"rack": 8, "units": [1]})
+        self.assertNotEqual(a, b)
+
+    def test_fingerprint_unresolved_rack_keys_on_uuid(self):
+        """An unresolved rack ref still fingerprints (in-batch grouping)."""
+        ref = UnresolvedReference(object_type="dcim.rack", uuid="u-1")
+        a = self.matcher.fingerprint({"rack": ref, "units": [1]})
+        b = self.matcher.fingerprint({"rack": ref, "units": [1]})
+        self.assertIsNotNone(a)
+        self.assertEqual(a, b)
+
+    def test_fingerprint_none_when_units_missing(self):
+        """No units -> no fingerprint."""
+        self.assertIsNone(self.matcher.fingerprint({"rack": 7}))
+
+
+class RackReservationCacheKeyTestCase(TestCase):
+    """The scalar-only find-object cache must be disabled for this type.
+
+    Identity lives in the units ArrayField, which the scalar-only cache key
+    skips: without the carve-out, two different reservations on one rack
+    share a key and serve each other's cached answers -- including inside
+    this very test file (the lookup tests below differ only in units).
+    """
+
+    def test_find_obj_cache_key_disabled(self):
+        """No cache key for dcim.rackreservation, ever."""
+        data = {"rack": 1, "units": [1, 2], "description": "x", "status": "active"}
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.rackreservation"))
+
+
+class RackReservationMatcherLookupTestCase(TestCase):
+    """find_existing_object behavior against real rows (registration included)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """One rack with one existing reservation on units [1, 2]."""
+        cls.site = Site.objects.create(name="rrm-site", slug="rrm-site")
+        cls.location = Location.objects.create(
+            name="rrm-loc", slug="rrm-loc", site=cls.site
+        )
+        cls.rack = Rack.objects.create(
+            name="rrm-rack", site=cls.site, location=cls.location
+        )
+        cls.user = User.objects.create(username="rrm-user")
+        cls.existing = RackReservation.objects.create(
+            rack=cls.rack, units=[1, 2], user=cls.user, description="seed"
+        )
+
+    def _data(self, units):
+        return {"rack": self.rack.pk, "units": units, "description": "x"}
+
+    def test_identical_units_match(self):
+        """Same rack + same units -> the existing reservation."""
+        found = find_existing_object(self._data([1, 2]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_overlap_matches(self):
+        """Sharing one unit is identity: [2, 3] matches the [1, 2] row."""
+        found = find_existing_object(self._data([2, 3]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_order_and_duplicates_insensitive(self):
+        """[2, 2, 1] matches the [1, 2] row."""
+        found = find_existing_object(self._data([2, 2, 1]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_disjoint_units_no_match(self):
+        """[5, 6] shares nothing with [1, 2] -> create."""
+        self.assertIsNone(
+            find_existing_object(self._data([5, 6]), "dcim.rackreservation")
+        )
+
+    def test_other_rack_no_match(self):
+        """Same units on another rack -> create."""
+        rack2 = Rack.objects.create(
+            name="rrm-rack2", site=self.site, location=self.location
+        )
+        data = {"rack": rack2.pk, "units": [1, 2], "description": "x"}
+        self.assertIsNone(find_existing_object(data, "dcim.rackreservation"))
+
+    def test_multi_overlap_raises_ambiguous(self):
+        """A payload spanning two reservations refuses to pick one."""
+        other = RackReservation.objects.create(
+            rack=self.rack, units=[3], user=self.user, description="seed2"
+        )
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            find_existing_object(self._data([2, 3]), "dcim.rackreservation")
+        msg = str(cm.exception)
+        self.assertIn(str(self.existing.pk), msg)
+        self.assertIn(str(other.pk), msg)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rackreservation_matcher.py
@@ -102,7 +102,8 @@ class RackReservationMatcherFingerprintTestCase(TestCase):
 
 
 class RackReservationCacheKeyTestCase(TestCase):
-    """The scalar-only find-object cache must be disabled for this type.
+    """
+    The scalar-only find-object cache must be disabled for this type.
 
     Identity lives in the units ArrayField, which the scalar-only cache key
     skips: without the carve-out, two different reservations on one rack


### PR DESCRIPTION
## Summary

`dcim.rackreservation` had no matchers at all — no unique constraint for the builtin derivation, no logical matcher — so every re-ingest of an existing reservation planned a duplicate CREATE that failed NetBox's `clean()` overlap validation ("The following units have already been reserved"). A producer re-sending its reservations each discovery cycle accumulated one FAILED ingestion log per reservation per cycle, forever.

This adds an identity for the type: **unit overlap within a rack**.

- `RackReservationUnitOverlapMatcher` (custom matcher, same family as the cable termination-set matcher): same rack + at least one shared unit → same reservation. Matching uses Postgres `ArrayField.__overlap`, order- and duplicate-insensitive; the submitted fields then ride the normal update path (last-writer-wins, units replaced wholesale — grow and shrink both converge).
- A payload overlapping **two or more** existing reservations has no single-row answer, so `resolve()` raises `AmbiguousObjectMatch` at plan time, naming the conflicting rows and the remedies — instead of today's opaque apply-time 400.
- `dcim.rackreservation` joins `_REQUIRES_PRE_SAVE_MATCH` (find-and-update flavor): the overlap rule lives only in `clean()`, so there is no IntegrityError backstop; the pre-save re-match covers the planned-before-it-existed case. This also makes the semantics batch-invariant: two overlapping payloads in one batch converge onto one row exactly as they would across two cycles.
- `_find_obj_cache_key` opts the type out of the scalar find-object cache (identity lives in the `units` list, which the scalar-only key cannot see) — same carve-out and reasoning as cable.
- Matching-criteria documentation regenerated (new `dcim.rackreservation` section).

Scope note: convergence requires the rack ref itself to re-match; the location-less rack shape has a separate known matching gap (tracked in MON-324) and is out of scope here.

Fixes MON-325.

## Testing

- 20 matcher unit tests (gates, bool-excluding pk guards, fingerprint order/duplicate insensitivity, overlap/disjoint/multi-overlap lookup, cache opt-out, pre-save routing).
- 8 integration tests via `generate_changeset`/`apply_changeset` round-trips: identical re-ingest → all-NOOP; grow and shrink → in-place UPDATE of the same pk; disjoint → clean second CREATE; multi-overlap → plan-time ambiguity error with untouched DB; batch-invariance (two overlapping CREATEs planned together → one row, last writer wins); stale CREATE adoption; description/user/tenant/status flow-through.
- Test files byte-identical across the v4.4.x / v4.5.x / v4.6.x trees.
- Full v4.6 suite: 855/859 passing; the 4 red tests (settings views, plugin-config introspect URL) fail identically on develop — pre-existing environmental issues, untouched by this branch.

## Follow-up in this PR: matching-criteria doc rendering for custom matchers

The regenerated doc initially rendered the new matcher (like the existing cable/VC custom matchers) with an empty Fields column and a generic "Custom matcher" description. The generator now **derives** both instead of guessing: descriptions come from each custom matcher class's docstring first line (gated so expression-based builtin rows keep their honest generic label), and fields come from functional attributes (`a_field`/`b_field`, `ip_fields`) plus a small explicit map for classes with nothing introspectable. This also populated Fields for the four IP matcher rows and corrected a pre-existing wrong row: the no-VRF IP-range matcher was documented as matching "within VRF context".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
