### PR TITLE
ci: stop cross-PR queueing, fix the coverage tracer overhead, instrument the migration phase

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -44,11 +44,13 @@ jobs:
         uses: actions/checkout@v7
       # Host interpreter for installing the package and running Ruff only.
       # The test suite runs inside the NetBox images (Python 3.12 for 4.4/4.5,
-      # 3.14 for 4.6/4.7), so this version does not describe the tests.
+      # 3.14 for 4.6/4.7), so this version does not describe the tests. It is
+      # the package's declared floor (requires-python in pyproject.toml), so
+      # the install step below doubles as the check that the floor still holds.
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -38,15 +38,17 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python: [ "3.10" ]
         netbox: [ "v4.7.0", "v4.6.10", "v4.5.5", "v4.4.10" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      # Host interpreter for installing the package and running Ruff only.
+      # The test suite runs inside the NetBox images (Python 3.12 for 4.4/4.5,
+      # 3.14 for 4.6/4.7), so this version does not describe the tests.
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python }}
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -4,19 +4,28 @@ on:
   pull_request:
     paths:
       - "netbox_diode_plugin/**"
+      - ".github/workflows/lint-tests.yml"
+      - "Makefile"
+      - "docker/**"
   push:
     branches:
       - "!release"
     paths:
       - "netbox_diode_plugin/**"
+      - ".github/workflows/lint-tests.yml"
+      - "Makefile"
+      - "docker/**"
 
 env:
   # Default NetBox version used for coverage reporting
   DEFAULT_NETBOX_VERSION: "v4.6.10"
 
+# One run per pull request (or per branch for pushes and manual dispatch), so
+# PRs no longer queue behind each other repo-wide. Superseded runs are cancelled
+# only for pull_request events; a push to a real branch always runs to completion.
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write
@@ -55,7 +64,7 @@ jobs:
           make NETBOX_VERSION=${{ matrix.netbox }} docker-compose-netbox-plugin-test-cover
         continue-on-error: true
       - name: Check results
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           if [[ "${{ steps.lint.outcome }}" == "failure" || "${{ steps.test.outcome }}" == "failure" ]]; then
             echo "Either linting or tests failed"

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ DOCKER_COMMON_PATH := docker/common
 DOCKER_OVERRIDE := $(DOCKER_PATH)/docker-compose.override.yaml
 COMPOSE_FILES := -f $(DOCKER_COMMON_PATH)/docker-compose.yaml $(if $(wildcard $(DOCKER_OVERRIDE)),-f $(DOCKER_OVERRIDE))
 # CI-only overlay (GitHub sets CI=true): relaxes Postgres durability for the
-# throwaway test database. Never included for developer stacks.
-ifneq ($(CI),)
+# throwaway test database. Never included for developer stacks, including when
+# CI is set to a false-ish value such as "false" or "0".
+ifeq ($(CI),true)
   COMPOSE_FILES += -f $(DOCKER_COMMON_PATH)/docker-compose.ci.yaml
 endif
 TEST_SELECTOR := "/opt/netbox/netbox/netbox_diode_plugin/tests/$(NETBOX_MINOR_VERSION)/tests/"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ DOCKER_PATH := docker/$(NETBOX_MINOR_VERSION)
 DOCKER_COMMON_PATH := docker/common
 DOCKER_OVERRIDE := $(DOCKER_PATH)/docker-compose.override.yaml
 COMPOSE_FILES := -f $(DOCKER_COMMON_PATH)/docker-compose.yaml $(if $(wildcard $(DOCKER_OVERRIDE)),-f $(DOCKER_OVERRIDE))
+# CI-only overlay (GitHub sets CI=true): relaxes Postgres durability for the
+# throwaway test database. Never included for developer stacks.
+ifneq ($(CI),)
+  COMPOSE_FILES += -f $(DOCKER_COMMON_PATH)/docker-compose.ci.yaml
+endif
 TEST_SELECTOR := "/opt/netbox/netbox/netbox_diode_plugin/tests/$(NETBOX_MINOR_VERSION)/tests/"
 
 # Export variables so they're available to docker-compose
@@ -42,7 +47,7 @@ docker-compose-netbox-plugin-test-lint:
 
 .PHONY: docker-compose-netbox-plugin-test-cover
 docker-compose-netbox-plugin-test-cover:
-	@$(DOCKER_COMPOSE) $(COMPOSE_FILES) -f $(DOCKER_COMMON_PATH)/docker-compose.test.yaml run --rm -u root -e COVERAGE_FILE=/opt/netbox/netbox/coverage/.coverage netbox sh -c "coverage run --source=netbox_diode_plugin --omit=*/migrations/* ./manage.py test --keepdb $(TEST_SELECTOR) && coverage xml -o /opt/netbox/netbox/coverage/report.xml && coverage report -m | tee /opt/netbox/netbox/coverage/report.txt"; \
+	@$(DOCKER_COMPOSE) $(COMPOSE_FILES) -f $(DOCKER_COMMON_PATH)/docker-compose.test.yaml run --rm -u root -e COVERAGE_FILE=/opt/netbox/netbox/coverage/.coverage -e COVERAGE_CORE=sysmon netbox sh -c "echo \"[timing] test start \$$(date -u +%T)\" && coverage run --source=netbox_diode_plugin --omit=*/migrations/* ./manage.py test --keepdb $(TEST_SELECTOR); rc=\$$?; echo \"[timing] test end \$$(date -u +%T)\"; [ \$$rc -eq 0 ] && coverage xml -o /opt/netbox/netbox/coverage/report.xml && coverage report -m | tee /opt/netbox/netbox/coverage/report.txt; exit \$$rc"; \
 	EXIT_CODE=$$?; \
 	$(MAKE) docker-compose-netbox-plugin-down; \
 	exit $$EXIT_CODE

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ docker-compose-netbox-plugin-test-lint:
 
 .PHONY: docker-compose-netbox-plugin-test-cover
 docker-compose-netbox-plugin-test-cover:
-	@$(DOCKER_COMPOSE) $(COMPOSE_FILES) -f $(DOCKER_COMMON_PATH)/docker-compose.test.yaml run --rm -u root -e COVERAGE_FILE=/opt/netbox/netbox/coverage/.coverage -e COVERAGE_CORE=sysmon netbox sh -c "echo \"[timing] test start \$$(date -u +%T)\" && coverage run --source=netbox_diode_plugin --omit=*/migrations/* ./manage.py test --keepdb $(TEST_SELECTOR); rc=\$$?; echo \"[timing] test end \$$(date -u +%T)\"; [ \$$rc -eq 0 ] && coverage xml -o /opt/netbox/netbox/coverage/report.xml && coverage report -m | tee /opt/netbox/netbox/coverage/report.txt; exit \$$rc"; \
+	@$(DOCKER_COMPOSE) $(COMPOSE_FILES) -f $(DOCKER_COMMON_PATH)/docker-compose.test.yaml run --rm -u root -e COVERAGE_FILE=/opt/netbox/netbox/coverage/.coverage -e COVERAGE_CORE=sysmon netbox sh -c "echo \"[timing] test start \$$(date -u +%T)\" && coverage run --source=netbox_diode_plugin --omit=*/migrations/* ./manage.py test --keepdb $(TEST_SELECTOR); rc=\$$?; echo \"[timing] test end \$$(date -u +%T)\"; if [ \$$rc -eq 0 ]; then coverage xml -o /opt/netbox/netbox/coverage/report.xml && coverage report -m > /opt/netbox/netbox/coverage/report.txt; rc=\$$?; cat /opt/netbox/netbox/coverage/report.txt; fi; exit \$$rc"; \
 	EXIT_CODE=$$?; \
 	$(MAKE) docker-compose-netbox-plugin-down; \
 	exit $$EXIT_CODE

--- a/docker/common/docker-compose.ci.yaml
+++ b/docker/common/docker-compose.ci.yaml
@@ -1,0 +1,13 @@
+# CI-only overlay, included by the Makefile when CI is set. The test database is
+# thrown away with the runner, so Postgres durability guarantees buy nothing and
+# cost real time during NetBox's migrations and the test run itself.
+services:
+  netbox-postgres:
+    command:
+      - postgres
+      - -c
+      - fsync=off
+      - -c
+      - synchronous_commit=off
+      - -c
+      - full_page_writes=off

--- a/docker/v4.4.x/Dockerfile
+++ b/docker/v4.4.x/Dockerfile
@@ -9,6 +9,12 @@ COPY common/netbox/local_settings.py /opt/netbox/netbox/netbox/local_settings.py
 RUN chmod 755 /opt/netbox/netbox/netbox/local_settings.py && \
     chown unit:root /opt/netbox/netbox/netbox/local_settings.py
 
+# NetBox 4.4 re-runs a Postgres table-list introspection on every ObjectType
+# lookup; 4.5 caches it. Backport the cache so the 4.4 test leg is not
+# dominated by that check (see the script's docstring).
+COPY v4.4.x/patch-object-type-cache.py /opt/netbox/
+RUN /opt/netbox/venv/bin/python /opt/netbox/patch-object-type-cache.py
+
 COPY v4.4.x/requirements-diode-netbox-plugin.txt /opt/netbox/
 ENV VIRTUAL_ENV=/opt/netbox/venv
 RUN /usr/local/bin/uv pip install -r /opt/netbox/requirements-diode-netbox-plugin.txt

--- a/docker/v4.4.x/patch-object-type-cache.py
+++ b/docker/v4.4.x/patch-object-type-cache.py
@@ -1,0 +1,57 @@
+"""
+Backport NetBox 4.5's ObjectType introspection cache into the 4.4 test image.
+
+NetBox 4.4's ``ObjectTypeManager.get_for_model`` asks Postgres for the full
+table list (``connection.introspection.table_names()``) on every call, to
+detect a pre-4.4 migration state. Serializers, change logging and event
+queueing call it constantly, so the 4.4 test suite spends a third of its time
+on that catalog scan and issues ~60% more SQL than 4.5, where NetBox caches the
+answer once per process. This applies the same cache, so the 4.4 CI leg
+measures the plugin rather than that check. The 4.4 series receives no further
+upstream releases, so the fix will not arrive from there.
+
+Build-time only: it rewrites the file inside the image and fails the build if
+the expected block is not found, so a base-image change cannot silently turn
+the patch into a no-op.
+"""
+
+import sys
+
+PATH = "/opt/netbox/netbox/core/models/object_types.py"
+
+OLD_CLASS = """class ObjectTypeManager(models.Manager):
+
+    def get_queryset(self):
+"""
+NEW_CLASS = """class ObjectTypeManager(models.Manager):
+
+    # Cache the result of introspection to avoid repeated queries.
+    _table_exists = False
+
+    def get_queryset(self):
+"""
+
+OLD_CHECK = """        if 'core_objecttype' not in connection.introspection.table_names():
+            ct = ContentType.objects.get_for_model(model, for_concrete_model=for_concrete_model)
+            ct.features = get_model_features(ct.model_class())
+            return ct
+"""
+NEW_CHECK = """        if not ObjectTypeManager._table_exists:
+            if 'core_objecttype' not in connection.introspection.table_names():
+                ct = ContentType.objects.get_for_model(model, for_concrete_model=for_concrete_model)
+                ct.features = get_model_features(ct.model_class())
+                return ct
+            ObjectTypeManager._table_exists = True
+"""
+
+with open(PATH) as fh:
+    source = fh.read()
+
+for old in (OLD_CLASS, OLD_CHECK):
+    if source.count(old) != 1:
+        sys.exit(f"patch-object-type-cache: expected block not found exactly once in {PATH}")
+
+source = source.replace(OLD_CLASS, NEW_CLASS, 1).replace(OLD_CHECK, NEW_CHECK, 1)
+with open(PATH, "w") as fh:
+    fh.write(source)
+print("patch-object-type-cache: applied")

--- a/docker/v4.4.x/requirements-diode-netbox-plugin.txt
+++ b/docker/v4.4.x/requirements-diode-netbox-plugin.txt
@@ -1,6 +1,6 @@
 Brotli==1.2.0
 certifi==2024.7.4
-coverage==7.6.0
+coverage==7.16.0
 grpcio==1.62.1
 protobuf==5.29.6
 pytest==9.0.3

--- a/docker/v4.5.x/requirements-diode-netbox-plugin.txt
+++ b/docker/v4.5.x/requirements-diode-netbox-plugin.txt
@@ -1,6 +1,6 @@
 Brotli==1.2.0
 certifi==2024.7.4
-coverage==7.6.0
+coverage==7.16.0
 grpcio==1.62.1
 protobuf==5.29.6
 pytest==9.0.3

--- a/docker/v4.6.x/requirements-diode-netbox-plugin.txt
+++ b/docker/v4.6.x/requirements-diode-netbox-plugin.txt
@@ -1,6 +1,6 @@
 Brotli==1.2.0
 certifi==2024.7.4
-coverage==7.6.0
+coverage==7.16.0
 grpcio==1.76.0
 protobuf==5.29.6
 pytest==9.0.3

--- a/docker/v4.7.x/requirements-diode-netbox-plugin.txt
+++ b/docker/v4.7.x/requirements-diode-netbox-plugin.txt
@@ -1,6 +1,6 @@
 Brotli==1.2.0
 certifi==2024.7.4
-coverage==7.6.0
+coverage==7.16.0
 grpcio==1.76.0
 protobuf==5.29.6
 pytest==9.0.3


### PR DESCRIPTION
## Summary

The "Lint and tests" workflow takes 12–19 minutes per matrix job plus, on busy days, 10–15 minutes of queueing. Measured breakdown of one job (v4.4.10, 17m36s): ~25 s image pull/build, ~4 min NetBox migrations into the test database, 12.6 min of tests, seconds of coverage reporting. Four changes; the first three were chosen after an adversarial review of four candidates, the fourth came out of profiling the v4.4.10 leg once the others had landed:

- **One workflow run per pull request.** The concurrency group was the bare workflow name, so every run in the repo queued behind whichever was in progress. Group by PR number (or ref for pushes and manual dispatch); cancel superseded runs only for `pull_request` events; `Check results` no longer runs on cancelled jobs. The workflow now also triggers on changes to itself, the Makefile and `docker/**`.
- **Remove the coverage tracer overhead instead of dropping coverage.** `coverage==7.6.0` has no wheel for Python 3.14, so the v4.6/v4.7 images fell back to the pure-Python tracer: locally the suite ran 260 s under coverage vs 118 s plain (2.2×). Pinning `coverage==7.16.0` and selecting `COVERAGE_CORE=sysmon` ran at plain speed with identical reports. Coverage stays on all four legs. Verification gate: per-job `coverage report` TOTAL statement counts against `develop`'s last green run (631bcc1) — v4.4.10 12435→12435 and v4.5.5 12638→12638 (identical); v4.6.10 13049→13020 and v4.7.0 12861→12832 (29 fewer). The 29 are docstrings and dataclass field annotations that coverage 7.6.0 mis-counted as statements on Python 3.14 (7.6.0 runs there "without C extension"); 7.16.0 excludes them with both the C core and sysmon, so no executable line lost measurement. The coverage comment posted (13020 statements, 95%).
- **Measure before caching the database.** A CI-only compose overlay (included by the Makefile only when `CI` is exactly `true`, the value GitHub Actions sets; never for developer stacks, including `CI=false` or `CI=0`) turns off `fsync`, `synchronous_commit` and `full_page_writes` on the throwaway Postgres, and the test recipe prints `[timing]` markers around `manage.py test` so the migration phase is measured rather than inferred. A cached, pre-migrated test database (dump restores in ~2 s) is deferred until those numbers say the migrations are still worth it.
- **Stop NetBox 4.4 from listing every Postgres table on each `ObjectType` lookup.** Profiling showed the v4.4.10 leg running fewer tests than v4.5.5 on the same Python 3.12, yet 4× slower in CI. NetBox 4.4's `ObjectTypeManager.get_for_model` calls `connection.introspection.table_names()` (a catalog scan) on every call to detect a pre-4.4 migration state; serializers, change logging and event queueing hit it constantly (5,400 calls in one 101-test file, a third of the leg's CPU, ~60% more SQL than 4.5, and CI's slower Postgres widened the gap). NetBox 4.5 caches that answer once per process. The 4.4 series receives no further upstream releases, so `docker/v4.4.x/patch-object-type-cache.py` backports the same cache at image build time; it asserts the exact original block so a base-image change fails the build rather than silently skipping. Plugin code under test is untouched; behaviour is identical once the table exists, which is always the case after migrations. Locally the full 4.4 suite went from 214 s to 105 s, level with 4.5 (102 s).

Rejected by the review: running the suite with Django's `--parallel` (the find-object cache is a shared Redis keyed on bare pks, and cloned test databases have identical pk sequences, so cross-worker hits can return the wrong row), and coverage-only-on-the-default-job (superseded by the tracer fix).

Also: the matrix's single-value `python: ["3.10"]` axis only chose the runner interpreter used for `pip install` and Ruff, while the suite runs inside the NetBox images (3.12 for 4.4/4.5, 3.14 for 4.6/4.7), so `tests (3.10, v4.4.10)` described nothing the tests ran on. The axis is dropped (jobs are now `tests (v4.4.10)` etc.). The host interpreter stays on 3.10, the package's declared floor, with a comment saying that the install step doubles as the check that the floor still holds. If branch protection on `develop` lists the old job names as required checks, those rules need updating before merge.

Expected effect: no more cross-PR queueing, and the test phase of the Python 3.14 legs roughly halves; the overlay's effect on the ~4-minute migration phase will be read off this PR's run.

## Measured on this PR's final run (3ace0e0) vs `develop`'s last green run

| Job | test phase before → after | job total before → after |
|---|---|---|
| v4.4.10 | 811 s → 271 s | 17m36s → 8m18s |
| v4.5.5 | 379 s → 265 s | 12m11s → 8m38s |
| v4.6.10 | 540 s → 251 s | 15m58s → 8m22s |
| v4.7.0 | 476 s → 236 s | 16m55s → 9m24s |

An earlier run of this PR (before the 4.4 change) had v4.4.10 at 710 s / 15 min while the others were already at 179–299 s, which is what prompted the profiling. All four legs now finish within a minute of each other. The Postgres durability overlay took 1.4–3.7 minutes off every job's migration phase, but that phase is still 3–4.5 minutes, so a cached pre-migrated test database (restores in ~2 s) remains the next lever, as a follow-up.

## Testing

- Workflow YAML parses; `docker compose config` with the overlay renders the Postgres flags; the cover recipe's shell quoting verified by execution, and its exit paths (tests pass / `coverage xml` fails / `coverage report` fails / tests fail) verified with stub commands so a reporting failure fails the job.
- The 4.4 image patch: built locally, the patched block verified in the image, and the full v4.4 suite run green (784 tests, 105 s).
- No plugin code changes; CI on this PR is the validation: all four legs green, coverage TOTALs as analysed above, `[timing]` markers present in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
