### PR TITLE
feat: site-scoped identity for location-less rack payloads so re-ingest converges (MON-324)

### DIFF
--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -272,9 +272,10 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_asset_tag | 1 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
-| dcim_rack_unique_location_name | 2 | builtin | location, name | N/A | Matches on unique constraint fields: location, name | All versions |
-| dcim_rack_unique_location_facility_id | 3 | builtin | location, facility_id | N/A | Matches on unique constraint fields: location, facility_id | All versions |
+| logical_rack_site_name_no_location | 1 | logical | site, name | N/A | Match a location-less rack payload by (site, name), any location. | All versions |
+| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| dcim_rack_unique_location_name | 3 | builtin | location, name | N/A | Matches on unique constraint fields: location, name | All versions |
+| dcim_rack_unique_location_facility_id | 4 | builtin | location, facility_id | N/A | Matches on unique constraint fields: location, facility_id | All versions |
 
 ## dcim.rackgroup
 

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -1267,13 +1267,13 @@ def _refuse_write_through_bound_ref(change: Change, bound_only: dict) -> None:
 
     Only the same object_type; a ref-only update of a DIFFERENT type is already
     declined by _instance_for_deferred_update. Nothing plannable reaches either
-    case, and that is pinned rather than assumed: dcim.virtualchassis is the
-    only bind-only type and it is absent from
-    transformer._IS_CIRCULAR_REFERENCE, so generate-diff never emits a VC
-    update without an object_id (test_bind_only_types_are_not_circular_
-    references fails the moment that changes). This guard is for the two ways
-    the shape arrives anyway -- a changeset a client hands to apply-change-set
-    or bulk-apply directly, and one planned before another worker created the
+    case, and that is pinned rather than assumed: every bind-only type is
+    absent from transformer._IS_CIRCULAR_REFERENCE (dcim.virtualchassis and
+    dcim.rack today), so generate-diff never emits an update for one of them
+    without an object_id (test_bind_only_types_are_not_circular_references
+    fails the moment that changes). This guard is for the two ways the shape
+    arrives anyway -- a changeset a client hands to apply-change-set or
+    bulk-apply directly, and one planned before another worker created the
     row the bind now finds.
 
     A caller that means to write the row can still say so, with an explicit

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -156,6 +156,18 @@ def _pk_or_content_type_ref(value):
     # For regular related fields, get the primary key
     return  value.pk if value is not None else None
 
+# CREATE data drops None values (the serializer supplies defaults), which
+# erases the distinction between "field not submitted" and "field
+# explicitly null". For the types below, apply-path semantics depend on
+# that distinction for the named keys -- the rack pre-save gate and the
+# located-rack adopter must be able to tell an asserted null location from
+# an absent one -- so an explicitly-submitted null survives into CREATE
+# change data.
+_CREATE_PRESERVED_NULL_KEYS = {
+    "dcim.rack": ("location",),
+}
+
+
 def clean_diff_data(data: dict, exclude_empty_values: bool = True) -> dict:
     """Clean diff data by removing null values."""
     result = {}
@@ -213,6 +225,11 @@ def diff_to_change(
 
     if change_type != ChangeType.NOOP:
         change.data = _tidy(postchange_data, exclude_empty_values=not preserve_empty)
+        if change_type == ChangeType.CREATE:
+            for key in _CREATE_PRESERVED_NULL_KEYS.get(object_type, ()):
+                if key in postchange_data and postchange_data[key] is None:
+                    change.data[key] = None
+            change.data = sort_dict_recursively(change.data)
 
     return change
 

--- a/netbox_diode_plugin/api/differ.py
+++ b/netbox_diode_plugin/api/differ.py
@@ -159,12 +159,13 @@ def _pk_or_content_type_ref(value):
 # CREATE data drops None values (the serializer supplies defaults), which
 # erases the distinction between "field not submitted" and "field
 # explicitly null". For the types below, apply-path semantics depend on
-# that distinction for the named keys -- the rack pre-save gate and the
-# located-rack adopter must be able to tell an asserted null location from
-# an absent one -- so an explicitly-submitted null survives into CREATE
-# change data.
+# that distinction for the named keys -- the rack pre-save gate must be
+# able to tell an asserted null location from an absent one, and the rack
+# site-name matcher treats an asserted-empty asset tag or facility id as a
+# discriminator -- so an explicitly-submitted null (or empty string,
+# normalised to null) survives into CREATE change data.
 _CREATE_PRESERVED_NULL_KEYS = {
-    "dcim.rack": ("location",),
+    "dcim.rack": ("location", "asset_tag", "facility_id"),
 }
 
 
@@ -227,7 +228,10 @@ def diff_to_change(
         change.data = _tidy(postchange_data, exclude_empty_values=not preserve_empty)
         if change_type == ChangeType.CREATE:
             for key in _CREATE_PRESERVED_NULL_KEYS.get(object_type, ()):
-                if key in postchange_data and postchange_data[key] is None:
+                # An explicitly empty string asserts the same "none" as null
+                # and is normalised to null: a unique nullable column admits
+                # many nulls but only one empty string.
+                if key in postchange_data and postchange_data[key] in (None, ""):
                     change.data[key] = None
             change.data = sort_dict_recursively(change.data)
 

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -250,23 +250,25 @@ def _virtualchassis_pre_save_match_applies(data: dict) -> bool:
 
 def _rack_pre_save_match_applies(data: dict) -> bool:
     """
-    The rack pre-save match covers only shapes the DB cannot backstop.
+    The rack pre-save match covers only the location-less shape.
 
     A located CREATE racing a duplicate hits the (location, name)
     constraint and recovers through the create path's IntegrityError
-    fallback. A CREATE with location absent or explicitly null lands in
-    NULLS DISTINCT territory where nothing stops the duplicate, so those
-    take the pre-save match. Admitting the explicit null is deliberate and
-    depends on the differ preserving it into CREATE data
-    (differ._CREATE_PRESERVED_NULL_KEYS): at match time the site-name
-    matcher then stands aside (location key present), and the bind goes
-    through the auto-derived (location, name) constraint matcher instead,
-    via its ordinary IS NULL filter on location -- this branch carries no
-    site-scoped null-location matcher, so that bind is not scoped to the
-    payload's site and may resolve onto a location-null rack of the same
-    name in a different site.
+    fallback, so it needs no pre-save match. A CREATE with the location
+    key ABSENT lands in NULLS DISTINCT territory where nothing stops the
+    duplicate, and only the site-scoped RackSiteNameMatcher can answer
+    for it, so that shape takes the pre-save match.
+
+    An explicit ``location: null`` is deliberately NOT admitted: the
+    site-name matcher stands aside for it, and the only matcher left is
+    the derived (location, name) one, whose IS NULL filter carries no
+    site term -- a pre-save bind through it would attach a same-named
+    rack from ANOTHER site. Such CREATEs insert as they do without this
+    branch. Telling the two shapes apart at apply time depends on the
+    differ preserving the explicit null into CREATE data
+    (differ._CREATE_PRESERVED_NULL_KEYS).
     """
-    return data.get("location") is None
+    return "location" not in data
 
 
 # Payload-level narrowing for entries in _REQUIRES_PRE_SAVE_MATCH whose

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -14,7 +14,7 @@ from django.contrib.contenttypes.fields import ContentType
 from django.core.cache import cache as django_cache
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
-from django.db.models import F, Value
+from django.db.models import Count, F, Value
 from django.db.models.fields import SlugField
 from django.db.models.lookups import Exact
 from django.db.models.query_utils import Q
@@ -935,6 +935,12 @@ _LOGICAL_MATCHERS = {
             name="logical_mac_address_within_parent",
             model_class=get_object_type_model("dcim.macaddress"),
             condition=Q(assigned_object_id__isnull=True),
+        ),
+    ],
+    "dcim.rack": lambda: [
+        RackSiteNameMatcher(
+            model_class=get_object_type_model("dcim.rack"),
+            name="logical_rack_site_name_no_location",
         ),
     ],
     "dcim.rackreservation": lambda: [
@@ -1978,6 +1984,193 @@ class RackReservationUnitOverlapMatcher:
             "reservations, or merge/delete the overlapping reservations in "
             "NetBox.",
             "dcim.rackreservation",
+        )
+
+
+@dataclass
+class RackSiteNameMatcher:
+    """
+    Match a location-less rack payload by (site, name), any location.
+
+    Rack identity in NetBox is location-scoped with NULLS DISTINCT, so a
+    payload carrying only name + site has no constraint-derived matcher
+    and would duplicate the rack on every re-ingest. This matcher reads
+    such a payload as "the rack called <name> in site <site>": it asserts
+    nothing about location, so the row's location is neither filtered on
+    nor written (key-absent fields are never diffed).
+
+    A payload carrying the location key, a value or an explicit null, is
+    owned by the constraint matchers. A payload carrying an asset tag is a
+    subtler split: ``unique_asset_tag`` must keep winning WHEN IT CAN, so
+    ``has_required_fields`` no longer refuses a tagged payload outright.
+    ``fingerprint`` still abstains for any truthy asset_tag with no DB
+    access, so in-batch nodes carrying different tags never dedupe-merge
+    here; ``build_queryset`` abstains only when a rack already carries
+    that tag, and otherwise proceeds, so the first payload that ADDS a tag
+    to an existing tagless rack binds it (the UPDATE sets the tag) instead
+    of duplicating the rack and stranding the original. Resolution among
+    several candidates is bounded by populated-ness; see resolve().
+    """
+
+    model_class: type[models.Model]
+    name: str
+
+    min_version: str | None = None
+    max_version: str | None = None
+
+    def has_required_fields(self, data: dict) -> bool:
+        """
+        Location-less shape only: name + site, no location key.
+
+        An asset tag no longer gates this matcher off outright -- see the
+        class docstring for the split between fingerprint (always abstains
+        for a truthy tag) and build_queryset (abstains only when the tag is
+        already bound elsewhere).
+        """
+        name = data.get("name")
+        return (
+            isinstance(name, str)
+            and bool(name)
+            and data.get("site") is not None
+            and "location" not in data
+        )
+
+    @staticmethod
+    def _real_int(value) -> bool:
+        """Accept only real ints: bool would otherwise mean pk 1."""
+        return isinstance(value, int) and not isinstance(value, bool)
+
+    def fingerprint(self, data: dict) -> int | None:
+        """
+        In-batch dedupe key: site ref + name, gated to the location-less shape.
+
+        Abstains for any truthy asset_tag without touching the DB: two
+        in-batch nodes carrying different tags must not dedupe-merge, even
+        though build_queryset may still bind an existing tagless rack for
+        either of them individually at lookup time.
+
+        Deliberately NOT an ungated name key: two genuinely different
+        same-named racks in different locations of one site, sent in one
+        batch, must not dedupe-merge. Mixed-shape convergence happens at
+        apply (pre-save bind, located-CREATE adoption), not here.
+        """
+        if not self.has_required_fields(data):
+            return None
+        if data.get("asset_tag"):
+            return None
+        site = data.get("site")
+        if isinstance(site, UnresolvedReference):
+            site_key = ("__uuid__", site.uuid)
+        elif self._real_int(site):
+            site_key = site
+        else:
+            site_key = ("__str__", str(site))
+        return hash((self.model_class.__name__, self.name, site_key, data["name"]))
+
+    def build_queryset(self, data: dict) -> models.QuerySet | None:
+        """
+        Site-wide name query, only when site is a resolved int pk.
+
+        Abstains when a rack already carries this payload's asset tag, so
+        unique_asset_tag keeps winning whenever it can; otherwise proceeds,
+        letting a payload that adds a tag to an existing tagless rack bind
+        it instead of duplicating the rack.
+        """
+        if not self.has_required_fields(data):
+            return None
+        site = data.get("site")
+        if not self._real_int(site):
+            return None
+        tag = data.get("asset_tag")
+        if tag and self.model_class.objects.filter(asset_tag=tag).exists():
+            return None
+        return self.model_class.objects.filter(site_id=site, name=data["name"])
+
+    def resolve(self, queryset: models.QuerySet, data: dict):
+        """
+        Choose among same-(site, name) candidates, bounded by populated-ness.
+
+        One row binds outright. Among several, a SOLE populated row (it has
+        devices or reservations) wins -- empty duplicates starve rather
+        than absorb references. With no populated row the oldest
+        location-null row wins (the shape this payload created before the
+        fix existed). Several populated rows -- or none populated and none
+        null -- refuse loudly: binding would be a data move made on the
+        strength of a name.
+
+        Populated-ness and location are read from ONE annotated, joined
+        query rather than a per-row devices.exists() / reservations.exists()
+        / .count() probe each -- a candidate list of N rows previously cost
+        up to 3N extra queries just to decide whether to raise.
+        """
+        rows = list(
+            queryset.annotate(
+                n_dev=Count("devices", distinct=True),
+                n_res=Count("reservations", distinct=True),
+            )
+            .select_related("location")
+            .order_by("pk")
+        )
+        if not rows:
+            return None
+        if len(rows) == 1:
+            return rows[0]
+        populated = [r for r in rows if r.n_dev or r.n_res]
+        if len(populated) == 1:
+            return populated[0]
+        if not populated:
+            nulls = [r for r in rows if r.location_id is None]
+            if nulls:
+                return nulls[0]
+        raise self._ambiguous_match(rows, populated, data)
+
+    @staticmethod
+    def _rack_listing_entry(r) -> str:
+        """One row's listing entry: pk, location label, devices/reservations."""
+        location = (
+            "location=None" if r.location_id is None
+            else f"location={r.location.name} ({r.location_id})"
+        )
+        return f"pk={r.pk} {location} devices={r.n_dev} reservations={r.n_res}"
+
+    @classmethod
+    def _rack_listing(cls, rows: list, populated: list) -> str:
+        """
+        Full detail for populated rows; empty rows collapse into counts.
+
+        With no populated row at all (the caller's own tie-break already
+        failed to find a safe pick), every row is named in full instead --
+        there is nothing populated to distinguish them by, and the row
+        count in that shape stays small in practice.
+        """
+        if not populated:
+            return "; ".join(cls._rack_listing_entry(r) for r in rows)
+        entries = [cls._rack_listing_entry(r) for r in populated]
+        empty = [r for r in rows if r not in populated]
+        empty_null = sum(1 for r in empty if r.location_id is None)
+        empty_located = len(empty) - empty_null
+        if empty_null:
+            entries.append(f"and {empty_null} empty location-null rows")
+        if empty_located:
+            entries.append(f"and {empty_located} empty located rows")
+        return "; ".join(entries)
+
+    def _ambiguous_match(
+        self, rows: list, populated: list, data: dict
+    ) -> AmbiguousObjectMatch:
+        """Build the refusal naming every populated row and the site."""
+        listing = self._rack_listing(rows, populated)
+        site_pk = data.get("site")
+        site_name = (
+            get_object_type_model("dcim.site").objects
+            .filter(pk=site_pk).values_list("name", flat=True).first()
+        )
+        return AmbiguousObjectMatch(
+            f"dcim.rack payload name {data.get('name')!r} in site "
+            f"{site_name!r} (pk {site_pk}) matches {len(rows)} racks and none "
+            f"can be chosen safely: {listing}. Disambiguate with a location "
+            "key or an asset tag, or merge/rename the racks in NetBox.",
+            "dcim.rack",
         )
 
 

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -2160,7 +2160,7 @@ class RackSiteNameMatcher:
         Choose among same-(site, name) candidates, bounded by populated-ness.
 
         One row binds outright. Among several, a SOLE populated row (it has
-        devices or reservations) wins -- empty duplicates starve rather
+        devices, reservations or power feeds) wins -- empty duplicates starve rather
         than absorb references. With no populated row the oldest
         location-null row wins (the shape this payload created before the
         fix existed). Several populated rows -- or none populated and none
@@ -2168,7 +2168,7 @@ class RackSiteNameMatcher:
         strength of a name.
 
         Populated-ness and location are read from ONE annotated, joined
-        query rather than a per-row devices.exists() / reservations.exists()
+        query rather than per-row devices/reservations/powerfeeds .exists()
         / .count() probe each -- a candidate list of N rows previously cost
         up to 3N extra queries just to decide whether to raise.
         """
@@ -2176,6 +2176,7 @@ class RackSiteNameMatcher:
             queryset.annotate(
                 n_dev=Count("devices", distinct=True),
                 n_res=Count("reservations", distinct=True),
+                n_pf=Count("powerfeeds", distinct=True),
             )
             .select_related("location")
             .order_by("pk")
@@ -2184,7 +2185,7 @@ class RackSiteNameMatcher:
             return None
         if len(rows) == 1:
             return rows[0]
-        populated = [r for r in rows if r.n_dev or r.n_res]
+        populated = [r for r in rows if r.n_dev or r.n_res or r.n_pf]
         if len(populated) == 1:
             return populated[0]
         if not populated:
@@ -2195,12 +2196,12 @@ class RackSiteNameMatcher:
 
     @staticmethod
     def _rack_listing_entry(r) -> str:
-        """One row's listing entry: pk, location label, devices/reservations."""
+        """One row's listing entry: pk, location label, devices/reservations/power feeds."""
         location = (
             "location=None" if r.location_id is None
             else f"location={r.location.name} ({r.location_id})"
         )
-        return f"pk={r.pk} {location} devices={r.n_dev} reservations={r.n_res}"
+        return f"pk={r.pk} {location} devices={r.n_dev} reservations={r.n_res} powerfeeds={r.n_pf}"
 
     @classmethod
     def _rack_listing(cls, rows: list, populated: list) -> str:

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -2126,8 +2126,8 @@ class RackSiteNameMatcher:
         an explicitly empty tag is an assertion of taglessness and is held
         to the same rule.
         A submitted facility_id narrows the same way: a candidate with that
-        facility id wins outright, and candidates with a different one are
-        excluded.
+        facility id wins outright, candidates with a different one are
+        excluded, and an explicitly empty value binds only racks without one.
         """
         if not self.has_required_fields(data):
             return None
@@ -2144,13 +2144,15 @@ class RackSiteNameMatcher:
             # tag is a different physical rack, and binding it would rewrite
             # (or clear) its identity with this payload's value.
             qs = qs.filter(models.Q(asset_tag__isnull=True) | models.Q(asset_tag=""))
-        facility_id = data.get("facility_id")
-        if facility_id:
+        if "facility_id" in data:
             # facility_id discriminates same-named racks the way an asset tag
             # does: a candidate carrying THIS facility id is the rack meant,
-            # and one carrying a different id is another physical rack.
-            exact = qs.filter(facility_id=facility_id)
-            if exact.exists():
+            # one carrying a different id is another physical rack, and an
+            # explicitly empty value asserts "no facility id" -- it may bind
+            # only a rack that has none.
+            facility_id = data["facility_id"]
+            exact = qs.filter(facility_id=facility_id) if facility_id else qs.none()
+            if facility_id and exact.exists():
                 qs = exact
             else:
                 qs = qs.filter(

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -2114,19 +2114,26 @@ class RackSiteNameMatcher:
         Site-wide name query, only when site is a resolved int pk.
 
         Abstains when a rack already carries this payload's asset tag, so
-        unique_asset_tag keeps winning whenever it can; otherwise proceeds,
-        letting a payload that adds a tag to an existing tagless rack bind
-        it instead of duplicating the rack.
+        unique_asset_tag keeps winning whenever it can; otherwise proceeds
+        over TAGLESS candidates only, letting a payload that adds a tag to
+        an existing tagless rack bind it instead of duplicating the rack,
+        while never binding a same-named rack that carries a different tag.
         """
         if not self.has_required_fields(data):
             return None
         site = data.get("site")
         if not self._real_int(site):
             return None
+        qs = self.model_class.objects.filter(site_id=site, name=data["name"])
         tag = data.get("asset_tag")
-        if tag and self.model_class.objects.filter(asset_tag=tag).exists():
-            return None
-        return self.model_class.objects.filter(site_id=site, name=data["name"])
+        if tag:
+            if self.model_class.objects.filter(asset_tag=tag).exists():
+                return None
+            # A new tag may only be attached to a TAGLESS rack: a same-named
+            # rack carrying a different tag is a different physical rack, and
+            # binding it would rewrite its identity with this payload's tag.
+            qs = qs.filter(models.Q(asset_tag__isnull=True) | models.Q(asset_tag=""))
+        return qs
 
     def resolve(self, queryset: models.QuerySet, data: dict):
         """

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -2122,7 +2122,9 @@ class RackSiteNameMatcher:
         unique_asset_tag keeps winning whenever it can; otherwise proceeds
         over TAGLESS candidates only, letting a payload that adds a tag to
         an existing tagless rack bind it instead of duplicating the rack,
-        while never binding a same-named rack that carries a different tag.
+        while never binding a same-named rack that carries a different tag;
+        an explicitly empty tag is an assertion of taglessness and is held
+        to the same rule.
         A submitted facility_id narrows the same way: a candidate with that
         facility id wins outright, and candidates with a different one are
         excluded.
@@ -2133,13 +2135,14 @@ class RackSiteNameMatcher:
         if not self._real_int(site):
             return None
         qs = self.model_class.objects.filter(site_id=site, name=data["name"])
-        tag = data.get("asset_tag")
-        if tag:
-            if self.model_class.objects.filter(asset_tag=tag).exists():
+        if "asset_tag" in data:
+            tag = data["asset_tag"]
+            if tag and self.model_class.objects.filter(asset_tag=tag).exists():
                 return None
-            # A new tag may only be attached to a TAGLESS rack: a same-named
-            # rack carrying a different tag is a different physical rack, and
-            # binding it would rewrite its identity with this payload's tag.
+            # An asserted tag state -- a new tag, or explicitly none -- may
+            # only bind a TAGLESS rack: a same-named rack carrying a different
+            # tag is a different physical rack, and binding it would rewrite
+            # (or clear) its identity with this payload's value.
             qs = qs.filter(models.Q(asset_tag__isnull=True) | models.Q(asset_tag=""))
         facility_id = data.get("facility_id")
         if facility_id:

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -2094,7 +2094,7 @@ class RackSiteNameMatcher:
         Deliberately NOT an ungated name key: two genuinely different
         same-named racks in different locations of one site, sent in one
         batch, must not dedupe-merge. Mixed-shape convergence happens at
-        apply (pre-save bind, located-CREATE adoption), not here.
+        apply (the bind-only pre-save match), not here.
         """
         if not self.has_required_fields(data):
             return None

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -2109,7 +2109,10 @@ class RackSiteNameMatcher:
             site_key = site
         else:
             site_key = ("__str__", str(site))
-        return hash((self.model_class.__name__, self.name, site_key, data["name"]))
+        return hash((
+            self.model_class.__name__, self.name, site_key, data["name"],
+            data.get("facility_id") or None,
+        ))
 
     def build_queryset(self, data: dict) -> models.QuerySet | None:
         """
@@ -2120,6 +2123,9 @@ class RackSiteNameMatcher:
         over TAGLESS candidates only, letting a payload that adds a tag to
         an existing tagless rack bind it instead of duplicating the rack,
         while never binding a same-named rack that carries a different tag.
+        A submitted facility_id narrows the same way: a candidate with that
+        facility id wins outright, and candidates with a different one are
+        excluded.
         """
         if not self.has_required_fields(data):
             return None
@@ -2135,6 +2141,18 @@ class RackSiteNameMatcher:
             # rack carrying a different tag is a different physical rack, and
             # binding it would rewrite its identity with this payload's tag.
             qs = qs.filter(models.Q(asset_tag__isnull=True) | models.Q(asset_tag=""))
+        facility_id = data.get("facility_id")
+        if facility_id:
+            # facility_id discriminates same-named racks the way an asset tag
+            # does: a candidate carrying THIS facility id is the rack meant,
+            # and one carrying a different id is another physical rack.
+            exact = qs.filter(facility_id=facility_id)
+            if exact.exists():
+                qs = exact
+            else:
+                qs = qs.filter(
+                    models.Q(facility_id__isnull=True) | models.Q(facility_id="")
+                )
         return qs
 
     def resolve(self, queryset: models.QuerySet, data: dict):

--- a/netbox_diode_plugin/api/matcher.py
+++ b/netbox_diode_plugin/api/matcher.py
@@ -104,6 +104,13 @@ def invalidate_find_obj_entry(object_type: str, object_id: int):
 #     (mac_address, assigned_object_type, assigned_object_id).
 #   - dcim.modulebay: matched by (name, device); NetBox's parent-aware
 #     constraint does not catch unscoped duplicates the matcher dedupes.
+#   - dcim.rack: matched by (site, name) only when the payload has location
+#     absent or explicit null; NetBox's (location, name) constraint is NULLS
+#     DISTINCT and enforces nothing there. Only that location-less half of
+#     this type's payload space takes the pre-save match -- see
+#     _rack_pre_save_match_applies -- and it BINDS the row without writing to
+#     it, for the same non-authoritative-identity reason as virtual chassis
+#     below -- see _PRE_SAVE_MATCH_BIND_ONLY.
 #   - dcim.virtualchassis: matched by name when the payload has no master;
 #     NetBox has no uniqueness on VC name at all. Only the MASTERLESS half of
 #     this type's payload space takes the pre-save match -- see
@@ -156,6 +163,7 @@ _REQUIRES_PRE_SAVE_MATCH = frozenset({
     "dcim.macaddress",
     "dcim.module",
     "dcim.modulebay",
+    "dcim.rack",
     "dcim.rackreservation",
     "dcim.virtualchassis",
     "ipam.prefix",
@@ -240,10 +248,32 @@ def _virtualchassis_pre_save_match_applies(data: dict) -> bool:
     return data.get("master") is None
 
 
+def _rack_pre_save_match_applies(data: dict) -> bool:
+    """
+    The rack pre-save match covers only shapes the DB cannot backstop.
+
+    A located CREATE racing a duplicate hits the (location, name)
+    constraint and recovers through the create path's IntegrityError
+    fallback. A CREATE with location absent or explicitly null lands in
+    NULLS DISTINCT territory where nothing stops the duplicate, so those
+    take the pre-save match. Admitting the explicit null is deliberate and
+    depends on the differ preserving it into CREATE data
+    (differ._CREATE_PRESERVED_NULL_KEYS): at match time the site-name
+    matcher then stands aside (location key present), and the bind goes
+    through the auto-derived (location, name) constraint matcher instead,
+    via its ordinary IS NULL filter on location -- this branch carries no
+    site-scoped null-location matcher, so that bind is not scoped to the
+    payload's site and may resolve onto a location-null rack of the same
+    name in a different site.
+    """
+    return data.get("location") is None
+
+
 # Payload-level narrowing for entries in _REQUIRES_PRE_SAVE_MATCH whose
 # pre-save match is safe for only PART of their type's payload space. A type
 # with no gate here takes the pre-save match for every CREATE.
 _PRE_SAVE_MATCH_PAYLOAD_GATES = {
+    "dcim.rack": _rack_pre_save_match_applies,
     "dcim.virtualchassis": _virtualchassis_pre_save_match_applies,
 }
 
@@ -280,10 +310,10 @@ _PRE_SAVE_MATCH_PAYLOAD_GATES = {
 # still worth taking -- a wrong write into another source's live stack is
 # silent and unrepairable, a delayed write is neither -- but it is a trade.
 #
-# Why this set holds dcim.virtualchassis ALONE, when the no-uniqueness argument
-# above applies just as well to the nine other types this file's own gap list
-# names for absent uniqueness -- dcim.macaddress, dcim.modulebay, ipam.prefix,
-# ipam.vlan, ipam.vlangroup, ipam.vrf, virtualization.cluster,
+# Why this set holds dcim.virtualchassis and dcim.rack, when the no-uniqueness
+# argument above applies just as well to the nine other types this file's own
+# gap list names for absent uniqueness -- dcim.macaddress, dcim.modulebay,
+# ipam.prefix, ipam.vlan, ipam.vlangroup, ipam.vrf, virtualization.cluster,
 # virtualization.virtualmachine, wireless.wirelesslan (dcim.module is the
 # separate DB-constraint-backed entry above, and dcim.cable is matched by its
 # terminations): because those were measured to behave the same way, and to do
@@ -292,9 +322,20 @@ _PRE_SAVE_MATCH_PAYLOAD_GATES = {
 # fields through the pre-save match, IDENTICALLY on the parent commit and on
 # origin/develop, so none of it is a regression this branch introduces, and
 # widening the set here would change behaviour for four more types well outside
-# a VirtualChassis ingest PR. dcim.virtualchassis is in this set because this
-# branch is what put VC CREATEs on the pre-save path at all -- not because VC
-# is uniquely exposed. Broadening it is filed separately.
+# this PR's scope. dcim.virtualchassis is in this set because this branch is
+# what put VC CREATEs on the pre-save path at all -- not because VC is
+# uniquely exposed.
+#
+# dcim.rack is in this set for a related but distinct reason: a location-less
+# match binds on (site, name) alone, with location ignored, which is
+# non-authoritative identity, not proof the payload and the matched row
+# describe the same physical rack. And the CREATE data being applied is not
+# even purely the producer's own: transformer._set_defaults has already
+# injected status/width/u_height/starting_unit onto it when the producer left
+# them unasserted, so a write here could stamp those manufactured defaults
+# onto a row the payload never actually described -- see
+# _rack_pre_save_match_applies. Broadening this set further is filed
+# separately.
 #
 # Read narrowly, because this does NOT make a same-named row safe from ingest
 # generally. Once the row exists the matcher finds it by name, so the next
@@ -312,6 +353,7 @@ _PRE_SAVE_MATCH_PAYLOAD_GATES = {
 # applier._try_bind_existing_instance for the ref_id-update gap it does not
 # cover.
 _PRE_SAVE_MATCH_BIND_ONLY = frozenset({
+    "dcim.rack",
     "dcim.virtualchassis",
 })
 
@@ -331,10 +373,10 @@ def requires_pre_save_match(object_type: str, data: dict | None = None) -> bool:
     the safe direction: the pre-save match resolves a CREATE onto an existing
     row, and for every type outside _PRE_SAVE_MATCH_BIND_ONLY it then writes
     the payload there, so taking that route unproven is the direction that does
-    damage, while declining it only forgoes a dedupe. (For the one gated type
-    today, dcim.virtualchassis, the match is bind-only and writes nothing --
-    so the default is conservative about the resolution itself, not about a
-    write.)
+    damage, while declining it only forgoes a dedupe. (For the gated types
+    today, dcim.virtualchassis and dcim.rack, the match is bind-only and
+    writes nothing -- so the default is conservative about the resolution
+    itself, not about a write.)
     """
     if object_type not in _REQUIRES_PRE_SAVE_MATCH:
         return False
@@ -2499,32 +2541,35 @@ def _find_obj_cache_key(data: dict, object_type: str) -> str | None:
 
     Includes only simple scalar fields. Entities whose identity depends
     solely on unresolved references (no scalar fields at all) are not
-    cacheable.
+    cacheable. Some object types are never cached due to identity logic
+    that depends on factors the scalar-only key cannot express.
     """
-    if object_type == "dcim.cable":
-        # Cable identity lives entirely in list fields skipped by the scalar-only
-        # cache key; always run the authoritative build_queryset matcher loop.
-        return None
-
-    if object_type == "dcim.rackreservation":
-        # Reservation identity lives in the units ArrayField, which the
-        # scalar-only key below skips -- two different reservations on one
-        # rack could share a key and serve each other's cached answer.
-        # Returning None disables both the django and request-scoped caches.
-        return None
-
-    if object_type == "dcim.virtualchassis":
-        # Not cacheable, and the reason is identity rather than cost. The key
-        # below is built from SCALAR fields only, so it cannot see
-        # common.VC_MEMBER_HINT (a list, and private) -- two payloads naming the
-        # same chassis on behalf of DIFFERENT member devices would share one
-        # key, and the first one's answer would be served to the second, which
-        # is precisely the "pick a row the payload never identified" the
-        # VirtualChassisNameMatcher.resolve rules exist to prevent. A cached hit
-        # would also skip resolve() entirely, so an ambiguity that must be
-        # reported would instead answer with whatever row was cached before the
-        # duplicate appeared. Both caches (django and request-scoped) key off
-        # this function, so returning None disables both.
+    # Types whose lookup must never be served from the scalar-only key:
+    # - dcim.cable: identity lives entirely in the termination lists the key
+    #   skips; always run the authoritative build_queryset matcher loop.
+    # - dcim.rackreservation: identity lives in the units ArrayField the key
+    #   skips; two different reservations on one rack could share a key and
+    #   serve each other's cached answer.
+    # - dcim.virtualchassis: two hazards. The key cannot see
+    #   common.VC_MEMBER_HINT (a list, and private) -- two payloads naming the
+    #   same chassis on behalf of DIFFERENT member devices share one key and the
+    #   first answer is served to the second, precisely the "pick a row the
+    #   payload never identified" VirtualChassisNameMatcher.resolve exists to
+    #   prevent. And a cached hit skips resolve() entirely, so an ambiguity that
+    #   must be reported answers with whatever was cached before the duplicate
+    #   appeared.
+    # - dcim.rack: not a key-shape problem -- a cache hit skips resolve(), so
+    #   the ambiguity refusal and the populated/oldest-null choice would be
+    #   answered by whatever row was cached before a competing row appeared, and
+    #   row creation invalidates nothing.
+    # Returning None disables both the django and request-scoped caches.
+    non_cacheable_types = {
+        "dcim.cable",
+        "dcim.rack",
+        "dcim.rackreservation",
+        "dcim.virtualchassis",
+    }
+    if object_type in non_cacheable_types:
         return None
 
     items = []

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -130,8 +130,9 @@ class Command(BaseCommand):
             return [a_field, b_field]
 
         class_field_map = {
-            "VirtualChassisNameMatcher": ["name"],
             "RackReservationUnitOverlapMatcher": ["rack", "units"],
+            "RackSiteNameMatcher": ["site", "name"],
+            "VirtualChassisNameMatcher": ["name"],
         }
         mapped_fields = class_field_map.get(matcher.__class__.__name__)
         if mapped_fields:

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_generate_matching_docs.py
@@ -18,6 +18,7 @@ from netbox_diode_plugin.api.matcher import (
     GlobalIPNetworkIPMatcher,
     ObjectMatchCriteria,
     RackReservationUnitOverlapMatcher,
+    RackSiteNameMatcher,
     VirtualChassisNameMatcher,
 )
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
@@ -169,6 +170,13 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         result = self.command.get_matcher_fields(matcher)
         self.assertEqual(result, ["rack", "units"])
+
+    def test_get_matcher_fields_rack_site_name(self):
+        """Test deriving Fields for a real RackSiteNameMatcher via the class-name map."""
+        matcher = RackSiteNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["site", "name"])
 
     def test_get_matcher_fields_global_ip_network(self):
         """Test deriving Fields for a real GlobalIPNetworkIPMatcher via ip_fields."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_ingest_convergence.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Rack ingest convergence: site-scoped identity end-to-end."""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.matcher import AmbiguousObjectMatch
+
+
+class RackConvergenceTestCase(TestCase):
+    """Plan+apply round-trips for location-less rack identity."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Site, location, user pre-seeded; racks vary per test."""
+        cls.site = Site.objects.create(name="rc-site", slug="rc-site")
+        cls.location = Location.objects.create(
+            name="rc-loc", slug="rc-loc", site=cls.site
+        )
+        cls.user = User.objects.create(username="rc-owner")
+
+    def _reservation_entity(self, rack_extra=None):
+        rack = {"name": "rc-r1", "site": {"name": "rc-site"}}
+        rack.update(rack_extra or {})
+        return {"rack": rack, "units": [1, 2], "description": "rc",
+                "user": {"username": "rc-owner"}}
+
+    def _rack_entity(self, extra=None):
+        entity = {"name": "rc-r1", "site": {"name": "rc-site"}}
+        entity.update(extra or {})
+        return entity
+
+    def _plan(self, entity, object_type):
+        return generate_changeset(entity, object_type).change_set
+
+    def _apply(self, cs):
+        return apply_changeset(cs, request=None)
+
+    def _ingest(self, entity, object_type):
+        self._apply(self._plan(entity, object_type))
+
+    def test_mon324_repro_converges(self):
+        """The original bug: nested location-less rack duplicated per cycle."""
+        self._ingest(self._reservation_entity(), "dcim.rackreservation")
+        cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
+        non_noop = [c for c in cs.changes if c.change_type != ChangeType.NOOP]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_binds_operator_located_rack_location_untouched(self):
+        """A location-less ref binds the located rack and leaves its location."""
+        rack = Rack.objects.create(
+            name="rc-r1", site=self.site, location=self.location
+        )
+        cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
+        rack_creates = [c for c in cs.changes
+                        if c.object_type == "dcim.rack"
+                        and c.change_type == ChangeType.CREATE]
+        self.assertEqual(rack_creates, [], [c.to_dict() for c in rack_creates])
+        self._apply(cs)
+        rack.refresh_from_db()
+        self.assertEqual(rack.location_id, self.location.pk)
+        self.assertEqual(Rack.objects.count(), 1)
+
+    def test_two_populated_racks_fail_at_plan(self):
+        """Genuine ambiguity refuses loudly, DB untouched."""
+        loc2 = Location.objects.create(name="rc-loc2", slug="rc-loc2", site=self.site)
+        a = Rack.objects.create(name="rc-r1", site=self.site, location=self.location)
+        b = Rack.objects.create(name="rc-r1", site=self.site, location=loc2)
+        RackReservation.objects.create(rack=a, units=[1], user=self.user, description="a")
+        RackReservation.objects.create(rack=b, units=[2], user=self.user, description="b")
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            self._plan(self._reservation_entity(), "dcim.rackreservation")
+        self.assertIn(str(a.pk), str(cm.exception))
+        self.assertIn(str(b.pk), str(cm.exception))
+        self.assertEqual(Rack.objects.count(), 2)
+
+    def test_explicit_null_does_not_adopt_located_rack(self):
+        """With only a located rack, explicit null creates its own null rack."""
+        located = Rack.objects.create(
+            name="rc-r1", site=self.site, location=self.location
+        )
+        self._ingest(self._rack_entity({"location": None}), "dcim.rack")
+        located.refresh_from_db()
+        self.assertEqual(located.location_id, self.location.pk)
+        self.assertEqual(Rack.objects.count(), 2)
+        # third pass converges onto the null rack (all-NOOP)
+        cs = self._plan(self._rack_entity({"location": None}), "dcim.rack")
+        non_noop = [c for c in cs.changes if c.change_type != ChangeType.NOOP]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+
+    def test_stale_locationless_create_binds_only(self):
+        """Bind-only: the operator's distinctive fields survive a stale CREATE."""
+        cs = self._plan(self._rack_entity(), "dcim.rack")
+        rack = Rack.objects.create(
+            name="rc-r1", site=self.site, status="reserved", width=23, u_height=48
+        )
+        result = self._apply(cs)
+        rack.refresh_from_db()
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(rack.status, "reserved")
+        self.assertEqual(rack.width, 23)
+        self.assertEqual(rack.u_height, 48)
+        warnings = result.to_dict().get("warnings") or []
+        self.assertEqual(len(warnings), 1, warnings)
+        self.assertEqual(warnings[0]["object_type"], "dcim.rack")
+        self.assertEqual(warnings[0]["object_id"], rack.pk)
+        self.assertTrue(
+            {"status", "width", "u_height"} <= set(warnings[0]["fields"]),
+            warnings,
+        )
+
+    def test_mixed_batch_null_first_two_racks(self):
+        """
+        No rack adopter in this minimal design: a located CREATE beside a null rack.
+
+        A location-less CREATE applies first and creates a location-null rack.
+        A located CREATE for the same (site, name), planned separately and
+        applied second, then inserts its OWN row: the (location, name) DB
+        constraint has nothing to collide with (the null rack's location is
+        NULL, and the constraint is NULLS DISTINCT), and this branch carries
+        no adopter to notice the null sibling and reuse it instead. TWO
+        racks, unmerged, is the documented outcome here -- collapsing them
+        into one is out of this branch's scope.
+        """
+        cs_locationless = self._plan(self._rack_entity({"status": "reserved"}), "dcim.rack")
+        cs_located = self._plan(
+            self._rack_entity({"location": {"name": "rc-loc", "site": {"name": "rc-site"}}}),
+            "dcim.rack")
+        self._apply(cs_locationless)
+        self._apply(cs_located)
+        self.assertEqual(Rack.objects.count(), 2)
+        racks = list(Rack.objects.order_by("pk"))
+        null_rack, located_rack = racks[0], racks[1]
+        self.assertIsNone(null_rack.location_id)
+        self.assertEqual(null_rack.status, "reserved")
+        self.assertEqual(located_rack.location_id, self.location.pk)

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_ingest_convergence.py
@@ -44,7 +44,7 @@ class RackConvergenceTestCase(TestCase):
     def _ingest(self, entity, object_type):
         self._apply(self._plan(entity, object_type))
 
-    def test_mon324_repro_converges(self):
+    def test_location_less_rack_reingest_converges(self):
         """The original bug: nested location-less rack duplicated per cycle."""
         self._ingest(self._reservation_entity(), "dcim.rackreservation")
         cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
@@ -115,29 +115,3 @@ class RackConvergenceTestCase(TestCase):
             {"status", "width", "u_height"} <= set(warnings[0]["fields"]),
             warnings,
         )
-
-    def test_mixed_batch_null_first_two_racks(self):
-        """
-        No rack adopter in this minimal design: a located CREATE beside a null rack.
-
-        A location-less CREATE applies first and creates a location-null rack.
-        A located CREATE for the same (site, name), planned separately and
-        applied second, then inserts its OWN row: the (location, name) DB
-        constraint has nothing to collide with (the null rack's location is
-        NULL, and the constraint is NULLS DISTINCT), and this branch carries
-        no adopter to notice the null sibling and reuse it instead. TWO
-        racks, unmerged, is the documented outcome here -- collapsing them
-        into one is out of this branch's scope.
-        """
-        cs_locationless = self._plan(self._rack_entity({"status": "reserved"}), "dcim.rack")
-        cs_located = self._plan(
-            self._rack_entity({"location": {"name": "rc-loc", "site": {"name": "rc-site"}}}),
-            "dcim.rack")
-        self._apply(cs_locationless)
-        self._apply(cs_located)
-        self.assertEqual(Rack.objects.count(), 2)
-        racks = list(Rack.objects.order_by("pk"))
-        null_rack, located_rack = racks[0], racks[1]
-        self.assertIsNone(null_rack.location_id)
-        self.assertEqual(null_rack.status, "reserved")
-        self.assertEqual(located_rack.location_id, self.location.pk)

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -90,6 +90,22 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
     def _rack(self, name="r1", location=None, site=None):
         return Rack.objects.create(name=name, site=site or self.site, location=location)
 
+    def test_asset_tag_rule(self):
+        """A tag already on another rack wins; a new tag still binds by (site, name)."""
+        rack = self._rack()
+        tagged = Rack.objects.create(name="other", site=self.site2, asset_tag="rsm-AT1")
+        self.assertIsNone(
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"})
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT1"}, "dcim.rack"),
+            tagged,
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"}, "dcim.rack"),
+            rack,
+        )
+
     def _populate_device(self, rack):
         return Device.objects.create(
             name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -130,7 +130,7 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertEqual(find_existing_object({"name": "r1", "site": self.site.pk}, "dcim.rack"), rack)
 
     def test_facility_id_rule(self):
-        """A candidate carrying the submitted facility id wins; a different one is excluded."""
+        """A candidate carrying the submitted facility id wins; a different or asserted-empty one is excluded."""
         older_null = self._rack()
         located = self._rack(location=self.location)
         located.facility_id = "rsm-F1"
@@ -147,6 +147,15 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
         )
+        # an explicitly empty facility id asserts "none": even a populated F1 rack must not be cleared
+        self._populate_device(located)
+        for empty in ("", None):
+            self.assertEqual(
+                find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": empty}, "dcim.rack"),
+                older_null,
+            )
+        # ...while a bare {name, site} ref still prefers the populated F1 rack
+        self.assertEqual(self._find(), located)
 
     def test_power_feeds_count_as_populated(self):
         """A rack holding only power feeds is populated; it beats an empty null duplicate."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -248,9 +248,21 @@ class RackCreatePreservesExplicitNullTestCase(TestCase):
         self.assertIn("location", change.data)
         self.assertIsNone(change.data["location"])
 
+    def test_empty_discriminators_survive_as_null(self):
+        """Asserted-empty asset_tag / facility_id reach apply as explicit nulls."""
+        change = self._create_change(
+            {"name": "rpn-r3", "site": {"name": "rpn-site"}, "asset_tag": "", "facility_id": None}
+        )
+        self.assertIn("asset_tag", change.data)
+        self.assertIsNone(change.data["asset_tag"])
+        self.assertIn("facility_id", change.data)
+        self.assertIsNone(change.data["facility_id"])
+
     def test_absent_key_stays_absent(self):
         """A location-less entity's CREATE data has no location key."""
         change = self._create_change(
             {"name": "rpn-r2", "site": {"name": "rpn-site"}}
         )
         self.assertNotIn("location", change.data)
+        self.assertNotIn("asset_tag", change.data)
+        self.assertNotIn("facility_id", change.data)

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -2,7 +2,18 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Unit tests for RackSiteNameMatcher, rack differ preserve, and rack routing."""
 
-from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, RackReservation, Site
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Location,
+    Manufacturer,
+    PowerFeed,
+    PowerPanel,
+    Rack,
+    RackReservation,
+    Site,
+)
 from django.test import TestCase
 from users.models import User
 
@@ -129,6 +140,14 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
         )
+
+    def test_power_feeds_count_as_populated(self):
+        """A rack holding only power feeds is populated; it beats an empty null duplicate."""
+        self._rack()  # empty location-null duplicate
+        located = self._rack(location=self.location)
+        panel = PowerPanel.objects.create(site=self.site, name="rsm-panel")
+        PowerFeed.objects.create(power_panel=panel, rack=located, name="rsm-feed")
+        self.assertEqual(self._find(), located)
 
     def _populate_device(self, rack):
         return Device.objects.create(

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -51,11 +51,10 @@ class RackSiteNameMatcherGateTestCase(TestCase):
         """No location key: NULLS DISTINCT territory, no DB backstop."""
         self.assertTrue(requires_pre_save_match("dcim.rack", {"name": "r", "site": 1}))
 
-    def test_explicit_null_create_takes_pre_save_match(self):
-        """Explicit null is admitted; the (location, name) IS NULL constraint matcher binds."""
-        self.assertTrue(requires_pre_save_match(
+    def test_explicit_null_create_skips_pre_save_match(self):
+        """Explicit null is not admitted: its only matcher is site-blind."""
+        self.assertFalse(requires_pre_save_match(
             "dcim.rack", {"name": "r", "site": 1, "location": None}))
-
     def test_located_create_skips_pre_save_match(self):
         """A real location value keeps its DB-constraint backstop."""
         self.assertFalse(requires_pre_save_match(

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -91,7 +91,7 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         return Rack.objects.create(name=name, site=site or self.site, location=location)
 
     def test_asset_tag_rule(self):
-        """A tag already on another rack wins; a new tag still binds by (site, name)."""
+        """A tag already on another rack wins; a new tag binds only a tagless (site, name) rack."""
         rack = self._rack()
         tagged = Rack.objects.create(name="other", site=self.site2, asset_tag="rsm-AT1")
         self.assertIsNone(
@@ -104,6 +104,12 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertEqual(
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"}, "dcim.rack"),
             rack,
+        )
+        # a same-named rack carrying a DIFFERENT tag is another physical rack
+        rack.asset_tag = "rsm-AT-A"
+        rack.save()
+        self.assertIsNone(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
 
     def _populate_device(self, rack):

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -121,6 +121,13 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertIsNone(
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
+        # an explicitly empty tag asserts taglessness: it must not clear AT-A
+        for empty in ("", None):
+            self.assertIsNone(
+                find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": empty}, "dcim.rack")
+            )
+        # ...while a bare {name, site} ref (no tag asserted) still binds the tagged rack
+        self.assertEqual(find_existing_object({"name": "r1", "site": self.site.pk}, "dcim.rack"), rack)
 
     def test_facility_id_rule(self):
         """A candidate carrying the submitted facility id wins; a different one is excluded."""

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -111,6 +111,25 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
 
+    def test_facility_id_rule(self):
+        """A candidate carrying the submitted facility id wins; a different one is excluded."""
+        older_null = self._rack()
+        located = self._rack(location=self.location)
+        located.facility_id = "rsm-F1"
+        located.save()
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}, "dcim.rack"),
+            located,
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}, "dcim.rack"),
+            older_null,
+        )
+        self.assertNotEqual(
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
+        )
+
     def _populate_device(self, rack):
         return Device.objects.create(
             name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_rack_matcher.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for RackSiteNameMatcher, rack differ preserve, and rack routing."""
+
+from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.common import ChangeType, UnresolvedReference
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.matcher import (
+    AmbiguousObjectMatch,
+    RackSiteNameMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+    pre_save_match_binds_only,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+def _matcher():
+    return RackSiteNameMatcher(
+        model_class=get_object_type_model("dcim.rack"),
+        name="logical_rack_site_name_no_location",
+    )
+
+
+class RackSiteNameMatcherGateTestCase(TestCase):
+    """Gate, abstain and routing rules (no DB rows needed)."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_gate_shape(self):
+        """Fires on the location-less {name, site} shape; declines a location key."""
+        self.assertTrue(self.matcher.has_required_fields({"name": "r1", "site": 1}))
+        self.assertFalse(self.matcher.has_required_fields(
+            {"name": "r1", "site": 1, "location": 5}))
+        self.assertFalse(self.matcher.has_required_fields(
+            {"name": "r1", "site": 1, "location": None}))
+
+    def test_build_queryset_abstains_on_malformed_site(self):
+        """An in-batch site ref or a bool site must not become a pk filter."""
+        ref = UnresolvedReference(object_type="dcim.site", uuid="u-1")
+        self.assertIsNone(self.matcher.build_queryset({"name": "r1", "site": ref}))
+        self.assertIsNone(self.matcher.build_queryset({"name": "r1", "site": True}))
+
+    def test_location_less_create_takes_pre_save_match(self):
+        """No location key: NULLS DISTINCT territory, no DB backstop."""
+        self.assertTrue(requires_pre_save_match("dcim.rack", {"name": "r", "site": 1}))
+
+    def test_explicit_null_create_takes_pre_save_match(self):
+        """Explicit null is admitted; the (location, name) IS NULL constraint matcher binds."""
+        self.assertTrue(requires_pre_save_match(
+            "dcim.rack", {"name": "r", "site": 1, "location": None}))
+
+    def test_located_create_skips_pre_save_match(self):
+        """A real location value keeps its DB-constraint backstop."""
+        self.assertFalse(requires_pre_save_match(
+            "dcim.rack", {"name": "r", "site": 1, "location": 5}))
+
+    def test_rack_pre_save_match_is_bind_only(self):
+        """(site, name) identity is non-authoritative: bind, never write."""
+        self.assertTrue(pre_save_match_binds_only("dcim.rack"))
+
+    def test_find_obj_cache_key_disabled(self):
+        """No cache key for dcim.rack, ever -- a cache hit would skip resolve()."""
+        data = {"name": "r1", "site": 1, "status": "active"}
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.rack"))
+
+
+class RackSiteNameMatcherResolveTestCase(TestCase):
+    """find_existing_object behavior against real rows (registration included)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """One site with a location; helpers build racks/devices/reservations."""
+        cls.site = Site.objects.create(name="rsm-site", slug="rsm-site")
+        cls.site2 = Site.objects.create(name="rsm-site2", slug="rsm-site2")
+        cls.location = Location.objects.create(
+            name="rsm-loc", slug="rsm-loc", site=cls.site
+        )
+        cls.user = User.objects.create(username="rsm-user")
+        mfr = Manufacturer.objects.create(name="rsm-mfr", slug="rsm-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="rsm-dt", slug="rsm-dt")
+        cls.role = DeviceRole.objects.create(name="rsm-role", slug="rsm-role")
+
+    def _rack(self, name="r1", location=None, site=None):
+        return Rack.objects.create(name=name, site=site or self.site, location=location)
+
+    def _populate_device(self, rack):
+        return Device.objects.create(
+            name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,
+            device_type=self.dt, role=self.role,
+        )
+
+    def _populate_reservation(self, rack):
+        return RackReservation.objects.create(
+            rack=rack, units=[1], user=self.user, description="rsm"
+        )
+
+    def _find(self, name="r1"):
+        return find_existing_object({"name": name, "site": self.site.pk}, "dcim.rack")
+
+    def test_single_located_rack_binds(self):
+        """One candidate wins outright."""
+        rack = self._rack(location=self.location)
+        self.assertEqual(self._find(), rack)
+
+    def test_sole_populated_wins_over_empty_null(self):
+        """A populated located rack beats an empty null duplicate."""
+        located = self._rack(location=self.location)
+        self._populate_device(located)
+        self._rack()  # empty null duplicate
+        self.assertEqual(self._find(), located)
+
+    def test_no_populated_prefers_oldest_null(self):
+        """All empty: the oldest location-null row is the shape this payload made."""
+        self._rack(location=self.location)  # empty located, created first
+        old_null = self._rack()
+        self._rack()  # newer null
+        self.assertEqual(self._find(), old_null)
+
+    def test_two_populated_raises_naming_both_pks(self):
+        """Two populated candidates: binding would move references on a name."""
+        loc2 = Location.objects.create(name="rsm-loc3", slug="rsm-loc3", site=self.site)
+        a = self._rack(location=self.location)
+        self._populate_device(a)
+        b = self._rack(location=loc2)
+        self._populate_reservation(b)
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            self._find()
+        message = str(cm.exception)
+        self.assertIn(str(a.pk), message)
+        self.assertIn(str(b.pk), message)
+
+    def test_other_site_same_name_no_match(self):
+        """Site scope is hard."""
+        self._rack(site=self.site2)
+        self.assertIsNone(self._find())
+
+
+class RackCreatePreservesExplicitNullTestCase(TestCase):
+    """
+    CREATE change data keeps an explicitly-submitted location: null.
+
+    CREATE data drops None values, which erases the difference between
+    "not submitted" and "explicitly null" -- and the rack pre-save gate
+    depends on that difference at apply time.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A site for the rack entities to resolve against."""
+        cls.site = Site.objects.create(name="rpn-site", slug="rpn-site")
+
+    def _create_change(self, entity):
+        """Generate a changeset and extract the rack CREATE change."""
+        cs = generate_changeset(entity, "dcim.rack").change_set
+        creates = [c for c in cs.changes
+                   if c.object_type == "dcim.rack"
+                   and c.change_type == ChangeType.CREATE]
+        self.assertEqual(len(creates), 1, [c.to_dict() for c in cs.changes])
+        return creates[0]
+
+    def test_explicit_null_survives_into_create_data(self):
+        """location: null is a producer assertion; it must reach apply."""
+        change = self._create_change(
+            {"name": "rpn-r1", "site": {"name": "rpn-site"}, "location": None}
+        )
+        self.assertIn("location", change.data)
+        self.assertIsNone(change.data["location"])
+
+    def test_absent_key_stays_absent(self):
+        """A location-less entity's CREATE data has no location key."""
+        change = self._create_change(
+            {"name": "rpn-r2", "site": {"name": "rpn-site"}}
+        )
+        self.assertNotIn("location", change.data)

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_vc_name_matcher.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_vc_name_matcher.py
@@ -20,6 +20,7 @@ from netbox_diode_plugin.api.common import (
     UnresolvedReference,
 )
 from netbox_diode_plugin.api.matcher import (
+    _PRE_SAVE_MATCH_BIND_ONLY,
     _REQUIRES_PRE_SAVE_MATCH,
     AmbiguousObjectMatch,
     find_existing_object,
@@ -710,8 +711,31 @@ class PreSaveMatchBindOnlyTests(TestCase):
         "dcim.inventoryitem",
     )
 
+    #: Every _REQUIRES_PRE_SAVE_MATCH entry EXCEPT the two bind-only types
+    #: (dcim.virtualchassis, dcim.rack), hardcoded rather than derived from
+    #: _REQUIRES_PRE_SAVE_MATCH - _PRE_SAVE_MATCH_BIND_ONLY: a derived loop
+    #: would pass trivially however _PRE_SAVE_MATCH_BIND_ONLY grew, because
+    #: whatever got added to it would also be subtracted out of the set this
+    #: test iterates. Writing the members out means a third type added to
+    #: _PRE_SAVE_MATCH_BIND_ONLY without a matching change here fails this
+    #: test instead of silently narrowing what it covers.
+    NON_BIND_ONLY_PRE_SAVE_TYPES = (
+        "dcim.cable",
+        "dcim.macaddress",
+        "dcim.module",
+        "dcim.modulebay",
+        "dcim.rackreservation",
+        "ipam.prefix",
+        "ipam.vlan",
+        "ipam.vlangroup",
+        "ipam.vrf",
+        "virtualization.cluster",
+        "virtualization.virtualmachine",
+        "wireless.wirelesslan",
+    )
+
     def test_virtualchassis_binds_without_writing(self):
-        """The one bind-only type, and the reason the seam exists at all."""
+        """The original bind-only type, and the reason the seam exists at all."""
         self.assertTrue(pre_save_match_binds_only("dcim.virtualchassis"))
 
     def test_every_other_pre_save_matched_type_still_applies_its_payload(self):
@@ -719,11 +743,16 @@ class PreSaveMatchBindOnlyTests(TestCase):
         Naming them all: this is a behavioural change nobody else may inherit.
 
         dcim.module's find-first, for one, exists precisely to APPLY a payload
-        that the IntegrityError recovery it replaced used to discard.
+        that the IntegrityError recovery it replaced used to discard. The
+        bind-only membership itself is pinned separately, so growing it (as
+        dcim.rack did) does not silently widen what this test lets through.
         """
-        for object_type in sorted(_REQUIRES_PRE_SAVE_MATCH - {"dcim.virtualchassis"}):
+        for object_type in self.NON_BIND_ONLY_PRE_SAVE_TYPES:
             with self.subTest(object_type=object_type):
+                self.assertIn(object_type, _REQUIRES_PRE_SAVE_MATCH)
                 self.assertFalse(pre_save_match_binds_only(object_type))
+        self.assertEqual(
+            _PRE_SAVE_MATCH_BIND_ONLY, {"dcim.virtualchassis", "dcim.rack"})
 
     def test_no_auto_created_component_is_bind_only(self):
         """
@@ -744,7 +773,7 @@ class PreSaveMatchBindOnlyTests(TestCase):
 
     def test_a_type_with_no_pre_save_match_at_all_is_not_bind_only(self):
         """Bind-only narrows the find-first route; it is not a route of its own."""
-        for object_type in ("dcim.site", "dcim.device", "dcim.rack"):
+        for object_type in ("dcim.site", "dcim.device", "dcim.location"):
             with self.subTest(object_type=object_type):
                 self.assertFalse(pre_save_match_binds_only(object_type))
                 self.assertFalse(requires_pre_save_match(object_type, {}))

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_generate_matching_docs.py
@@ -18,6 +18,7 @@ from netbox_diode_plugin.api.matcher import (
     GlobalIPNetworkIPMatcher,
     ObjectMatchCriteria,
     RackReservationUnitOverlapMatcher,
+    RackSiteNameMatcher,
     VirtualChassisNameMatcher,
 )
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
@@ -169,6 +170,13 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         result = self.command.get_matcher_fields(matcher)
         self.assertEqual(result, ["rack", "units"])
+
+    def test_get_matcher_fields_rack_site_name(self):
+        """Test deriving Fields for a real RackSiteNameMatcher via the class-name map."""
+        matcher = RackSiteNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["site", "name"])
 
     def test_get_matcher_fields_global_ip_network(self):
         """Test deriving Fields for a real GlobalIPNetworkIPMatcher via ip_fields."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_ingest_convergence.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Rack ingest convergence: site-scoped identity end-to-end."""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.matcher import AmbiguousObjectMatch
+
+
+class RackConvergenceTestCase(TestCase):
+    """Plan+apply round-trips for location-less rack identity."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Site, location, user pre-seeded; racks vary per test."""
+        cls.site = Site.objects.create(name="rc-site", slug="rc-site")
+        cls.location = Location.objects.create(
+            name="rc-loc", slug="rc-loc", site=cls.site
+        )
+        cls.user = User.objects.create(username="rc-owner")
+
+    def _reservation_entity(self, rack_extra=None):
+        rack = {"name": "rc-r1", "site": {"name": "rc-site"}}
+        rack.update(rack_extra or {})
+        return {"rack": rack, "units": [1, 2], "description": "rc",
+                "user": {"username": "rc-owner"}}
+
+    def _rack_entity(self, extra=None):
+        entity = {"name": "rc-r1", "site": {"name": "rc-site"}}
+        entity.update(extra or {})
+        return entity
+
+    def _plan(self, entity, object_type):
+        return generate_changeset(entity, object_type).change_set
+
+    def _apply(self, cs):
+        return apply_changeset(cs, request=None)
+
+    def _ingest(self, entity, object_type):
+        self._apply(self._plan(entity, object_type))
+
+    def test_mon324_repro_converges(self):
+        """The original bug: nested location-less rack duplicated per cycle."""
+        self._ingest(self._reservation_entity(), "dcim.rackreservation")
+        cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
+        non_noop = [c for c in cs.changes if c.change_type != ChangeType.NOOP]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_binds_operator_located_rack_location_untouched(self):
+        """A location-less ref binds the located rack and leaves its location."""
+        rack = Rack.objects.create(
+            name="rc-r1", site=self.site, location=self.location
+        )
+        cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
+        rack_creates = [c for c in cs.changes
+                        if c.object_type == "dcim.rack"
+                        and c.change_type == ChangeType.CREATE]
+        self.assertEqual(rack_creates, [], [c.to_dict() for c in rack_creates])
+        self._apply(cs)
+        rack.refresh_from_db()
+        self.assertEqual(rack.location_id, self.location.pk)
+        self.assertEqual(Rack.objects.count(), 1)
+
+    def test_two_populated_racks_fail_at_plan(self):
+        """Genuine ambiguity refuses loudly, DB untouched."""
+        loc2 = Location.objects.create(name="rc-loc2", slug="rc-loc2", site=self.site)
+        a = Rack.objects.create(name="rc-r1", site=self.site, location=self.location)
+        b = Rack.objects.create(name="rc-r1", site=self.site, location=loc2)
+        RackReservation.objects.create(rack=a, units=[1], user=self.user, description="a")
+        RackReservation.objects.create(rack=b, units=[2], user=self.user, description="b")
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            self._plan(self._reservation_entity(), "dcim.rackreservation")
+        self.assertIn(str(a.pk), str(cm.exception))
+        self.assertIn(str(b.pk), str(cm.exception))
+        self.assertEqual(Rack.objects.count(), 2)
+
+    def test_explicit_null_does_not_adopt_located_rack(self):
+        """With only a located rack, explicit null creates its own null rack."""
+        located = Rack.objects.create(
+            name="rc-r1", site=self.site, location=self.location
+        )
+        self._ingest(self._rack_entity({"location": None}), "dcim.rack")
+        located.refresh_from_db()
+        self.assertEqual(located.location_id, self.location.pk)
+        self.assertEqual(Rack.objects.count(), 2)
+        # third pass converges onto the null rack (all-NOOP)
+        cs = self._plan(self._rack_entity({"location": None}), "dcim.rack")
+        non_noop = [c for c in cs.changes if c.change_type != ChangeType.NOOP]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+
+    def test_stale_locationless_create_binds_only(self):
+        """Bind-only: the operator's distinctive fields survive a stale CREATE."""
+        cs = self._plan(self._rack_entity(), "dcim.rack")
+        rack = Rack.objects.create(
+            name="rc-r1", site=self.site, status="reserved", width=23, u_height=48
+        )
+        result = self._apply(cs)
+        rack.refresh_from_db()
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(rack.status, "reserved")
+        self.assertEqual(rack.width, 23)
+        self.assertEqual(rack.u_height, 48)
+        warnings = result.to_dict().get("warnings") or []
+        self.assertEqual(len(warnings), 1, warnings)
+        self.assertEqual(warnings[0]["object_type"], "dcim.rack")
+        self.assertEqual(warnings[0]["object_id"], rack.pk)
+        self.assertTrue(
+            {"status", "width", "u_height"} <= set(warnings[0]["fields"]),
+            warnings,
+        )
+
+    def test_mixed_batch_null_first_two_racks(self):
+        """
+        No rack adopter in this minimal design: a located CREATE beside a null rack.
+
+        A location-less CREATE applies first and creates a location-null rack.
+        A located CREATE for the same (site, name), planned separately and
+        applied second, then inserts its OWN row: the (location, name) DB
+        constraint has nothing to collide with (the null rack's location is
+        NULL, and the constraint is NULLS DISTINCT), and this branch carries
+        no adopter to notice the null sibling and reuse it instead. TWO
+        racks, unmerged, is the documented outcome here -- collapsing them
+        into one is out of this branch's scope.
+        """
+        cs_locationless = self._plan(self._rack_entity({"status": "reserved"}), "dcim.rack")
+        cs_located = self._plan(
+            self._rack_entity({"location": {"name": "rc-loc", "site": {"name": "rc-site"}}}),
+            "dcim.rack")
+        self._apply(cs_locationless)
+        self._apply(cs_located)
+        self.assertEqual(Rack.objects.count(), 2)
+        racks = list(Rack.objects.order_by("pk"))
+        null_rack, located_rack = racks[0], racks[1]
+        self.assertIsNone(null_rack.location_id)
+        self.assertEqual(null_rack.status, "reserved")
+        self.assertEqual(located_rack.location_id, self.location.pk)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_ingest_convergence.py
@@ -44,7 +44,7 @@ class RackConvergenceTestCase(TestCase):
     def _ingest(self, entity, object_type):
         self._apply(self._plan(entity, object_type))
 
-    def test_mon324_repro_converges(self):
+    def test_location_less_rack_reingest_converges(self):
         """The original bug: nested location-less rack duplicated per cycle."""
         self._ingest(self._reservation_entity(), "dcim.rackreservation")
         cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
@@ -115,29 +115,3 @@ class RackConvergenceTestCase(TestCase):
             {"status", "width", "u_height"} <= set(warnings[0]["fields"]),
             warnings,
         )
-
-    def test_mixed_batch_null_first_two_racks(self):
-        """
-        No rack adopter in this minimal design: a located CREATE beside a null rack.
-
-        A location-less CREATE applies first and creates a location-null rack.
-        A located CREATE for the same (site, name), planned separately and
-        applied second, then inserts its OWN row: the (location, name) DB
-        constraint has nothing to collide with (the null rack's location is
-        NULL, and the constraint is NULLS DISTINCT), and this branch carries
-        no adopter to notice the null sibling and reuse it instead. TWO
-        racks, unmerged, is the documented outcome here -- collapsing them
-        into one is out of this branch's scope.
-        """
-        cs_locationless = self._plan(self._rack_entity({"status": "reserved"}), "dcim.rack")
-        cs_located = self._plan(
-            self._rack_entity({"location": {"name": "rc-loc", "site": {"name": "rc-site"}}}),
-            "dcim.rack")
-        self._apply(cs_locationless)
-        self._apply(cs_located)
-        self.assertEqual(Rack.objects.count(), 2)
-        racks = list(Rack.objects.order_by("pk"))
-        null_rack, located_rack = racks[0], racks[1]
-        self.assertIsNone(null_rack.location_id)
-        self.assertEqual(null_rack.status, "reserved")
-        self.assertEqual(located_rack.location_id, self.location.pk)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -90,6 +90,22 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
     def _rack(self, name="r1", location=None, site=None):
         return Rack.objects.create(name=name, site=site or self.site, location=location)
 
+    def test_asset_tag_rule(self):
+        """A tag already on another rack wins; a new tag still binds by (site, name)."""
+        rack = self._rack()
+        tagged = Rack.objects.create(name="other", site=self.site2, asset_tag="rsm-AT1")
+        self.assertIsNone(
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"})
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT1"}, "dcim.rack"),
+            tagged,
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"}, "dcim.rack"),
+            rack,
+        )
+
     def _populate_device(self, rack):
         return Device.objects.create(
             name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -130,7 +130,7 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertEqual(find_existing_object({"name": "r1", "site": self.site.pk}, "dcim.rack"), rack)
 
     def test_facility_id_rule(self):
-        """A candidate carrying the submitted facility id wins; a different one is excluded."""
+        """A candidate carrying the submitted facility id wins; a different or asserted-empty one is excluded."""
         older_null = self._rack()
         located = self._rack(location=self.location)
         located.facility_id = "rsm-F1"
@@ -147,6 +147,15 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
         )
+        # an explicitly empty facility id asserts "none": even a populated F1 rack must not be cleared
+        self._populate_device(located)
+        for empty in ("", None):
+            self.assertEqual(
+                find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": empty}, "dcim.rack"),
+                older_null,
+            )
+        # ...while a bare {name, site} ref still prefers the populated F1 rack
+        self.assertEqual(self._find(), located)
 
     def test_power_feeds_count_as_populated(self):
         """A rack holding only power feeds is populated; it beats an empty null duplicate."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -248,9 +248,21 @@ class RackCreatePreservesExplicitNullTestCase(TestCase):
         self.assertIn("location", change.data)
         self.assertIsNone(change.data["location"])
 
+    def test_empty_discriminators_survive_as_null(self):
+        """Asserted-empty asset_tag / facility_id reach apply as explicit nulls."""
+        change = self._create_change(
+            {"name": "rpn-r3", "site": {"name": "rpn-site"}, "asset_tag": "", "facility_id": None}
+        )
+        self.assertIn("asset_tag", change.data)
+        self.assertIsNone(change.data["asset_tag"])
+        self.assertIn("facility_id", change.data)
+        self.assertIsNone(change.data["facility_id"])
+
     def test_absent_key_stays_absent(self):
         """A location-less entity's CREATE data has no location key."""
         change = self._create_change(
             {"name": "rpn-r2", "site": {"name": "rpn-site"}}
         )
         self.assertNotIn("location", change.data)
+        self.assertNotIn("asset_tag", change.data)
+        self.assertNotIn("facility_id", change.data)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -2,7 +2,18 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Unit tests for RackSiteNameMatcher, rack differ preserve, and rack routing."""
 
-from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, RackReservation, Site
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Location,
+    Manufacturer,
+    PowerFeed,
+    PowerPanel,
+    Rack,
+    RackReservation,
+    Site,
+)
 from django.test import TestCase
 from users.models import User
 
@@ -129,6 +140,14 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
         )
+
+    def test_power_feeds_count_as_populated(self):
+        """A rack holding only power feeds is populated; it beats an empty null duplicate."""
+        self._rack()  # empty location-null duplicate
+        located = self._rack(location=self.location)
+        panel = PowerPanel.objects.create(site=self.site, name="rsm-panel")
+        PowerFeed.objects.create(power_panel=panel, rack=located, name="rsm-feed")
+        self.assertEqual(self._find(), located)
 
     def _populate_device(self, rack):
         return Device.objects.create(

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -51,11 +51,10 @@ class RackSiteNameMatcherGateTestCase(TestCase):
         """No location key: NULLS DISTINCT territory, no DB backstop."""
         self.assertTrue(requires_pre_save_match("dcim.rack", {"name": "r", "site": 1}))
 
-    def test_explicit_null_create_takes_pre_save_match(self):
-        """Explicit null is admitted; the (location, name) IS NULL constraint matcher binds."""
-        self.assertTrue(requires_pre_save_match(
+    def test_explicit_null_create_skips_pre_save_match(self):
+        """Explicit null is not admitted: its only matcher is site-blind."""
+        self.assertFalse(requires_pre_save_match(
             "dcim.rack", {"name": "r", "site": 1, "location": None}))
-
     def test_located_create_skips_pre_save_match(self):
         """A real location value keeps its DB-constraint backstop."""
         self.assertFalse(requires_pre_save_match(

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -91,7 +91,7 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         return Rack.objects.create(name=name, site=site or self.site, location=location)
 
     def test_asset_tag_rule(self):
-        """A tag already on another rack wins; a new tag still binds by (site, name)."""
+        """A tag already on another rack wins; a new tag binds only a tagless (site, name) rack."""
         rack = self._rack()
         tagged = Rack.objects.create(name="other", site=self.site2, asset_tag="rsm-AT1")
         self.assertIsNone(
@@ -104,6 +104,12 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertEqual(
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"}, "dcim.rack"),
             rack,
+        )
+        # a same-named rack carrying a DIFFERENT tag is another physical rack
+        rack.asset_tag = "rsm-AT-A"
+        rack.save()
+        self.assertIsNone(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
 
     def _populate_device(self, rack):

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -121,6 +121,13 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertIsNone(
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
+        # an explicitly empty tag asserts taglessness: it must not clear AT-A
+        for empty in ("", None):
+            self.assertIsNone(
+                find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": empty}, "dcim.rack")
+            )
+        # ...while a bare {name, site} ref (no tag asserted) still binds the tagged rack
+        self.assertEqual(find_existing_object({"name": "r1", "site": self.site.pk}, "dcim.rack"), rack)
 
     def test_facility_id_rule(self):
         """A candidate carrying the submitted facility id wins; a different one is excluded."""

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -111,6 +111,25 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
 
+    def test_facility_id_rule(self):
+        """A candidate carrying the submitted facility id wins; a different one is excluded."""
+        older_null = self._rack()
+        located = self._rack(location=self.location)
+        located.facility_id = "rsm-F1"
+        located.save()
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}, "dcim.rack"),
+            located,
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}, "dcim.rack"),
+            older_null,
+        )
+        self.assertNotEqual(
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
+        )
+
     def _populate_device(self, rack):
         return Device.objects.create(
             name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_rack_matcher.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for RackSiteNameMatcher, rack differ preserve, and rack routing."""
+
+from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.common import ChangeType, UnresolvedReference
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.matcher import (
+    AmbiguousObjectMatch,
+    RackSiteNameMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+    pre_save_match_binds_only,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+def _matcher():
+    return RackSiteNameMatcher(
+        model_class=get_object_type_model("dcim.rack"),
+        name="logical_rack_site_name_no_location",
+    )
+
+
+class RackSiteNameMatcherGateTestCase(TestCase):
+    """Gate, abstain and routing rules (no DB rows needed)."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_gate_shape(self):
+        """Fires on the location-less {name, site} shape; declines a location key."""
+        self.assertTrue(self.matcher.has_required_fields({"name": "r1", "site": 1}))
+        self.assertFalse(self.matcher.has_required_fields(
+            {"name": "r1", "site": 1, "location": 5}))
+        self.assertFalse(self.matcher.has_required_fields(
+            {"name": "r1", "site": 1, "location": None}))
+
+    def test_build_queryset_abstains_on_malformed_site(self):
+        """An in-batch site ref or a bool site must not become a pk filter."""
+        ref = UnresolvedReference(object_type="dcim.site", uuid="u-1")
+        self.assertIsNone(self.matcher.build_queryset({"name": "r1", "site": ref}))
+        self.assertIsNone(self.matcher.build_queryset({"name": "r1", "site": True}))
+
+    def test_location_less_create_takes_pre_save_match(self):
+        """No location key: NULLS DISTINCT territory, no DB backstop."""
+        self.assertTrue(requires_pre_save_match("dcim.rack", {"name": "r", "site": 1}))
+
+    def test_explicit_null_create_takes_pre_save_match(self):
+        """Explicit null is admitted; the (location, name) IS NULL constraint matcher binds."""
+        self.assertTrue(requires_pre_save_match(
+            "dcim.rack", {"name": "r", "site": 1, "location": None}))
+
+    def test_located_create_skips_pre_save_match(self):
+        """A real location value keeps its DB-constraint backstop."""
+        self.assertFalse(requires_pre_save_match(
+            "dcim.rack", {"name": "r", "site": 1, "location": 5}))
+
+    def test_rack_pre_save_match_is_bind_only(self):
+        """(site, name) identity is non-authoritative: bind, never write."""
+        self.assertTrue(pre_save_match_binds_only("dcim.rack"))
+
+    def test_find_obj_cache_key_disabled(self):
+        """No cache key for dcim.rack, ever -- a cache hit would skip resolve()."""
+        data = {"name": "r1", "site": 1, "status": "active"}
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.rack"))
+
+
+class RackSiteNameMatcherResolveTestCase(TestCase):
+    """find_existing_object behavior against real rows (registration included)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """One site with a location; helpers build racks/devices/reservations."""
+        cls.site = Site.objects.create(name="rsm-site", slug="rsm-site")
+        cls.site2 = Site.objects.create(name="rsm-site2", slug="rsm-site2")
+        cls.location = Location.objects.create(
+            name="rsm-loc", slug="rsm-loc", site=cls.site
+        )
+        cls.user = User.objects.create(username="rsm-user")
+        mfr = Manufacturer.objects.create(name="rsm-mfr", slug="rsm-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="rsm-dt", slug="rsm-dt")
+        cls.role = DeviceRole.objects.create(name="rsm-role", slug="rsm-role")
+
+    def _rack(self, name="r1", location=None, site=None):
+        return Rack.objects.create(name=name, site=site or self.site, location=location)
+
+    def _populate_device(self, rack):
+        return Device.objects.create(
+            name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,
+            device_type=self.dt, role=self.role,
+        )
+
+    def _populate_reservation(self, rack):
+        return RackReservation.objects.create(
+            rack=rack, units=[1], user=self.user, description="rsm"
+        )
+
+    def _find(self, name="r1"):
+        return find_existing_object({"name": name, "site": self.site.pk}, "dcim.rack")
+
+    def test_single_located_rack_binds(self):
+        """One candidate wins outright."""
+        rack = self._rack(location=self.location)
+        self.assertEqual(self._find(), rack)
+
+    def test_sole_populated_wins_over_empty_null(self):
+        """A populated located rack beats an empty null duplicate."""
+        located = self._rack(location=self.location)
+        self._populate_device(located)
+        self._rack()  # empty null duplicate
+        self.assertEqual(self._find(), located)
+
+    def test_no_populated_prefers_oldest_null(self):
+        """All empty: the oldest location-null row is the shape this payload made."""
+        self._rack(location=self.location)  # empty located, created first
+        old_null = self._rack()
+        self._rack()  # newer null
+        self.assertEqual(self._find(), old_null)
+
+    def test_two_populated_raises_naming_both_pks(self):
+        """Two populated candidates: binding would move references on a name."""
+        loc2 = Location.objects.create(name="rsm-loc3", slug="rsm-loc3", site=self.site)
+        a = self._rack(location=self.location)
+        self._populate_device(a)
+        b = self._rack(location=loc2)
+        self._populate_reservation(b)
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            self._find()
+        message = str(cm.exception)
+        self.assertIn(str(a.pk), message)
+        self.assertIn(str(b.pk), message)
+
+    def test_other_site_same_name_no_match(self):
+        """Site scope is hard."""
+        self._rack(site=self.site2)
+        self.assertIsNone(self._find())
+
+
+class RackCreatePreservesExplicitNullTestCase(TestCase):
+    """
+    CREATE change data keeps an explicitly-submitted location: null.
+
+    CREATE data drops None values, which erases the difference between
+    "not submitted" and "explicitly null" -- and the rack pre-save gate
+    depends on that difference at apply time.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A site for the rack entities to resolve against."""
+        cls.site = Site.objects.create(name="rpn-site", slug="rpn-site")
+
+    def _create_change(self, entity):
+        """Generate a changeset and extract the rack CREATE change."""
+        cs = generate_changeset(entity, "dcim.rack").change_set
+        creates = [c for c in cs.changes
+                   if c.object_type == "dcim.rack"
+                   and c.change_type == ChangeType.CREATE]
+        self.assertEqual(len(creates), 1, [c.to_dict() for c in cs.changes])
+        return creates[0]
+
+    def test_explicit_null_survives_into_create_data(self):
+        """location: null is a producer assertion; it must reach apply."""
+        change = self._create_change(
+            {"name": "rpn-r1", "site": {"name": "rpn-site"}, "location": None}
+        )
+        self.assertIn("location", change.data)
+        self.assertIsNone(change.data["location"])
+
+    def test_absent_key_stays_absent(self):
+        """A location-less entity's CREATE data has no location key."""
+        change = self._create_change(
+            {"name": "rpn-r2", "site": {"name": "rpn-site"}}
+        )
+        self.assertNotIn("location", change.data)

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_vc_name_matcher.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_vc_name_matcher.py
@@ -20,6 +20,7 @@ from netbox_diode_plugin.api.common import (
     UnresolvedReference,
 )
 from netbox_diode_plugin.api.matcher import (
+    _PRE_SAVE_MATCH_BIND_ONLY,
     _REQUIRES_PRE_SAVE_MATCH,
     AmbiguousObjectMatch,
     find_existing_object,
@@ -710,8 +711,31 @@ class PreSaveMatchBindOnlyTests(TestCase):
         "dcim.inventoryitem",
     )
 
+    #: Every _REQUIRES_PRE_SAVE_MATCH entry EXCEPT the two bind-only types
+    #: (dcim.virtualchassis, dcim.rack), hardcoded rather than derived from
+    #: _REQUIRES_PRE_SAVE_MATCH - _PRE_SAVE_MATCH_BIND_ONLY: a derived loop
+    #: would pass trivially however _PRE_SAVE_MATCH_BIND_ONLY grew, because
+    #: whatever got added to it would also be subtracted out of the set this
+    #: test iterates. Writing the members out means a third type added to
+    #: _PRE_SAVE_MATCH_BIND_ONLY without a matching change here fails this
+    #: test instead of silently narrowing what it covers.
+    NON_BIND_ONLY_PRE_SAVE_TYPES = (
+        "dcim.cable",
+        "dcim.macaddress",
+        "dcim.module",
+        "dcim.modulebay",
+        "dcim.rackreservation",
+        "ipam.prefix",
+        "ipam.vlan",
+        "ipam.vlangroup",
+        "ipam.vrf",
+        "virtualization.cluster",
+        "virtualization.virtualmachine",
+        "wireless.wirelesslan",
+    )
+
     def test_virtualchassis_binds_without_writing(self):
-        """The one bind-only type, and the reason the seam exists at all."""
+        """The original bind-only type, and the reason the seam exists at all."""
         self.assertTrue(pre_save_match_binds_only("dcim.virtualchassis"))
 
     def test_every_other_pre_save_matched_type_still_applies_its_payload(self):
@@ -719,11 +743,16 @@ class PreSaveMatchBindOnlyTests(TestCase):
         Naming them all: this is a behavioural change nobody else may inherit.
 
         dcim.module's find-first, for one, exists precisely to APPLY a payload
-        that the IntegrityError recovery it replaced used to discard.
+        that the IntegrityError recovery it replaced used to discard. The
+        bind-only membership itself is pinned separately, so growing it (as
+        dcim.rack did) does not silently widen what this test lets through.
         """
-        for object_type in sorted(_REQUIRES_PRE_SAVE_MATCH - {"dcim.virtualchassis"}):
+        for object_type in self.NON_BIND_ONLY_PRE_SAVE_TYPES:
             with self.subTest(object_type=object_type):
+                self.assertIn(object_type, _REQUIRES_PRE_SAVE_MATCH)
                 self.assertFalse(pre_save_match_binds_only(object_type))
+        self.assertEqual(
+            _PRE_SAVE_MATCH_BIND_ONLY, {"dcim.virtualchassis", "dcim.rack"})
 
     def test_no_auto_created_component_is_bind_only(self):
         """
@@ -744,7 +773,7 @@ class PreSaveMatchBindOnlyTests(TestCase):
 
     def test_a_type_with_no_pre_save_match_at_all_is_not_bind_only(self):
         """Bind-only narrows the find-first route; it is not a route of its own."""
-        for object_type in ("dcim.site", "dcim.device", "dcim.rack"):
+        for object_type in ("dcim.site", "dcim.device", "dcim.location"):
             with self.subTest(object_type=object_type):
                 self.assertFalse(pre_save_match_binds_only(object_type))
                 self.assertFalse(requires_pre_save_match(object_type, {}))

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_generate_matching_docs.py
@@ -18,6 +18,7 @@ from netbox_diode_plugin.api.matcher import (
     GlobalIPNetworkIPMatcher,
     ObjectMatchCriteria,
     RackReservationUnitOverlapMatcher,
+    RackSiteNameMatcher,
     VirtualChassisNameMatcher,
 )
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
@@ -169,6 +170,13 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         result = self.command.get_matcher_fields(matcher)
         self.assertEqual(result, ["rack", "units"])
+
+    def test_get_matcher_fields_rack_site_name(self):
+        """Test deriving Fields for a real RackSiteNameMatcher via the class-name map."""
+        matcher = RackSiteNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["site", "name"])
 
     def test_get_matcher_fields_global_ip_network(self):
         """Test deriving Fields for a real GlobalIPNetworkIPMatcher via ip_fields."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_ingest_convergence.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Rack ingest convergence: site-scoped identity end-to-end."""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.matcher import AmbiguousObjectMatch
+
+
+class RackConvergenceTestCase(TestCase):
+    """Plan+apply round-trips for location-less rack identity."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Site, location, user pre-seeded; racks vary per test."""
+        cls.site = Site.objects.create(name="rc-site", slug="rc-site")
+        cls.location = Location.objects.create(
+            name="rc-loc", slug="rc-loc", site=cls.site
+        )
+        cls.user = User.objects.create(username="rc-owner")
+
+    def _reservation_entity(self, rack_extra=None):
+        rack = {"name": "rc-r1", "site": {"name": "rc-site"}}
+        rack.update(rack_extra or {})
+        return {"rack": rack, "units": [1, 2], "description": "rc",
+                "user": {"username": "rc-owner"}}
+
+    def _rack_entity(self, extra=None):
+        entity = {"name": "rc-r1", "site": {"name": "rc-site"}}
+        entity.update(extra or {})
+        return entity
+
+    def _plan(self, entity, object_type):
+        return generate_changeset(entity, object_type).change_set
+
+    def _apply(self, cs):
+        return apply_changeset(cs, request=None)
+
+    def _ingest(self, entity, object_type):
+        self._apply(self._plan(entity, object_type))
+
+    def test_mon324_repro_converges(self):
+        """The original bug: nested location-less rack duplicated per cycle."""
+        self._ingest(self._reservation_entity(), "dcim.rackreservation")
+        cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
+        non_noop = [c for c in cs.changes if c.change_type != ChangeType.NOOP]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_binds_operator_located_rack_location_untouched(self):
+        """A location-less ref binds the located rack and leaves its location."""
+        rack = Rack.objects.create(
+            name="rc-r1", site=self.site, location=self.location
+        )
+        cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
+        rack_creates = [c for c in cs.changes
+                        if c.object_type == "dcim.rack"
+                        and c.change_type == ChangeType.CREATE]
+        self.assertEqual(rack_creates, [], [c.to_dict() for c in rack_creates])
+        self._apply(cs)
+        rack.refresh_from_db()
+        self.assertEqual(rack.location_id, self.location.pk)
+        self.assertEqual(Rack.objects.count(), 1)
+
+    def test_two_populated_racks_fail_at_plan(self):
+        """Genuine ambiguity refuses loudly, DB untouched."""
+        loc2 = Location.objects.create(name="rc-loc2", slug="rc-loc2", site=self.site)
+        a = Rack.objects.create(name="rc-r1", site=self.site, location=self.location)
+        b = Rack.objects.create(name="rc-r1", site=self.site, location=loc2)
+        RackReservation.objects.create(rack=a, units=[1], user=self.user, description="a")
+        RackReservation.objects.create(rack=b, units=[2], user=self.user, description="b")
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            self._plan(self._reservation_entity(), "dcim.rackreservation")
+        self.assertIn(str(a.pk), str(cm.exception))
+        self.assertIn(str(b.pk), str(cm.exception))
+        self.assertEqual(Rack.objects.count(), 2)
+
+    def test_explicit_null_does_not_adopt_located_rack(self):
+        """With only a located rack, explicit null creates its own null rack."""
+        located = Rack.objects.create(
+            name="rc-r1", site=self.site, location=self.location
+        )
+        self._ingest(self._rack_entity({"location": None}), "dcim.rack")
+        located.refresh_from_db()
+        self.assertEqual(located.location_id, self.location.pk)
+        self.assertEqual(Rack.objects.count(), 2)
+        # third pass converges onto the null rack (all-NOOP)
+        cs = self._plan(self._rack_entity({"location": None}), "dcim.rack")
+        non_noop = [c for c in cs.changes if c.change_type != ChangeType.NOOP]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+
+    def test_stale_locationless_create_binds_only(self):
+        """Bind-only: the operator's distinctive fields survive a stale CREATE."""
+        cs = self._plan(self._rack_entity(), "dcim.rack")
+        rack = Rack.objects.create(
+            name="rc-r1", site=self.site, status="reserved", width=23, u_height=48
+        )
+        result = self._apply(cs)
+        rack.refresh_from_db()
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(rack.status, "reserved")
+        self.assertEqual(rack.width, 23)
+        self.assertEqual(rack.u_height, 48)
+        warnings = result.to_dict().get("warnings") or []
+        self.assertEqual(len(warnings), 1, warnings)
+        self.assertEqual(warnings[0]["object_type"], "dcim.rack")
+        self.assertEqual(warnings[0]["object_id"], rack.pk)
+        self.assertTrue(
+            {"status", "width", "u_height"} <= set(warnings[0]["fields"]),
+            warnings,
+        )
+
+    def test_mixed_batch_null_first_two_racks(self):
+        """
+        No rack adopter in this minimal design: a located CREATE beside a null rack.
+
+        A location-less CREATE applies first and creates a location-null rack.
+        A located CREATE for the same (site, name), planned separately and
+        applied second, then inserts its OWN row: the (location, name) DB
+        constraint has nothing to collide with (the null rack's location is
+        NULL, and the constraint is NULLS DISTINCT), and this branch carries
+        no adopter to notice the null sibling and reuse it instead. TWO
+        racks, unmerged, is the documented outcome here -- collapsing them
+        into one is out of this branch's scope.
+        """
+        cs_locationless = self._plan(self._rack_entity({"status": "reserved"}), "dcim.rack")
+        cs_located = self._plan(
+            self._rack_entity({"location": {"name": "rc-loc", "site": {"name": "rc-site"}}}),
+            "dcim.rack")
+        self._apply(cs_locationless)
+        self._apply(cs_located)
+        self.assertEqual(Rack.objects.count(), 2)
+        racks = list(Rack.objects.order_by("pk"))
+        null_rack, located_rack = racks[0], racks[1]
+        self.assertIsNone(null_rack.location_id)
+        self.assertEqual(null_rack.status, "reserved")
+        self.assertEqual(located_rack.location_id, self.location.pk)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_ingest_convergence.py
@@ -44,7 +44,7 @@ class RackConvergenceTestCase(TestCase):
     def _ingest(self, entity, object_type):
         self._apply(self._plan(entity, object_type))
 
-    def test_mon324_repro_converges(self):
+    def test_location_less_rack_reingest_converges(self):
         """The original bug: nested location-less rack duplicated per cycle."""
         self._ingest(self._reservation_entity(), "dcim.rackreservation")
         cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
@@ -115,29 +115,3 @@ class RackConvergenceTestCase(TestCase):
             {"status", "width", "u_height"} <= set(warnings[0]["fields"]),
             warnings,
         )
-
-    def test_mixed_batch_null_first_two_racks(self):
-        """
-        No rack adopter in this minimal design: a located CREATE beside a null rack.
-
-        A location-less CREATE applies first and creates a location-null rack.
-        A located CREATE for the same (site, name), planned separately and
-        applied second, then inserts its OWN row: the (location, name) DB
-        constraint has nothing to collide with (the null rack's location is
-        NULL, and the constraint is NULLS DISTINCT), and this branch carries
-        no adopter to notice the null sibling and reuse it instead. TWO
-        racks, unmerged, is the documented outcome here -- collapsing them
-        into one is out of this branch's scope.
-        """
-        cs_locationless = self._plan(self._rack_entity({"status": "reserved"}), "dcim.rack")
-        cs_located = self._plan(
-            self._rack_entity({"location": {"name": "rc-loc", "site": {"name": "rc-site"}}}),
-            "dcim.rack")
-        self._apply(cs_locationless)
-        self._apply(cs_located)
-        self.assertEqual(Rack.objects.count(), 2)
-        racks = list(Rack.objects.order_by("pk"))
-        null_rack, located_rack = racks[0], racks[1]
-        self.assertIsNone(null_rack.location_id)
-        self.assertEqual(null_rack.status, "reserved")
-        self.assertEqual(located_rack.location_id, self.location.pk)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -90,6 +90,22 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
     def _rack(self, name="r1", location=None, site=None):
         return Rack.objects.create(name=name, site=site or self.site, location=location)
 
+    def test_asset_tag_rule(self):
+        """A tag already on another rack wins; a new tag still binds by (site, name)."""
+        rack = self._rack()
+        tagged = Rack.objects.create(name="other", site=self.site2, asset_tag="rsm-AT1")
+        self.assertIsNone(
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"})
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT1"}, "dcim.rack"),
+            tagged,
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"}, "dcim.rack"),
+            rack,
+        )
+
     def _populate_device(self, rack):
         return Device.objects.create(
             name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -130,7 +130,7 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertEqual(find_existing_object({"name": "r1", "site": self.site.pk}, "dcim.rack"), rack)
 
     def test_facility_id_rule(self):
-        """A candidate carrying the submitted facility id wins; a different one is excluded."""
+        """A candidate carrying the submitted facility id wins; a different or asserted-empty one is excluded."""
         older_null = self._rack()
         located = self._rack(location=self.location)
         located.facility_id = "rsm-F1"
@@ -147,6 +147,15 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
         )
+        # an explicitly empty facility id asserts "none": even a populated F1 rack must not be cleared
+        self._populate_device(located)
+        for empty in ("", None):
+            self.assertEqual(
+                find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": empty}, "dcim.rack"),
+                older_null,
+            )
+        # ...while a bare {name, site} ref still prefers the populated F1 rack
+        self.assertEqual(self._find(), located)
 
     def test_power_feeds_count_as_populated(self):
         """A rack holding only power feeds is populated; it beats an empty null duplicate."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -248,9 +248,21 @@ class RackCreatePreservesExplicitNullTestCase(TestCase):
         self.assertIn("location", change.data)
         self.assertIsNone(change.data["location"])
 
+    def test_empty_discriminators_survive_as_null(self):
+        """Asserted-empty asset_tag / facility_id reach apply as explicit nulls."""
+        change = self._create_change(
+            {"name": "rpn-r3", "site": {"name": "rpn-site"}, "asset_tag": "", "facility_id": None}
+        )
+        self.assertIn("asset_tag", change.data)
+        self.assertIsNone(change.data["asset_tag"])
+        self.assertIn("facility_id", change.data)
+        self.assertIsNone(change.data["facility_id"])
+
     def test_absent_key_stays_absent(self):
         """A location-less entity's CREATE data has no location key."""
         change = self._create_change(
             {"name": "rpn-r2", "site": {"name": "rpn-site"}}
         )
         self.assertNotIn("location", change.data)
+        self.assertNotIn("asset_tag", change.data)
+        self.assertNotIn("facility_id", change.data)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -2,7 +2,18 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Unit tests for RackSiteNameMatcher, rack differ preserve, and rack routing."""
 
-from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, RackReservation, Site
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Location,
+    Manufacturer,
+    PowerFeed,
+    PowerPanel,
+    Rack,
+    RackReservation,
+    Site,
+)
 from django.test import TestCase
 from users.models import User
 
@@ -129,6 +140,14 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
         )
+
+    def test_power_feeds_count_as_populated(self):
+        """A rack holding only power feeds is populated; it beats an empty null duplicate."""
+        self._rack()  # empty location-null duplicate
+        located = self._rack(location=self.location)
+        panel = PowerPanel.objects.create(site=self.site, name="rsm-panel")
+        PowerFeed.objects.create(power_panel=panel, rack=located, name="rsm-feed")
+        self.assertEqual(self._find(), located)
 
     def _populate_device(self, rack):
         return Device.objects.create(

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -51,11 +51,10 @@ class RackSiteNameMatcherGateTestCase(TestCase):
         """No location key: NULLS DISTINCT territory, no DB backstop."""
         self.assertTrue(requires_pre_save_match("dcim.rack", {"name": "r", "site": 1}))
 
-    def test_explicit_null_create_takes_pre_save_match(self):
-        """Explicit null is admitted; the (location, name) IS NULL constraint matcher binds."""
-        self.assertTrue(requires_pre_save_match(
+    def test_explicit_null_create_skips_pre_save_match(self):
+        """Explicit null is not admitted: its only matcher is site-blind."""
+        self.assertFalse(requires_pre_save_match(
             "dcim.rack", {"name": "r", "site": 1, "location": None}))
-
     def test_located_create_skips_pre_save_match(self):
         """A real location value keeps its DB-constraint backstop."""
         self.assertFalse(requires_pre_save_match(

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -91,7 +91,7 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         return Rack.objects.create(name=name, site=site or self.site, location=location)
 
     def test_asset_tag_rule(self):
-        """A tag already on another rack wins; a new tag still binds by (site, name)."""
+        """A tag already on another rack wins; a new tag binds only a tagless (site, name) rack."""
         rack = self._rack()
         tagged = Rack.objects.create(name="other", site=self.site2, asset_tag="rsm-AT1")
         self.assertIsNone(
@@ -104,6 +104,12 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertEqual(
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"}, "dcim.rack"),
             rack,
+        )
+        # a same-named rack carrying a DIFFERENT tag is another physical rack
+        rack.asset_tag = "rsm-AT-A"
+        rack.save()
+        self.assertIsNone(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
 
     def _populate_device(self, rack):

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -121,6 +121,13 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertIsNone(
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
+        # an explicitly empty tag asserts taglessness: it must not clear AT-A
+        for empty in ("", None):
+            self.assertIsNone(
+                find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": empty}, "dcim.rack")
+            )
+        # ...while a bare {name, site} ref (no tag asserted) still binds the tagged rack
+        self.assertEqual(find_existing_object({"name": "r1", "site": self.site.pk}, "dcim.rack"), rack)
 
     def test_facility_id_rule(self):
         """A candidate carrying the submitted facility id wins; a different one is excluded."""

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -111,6 +111,25 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
 
+    def test_facility_id_rule(self):
+        """A candidate carrying the submitted facility id wins; a different one is excluded."""
+        older_null = self._rack()
+        located = self._rack(location=self.location)
+        located.facility_id = "rsm-F1"
+        located.save()
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}, "dcim.rack"),
+            located,
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}, "dcim.rack"),
+            older_null,
+        )
+        self.assertNotEqual(
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
+        )
+
     def _populate_device(self, rack):
         return Device.objects.create(
             name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_rack_matcher.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for RackSiteNameMatcher, rack differ preserve, and rack routing."""
+
+from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.common import ChangeType, UnresolvedReference
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.matcher import (
+    AmbiguousObjectMatch,
+    RackSiteNameMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+    pre_save_match_binds_only,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+def _matcher():
+    return RackSiteNameMatcher(
+        model_class=get_object_type_model("dcim.rack"),
+        name="logical_rack_site_name_no_location",
+    )
+
+
+class RackSiteNameMatcherGateTestCase(TestCase):
+    """Gate, abstain and routing rules (no DB rows needed)."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_gate_shape(self):
+        """Fires on the location-less {name, site} shape; declines a location key."""
+        self.assertTrue(self.matcher.has_required_fields({"name": "r1", "site": 1}))
+        self.assertFalse(self.matcher.has_required_fields(
+            {"name": "r1", "site": 1, "location": 5}))
+        self.assertFalse(self.matcher.has_required_fields(
+            {"name": "r1", "site": 1, "location": None}))
+
+    def test_build_queryset_abstains_on_malformed_site(self):
+        """An in-batch site ref or a bool site must not become a pk filter."""
+        ref = UnresolvedReference(object_type="dcim.site", uuid="u-1")
+        self.assertIsNone(self.matcher.build_queryset({"name": "r1", "site": ref}))
+        self.assertIsNone(self.matcher.build_queryset({"name": "r1", "site": True}))
+
+    def test_location_less_create_takes_pre_save_match(self):
+        """No location key: NULLS DISTINCT territory, no DB backstop."""
+        self.assertTrue(requires_pre_save_match("dcim.rack", {"name": "r", "site": 1}))
+
+    def test_explicit_null_create_takes_pre_save_match(self):
+        """Explicit null is admitted; the (location, name) IS NULL constraint matcher binds."""
+        self.assertTrue(requires_pre_save_match(
+            "dcim.rack", {"name": "r", "site": 1, "location": None}))
+
+    def test_located_create_skips_pre_save_match(self):
+        """A real location value keeps its DB-constraint backstop."""
+        self.assertFalse(requires_pre_save_match(
+            "dcim.rack", {"name": "r", "site": 1, "location": 5}))
+
+    def test_rack_pre_save_match_is_bind_only(self):
+        """(site, name) identity is non-authoritative: bind, never write."""
+        self.assertTrue(pre_save_match_binds_only("dcim.rack"))
+
+    def test_find_obj_cache_key_disabled(self):
+        """No cache key for dcim.rack, ever -- a cache hit would skip resolve()."""
+        data = {"name": "r1", "site": 1, "status": "active"}
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.rack"))
+
+
+class RackSiteNameMatcherResolveTestCase(TestCase):
+    """find_existing_object behavior against real rows (registration included)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """One site with a location; helpers build racks/devices/reservations."""
+        cls.site = Site.objects.create(name="rsm-site", slug="rsm-site")
+        cls.site2 = Site.objects.create(name="rsm-site2", slug="rsm-site2")
+        cls.location = Location.objects.create(
+            name="rsm-loc", slug="rsm-loc", site=cls.site
+        )
+        cls.user = User.objects.create(username="rsm-user")
+        mfr = Manufacturer.objects.create(name="rsm-mfr", slug="rsm-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="rsm-dt", slug="rsm-dt")
+        cls.role = DeviceRole.objects.create(name="rsm-role", slug="rsm-role")
+
+    def _rack(self, name="r1", location=None, site=None):
+        return Rack.objects.create(name=name, site=site or self.site, location=location)
+
+    def _populate_device(self, rack):
+        return Device.objects.create(
+            name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,
+            device_type=self.dt, role=self.role,
+        )
+
+    def _populate_reservation(self, rack):
+        return RackReservation.objects.create(
+            rack=rack, units=[1], user=self.user, description="rsm"
+        )
+
+    def _find(self, name="r1"):
+        return find_existing_object({"name": name, "site": self.site.pk}, "dcim.rack")
+
+    def test_single_located_rack_binds(self):
+        """One candidate wins outright."""
+        rack = self._rack(location=self.location)
+        self.assertEqual(self._find(), rack)
+
+    def test_sole_populated_wins_over_empty_null(self):
+        """A populated located rack beats an empty null duplicate."""
+        located = self._rack(location=self.location)
+        self._populate_device(located)
+        self._rack()  # empty null duplicate
+        self.assertEqual(self._find(), located)
+
+    def test_no_populated_prefers_oldest_null(self):
+        """All empty: the oldest location-null row is the shape this payload made."""
+        self._rack(location=self.location)  # empty located, created first
+        old_null = self._rack()
+        self._rack()  # newer null
+        self.assertEqual(self._find(), old_null)
+
+    def test_two_populated_raises_naming_both_pks(self):
+        """Two populated candidates: binding would move references on a name."""
+        loc2 = Location.objects.create(name="rsm-loc3", slug="rsm-loc3", site=self.site)
+        a = self._rack(location=self.location)
+        self._populate_device(a)
+        b = self._rack(location=loc2)
+        self._populate_reservation(b)
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            self._find()
+        message = str(cm.exception)
+        self.assertIn(str(a.pk), message)
+        self.assertIn(str(b.pk), message)
+
+    def test_other_site_same_name_no_match(self):
+        """Site scope is hard."""
+        self._rack(site=self.site2)
+        self.assertIsNone(self._find())
+
+
+class RackCreatePreservesExplicitNullTestCase(TestCase):
+    """
+    CREATE change data keeps an explicitly-submitted location: null.
+
+    CREATE data drops None values, which erases the difference between
+    "not submitted" and "explicitly null" -- and the rack pre-save gate
+    depends on that difference at apply time.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A site for the rack entities to resolve against."""
+        cls.site = Site.objects.create(name="rpn-site", slug="rpn-site")
+
+    def _create_change(self, entity):
+        """Generate a changeset and extract the rack CREATE change."""
+        cs = generate_changeset(entity, "dcim.rack").change_set
+        creates = [c for c in cs.changes
+                   if c.object_type == "dcim.rack"
+                   and c.change_type == ChangeType.CREATE]
+        self.assertEqual(len(creates), 1, [c.to_dict() for c in cs.changes])
+        return creates[0]
+
+    def test_explicit_null_survives_into_create_data(self):
+        """location: null is a producer assertion; it must reach apply."""
+        change = self._create_change(
+            {"name": "rpn-r1", "site": {"name": "rpn-site"}, "location": None}
+        )
+        self.assertIn("location", change.data)
+        self.assertIsNone(change.data["location"])
+
+    def test_absent_key_stays_absent(self):
+        """A location-less entity's CREATE data has no location key."""
+        change = self._create_change(
+            {"name": "rpn-r2", "site": {"name": "rpn-site"}}
+        )
+        self.assertNotIn("location", change.data)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_user_rackreservation.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_user_rackreservation.py
@@ -2,7 +2,7 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Diode NetBox Plugin - User (match-only) + RackReservation ingest tests."""
 
-from dcim.models import RackReservation
+from dcim.models import Rack, RackReservation
 from django.test import TestCase
 from users.models import User
 
@@ -110,20 +110,26 @@ class RackReservationApplyTestCase(TestCase):
 
     def test_existing_user_resolution_is_idempotent(self):
         """
-        Re-ingesting resolves the same existing user each time; never mints one.
+        Re-ingesting the same entity converges: the second diff is all-NOOP.
 
-        Scoped to the USER guarantee: the match-only user is resolved (never
-        duplicated or created) and the reservation's user never changes across
-        re-ingests. NOTE: a full-changeset NOOP is NOT asserted here because
-        dcim.rackreservation is keyless AND its nested dcim.rack has no reliable
-        natural-key match when location is null (a re-diff re-creates the rack
-        and re-points the reservation) — both pre-existing behaviors unrelated
-        to this feature. The user, correctly, is the one node that stays matched.
+        The first ingest creates the rack and the reservation, resolving the
+        match-only user without minting it. The rack now matches on (site,
+        name) via the site-name matcher and the reservation matches via the
+        overlap matcher, so the second generate_changeset's diff carries no
+        non-NOOP changes at all -- there is nothing left to apply. The user,
+        as always, is a pure reference and never a change node.
         """
-        for _ in range(2):
-            r = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
-            # user is always a pure reference — never a change node
-            self.assertFalse(any(c.object_type == "users.user" for c in r.change_set.changes))
-            apply_changeset(r.change_set, request=None)
+        first = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+        self.assertFalse(
+            any(c.object_type == "users.user" for c in first.change_set.changes))
+        apply_changeset(first.change_set, request=None)
+
+        second = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+        self.assertFalse(
+            any(c.change_type != ChangeType.NOOP for c in second.change_set.changes))
+
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
         self.assertEqual(User.objects.filter(username="rr-owner").count(), 1)
-        self.assertTrue(all(rr.user_id == self.user.pk for rr in RackReservation.objects.all()))
+        rr = RackReservation.objects.first()
+        self.assertEqual(rr.user_id, self.user.pk)

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_vc_name_matcher.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_vc_name_matcher.py
@@ -20,6 +20,7 @@ from netbox_diode_plugin.api.common import (
     UnresolvedReference,
 )
 from netbox_diode_plugin.api.matcher import (
+    _PRE_SAVE_MATCH_BIND_ONLY,
     _REQUIRES_PRE_SAVE_MATCH,
     AmbiguousObjectMatch,
     find_existing_object,
@@ -710,8 +711,31 @@ class PreSaveMatchBindOnlyTests(TestCase):
         "dcim.inventoryitem",
     )
 
+    #: Every _REQUIRES_PRE_SAVE_MATCH entry EXCEPT the two bind-only types
+    #: (dcim.virtualchassis, dcim.rack), hardcoded rather than derived from
+    #: _REQUIRES_PRE_SAVE_MATCH - _PRE_SAVE_MATCH_BIND_ONLY: a derived loop
+    #: would pass trivially however _PRE_SAVE_MATCH_BIND_ONLY grew, because
+    #: whatever got added to it would also be subtracted out of the set this
+    #: test iterates. Writing the members out means a third type added to
+    #: _PRE_SAVE_MATCH_BIND_ONLY without a matching change here fails this
+    #: test instead of silently narrowing what it covers.
+    NON_BIND_ONLY_PRE_SAVE_TYPES = (
+        "dcim.cable",
+        "dcim.macaddress",
+        "dcim.module",
+        "dcim.modulebay",
+        "dcim.rackreservation",
+        "ipam.prefix",
+        "ipam.vlan",
+        "ipam.vlangroup",
+        "ipam.vrf",
+        "virtualization.cluster",
+        "virtualization.virtualmachine",
+        "wireless.wirelesslan",
+    )
+
     def test_virtualchassis_binds_without_writing(self):
-        """The one bind-only type, and the reason the seam exists at all."""
+        """The original bind-only type, and the reason the seam exists at all."""
         self.assertTrue(pre_save_match_binds_only("dcim.virtualchassis"))
 
     def test_every_other_pre_save_matched_type_still_applies_its_payload(self):
@@ -719,11 +743,16 @@ class PreSaveMatchBindOnlyTests(TestCase):
         Naming them all: this is a behavioural change nobody else may inherit.
 
         dcim.module's find-first, for one, exists precisely to APPLY a payload
-        that the IntegrityError recovery it replaced used to discard.
+        that the IntegrityError recovery it replaced used to discard. The
+        bind-only membership itself is pinned separately, so growing it (as
+        dcim.rack did) does not silently widen what this test lets through.
         """
-        for object_type in sorted(_REQUIRES_PRE_SAVE_MATCH - {"dcim.virtualchassis"}):
+        for object_type in self.NON_BIND_ONLY_PRE_SAVE_TYPES:
             with self.subTest(object_type=object_type):
+                self.assertIn(object_type, _REQUIRES_PRE_SAVE_MATCH)
                 self.assertFalse(pre_save_match_binds_only(object_type))
+        self.assertEqual(
+            _PRE_SAVE_MATCH_BIND_ONLY, {"dcim.virtualchassis", "dcim.rack"})
 
     def test_no_auto_created_component_is_bind_only(self):
         """
@@ -744,7 +773,7 @@ class PreSaveMatchBindOnlyTests(TestCase):
 
     def test_a_type_with_no_pre_save_match_at_all_is_not_bind_only(self):
         """Bind-only narrows the find-first route; it is not a route of its own."""
-        for object_type in ("dcim.site", "dcim.device", "dcim.rack"):
+        for object_type in ("dcim.site", "dcim.device", "dcim.location"):
             with self.subTest(object_type=object_type):
                 self.assertFalse(pre_save_match_binds_only(object_type))
                 self.assertFalse(requires_pre_save_match(object_type, {}))

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_generate_matching_docs.py
@@ -12,7 +12,15 @@ from django.core.management.base import CommandError
 from django.db.models import Q
 from django.test import TestCase
 
-from netbox_diode_plugin.api.matcher import AutoSlugMatcher, ObjectMatchCriteria
+from netbox_diode_plugin.api.matcher import (
+    AutoSlugMatcher,
+    CableTerminationSetMatcher,
+    GlobalIPNetworkIPMatcher,
+    ObjectMatchCriteria,
+    RackReservationUnitOverlapMatcher,
+    RackSiteNameMatcher,
+    VirtualChassisNameMatcher,
+)
 from netbox_diode_plugin.management.commands.generate_matching_docs import (
     Command,
     MatcherInfo,
@@ -128,6 +136,80 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         result = self.command.get_matcher_description(mock_matcher)
         self.assertEqual(result, "Matches IP range start_address, end_address within VRF context")
+
+    def test_get_matcher_description_ip_range_global_no_vrf(self):
+        """Test getting matcher description for IP range global-no-VRF matcher."""
+        mock_matcher = mock.MagicMock()
+        mock_matcher.name = "logical_ip_range_start_end_global_no_vrf"
+        mock_matcher.ip_fields = ["start_address", "end_address"]
+        mock_matcher.vrf_field = "vrf"
+
+        result = self.command.get_matcher_description(mock_matcher)
+        self.assertIn("no VRF", result)
+        self.assertEqual(
+            result, "Matches IP range start_address, end_address in global namespace (no VRF)"
+        )
+
+    def test_get_matcher_fields_cable_termination_set(self):
+        """Test deriving Fields for a real CableTerminationSetMatcher via a/b field names."""
+        matcher = CableTerminationSetMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["a_terminations", "b_terminations"])
+
+    def test_get_matcher_fields_virtual_chassis_name(self):
+        """Test deriving Fields for a real VirtualChassisNameMatcher via the class-name map."""
+        matcher = VirtualChassisNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["name"])
+
+    def test_get_matcher_fields_rackreservation_unit_overlap(self):
+        """Test deriving Fields for a real RackReservationUnitOverlapMatcher via the class-name map."""
+        matcher = RackReservationUnitOverlapMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["rack", "units"])
+
+    def test_get_matcher_fields_rack_site_name(self):
+        """Test deriving Fields for a real RackSiteNameMatcher via the class-name map."""
+        matcher = RackSiteNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["site", "name"])
+
+    def test_get_matcher_fields_global_ip_network(self):
+        """Test deriving Fields for a real GlobalIPNetworkIPMatcher via ip_fields."""
+        matcher = GlobalIPNetworkIPMatcher(
+            ip_fields=["address"], vrf_field="vrf", model_class=None, name="x"
+        )
+
+        result = self.command.get_matcher_fields(matcher)
+        self.assertEqual(result, ["address"])
+
+    def test_get_matcher_description_cable_termination_set_docstring(self):
+        """Test that CableTerminationSetMatcher's description derives from its docstring."""
+        matcher = CableTerminationSetMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = CableTerminationSetMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
+
+    def test_get_matcher_description_virtual_chassis_name_docstring(self):
+        """Test that VirtualChassisNameMatcher's description derives from its docstring."""
+        matcher = VirtualChassisNameMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = VirtualChassisNameMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
+
+    def test_get_matcher_description_rackreservation_unit_overlap_docstring(self):
+        """Test that RackReservationUnitOverlapMatcher's description derives from its docstring."""
+        matcher = RackReservationUnitOverlapMatcher(model_class=None, name="x")
+
+        result = self.command.get_matcher_description(matcher)
+        expected = RackReservationUnitOverlapMatcher.__doc__.strip().splitlines()[0].strip()
+        self.assertEqual(result, expected)
 
     def test_get_matcher_description_standard_fields(self):
         """Test getting matcher description for standard field-based matcher."""

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_ingest_convergence.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Rack ingest convergence: site-scoped identity end-to-end."""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import ChangeType
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.matcher import AmbiguousObjectMatch
+
+
+class RackConvergenceTestCase(TestCase):
+    """Plan+apply round-trips for location-less rack identity."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Site, location, user pre-seeded; racks vary per test."""
+        cls.site = Site.objects.create(name="rc-site", slug="rc-site")
+        cls.location = Location.objects.create(
+            name="rc-loc", slug="rc-loc", site=cls.site
+        )
+        cls.user = User.objects.create(username="rc-owner")
+
+    def _reservation_entity(self, rack_extra=None):
+        rack = {"name": "rc-r1", "site": {"name": "rc-site"}}
+        rack.update(rack_extra or {})
+        return {"rack": rack, "units": [1, 2], "description": "rc",
+                "user": {"username": "rc-owner"}}
+
+    def _rack_entity(self, extra=None):
+        entity = {"name": "rc-r1", "site": {"name": "rc-site"}}
+        entity.update(extra or {})
+        return entity
+
+    def _plan(self, entity, object_type):
+        return generate_changeset(entity, object_type).change_set
+
+    def _apply(self, cs):
+        return apply_changeset(cs, request=None)
+
+    def _ingest(self, entity, object_type):
+        self._apply(self._plan(entity, object_type))
+
+    def test_location_less_rack_reingest_converges(self):
+        """The original bug: nested location-less rack duplicated per cycle."""
+        self._ingest(self._reservation_entity(), "dcim.rackreservation")
+        cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
+        non_noop = [c for c in cs.changes if c.change_type != ChangeType.NOOP]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_binds_operator_located_rack_location_untouched(self):
+        """A location-less ref binds the located rack and leaves its location."""
+        rack = Rack.objects.create(
+            name="rc-r1", site=self.site, location=self.location
+        )
+        cs = self._plan(self._reservation_entity(), "dcim.rackreservation")
+        rack_creates = [c for c in cs.changes
+                        if c.object_type == "dcim.rack"
+                        and c.change_type == ChangeType.CREATE]
+        self.assertEqual(rack_creates, [], [c.to_dict() for c in rack_creates])
+        self._apply(cs)
+        rack.refresh_from_db()
+        self.assertEqual(rack.location_id, self.location.pk)
+        self.assertEqual(Rack.objects.count(), 1)
+
+    def test_two_populated_racks_fail_at_plan(self):
+        """Genuine ambiguity refuses loudly, DB untouched."""
+        loc2 = Location.objects.create(name="rc-loc2", slug="rc-loc2", site=self.site)
+        a = Rack.objects.create(name="rc-r1", site=self.site, location=self.location)
+        b = Rack.objects.create(name="rc-r1", site=self.site, location=loc2)
+        RackReservation.objects.create(rack=a, units=[1], user=self.user, description="a")
+        RackReservation.objects.create(rack=b, units=[2], user=self.user, description="b")
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            self._plan(self._reservation_entity(), "dcim.rackreservation")
+        self.assertIn(str(a.pk), str(cm.exception))
+        self.assertIn(str(b.pk), str(cm.exception))
+        self.assertEqual(Rack.objects.count(), 2)
+
+    def test_explicit_null_does_not_adopt_located_rack(self):
+        """With only a located rack, explicit null creates its own null rack."""
+        located = Rack.objects.create(
+            name="rc-r1", site=self.site, location=self.location
+        )
+        self._ingest(self._rack_entity({"location": None}), "dcim.rack")
+        located.refresh_from_db()
+        self.assertEqual(located.location_id, self.location.pk)
+        self.assertEqual(Rack.objects.count(), 2)
+        # third pass converges onto the null rack (all-NOOP)
+        cs = self._plan(self._rack_entity({"location": None}), "dcim.rack")
+        non_noop = [c for c in cs.changes if c.change_type != ChangeType.NOOP]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+
+    def test_stale_locationless_create_binds_only(self):
+        """Bind-only: the operator's distinctive fields survive a stale CREATE."""
+        cs = self._plan(self._rack_entity(), "dcim.rack")
+        rack = Rack.objects.create(
+            name="rc-r1", site=self.site, status="reserved", width=23, u_height=48
+        )
+        result = self._apply(cs)
+        rack.refresh_from_db()
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(rack.status, "reserved")
+        self.assertEqual(rack.width, 23)
+        self.assertEqual(rack.u_height, 48)
+        warnings = result.to_dict().get("warnings") or []
+        self.assertEqual(len(warnings), 1, warnings)
+        self.assertEqual(warnings[0]["object_type"], "dcim.rack")
+        self.assertEqual(warnings[0]["object_id"], rack.pk)
+        self.assertTrue(
+            {"status", "width", "u_height"} <= set(warnings[0]["fields"]),
+            warnings,
+        )

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for RackSiteNameMatcher, rack differ preserve, and rack routing."""
+
+from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.common import ChangeType, UnresolvedReference
+from netbox_diode_plugin.api.differ import generate_changeset
+from netbox_diode_plugin.api.matcher import (
+    AmbiguousObjectMatch,
+    RackSiteNameMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+    pre_save_match_binds_only,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+def _matcher():
+    return RackSiteNameMatcher(
+        model_class=get_object_type_model("dcim.rack"),
+        name="logical_rack_site_name_no_location",
+    )
+
+
+class RackSiteNameMatcherGateTestCase(TestCase):
+    """Gate, abstain and routing rules (no DB rows needed)."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_gate_shape(self):
+        """Fires on the location-less {name, site} shape; declines a location key."""
+        self.assertTrue(self.matcher.has_required_fields({"name": "r1", "site": 1}))
+        self.assertFalse(self.matcher.has_required_fields(
+            {"name": "r1", "site": 1, "location": 5}))
+        self.assertFalse(self.matcher.has_required_fields(
+            {"name": "r1", "site": 1, "location": None}))
+
+    def test_build_queryset_abstains_on_malformed_site(self):
+        """An in-batch site ref or a bool site must not become a pk filter."""
+        ref = UnresolvedReference(object_type="dcim.site", uuid="u-1")
+        self.assertIsNone(self.matcher.build_queryset({"name": "r1", "site": ref}))
+        self.assertIsNone(self.matcher.build_queryset({"name": "r1", "site": True}))
+
+    def test_location_less_create_takes_pre_save_match(self):
+        """No location key: NULLS DISTINCT territory, no DB backstop."""
+        self.assertTrue(requires_pre_save_match("dcim.rack", {"name": "r", "site": 1}))
+
+    def test_explicit_null_create_takes_pre_save_match(self):
+        """Explicit null is admitted; the (location, name) IS NULL constraint matcher binds."""
+        self.assertTrue(requires_pre_save_match(
+            "dcim.rack", {"name": "r", "site": 1, "location": None}))
+
+    def test_located_create_skips_pre_save_match(self):
+        """A real location value keeps its DB-constraint backstop."""
+        self.assertFalse(requires_pre_save_match(
+            "dcim.rack", {"name": "r", "site": 1, "location": 5}))
+
+    def test_rack_pre_save_match_is_bind_only(self):
+        """(site, name) identity is non-authoritative: bind, never write."""
+        self.assertTrue(pre_save_match_binds_only("dcim.rack"))
+
+    def test_find_obj_cache_key_disabled(self):
+        """No cache key for dcim.rack, ever -- a cache hit would skip resolve()."""
+        data = {"name": "r1", "site": 1, "status": "active"}
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.rack"))
+
+
+class RackSiteNameMatcherResolveTestCase(TestCase):
+    """find_existing_object behavior against real rows (registration included)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """One site with a location; helpers build racks/devices/reservations."""
+        cls.site = Site.objects.create(name="rsm-site", slug="rsm-site")
+        cls.site2 = Site.objects.create(name="rsm-site2", slug="rsm-site2")
+        cls.location = Location.objects.create(
+            name="rsm-loc", slug="rsm-loc", site=cls.site
+        )
+        cls.user = User.objects.create(username="rsm-user")
+        mfr = Manufacturer.objects.create(name="rsm-mfr", slug="rsm-mfr")
+        cls.dt = DeviceType.objects.create(manufacturer=mfr, model="rsm-dt", slug="rsm-dt")
+        cls.role = DeviceRole.objects.create(name="rsm-role", slug="rsm-role")
+
+    def _rack(self, name="r1", location=None, site=None):
+        return Rack.objects.create(name=name, site=site or self.site, location=location)
+
+    def test_asset_tag_rule(self):
+        """A tag already on another rack wins; a new tag binds only a tagless (site, name) rack."""
+        rack = self._rack()
+        tagged = Rack.objects.create(name="other", site=self.site2, asset_tag="rsm-AT1")
+        self.assertIsNone(
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"})
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT1"}, "dcim.rack"),
+            tagged,
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-NEW"}, "dcim.rack"),
+            rack,
+        )
+        # a same-named rack carrying a DIFFERENT tag is another physical rack
+        rack.asset_tag = "rsm-AT-A"
+        rack.save()
+        self.assertIsNone(
+            find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
+        )
+
+    def _populate_device(self, rack):
+        return Device.objects.create(
+            name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,
+            device_type=self.dt, role=self.role,
+        )
+
+    def _populate_reservation(self, rack):
+        return RackReservation.objects.create(
+            rack=rack, units=[1], user=self.user, description="rsm"
+        )
+
+    def _find(self, name="r1"):
+        return find_existing_object({"name": name, "site": self.site.pk}, "dcim.rack")
+
+    def test_single_located_rack_binds(self):
+        """One candidate wins outright."""
+        rack = self._rack(location=self.location)
+        self.assertEqual(self._find(), rack)
+
+    def test_sole_populated_wins_over_empty_null(self):
+        """A populated located rack beats an empty null duplicate."""
+        located = self._rack(location=self.location)
+        self._populate_device(located)
+        self._rack()  # empty null duplicate
+        self.assertEqual(self._find(), located)
+
+    def test_no_populated_prefers_oldest_null(self):
+        """All empty: the oldest location-null row is the shape this payload made."""
+        self._rack(location=self.location)  # empty located, created first
+        old_null = self._rack()
+        self._rack()  # newer null
+        self.assertEqual(self._find(), old_null)
+
+    def test_two_populated_raises_naming_both_pks(self):
+        """Two populated candidates: binding would move references on a name."""
+        loc2 = Location.objects.create(name="rsm-loc3", slug="rsm-loc3", site=self.site)
+        a = self._rack(location=self.location)
+        self._populate_device(a)
+        b = self._rack(location=loc2)
+        self._populate_reservation(b)
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            self._find()
+        message = str(cm.exception)
+        self.assertIn(str(a.pk), message)
+        self.assertIn(str(b.pk), message)
+
+    def test_other_site_same_name_no_match(self):
+        """Site scope is hard."""
+        self._rack(site=self.site2)
+        self.assertIsNone(self._find())
+
+
+class RackCreatePreservesExplicitNullTestCase(TestCase):
+    """
+    CREATE change data keeps an explicitly-submitted location: null.
+
+    CREATE data drops None values, which erases the difference between
+    "not submitted" and "explicitly null" -- and the rack pre-save gate
+    depends on that difference at apply time.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A site for the rack entities to resolve against."""
+        cls.site = Site.objects.create(name="rpn-site", slug="rpn-site")
+
+    def _create_change(self, entity):
+        """Generate a changeset and extract the rack CREATE change."""
+        cs = generate_changeset(entity, "dcim.rack").change_set
+        creates = [c for c in cs.changes
+                   if c.object_type == "dcim.rack"
+                   and c.change_type == ChangeType.CREATE]
+        self.assertEqual(len(creates), 1, [c.to_dict() for c in cs.changes])
+        return creates[0]
+
+    def test_explicit_null_survives_into_create_data(self):
+        """location: null is a producer assertion; it must reach apply."""
+        change = self._create_change(
+            {"name": "rpn-r1", "site": {"name": "rpn-site"}, "location": None}
+        )
+        self.assertIn("location", change.data)
+        self.assertIsNone(change.data["location"])
+
+    def test_absent_key_stays_absent(self):
+        """A location-less entity's CREATE data has no location key."""
+        change = self._create_change(
+            {"name": "rpn-r2", "site": {"name": "rpn-site"}}
+        )
+        self.assertNotIn("location", change.data)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
@@ -130,7 +130,7 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertEqual(find_existing_object({"name": "r1", "site": self.site.pk}, "dcim.rack"), rack)
 
     def test_facility_id_rule(self):
-        """A candidate carrying the submitted facility id wins; a different one is excluded."""
+        """A candidate carrying the submitted facility id wins; a different or asserted-empty one is excluded."""
         older_null = self._rack()
         located = self._rack(location=self.location)
         located.facility_id = "rsm-F1"
@@ -147,6 +147,15 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
         )
+        # an explicitly empty facility id asserts "none": even a populated F1 rack must not be cleared
+        self._populate_device(located)
+        for empty in ("", None):
+            self.assertEqual(
+                find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": empty}, "dcim.rack"),
+                older_null,
+            )
+        # ...while a bare {name, site} ref still prefers the populated F1 rack
+        self.assertEqual(self._find(), located)
 
     def test_power_feeds_count_as_populated(self):
         """A rack holding only power feeds is populated; it beats an empty null duplicate."""

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
@@ -248,9 +248,21 @@ class RackCreatePreservesExplicitNullTestCase(TestCase):
         self.assertIn("location", change.data)
         self.assertIsNone(change.data["location"])
 
+    def test_empty_discriminators_survive_as_null(self):
+        """Asserted-empty asset_tag / facility_id reach apply as explicit nulls."""
+        change = self._create_change(
+            {"name": "rpn-r3", "site": {"name": "rpn-site"}, "asset_tag": "", "facility_id": None}
+        )
+        self.assertIn("asset_tag", change.data)
+        self.assertIsNone(change.data["asset_tag"])
+        self.assertIn("facility_id", change.data)
+        self.assertIsNone(change.data["facility_id"])
+
     def test_absent_key_stays_absent(self):
         """A location-less entity's CREATE data has no location key."""
         change = self._create_change(
             {"name": "rpn-r2", "site": {"name": "rpn-site"}}
         )
         self.assertNotIn("location", change.data)
+        self.assertNotIn("asset_tag", change.data)
+        self.assertNotIn("facility_id", change.data)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
@@ -2,7 +2,18 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Unit tests for RackSiteNameMatcher, rack differ preserve, and rack routing."""
 
-from dcim.models import Device, DeviceRole, DeviceType, Location, Manufacturer, Rack, RackReservation, Site
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Location,
+    Manufacturer,
+    PowerFeed,
+    PowerPanel,
+    Rack,
+    RackReservation,
+    Site,
+)
 from django.test import TestCase
 from users.models import User
 
@@ -129,6 +140,14 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
             _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
         )
+
+    def test_power_feeds_count_as_populated(self):
+        """A rack holding only power feeds is populated; it beats an empty null duplicate."""
+        self._rack()  # empty location-null duplicate
+        located = self._rack(location=self.location)
+        panel = PowerPanel.objects.create(site=self.site, name="rsm-panel")
+        PowerFeed.objects.create(power_panel=panel, rack=located, name="rsm-feed")
+        self.assertEqual(self._find(), located)
 
     def _populate_device(self, rack):
         return Device.objects.create(

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
@@ -51,11 +51,10 @@ class RackSiteNameMatcherGateTestCase(TestCase):
         """No location key: NULLS DISTINCT territory, no DB backstop."""
         self.assertTrue(requires_pre_save_match("dcim.rack", {"name": "r", "site": 1}))
 
-    def test_explicit_null_create_takes_pre_save_match(self):
-        """Explicit null is admitted; the (location, name) IS NULL constraint matcher binds."""
-        self.assertTrue(requires_pre_save_match(
+    def test_explicit_null_create_skips_pre_save_match(self):
+        """Explicit null is not admitted: its only matcher is site-blind."""
+        self.assertFalse(requires_pre_save_match(
             "dcim.rack", {"name": "r", "site": 1, "location": None}))
-
     def test_located_create_skips_pre_save_match(self):
         """A real location value keeps its DB-constraint backstop."""
         self.assertFalse(requires_pre_save_match(

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
@@ -121,6 +121,13 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
         self.assertIsNone(
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
+        # an explicitly empty tag asserts taglessness: it must not clear AT-A
+        for empty in ("", None):
+            self.assertIsNone(
+                find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": empty}, "dcim.rack")
+            )
+        # ...while a bare {name, site} ref (no tag asserted) still binds the tagged rack
+        self.assertEqual(find_existing_object({"name": "r1", "site": self.site.pk}, "dcim.rack"), rack)
 
     def test_facility_id_rule(self):
         """A candidate carrying the submitted facility id wins; a different one is excluded."""

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rack_matcher.py
@@ -111,6 +111,25 @@ class RackSiteNameMatcherResolveTestCase(TestCase):
             find_existing_object({"name": "r1", "site": self.site.pk, "asset_tag": "rsm-AT-B"}, "dcim.rack")
         )
 
+    def test_facility_id_rule(self):
+        """A candidate carrying the submitted facility id wins; a different one is excluded."""
+        older_null = self._rack()
+        located = self._rack(location=self.location)
+        located.facility_id = "rsm-F1"
+        located.save()
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}, "dcim.rack"),
+            located,
+        )
+        self.assertEqual(
+            find_existing_object({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}, "dcim.rack"),
+            older_null,
+        )
+        self.assertNotEqual(
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F1"}),
+            _matcher().fingerprint({"name": "r1", "site": self.site.pk, "facility_id": "rsm-F2"}),
+        )
+
     def _populate_device(self, rack):
         return Device.objects.create(
             name=f"rsm-dev-{rack.pk}", site=rack.site, rack=rack,

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_user_rackreservation.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_user_rackreservation.py
@@ -2,7 +2,7 @@
 # Copyright 2026 NetBox Labs, Inc.
 """Diode NetBox Plugin - User (match-only) + RackReservation ingest tests."""
 
-from dcim.models import RackReservation
+from dcim.models import Rack, RackReservation
 from django.test import TestCase
 from users.models import User
 
@@ -110,20 +110,26 @@ class RackReservationApplyTestCase(TestCase):
 
     def test_existing_user_resolution_is_idempotent(self):
         """
-        Re-ingesting resolves the same existing user each time; never mints one.
+        Re-ingesting the same entity converges: the second diff is all-NOOP.
 
-        Scoped to the USER guarantee: the match-only user is resolved (never
-        duplicated or created) and the reservation's user never changes across
-        re-ingests. NOTE: a full-changeset NOOP is NOT asserted here because
-        dcim.rackreservation is keyless AND its nested dcim.rack has no reliable
-        natural-key match when location is null (a re-diff re-creates the rack
-        and re-points the reservation) — both pre-existing behaviors unrelated
-        to this feature. The user, correctly, is the one node that stays matched.
+        The first ingest creates the rack and the reservation, resolving the
+        match-only user without minting it. The rack now matches on (site,
+        name) via the site-name matcher and the reservation matches via the
+        overlap matcher, so the second generate_changeset's diff carries no
+        non-NOOP changes at all -- there is nothing left to apply. The user,
+        as always, is a pure reference and never a change node.
         """
-        for _ in range(2):
-            r = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
-            # user is always a pure reference — never a change node
-            self.assertFalse(any(c.object_type == "users.user" for c in r.change_set.changes))
-            apply_changeset(r.change_set, request=None)
+        first = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+        self.assertFalse(
+            any(c.object_type == "users.user" for c in first.change_set.changes))
+        apply_changeset(first.change_set, request=None)
+
+        second = generate_changeset(self._entity("rr-owner"), "dcim.rackreservation")
+        self.assertFalse(
+            any(c.change_type != ChangeType.NOOP for c in second.change_set.changes))
+
+        self.assertEqual(Rack.objects.count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
         self.assertEqual(User.objects.filter(username="rr-owner").count(), 1)
-        self.assertTrue(all(rr.user_id == self.user.pk for rr in RackReservation.objects.all()))
+        rr = RackReservation.objects.first()
+        self.assertEqual(rr.user_id, self.user.pk)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_vc_name_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_vc_name_matcher.py
@@ -20,6 +20,7 @@ from netbox_diode_plugin.api.common import (
     UnresolvedReference,
 )
 from netbox_diode_plugin.api.matcher import (
+    _PRE_SAVE_MATCH_BIND_ONLY,
     _REQUIRES_PRE_SAVE_MATCH,
     AmbiguousObjectMatch,
     find_existing_object,
@@ -710,8 +711,31 @@ class PreSaveMatchBindOnlyTests(TestCase):
         "dcim.inventoryitem",
     )
 
+    #: Every _REQUIRES_PRE_SAVE_MATCH entry EXCEPT the two bind-only types
+    #: (dcim.virtualchassis, dcim.rack), hardcoded rather than derived from
+    #: _REQUIRES_PRE_SAVE_MATCH - _PRE_SAVE_MATCH_BIND_ONLY: a derived loop
+    #: would pass trivially however _PRE_SAVE_MATCH_BIND_ONLY grew, because
+    #: whatever got added to it would also be subtracted out of the set this
+    #: test iterates. Writing the members out means a third type added to
+    #: _PRE_SAVE_MATCH_BIND_ONLY without a matching change here fails this
+    #: test instead of silently narrowing what it covers.
+    NON_BIND_ONLY_PRE_SAVE_TYPES = (
+        "dcim.cable",
+        "dcim.macaddress",
+        "dcim.module",
+        "dcim.modulebay",
+        "dcim.rackreservation",
+        "ipam.prefix",
+        "ipam.vlan",
+        "ipam.vlangroup",
+        "ipam.vrf",
+        "virtualization.cluster",
+        "virtualization.virtualmachine",
+        "wireless.wirelesslan",
+    )
+
     def test_virtualchassis_binds_without_writing(self):
-        """The one bind-only type, and the reason the seam exists at all."""
+        """The original bind-only type, and the reason the seam exists at all."""
         self.assertTrue(pre_save_match_binds_only("dcim.virtualchassis"))
 
     def test_every_other_pre_save_matched_type_still_applies_its_payload(self):
@@ -719,11 +743,16 @@ class PreSaveMatchBindOnlyTests(TestCase):
         Naming them all: this is a behavioural change nobody else may inherit.
 
         dcim.module's find-first, for one, exists precisely to APPLY a payload
-        that the IntegrityError recovery it replaced used to discard.
+        that the IntegrityError recovery it replaced used to discard. The
+        bind-only membership itself is pinned separately, so growing it (as
+        dcim.rack did) does not silently widen what this test lets through.
         """
-        for object_type in sorted(_REQUIRES_PRE_SAVE_MATCH - {"dcim.virtualchassis"}):
+        for object_type in self.NON_BIND_ONLY_PRE_SAVE_TYPES:
             with self.subTest(object_type=object_type):
+                self.assertIn(object_type, _REQUIRES_PRE_SAVE_MATCH)
                 self.assertFalse(pre_save_match_binds_only(object_type))
+        self.assertEqual(
+            _PRE_SAVE_MATCH_BIND_ONLY, {"dcim.virtualchassis", "dcim.rack"})
 
     def test_no_auto_created_component_is_bind_only(self):
         """
@@ -744,7 +773,7 @@ class PreSaveMatchBindOnlyTests(TestCase):
 
     def test_a_type_with_no_pre_save_match_at_all_is_not_bind_only(self):
         """Bind-only narrows the find-first route; it is not a route of its own."""
-        for object_type in ("dcim.site", "dcim.device", "dcim.rack"):
+        for object_type in ("dcim.site", "dcim.device", "dcim.location"):
             with self.subTest(object_type=object_type):
                 self.assertFalse(pre_save_match_binds_only(object_type))
                 self.assertFalse(requires_pre_save_match(object_type, {}))


### PR DESCRIPTION
## Summary

Rack matching derived entirely from NetBox's unique constraints (`unique_asset_tag`, `(location, name)`, `(location, facility_id)`), and both constraint matchers require the `location` KEY in the payload. A rack ref carrying only `name` + `site` — the shape discovery producers naturally send — therefore never matched anything: every re-ingest planned a fresh rack CREATE, and NetBox accepted the duplicate because rack-name uniqueness is location-scoped with NULLS DISTINCT. Any entity nesting such a ref (devices, rack reservations) inherited the duplication.

This adds one logical matcher and routes rack creates through the pre-save match:

- **`logical_rack_site_name_no_location`** (`RackSiteNameMatcher`): a location-less `{name, site}` payload means "the rack called *name* in site *site*", whatever its location. It fires only when the `location` key is strictly absent; payloads carrying a location (a value or an explicit null) or an asset tag that already belongs to a rack stay with the constraint matchers. An asserted asset tag (a new tag, or an explicitly empty one) binds only a tagless same-named rack, and a submitted `facility_id` narrows the candidates the same way (an exact match wins; a different facility ID is another rack; an explicitly empty one binds only racks without one). Among several same-named racks in a site, resolution is populated-bounded (the VirtualChassis doctrine): a sole rack with devices, reservations or power feeds wins, so empty duplicates starve; none populated → the oldest location-null rack; two-plus populated → `AmbiguousObjectMatch` at plan time naming the candidates.
- **Pre-save match, bind-only, gated**: location-less rack CREATEs (the NULLS-DISTINCT territory no constraint can backstop) re-match at apply and bind without writing, since their data carries transformer-injected defaults the producer never asserted. Located and explicit-null CREATEs are not routed through it (the only matcher left for an explicit null is the site-blind `(location, name)` one, so those insert exactly as on `develop`).
- **Differ**: explicitly-submitted `location: null`, and asserted-empty `asset_tag` / `facility_id` (normalised to null), survive into rack CREATE change data (CREATEs otherwise drop empties) so the apply-time gate and matcher see the same shape the plan did. Scoped to `dcim.rack`.
- **Find-object cache carve-out** for `dcim.rack`: a cache hit would skip the matcher's `resolve()`.
- Matching-criteria doc regenerated.

Out of scope, deliberately: adopting location-null duplicates when a *located* payload later arrives; any change to the explicit-`location: null` path (which remains site-blind as it is on `develop`, a pre-existing gap worth its own follow-up); and stale-plan last-writer-wins on identity fields such as asset tags, which is the plugin-wide behavior for every matched object.

Fixes MON-324.

## Testing

- Matcher unit tests: gate and abstain rules, the populated-bounded resolve cases (including power feeds), ambiguity, cross-site isolation, the asset-tag and facility-ID rules, pre-save routing and bind-only membership, cache opt-out, and the differ preserve.
- Integration (plan+apply round-trips): the MON-324 repro converges to all-NOOP; an operator-located rack is bound with its location untouched; two populated same-named racks fail loudly at plan; a stale location-less CREATE binds without overwriting the operator's fields; an explicit-null payload creates its own null rack rather than adopting a located one.
- Two pre-existing tests updated for the intended behavior change (one pinned the old duplicate-rack outcome; one assumed VirtualChassis was the only bind-only type).
- Test files byte-identical across the v4.4.x / v4.5.x / v4.6.x / v4.7.x trees; ruff clean.
- Full v4.6 suite: the only red tests are the four known environmental failures that fail identically on `develop`. CI covers v4.4.10, v4.5.5, v4.6.10 and v4.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
