### PR TITLE
fix: treat NetBox 4.7 cooling components as template-instantiated in the applier (MON-359)

### DIFF
--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -114,6 +114,30 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | dcim_consoleserverport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
 
+## dcim.coolingfeed
+
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|---------------------|------|--------|-----------|-------------|---------------------|
+| dcim_coolingfeed_unique_cooling_source_name | 1 | builtin | cooling_source, name | N/A | Matches on unique constraint fields: cooling_source, name | All versions |
+
+## dcim.coolingintake
+
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|---------------------|------|--------|-----------|-------------|---------------------|
+| dcim_coolingintake_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.coolingoutflow
+
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|---------------------|------|--------|-----------|-------------|---------------------|
+| dcim_coolingoutflow_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+
+## dcim.coolingsource
+
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|---------------------|------|--------|-----------|-------------|---------------------|
+| dcim_coolingsource_unique_site_name | 1 | builtin | site, name | N/A | Matches on unique constraint fields: site, name | All versions |
+
 ## dcim.device
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
@@ -122,10 +146,9 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
 | unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
 | unique_oob_ip | 4 | builtin | oob_ip | N/A | Matches on unique field(s): oob_ip | All versions |
-| dcim_device_unique_name_site_tenant | 5 | builtin |  | N/A | Custom matcher | All versions |
-| dcim_device_unique_name_site | 6 | builtin |  | tenant is NULL | Custom matcher | All versions |
-| dcim_device_unique_rack_position_face | 7 | builtin | rack, position, face | N/A | Matches on unique constraint fields: rack, position, face | All versions |
-| dcim_device_unique_virtual_chassis_vc_position | 8 | builtin | virtual_chassis, vc_position | N/A | Matches on unique constraint fields: virtual_chassis, vc_position | All versions |
+| dcim_device_unique_name_site_tenant | 5 | builtin |  | name is NOT NULL | Custom matcher | All versions |
+| dcim_device_unique_rack_position_face | 6 | builtin | rack, position, face | N/A | Matches on unique constraint fields: rack, position, face | All versions |
+| dcim_device_unique_virtual_chassis_vc_position | 7 | builtin | virtual_chassis, vc_position | N/A | Matches on unique constraint fields: virtual_chassis, vc_position | All versions |
 
 ## dcim.devicebay
 
@@ -141,10 +164,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | logical_device_role_name_no_parent | 1 | logical | name | parent is NULL | Matches on fields: name where parent is NULL | ≥4.3.0 |
 | logical_device_role_slug_no_parent | 2 | logical | slug | parent is NULL | Matches on fields: slug where parent is NULL | ≥4.3.0 |
 | dcim_devicerole_parent_name | 3 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| dcim_devicerole_name | 4 | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
-| dcim_devicerole_parent_slug | 5 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
-| dcim_devicerole_slug | 6 | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
-| unique_autoslug_slug | 7 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_devicerole_parent_slug | 4 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
+| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.devicetype
 
@@ -166,6 +187,7 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
 | dcim_interface_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_interface_unique_parent_channel_id | 3 | builtin | parent, channel_id | N/A | Matches on unique constraint fields: parent, channel_id | All versions |
 
 ## dcim.inventoryitem
 
@@ -188,10 +210,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | dcim_location_parent_name | 1 | builtin | site, parent, name | N/A | Matches on unique constraint fields: site, parent, name | All versions |
-| dcim_location_name | 2 | builtin | site, name | parent is NULL | Matches on unique constraint fields: site, name where parent is NULL | All versions |
-| dcim_location_parent_slug | 3 | builtin | site, parent, slug | N/A | Matches on unique constraint fields: site, parent, slug | All versions |
-| dcim_location_slug | 4 | builtin | site, slug | parent is NULL | Matches on unique constraint fields: site, slug where parent is NULL | All versions |
-| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_location_parent_slug | 2 | builtin | site, parent, slug | N/A | Matches on unique constraint fields: site, parent, slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.macaddress
 
@@ -222,6 +242,14 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | logical_module_bay_name_on_device | 1 | logical | name, device | N/A | Matches on fields: name, device | All versions |
 | dcim_modulebay_unique_device_module_name | 2 | builtin | device, module, name | N/A | Matches on unique constraint fields: device, module, name | All versions |
 
+## dcim.modulebaytype
+
+| Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
+|--------------|---------------------|------|--------|-----------|-------------|---------------------|
+| dcim_modulebaytype_unique_manufacturer_name | 1 | builtin | manufacturer, name | N/A | Matches on unique constraint fields: manufacturer, name | All versions |
+| dcim_modulebaytype_unique_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+
 ## dcim.moduletype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
@@ -239,10 +267,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | dcim_platform_manufacturer_name | 1 | builtin | manufacturer, name | N/A | Matches on unique constraint fields: manufacturer, name | All versions |
-| dcim_platform_name | 2 | builtin | name | manufacturer is NULL | Matches on unique constraint fields: name where manufacturer is NULL | All versions |
-| dcim_platform_manufacturer_slug | 3 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
-| dcim_platform_slug | 4 | builtin | slug | manufacturer is NULL | Matches on unique constraint fields: slug where manufacturer is NULL | All versions |
-| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_platform_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.powerfeed
 
@@ -319,10 +345,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | dcim_region_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| dcim_region_name | 2 | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
-| dcim_region_parent_slug | 3 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
-| dcim_region_slug | 4 | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
-| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_region_parent_slug | 2 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.site
 
@@ -337,10 +361,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | dcim_sitegroup_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| dcim_sitegroup_name | 2 | builtin | name | parent is NULL | Matches on unique constraint fields: name where parent is NULL | All versions |
-| dcim_sitegroup_parent_slug | 3 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
-| dcim_sitegroup_slug | 4 | builtin | slug | parent is NULL | Matches on unique constraint fields: slug where parent is NULL | All versions |
-| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_sitegroup_parent_slug | 2 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## dcim.virtualchassis
 
@@ -548,10 +570,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | tenancy_tenant_unique_group_name | 1 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| tenancy_tenant_unique_name | 2 | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
-| tenancy_tenant_unique_group_slug | 3 | builtin | group, slug | N/A | Matches on unique constraint fields: group, slug | All versions |
-| tenancy_tenant_unique_slug | 4 | builtin | slug | group is NULL | Matches on unique constraint fields: slug where group is NULL | All versions |
-| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| tenancy_tenant_unique_group_slug | 2 | builtin | group, slug | N/A | Matches on unique constraint fields: group, slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## tenancy.tenantgroup
 
@@ -617,10 +637,8 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | logical_virtual_machine_name_no_cluster | 1 | logical | name | cluster is NULL | Matches on fields: name where cluster is NULL | All versions |
 | unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
 | unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
-| virtualization_virtualmachine_unique_name_cluster_tenant | 4 | builtin |  | N/A | Custom matcher | All versions |
-| virtualization_virtualmachine_unique_name_cluster | 5 | builtin |  | tenant is NULL | Custom matcher | All versions |
-| virtualization_virtualmachine_unique_name_device_tenant | 6 | builtin |  | cluster is NULL AND device is NOT NULL | Custom matcher | All versions |
-| virtualization_virtualmachine_unique_name_device | 7 | builtin |  | cluster is NULL AND device is NOT NULL AND tenant is NULL | Custom matcher | All versions |
+| virtualization_virtualmachine_unique_name_cluster_tenant | 4 | builtin |  | cluster is NOT NULL | Custom matcher | All versions |
+| virtualization_virtualmachine_unique_name_device_tenant | 5 | builtin |  | cluster is NULL AND device is NOT NULL | Custom matcher | All versions |
 
 ## virtualization.virtualmachinetype
 
@@ -686,8 +704,6 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| vpn_tunnel_group_name | 2 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| vpn_tunnel_name | 3 | builtin | name | group is NULL | Matches on unique constraint fields: name where group is NULL | All versions |
 
 ## vpn.tunnelgroup
 
@@ -717,8 +733,7 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
 | unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| wireless_wirelesslangroup_unique_parent_name | 3 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
 
 ## wireless.wirelesslink
 

--- a/docs/matching-criteria-documentation.md
+++ b/docs/matching-criteria-documentation.md
@@ -2,6 +2,10 @@
 
 This document describes how the Diode NetBox Plugin matches existing objects when applying changes. The matchers will be applied in the order of their precedence, unttil one of them matches.
 
+Generated on NetBox 4.7.0.
+
+Builtin matchers are derived from that release's model constraints and are listed as they exist there. Other NetBox releases the plugin supports may declare the same identity through different constraints (for example, NetBox 4.7 replaced conditional constraint pairs such as `name where parent is NULL` with single `nulls_distinct=False` constraints); the matcher derives whichever form the running release declares. In the Version Constraints column, "NetBox <version>" on a builtin row means the row reflects that release; a version range on a logical row is the plugin's own gate.
+
 ## Matcher Types
 
 - **Logical Matchers**: Custom matching criteria that represent likely user intent
@@ -11,84 +15,84 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| circuits_circuit_unique_provider_cid | 1 | builtin | provider, cid | N/A | Matches on unique constraint fields: provider, cid | All versions |
-| circuits_circuit_unique_provideraccount_cid | 2 | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |
+| circuits_circuit_unique_provider_cid | 1 | builtin | provider, cid | N/A | Matches on unique constraint fields: provider, cid | NetBox 4.7.0 |
+| circuits_circuit_unique_provideraccount_cid | 2 | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | NetBox 4.7.0 |
 
 ## circuits.circuitgroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## circuits.circuitgroupassignment
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| circuits_circuitgroupassignment_unique_member_group | 1 | builtin | member_type, member_id, group | N/A | Matches on unique constraint fields: member_type, member_id, group | All versions |
+| circuits_circuitgroupassignment_unique_member_group | 1 | builtin | member_type, member_id, group | N/A | Matches on unique constraint fields: member_type, member_id, group | NetBox 4.7.0 |
 
 ## circuits.circuittermination
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| circuits_circuittermination_unique_circuit_term_side | 1 | builtin | circuit, term_side | N/A | Matches on unique constraint fields: circuit, term_side | All versions |
+| circuits_circuittermination_unique_circuit_term_side | 1 | builtin | circuit, term_side | N/A | Matches on unique constraint fields: circuit, term_side | NetBox 4.7.0 |
 
 ## circuits.circuittype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## circuits.provider
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## circuits.provideraccount
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| circuits_provideraccount_unique_provider_account | 1 | builtin | provider, account | N/A | Matches on unique constraint fields: provider, account | All versions |
-| circuits_provideraccount_unique_provider_name | 2 | builtin | provider, name | name =  | Matches on unique constraint fields: provider, name where name =  | All versions |
+| circuits_provideraccount_unique_provider_account | 1 | builtin | provider, account | N/A | Matches on unique constraint fields: provider, account | NetBox 4.7.0 |
+| circuits_provideraccount_unique_provider_name | 2 | builtin | provider, name | name =  | Matches on unique constraint fields: provider, name where name =  | NetBox 4.7.0 |
 
 ## circuits.providernetwork
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| circuits_providernetwork_unique_provider_name | 1 | builtin | provider, name | N/A | Matches on unique constraint fields: provider, name | All versions |
+| circuits_providernetwork_unique_provider_name | 1 | builtin | provider, name | N/A | Matches on unique constraint fields: provider, name | NetBox 4.7.0 |
 
 ## circuits.virtualcircuit
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| circuits_virtualcircuit_unique_provider_network_cid | 1 | builtin | provider_network, cid | N/A | Matches on unique constraint fields: provider_network, cid | All versions |
-| circuits_virtualcircuit_unique_provideraccount_cid | 2 | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | All versions |
+| circuits_virtualcircuit_unique_provider_network_cid | 1 | builtin | provider_network, cid | N/A | Matches on unique constraint fields: provider_network, cid | NetBox 4.7.0 |
+| circuits_virtualcircuit_unique_provideraccount_cid | 2 | builtin | provider_account, cid | N/A | Matches on unique constraint fields: provider_account, cid | NetBox 4.7.0 |
 
 ## circuits.virtualcircuittermination
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_interface | 1 | builtin | interface | N/A | Matches on unique field(s): interface | All versions |
+| unique_interface | 1 | builtin | interface | N/A | Matches on unique field(s): interface | NetBox 4.7.0 |
 
 ## circuits.virtualcircuittype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## core.managedfile
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| core_managedfile_unique_root_path | 1 | builtin | file_root, file_path | N/A | Matches on unique constraint fields: file_root, file_path | All versions |
+| core_managedfile_unique_root_path | 1 | builtin | file_root, file_path | N/A | Matches on unique constraint fields: file_root, file_path | NetBox 4.7.0 |
 
 ## dcim.cable
 
@@ -100,62 +104,62 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## dcim.consoleport
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_consoleport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_consoleport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.consoleserverport
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_consoleserverport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_consoleserverport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.coolingfeed
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_coolingfeed_unique_cooling_source_name | 1 | builtin | cooling_source, name | N/A | Matches on unique constraint fields: cooling_source, name | All versions |
+| dcim_coolingfeed_unique_cooling_source_name | 1 | builtin | cooling_source, name | N/A | Matches on unique constraint fields: cooling_source, name | NetBox 4.7.0 |
 
 ## dcim.coolingintake
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_coolingintake_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_coolingintake_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.coolingoutflow
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_coolingoutflow_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_coolingoutflow_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.coolingsource
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_coolingsource_unique_site_name | 1 | builtin | site, name | N/A | Matches on unique constraint fields: site, name | All versions |
+| dcim_coolingsource_unique_site_name | 1 | builtin | site, name | N/A | Matches on unique constraint fields: site, name | NetBox 4.7.0 |
 
 ## dcim.device
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_asset_tag | 1 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
-| unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
-| unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
-| unique_oob_ip | 4 | builtin | oob_ip | N/A | Matches on unique field(s): oob_ip | All versions |
-| dcim_device_unique_name_site_tenant | 5 | builtin |  | name is NOT NULL | Custom matcher | All versions |
-| dcim_device_unique_rack_position_face | 6 | builtin | rack, position, face | N/A | Matches on unique constraint fields: rack, position, face | All versions |
-| dcim_device_unique_virtual_chassis_vc_position | 7 | builtin | virtual_chassis, vc_position | N/A | Matches on unique constraint fields: virtual_chassis, vc_position | All versions |
+| unique_asset_tag | 1 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | NetBox 4.7.0 |
+| unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | NetBox 4.7.0 |
+| unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | NetBox 4.7.0 |
+| unique_oob_ip | 4 | builtin | oob_ip | N/A | Matches on unique field(s): oob_ip | NetBox 4.7.0 |
+| dcim_device_unique_name_site_tenant | 5 | builtin |  | name is NOT NULL | Custom matcher | NetBox 4.7.0 |
+| dcim_device_unique_rack_position_face | 6 | builtin | rack, position, face | N/A | Matches on unique constraint fields: rack, position, face | NetBox 4.7.0 |
+| dcim_device_unique_virtual_chassis_vc_position | 7 | builtin | virtual_chassis, vc_position | N/A | Matches on unique constraint fields: virtual_chassis, vc_position | NetBox 4.7.0 |
 
 ## dcim.devicebay
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_installed_device | 1 | builtin | installed_device | N/A | Matches on unique field(s): installed_device | All versions |
-| dcim_devicebay_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| unique_installed_device | 1 | builtin | installed_device | N/A | Matches on unique field(s): installed_device | NetBox 4.7.0 |
+| dcim_devicebay_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.devicerole
 
@@ -163,55 +167,55 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_device_role_name_no_parent | 1 | logical | name | parent is NULL | Matches on fields: name where parent is NULL | ≥4.3.0 |
 | logical_device_role_slug_no_parent | 2 | logical | slug | parent is NULL | Matches on fields: slug where parent is NULL | ≥4.3.0 |
-| dcim_devicerole_parent_name | 3 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| dcim_devicerole_parent_slug | 4 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
-| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_devicerole_parent_name | 3 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | NetBox 4.7.0 |
+| dcim_devicerole_parent_slug | 4 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 5 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.devicetype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_devicetype_unique_manufacturer_model | 1 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
-| dcim_devicetype_unique_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_devicetype_unique_manufacturer_model | 1 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | NetBox 4.7.0 |
+| dcim_devicetype_unique_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.frontport
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_frontport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_frontport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.interface
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
-| dcim_interface_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
-| dcim_interface_unique_parent_channel_id | 3 | builtin | parent, channel_id | N/A | Matches on unique constraint fields: parent, channel_id | All versions |
+| unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | NetBox 4.7.0 |
+| dcim_interface_unique_device_name | 2 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
+| dcim_interface_unique_parent_channel_id | 3 | builtin | parent, channel_id | N/A | Matches on unique constraint fields: parent, channel_id | NetBox 4.7.0 |
 
 ## dcim.inventoryitem
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_inventory_item_name_on_device_no_parent | 1 | logical | name, device | parent is NULL | Matches on fields: name, device where parent is NULL | All versions |
-| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
-| dcim_inventoryitem_unique_device_parent_name | 3 | builtin | device, parent, name | N/A | Matches on unique constraint fields: device, parent, name | All versions |
+| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | NetBox 4.7.0 |
+| dcim_inventoryitem_unique_device_parent_name | 3 | builtin | device, parent, name | N/A | Matches on unique constraint fields: device, parent, name | NetBox 4.7.0 |
 
 ## dcim.inventoryitemrole
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.location
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_location_parent_name | 1 | builtin | site, parent, name | N/A | Matches on unique constraint fields: site, parent, name | All versions |
-| dcim_location_parent_slug | 2 | builtin | site, parent, slug | N/A | Matches on unique constraint fields: site, parent, slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_location_parent_name | 1 | builtin | site, parent, name | N/A | Matches on unique constraint fields: site, parent, name | NetBox 4.7.0 |
+| dcim_location_parent_slug | 2 | builtin | site, parent, slug | N/A | Matches on unique constraint fields: site, parent, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.macaddress
 
@@ -224,92 +228,92 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.module
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_module_bay | 1 | builtin | module_bay | N/A | Matches on unique field(s): module_bay | All versions |
-| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
+| unique_module_bay | 1 | builtin | module_bay | N/A | Matches on unique field(s): module_bay | NetBox 4.7.0 |
+| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | NetBox 4.7.0 |
 
 ## dcim.modulebay
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_module_bay_name_on_device | 1 | logical | name, device | N/A | Matches on fields: name, device | All versions |
-| dcim_modulebay_unique_device_module_name | 2 | builtin | device, module, name | N/A | Matches on unique constraint fields: device, module, name | All versions |
+| dcim_modulebay_unique_device_module_name | 2 | builtin | device, module, name | N/A | Matches on unique constraint fields: device, module, name | NetBox 4.7.0 |
 
 ## dcim.modulebaytype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_modulebaytype_unique_manufacturer_name | 1 | builtin | manufacturer, name | N/A | Matches on unique constraint fields: manufacturer, name | All versions |
-| dcim_modulebaytype_unique_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_modulebaytype_unique_manufacturer_name | 1 | builtin | manufacturer, name | N/A | Matches on unique constraint fields: manufacturer, name | NetBox 4.7.0 |
+| dcim_modulebaytype_unique_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.moduletype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_moduletype_unique_manufacturer_model | 1 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
+| dcim_moduletype_unique_manufacturer_model | 1 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | NetBox 4.7.0 |
 
 ## dcim.moduletypeprofile
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## dcim.platform
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_platform_manufacturer_name | 1 | builtin | manufacturer, name | N/A | Matches on unique constraint fields: manufacturer, name | All versions |
-| dcim_platform_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_platform_manufacturer_name | 1 | builtin | manufacturer, name | N/A | Matches on unique constraint fields: manufacturer, name | NetBox 4.7.0 |
+| dcim_platform_manufacturer_slug | 2 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.powerfeed
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_powerfeed_unique_power_panel_name | 1 | builtin | power_panel, name | N/A | Matches on unique constraint fields: power_panel, name | All versions |
+| dcim_powerfeed_unique_power_panel_name | 1 | builtin | power_panel, name | N/A | Matches on unique constraint fields: power_panel, name | NetBox 4.7.0 |
 
 ## dcim.poweroutlet
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_poweroutlet_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_poweroutlet_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.powerpanel
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_powerpanel_unique_site_name | 1 | builtin | site, name | N/A | Matches on unique constraint fields: site, name | All versions |
+| dcim_powerpanel_unique_site_name | 1 | builtin | site, name | N/A | Matches on unique constraint fields: site, name | NetBox 4.7.0 |
 
 ## dcim.powerport
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_powerport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_powerport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.rack
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_rack_site_name_no_location | 1 | logical | site, name | N/A | Match a location-less rack payload by (site, name), any location. | All versions |
-| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | All versions |
-| dcim_rack_unique_location_name | 3 | builtin | location, name | N/A | Matches on unique constraint fields: location, name | All versions |
-| dcim_rack_unique_location_facility_id | 4 | builtin | location, facility_id | N/A | Matches on unique constraint fields: location, facility_id | All versions |
+| unique_asset_tag | 2 | builtin | asset_tag | N/A | Matches on unique field(s): asset_tag | NetBox 4.7.0 |
+| dcim_rack_unique_location_name | 3 | builtin | location, name | N/A | Matches on unique constraint fields: location, name | NetBox 4.7.0 |
+| dcim_rack_unique_location_facility_id | 4 | builtin | location, facility_id | N/A | Matches on unique constraint fields: location, facility_id | NetBox 4.7.0 |
 
 ## dcim.rackgroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.rackreservation
 
@@ -321,82 +325,82 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.racktype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_slug | 1 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| dcim_racktype_unique_manufacturer_model | 2 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | All versions |
-| dcim_racktype_unique_manufacturer_slug | 3 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | All versions |
-| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_slug | 1 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| dcim_racktype_unique_manufacturer_model | 2 | builtin | manufacturer, model | N/A | Matches on unique constraint fields: manufacturer, model | NetBox 4.7.0 |
+| dcim_racktype_unique_manufacturer_slug | 3 | builtin | manufacturer, slug | N/A | Matches on unique constraint fields: manufacturer, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.rearport
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_rearport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| dcim_rearport_unique_device_name | 1 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## dcim.region
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_region_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| dcim_region_parent_slug | 2 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_region_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | NetBox 4.7.0 |
+| dcim_region_parent_slug | 2 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.site
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.sitegroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| dcim_sitegroup_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| dcim_sitegroup_parent_slug | 2 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| dcim_sitegroup_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | NetBox 4.7.0 |
+| dcim_sitegroup_parent_slug | 2 | builtin | parent, slug | N/A | Matches on unique constraint fields: parent, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## dcim.virtualchassis
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_vc_name_no_master | 1 | logical | name | N/A | Best-effort VirtualChassis matcher: by name, only when the payload has no master. | All versions |
-| unique_master | 2 | builtin | master | N/A | Matches on unique field(s): master | All versions |
+| unique_master | 2 | builtin | master | N/A | Matches on unique field(s): master | NetBox 4.7.0 |
 
 ## dcim.virtualdevicecontext
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_primary_ip4 | 1 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
-| unique_primary_ip6 | 2 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
-| dcim_virtualdevicecontext_device_identifier | 3 | builtin | device, identifier | N/A | Matches on unique constraint fields: device, identifier | All versions |
-| dcim_virtualdevicecontext_device_name | 4 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | All versions |
+| unique_primary_ip4 | 1 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | NetBox 4.7.0 |
+| unique_primary_ip6 | 2 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | NetBox 4.7.0 |
+| dcim_virtualdevicecontext_device_identifier | 3 | builtin | device, identifier | N/A | Matches on unique constraint fields: device, identifier | NetBox 4.7.0 |
+| dcim_virtualdevicecontext_device_name | 4 | builtin | device, name | N/A | Matches on unique constraint fields: device, name | NetBox 4.7.0 |
 
 ## extras.customfield
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## extras.customfieldchoiceset
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## extras.customlink
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## extras.journalentry
 
@@ -408,9 +412,9 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## ipam.aggregate
 
@@ -423,15 +427,15 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_asn | 1 | builtin | asn | N/A | Matches on unique field(s): asn | All versions |
+| unique_asn | 1 | builtin | asn | N/A | Matches on unique field(s): asn | NetBox 4.7.0 |
 
 ## ipam.asnrange
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## ipam.fhrpgroup
 
@@ -443,7 +447,7 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| ipam_fhrpgroupassignment_unique_interface_group | 1 | builtin | interface_type, interface_id, group | N/A | Matches on unique constraint fields: interface_type, interface_id, group | All versions |
+| ipam_fhrpgroupassignment_unique_interface_group | 1 | builtin | interface_type, interface_id, group | N/A | Matches on unique constraint fields: interface_type, interface_id, group | NetBox 4.7.0 |
 
 ## ipam.ipaddress
 
@@ -470,23 +474,23 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## ipam.role
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## ipam.routetarget
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## ipam.service
 
@@ -503,32 +507,32 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_vlan_vid_no_group_or_svlan_or_site | 1 | logical | vid | group is NULL AND qinq_svlan is NULL AND site is NULL | Matches on fields: vid where group is NULL AND qinq_svlan is NULL AND site is NULL | All versions |
 | logical_vlan_in_site | 2 | logical | vid, site | group is NULL AND qinq_svlan is NULL AND site is NOT NULL | Matches on fields: vid, site where group is NULL AND qinq_svlan is NULL AND site is NOT NULL | All versions |
-| ipam_vlan_unique_group_vid | 3 | builtin | group, vid | N/A | Matches on unique constraint fields: group, vid | All versions |
-| ipam_vlan_unique_group_name | 4 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| ipam_vlan_unique_qinq_svlan_vid | 5 | builtin | qinq_svlan, vid | N/A | Matches on unique constraint fields: qinq_svlan, vid | All versions |
-| ipam_vlan_unique_qinq_svlan_name | 6 | builtin | qinq_svlan, name | N/A | Matches on unique constraint fields: qinq_svlan, name | All versions |
+| ipam_vlan_unique_group_vid | 3 | builtin | group, vid | N/A | Matches on unique constraint fields: group, vid | NetBox 4.7.0 |
+| ipam_vlan_unique_group_name | 4 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | NetBox 4.7.0 |
+| ipam_vlan_unique_qinq_svlan_vid | 5 | builtin | qinq_svlan, vid | N/A | Matches on unique constraint fields: qinq_svlan, vid | NetBox 4.7.0 |
+| ipam_vlan_unique_qinq_svlan_name | 6 | builtin | qinq_svlan, name | N/A | Matches on unique constraint fields: qinq_svlan, name | NetBox 4.7.0 |
 
 ## ipam.vlangroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_vlan_group_name_no_scope | 1 | logical | name | scope_type is NULL | Matches on fields: name where scope_type is NULL | All versions |
-| ipam_vlangroup_unique_scope_name | 2 | builtin | scope_type, scope_id, name | N/A | Matches on unique constraint fields: scope_type, scope_id, name | All versions |
-| ipam_vlangroup_unique_scope_slug | 3 | builtin | scope_type, scope_id, slug | N/A | Matches on unique constraint fields: scope_type, scope_id, slug | All versions |
-| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| ipam_vlangroup_unique_scope_name | 2 | builtin | scope_type, scope_id, name | N/A | Matches on unique constraint fields: scope_type, scope_id, name | NetBox 4.7.0 |
+| ipam_vlangroup_unique_scope_slug | 3 | builtin | scope_type, scope_id, slug | N/A | Matches on unique constraint fields: scope_type, scope_id, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 4 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## ipam.vlantranslationpolicy
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## ipam.vlantranslationrule
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| ipam_vlantranslationrule_unique_policy_local_vid | 1 | builtin | policy, local_vid | N/A | Matches on unique constraint fields: policy, local_vid | All versions |
-| ipam_vlantranslationrule_unique_policy_remote_vid | 2 | builtin | policy, remote_vid | N/A | Matches on unique constraint fields: policy, remote_vid | All versions |
+| ipam_vlantranslationrule_unique_policy_local_vid | 1 | builtin | policy, local_vid | N/A | Matches on unique constraint fields: policy, local_vid | NetBox 4.7.0 |
+| ipam_vlantranslationrule_unique_policy_remote_vid | 2 | builtin | policy, remote_vid | N/A | Matches on unique constraint fields: policy, remote_vid | NetBox 4.7.0 |
 
 ## ipam.vrf
 
@@ -536,7 +540,7 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_vrf_name_no_tenant | 1 | logical | name | rd is NULL AND tenant is NULL | Matches on fields: name where rd is NULL AND tenant is NULL | All versions |
 | logical_vrf_name_within_tenant | 2 | logical | name, tenant | rd is NULL AND tenant is NOT NULL | Matches on fields: name, tenant where rd is NULL AND tenant is NOT NULL | All versions |
-| unique_rd | 3 | builtin | rd | N/A | Matches on unique field(s): rd | All versions |
+| unique_rd | 3 | builtin | rd | N/A | Matches on unique field(s): rd | NetBox 4.7.0 |
 
 ## tenancy.contact
 
@@ -548,56 +552,56 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| tenancy_contactassignment_unique_object_contact_role | 1 | builtin | object_type, object_id, contact, role | N/A | Matches on unique constraint fields: object_type, object_id, contact, role | All versions |
+| tenancy_contactassignment_unique_object_contact_role | 1 | builtin | object_type, object_id, contact, role | N/A | Matches on unique constraint fields: object_type, object_id, contact, role | NetBox 4.7.0 |
 
 ## tenancy.contactgroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| tenancy_contactgroup_unique_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | All versions |
-| unique_autoslug_slug | 2 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| tenancy_contactgroup_unique_parent_name | 1 | builtin | parent, name | N/A | Matches on unique constraint fields: parent, name | NetBox 4.7.0 |
+| unique_autoslug_slug | 2 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## tenancy.contactrole
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## tenancy.tenant
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| tenancy_tenant_unique_group_name | 1 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| tenancy_tenant_unique_group_slug | 2 | builtin | group, slug | N/A | Matches on unique constraint fields: group, slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| tenancy_tenant_unique_group_name | 1 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | NetBox 4.7.0 |
+| tenancy_tenant_unique_group_slug | 2 | builtin | group, slug | N/A | Matches on unique constraint fields: group, slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## tenancy.tenantgroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## users.owner
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## users.ownergroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## users.user
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_username | 1 | builtin | username | N/A | Matches on unique field(s): username | All versions |
+| unique_username | 1 | builtin | username | N/A | Matches on unique field(s): username | NetBox 4.7.0 |
 
 ## virtualization.cluster
 
@@ -605,119 +609,119 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_cluster_within_scope | 1 | logical | name, scope_type, scope_id | scope_type is NOT NULL | Matches on fields: name, scope_type, scope_id where scope_type is NOT NULL | All versions |
 | logical_cluster_with_no_scope_or_group | 2 | logical | name | group is NULL AND scope_type is NULL | Matches on fields: name where group is NULL AND scope_type is NULL | All versions |
-| virtualization_cluster_unique_group_name | 3 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | All versions |
-| virtualization_cluster_unique__site_name | 4 | builtin | _site, name | N/A | Matches on unique constraint fields: _site, name | All versions |
+| virtualization_cluster_unique_group_name | 3 | builtin | group, name | N/A | Matches on unique constraint fields: group, name | NetBox 4.7.0 |
+| virtualization_cluster_unique__site_name | 4 | builtin | _site, name | N/A | Matches on unique constraint fields: _site, name | NetBox 4.7.0 |
 
 ## virtualization.clustergroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## virtualization.clustertype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## virtualization.virtualdisk
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| virtualization_virtualdisk_unique_virtual_machine_name | 1 | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |
+| virtualization_virtualdisk_unique_virtual_machine_name | 1 | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | NetBox 4.7.0 |
 
 ## virtualization.virtualmachine
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
 | logical_virtual_machine_name_no_cluster | 1 | logical | name | cluster is NULL | Matches on fields: name where cluster is NULL | All versions |
-| unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | All versions |
-| unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | All versions |
-| virtualization_virtualmachine_unique_name_cluster_tenant | 4 | builtin |  | cluster is NOT NULL | Custom matcher | All versions |
-| virtualization_virtualmachine_unique_name_device_tenant | 5 | builtin |  | cluster is NULL AND device is NOT NULL | Custom matcher | All versions |
+| unique_primary_ip4 | 2 | builtin | primary_ip4 | N/A | Matches on unique field(s): primary_ip4 | NetBox 4.7.0 |
+| unique_primary_ip6 | 3 | builtin | primary_ip6 | N/A | Matches on unique field(s): primary_ip6 | NetBox 4.7.0 |
+| virtualization_virtualmachine_unique_name_cluster_tenant | 4 | builtin |  | cluster is NOT NULL | Custom matcher | NetBox 4.7.0 |
+| virtualization_virtualmachine_unique_name_device_tenant | 5 | builtin |  | cluster is NULL AND device is NOT NULL | Custom matcher | NetBox 4.7.0 |
 
 ## virtualization.virtualmachinetype
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_slug | 1 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| virtualization_virtualmachinetype_unique_name | 2 | builtin |  | N/A | Custom matcher | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_slug | 1 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| virtualization_virtualmachinetype_unique_name | 2 | builtin |  | N/A | Custom matcher | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## virtualization.vminterface
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | All versions |
-| virtualization_vminterface_unique_virtual_machine_name | 2 | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | All versions |
+| unique_primary_mac_address | 1 | builtin | primary_mac_address | N/A | Matches on unique field(s): primary_mac_address | NetBox 4.7.0 |
+| virtualization_vminterface_unique_virtual_machine_name | 2 | builtin | virtual_machine, name | N/A | Matches on unique constraint fields: virtual_machine, name | NetBox 4.7.0 |
 
 ## vpn.ikepolicy
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## vpn.ikeproposal
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## vpn.ipsecpolicy
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## vpn.ipsecprofile
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## vpn.ipsecproposal
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## vpn.l2vpn
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## vpn.l2vpntermination
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| vpn_l2vpntermination_assigned_object | 1 | builtin | assigned_object_type, assigned_object_id | N/A | Matches on unique constraint fields: assigned_object_type, assigned_object_id | All versions |
+| vpn_l2vpntermination_assigned_object | 1 | builtin | assigned_object_type, assigned_object_id | N/A | Matches on unique constraint fields: assigned_object_type, assigned_object_id | NetBox 4.7.0 |
 
 ## vpn.tunnel
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
 
 ## vpn.tunnelgroup
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## vpn.tunneltermination
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| vpn_tunneltermination_termination | 1 | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | All versions |
+| vpn_tunneltermination_termination | 1 | builtin | termination_type, termination_id | N/A | Matches on unique constraint fields: termination_type, termination_id | NetBox 4.7.0 |
 
 ## wireless.wirelesslan
 
@@ -731,12 +735,12 @@ This document describes how the Diode NetBox Plugin matches existing objects whe
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | All versions |
-| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | All versions |
-| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | All versions |
+| unique_name | 1 | builtin | name | N/A | Matches on unique field(s): name | NetBox 4.7.0 |
+| unique_slug | 2 | builtin | slug | N/A | Matches on unique field(s): slug | NetBox 4.7.0 |
+| unique_autoslug_slug | 3 | builtin | slug | N/A | Matches on auto-generated slug field: slug | NetBox 4.7.0 |
 
 ## wireless.wirelesslink
 
 | Matcher Name | Order of Precedence | Type | Fields | Condition | Description | Version Constraints |
 |--------------|---------------------|------|--------|-----------|-------------|---------------------|
-| wireless_wirelesslink_unique_interfaces | 1 | builtin | interface_a, interface_b | N/A | Matches on unique constraint fields: interface_a, interface_b | All versions |
+| wireless_wirelesslink_unique_interfaces | 1 | builtin | interface_a, interface_b | N/A | Matches on unique constraint fields: interface_a, interface_b | NetBox 4.7.0 |

--- a/netbox_diode_plugin/api/applier.py
+++ b/netbox_diode_plugin/api/applier.py
@@ -99,6 +99,8 @@ def _is_auto_created_component(object_type: str) -> bool:
         "dcim.consoleserverport",
         "dcim.powerport",
         "dcim.poweroutlet",
+        "dcim.coolingintake",
+        "dcim.coolingoutflow",
         "dcim.interface",
         "dcim.rearport",
         "dcim.frontport",

--- a/netbox_diode_plugin/management/commands/generate_matching_docs.py
+++ b/netbox_diode_plugin/management/commands/generate_matching_docs.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from netbox_diode_plugin.api.differ import extract_supported_models
@@ -240,8 +241,16 @@ class Command(BaseCommand):
 
         return combined
 
-    def generate_markdown_table(self, docs: dict[str, list[MatcherInfo]]) -> str:
-        """Generate a markdown table from the documentation."""
+    def generate_markdown_table(self, docs: dict[str, list[MatcherInfo]], netbox_version: str | None = None) -> str:
+        """
+        Generate a markdown table from the documentation.
+
+        Builtin matchers are derived from the model constraints of the NetBox
+        release the command runs on, so the document is scoped to that release:
+        its version is stamped in the header and on every builtin row that has
+        no plugin-side version gate. Logical matchers carry the plugin's own
+        min/max gates, which hold across releases.
+        """
         markdown = []
         markdown.append("# NetBox Diode Plugin - Object Matching Criteria")
         markdown.append("")
@@ -250,6 +259,19 @@ class Command(BaseCommand):
             "The matchers will be applied in the order of their precedence, unttil one of them matches."
         )
         markdown.append("")
+        if netbox_version:
+            markdown.append(f"Generated on NetBox {netbox_version}.")
+            markdown.append("")
+            markdown.append(
+                "Builtin matchers are derived from that release's model constraints and are listed as they exist "
+                "there. Other NetBox releases the plugin supports may declare the same identity through different "
+                "constraints (for example, NetBox 4.7 replaced conditional constraint pairs such as "
+                "`name where parent is NULL` with single `nulls_distinct=False` constraints); the matcher derives "
+                "whichever form the running release declares. In the Version Constraints column, "
+                "\"NetBox <version>\" on a builtin row means the row reflects that release; a version range on a "
+                "logical row is the plugin's own gate."
+            )
+            markdown.append("")
         markdown.append("## Matcher Types")
         markdown.append("")
         markdown.append("- **Logical Matchers**: Custom matching criteria that represent likely user intent")
@@ -284,7 +306,12 @@ class Command(BaseCommand):
                 fields_str = ", ".join(matcher.fields).replace("|", "\\|") if matcher.fields else ""
                 condition_str = matcher.condition.replace("|", "\\|") if matcher.condition and matcher.condition != "None" else "N/A"
                 description = matcher.description.replace("|", "\\|") if matcher.description else "N/A"
-                version_str = matcher.version_constraints.replace("|", "\\|") if matcher.version_constraints else "All versions"
+                if matcher.version_constraints:
+                    version_str = matcher.version_constraints.replace("|", "\\|")
+                elif netbox_version and matcher.matcher_source == "builtin":
+                    version_str = f"NetBox {netbox_version}"
+                else:
+                    version_str = "All versions"
 
                 markdown.append(
                     f"| {name} | {precedence} | {matcher_type} | {fields_str} | {condition_str} | {description} | {version_str} |"
@@ -293,6 +320,13 @@ class Command(BaseCommand):
             markdown.append("")
 
         return "\n".join(markdown)
+
+    @staticmethod
+    def get_netbox_version() -> str | None:
+        """The running NetBox release, or None when it cannot be read."""
+        release = getattr(settings, "RELEASE", None)
+        version = getattr(release, "version", None) or getattr(settings, "VERSION", None)
+        return str(version) if version else None
 
     def handle(self, *args, **options):
         """Handle the command execution."""
@@ -306,5 +340,6 @@ class Command(BaseCommand):
         combined_docs = self.combine_matchers(logical_docs, builtin_docs)
 
         self.stdout.write("Generating markdown documentation...")
-        markdown_content = self.generate_markdown_table(combined_docs)
+        markdown_content = self.generate_markdown_table(
+            combined_docs, netbox_version=self.get_netbox_version())
         self.stdout.write(markdown_content)

--- a/netbox_diode_plugin/tests/v4.4.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.4.x/tests/test_generate_matching_docs.py
@@ -7,6 +7,7 @@ import sys
 from unittest import mock
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db.models import Q
@@ -709,3 +710,45 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         # Check that empty fields list is handled
         self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result)
+
+
+
+class DocumentVersionScopeTestCase(TestCase):
+    """The generated document is scoped to the NetBox release it was produced on."""
+
+    def setUp(self):
+        """Set up test."""
+        self.command = Command()
+        self.docs = {
+            "dcim.site": [
+                MatcherInfo(name="logical_site", matcher_source="logical",
+                            fields=["name"], description="logical, no gate"),
+                MatcherInfo(name="logical_gated", matcher_source="logical",
+                            fields=["slug"], description="logical, gated", version_constraints="≥4.3.0"),
+                MatcherInfo(name="dcim_site_unique_name", matcher_source="builtin",
+                            fields=["name"], description="builtin"),
+            ],
+        }
+
+    def test_header_and_builtin_rows_carry_the_release(self):
+        """A builtin row without a plugin gate is stamped with the release, not "All versions"."""
+        result = self.command.generate_markdown_table(self.docs, netbox_version="4.7.0")
+        self.assertIn("Generated on NetBox 4.7.0.", result)
+        self.assertIn("nulls_distinct=False", result)
+        self.assertIn("| dcim_site_unique_name | 3 | builtin | name | N/A | builtin | NetBox 4.7.0 |", result)
+        self.assertIn("| logical_site | 1 | logical | name | N/A | logical, no gate | All versions |", result)
+        self.assertIn("| logical_gated | 2 | logical | slug | N/A | logical, gated | ≥4.3.0 |", result)
+
+    def test_without_a_release_nothing_is_stamped(self):
+        """Callers that pass no release keep the previous output."""
+        result = self.command.generate_markdown_table(self.docs)
+        self.assertNotIn("Generated on NetBox", result)
+        self.assertIn("| dcim_site_unique_name | 3 | builtin | name | N/A | builtin | All versions |", result)
+
+    def test_handle_stamps_the_running_release(self):
+        """The command reads the release from settings and passes it through."""
+        self.assertEqual(self.command.get_netbox_version(), str(settings.RELEASE.version))
+        self.command.stdout = io.StringIO()
+        with mock.patch.object(self.command, "get_netbox_version", return_value="9.9.9"):
+            self.command.handle()
+        self.assertIn("Generated on NetBox 9.9.9.", self.command.stdout.getvalue())

--- a/netbox_diode_plugin/tests/v4.5.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.5.x/tests/test_generate_matching_docs.py
@@ -7,6 +7,7 @@ import sys
 from unittest import mock
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db.models import Q
@@ -709,3 +710,45 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         # Check that empty fields list is handled
         self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result)
+
+
+
+class DocumentVersionScopeTestCase(TestCase):
+    """The generated document is scoped to the NetBox release it was produced on."""
+
+    def setUp(self):
+        """Set up test."""
+        self.command = Command()
+        self.docs = {
+            "dcim.site": [
+                MatcherInfo(name="logical_site", matcher_source="logical",
+                            fields=["name"], description="logical, no gate"),
+                MatcherInfo(name="logical_gated", matcher_source="logical",
+                            fields=["slug"], description="logical, gated", version_constraints="≥4.3.0"),
+                MatcherInfo(name="dcim_site_unique_name", matcher_source="builtin",
+                            fields=["name"], description="builtin"),
+            ],
+        }
+
+    def test_header_and_builtin_rows_carry_the_release(self):
+        """A builtin row without a plugin gate is stamped with the release, not "All versions"."""
+        result = self.command.generate_markdown_table(self.docs, netbox_version="4.7.0")
+        self.assertIn("Generated on NetBox 4.7.0.", result)
+        self.assertIn("nulls_distinct=False", result)
+        self.assertIn("| dcim_site_unique_name | 3 | builtin | name | N/A | builtin | NetBox 4.7.0 |", result)
+        self.assertIn("| logical_site | 1 | logical | name | N/A | logical, no gate | All versions |", result)
+        self.assertIn("| logical_gated | 2 | logical | slug | N/A | logical, gated | ≥4.3.0 |", result)
+
+    def test_without_a_release_nothing_is_stamped(self):
+        """Callers that pass no release keep the previous output."""
+        result = self.command.generate_markdown_table(self.docs)
+        self.assertNotIn("Generated on NetBox", result)
+        self.assertIn("| dcim_site_unique_name | 3 | builtin | name | N/A | builtin | All versions |", result)
+
+    def test_handle_stamps_the_running_release(self):
+        """The command reads the release from settings and passes it through."""
+        self.assertEqual(self.command.get_netbox_version(), str(settings.RELEASE.version))
+        self.command.stdout = io.StringIO()
+        with mock.patch.object(self.command, "get_netbox_version", return_value="9.9.9"):
+            self.command.handle()
+        self.assertIn("Generated on NetBox 9.9.9.", self.command.stdout.getvalue())

--- a/netbox_diode_plugin/tests/v4.6.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.6.x/tests/test_generate_matching_docs.py
@@ -7,6 +7,7 @@ import sys
 from unittest import mock
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db.models import Q
@@ -709,3 +710,45 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         # Check that empty fields list is handled
         self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result)
+
+
+
+class DocumentVersionScopeTestCase(TestCase):
+    """The generated document is scoped to the NetBox release it was produced on."""
+
+    def setUp(self):
+        """Set up test."""
+        self.command = Command()
+        self.docs = {
+            "dcim.site": [
+                MatcherInfo(name="logical_site", matcher_source="logical",
+                            fields=["name"], description="logical, no gate"),
+                MatcherInfo(name="logical_gated", matcher_source="logical",
+                            fields=["slug"], description="logical, gated", version_constraints="≥4.3.0"),
+                MatcherInfo(name="dcim_site_unique_name", matcher_source="builtin",
+                            fields=["name"], description="builtin"),
+            ],
+        }
+
+    def test_header_and_builtin_rows_carry_the_release(self):
+        """A builtin row without a plugin gate is stamped with the release, not "All versions"."""
+        result = self.command.generate_markdown_table(self.docs, netbox_version="4.7.0")
+        self.assertIn("Generated on NetBox 4.7.0.", result)
+        self.assertIn("nulls_distinct=False", result)
+        self.assertIn("| dcim_site_unique_name | 3 | builtin | name | N/A | builtin | NetBox 4.7.0 |", result)
+        self.assertIn("| logical_site | 1 | logical | name | N/A | logical, no gate | All versions |", result)
+        self.assertIn("| logical_gated | 2 | logical | slug | N/A | logical, gated | ≥4.3.0 |", result)
+
+    def test_without_a_release_nothing_is_stamped(self):
+        """Callers that pass no release keep the previous output."""
+        result = self.command.generate_markdown_table(self.docs)
+        self.assertNotIn("Generated on NetBox", result)
+        self.assertIn("| dcim_site_unique_name | 3 | builtin | name | N/A | builtin | All versions |", result)
+
+    def test_handle_stamps_the_running_release(self):
+        """The command reads the release from settings and passes it through."""
+        self.assertEqual(self.command.get_netbox_version(), str(settings.RELEASE.version))
+        self.command.stdout = io.StringIO()
+        with mock.patch.object(self.command, "get_netbox_version", return_value="9.9.9"):
+            self.command.handle()
+        self.assertIn("Generated on NetBox 9.9.9.", self.command.stdout.getvalue())

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_cooling_component_templates.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_cooling_component_templates.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Diode NetBox Plugin - Tests: cooling components instantiated from templates."""
+
+import uuid
+from decimal import Decimal
+
+from dcim.models import (
+    CoolingIntake,
+    CoolingIntakeTemplate,
+    CoolingOutflow,
+    CoolingOutflowTemplate,
+    Device,
+    DeviceType,
+    Manufacturer,
+)
+
+from .test_api_apply_change_set import BaseApplyChangeSet
+
+
+class CoolingComponentTemplateTestCase(BaseApplyChangeSet):
+    """
+    Cooling intakes and outflows are instantiated from device-type templates.
+
+    NetBox 4.7 creates them on the device's first save exactly like interfaces
+    and the other component templates, so a CREATE for such a component must be
+    applied to the instantiated row -- not duplicated, and not silently dropped
+    in favour of the template's defaults.
+    """
+
+    @staticmethod
+    def _create(object_type, ref_id, data, new_refs=None):
+        change = {
+            "change_id": str(uuid.uuid4()),
+            "change_type": "create",
+            "object_version": None,
+            "object_type": object_type,
+            "object_id": None,
+            "ref_id": ref_id,
+            "data": data,
+        }
+        if new_refs:
+            change["new_refs"] = new_refs
+        return change
+
+    @staticmethod
+    def _payload(*changes):
+        return {"id": str(uuid.uuid4()), "changes": list(changes)}
+
+    def setUp(self):
+        """A device type whose templates yield one intake and one outflow."""
+        super().setUp()
+        self.device_type = DeviceType.objects.create(
+            manufacturer=Manufacturer.objects.first(),
+            model="Device with Cooling Templates",
+            slug="device-with-cooling-templates",
+        )
+        CoolingIntakeTemplate.objects.create(device_type=self.device_type, name="intake-1")
+        CoolingOutflowTemplate.objects.create(device_type=self.device_type, name="outflow-1")
+
+    def _device_change(self):
+        return self._create("dcim.device", "device-1", {
+            "name": "Cooled Device",
+            "device_type": self.device_type.id,
+            "role": self.roles[0].id,
+            "site": self.sites[0].id,
+        })
+
+    def _intake_data(self, device):
+        return {
+            "name": "intake-1",
+            "device": device,
+            "type": "uqd",
+            "diameter": "12.70",
+            "diameter_unit": "mm",
+            "max_flow": "3.50",
+            "max_flow_unit": "lpm",
+            "description": "Ingested intake",
+        }
+
+    def _outflow_data(self, device, intake):
+        return {
+            "name": "outflow-1",
+            "device": device,
+            "type": "qdc",
+            "diameter": "12.70",
+            "diameter_unit": "mm",
+            "cooling_intake": intake,
+            "description": "Ingested outflow",
+        }
+
+    def _assert_ingested(self, device):
+        intakes = CoolingIntake.objects.filter(device=device, name="intake-1")
+        outflows = CoolingOutflow.objects.filter(device=device, name="outflow-1")
+        self.assertEqual(intakes.count(), 1, "intake should be reused, not duplicated")
+        self.assertEqual(outflows.count(), 1, "outflow should be reused, not duplicated")
+        intake, outflow = intakes.get(), outflows.get()
+        self.assertEqual(intake.type, "uqd")
+        self.assertEqual(intake.diameter, Decimal("12.70"))
+        self.assertEqual(intake.diameter_unit, "mm")
+        self.assertEqual(intake.max_flow, Decimal("3.50"))
+        self.assertEqual(intake.max_flow_unit, "lpm")
+        self.assertEqual(intake.description, "Ingested intake")
+        self.assertEqual(outflow.type, "qdc")
+        self.assertEqual(outflow.diameter, Decimal("12.70"))
+        self.assertEqual(outflow.cooling_intake_id, intake.id)
+        self.assertEqual(outflow.description, "Ingested outflow")
+
+    def test_device_save_instantiates_cooling_components(self):
+        """Premise: NetBox instantiates both templates with their defaults."""
+        self.send_request(self._payload(self._device_change()))
+        device = Device.objects.get(name="Cooled Device")
+        intake = CoolingIntake.objects.get(device=device, name="intake-1")
+        outflow = CoolingOutflow.objects.get(device=device, name="outflow-1")
+        self.assertIsNone(intake.type)
+        self.assertEqual(intake.description, "")
+        self.assertIsNone(outflow.cooling_intake)
+
+    def test_device_and_cooling_components_in_one_changeset(self):
+        """The discovery shape: device, intake and outflow created together by ref."""
+        self.send_request(self._payload(
+            self._device_change(),
+            self._create("dcim.coolingintake", "intake-1",
+                         self._intake_data("device-1"), new_refs=["device"]),
+            self._create("dcim.coolingoutflow", "outflow-1",
+                         self._outflow_data("device-1", "intake-1"),
+                         new_refs=["device", "cooling_intake"]),
+        ))
+        self._assert_ingested(Device.objects.get(name="Cooled Device"))
+
+    def test_cooling_components_ingested_after_the_device(self):
+        """A later request against an existing device updates the instantiated rows."""
+        self.send_request(self._payload(self._device_change()))
+        device = Device.objects.get(name="Cooled Device")
+        intake = CoolingIntake.objects.get(device=device, name="intake-1")
+        self.send_request(self._payload(
+            self._create("dcim.coolingintake", "intake-1", self._intake_data(device.id)),
+        ))
+        self.send_request(self._payload(
+            self._create("dcim.coolingoutflow", "outflow-1",
+                         self._outflow_data(device.id, intake.id)),
+        ))
+        self._assert_ingested(device)

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_generate_matching_docs.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_generate_matching_docs.py
@@ -7,6 +7,7 @@ import sys
 from unittest import mock
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db.models import Q
@@ -709,3 +710,45 @@ class GenerateMatchingDocsCommandTestCase(TestCase):
 
         # Check that empty fields list is handled
         self.assertIn("| test_matcher | 1 | logical |  | N/A | Test description | All versions |", result)
+
+
+
+class DocumentVersionScopeTestCase(TestCase):
+    """The generated document is scoped to the NetBox release it was produced on."""
+
+    def setUp(self):
+        """Set up test."""
+        self.command = Command()
+        self.docs = {
+            "dcim.site": [
+                MatcherInfo(name="logical_site", matcher_source="logical",
+                            fields=["name"], description="logical, no gate"),
+                MatcherInfo(name="logical_gated", matcher_source="logical",
+                            fields=["slug"], description="logical, gated", version_constraints="≥4.3.0"),
+                MatcherInfo(name="dcim_site_unique_name", matcher_source="builtin",
+                            fields=["name"], description="builtin"),
+            ],
+        }
+
+    def test_header_and_builtin_rows_carry_the_release(self):
+        """A builtin row without a plugin gate is stamped with the release, not "All versions"."""
+        result = self.command.generate_markdown_table(self.docs, netbox_version="4.7.0")
+        self.assertIn("Generated on NetBox 4.7.0.", result)
+        self.assertIn("nulls_distinct=False", result)
+        self.assertIn("| dcim_site_unique_name | 3 | builtin | name | N/A | builtin | NetBox 4.7.0 |", result)
+        self.assertIn("| logical_site | 1 | logical | name | N/A | logical, no gate | All versions |", result)
+        self.assertIn("| logical_gated | 2 | logical | slug | N/A | logical, gated | ≥4.3.0 |", result)
+
+    def test_without_a_release_nothing_is_stamped(self):
+        """Callers that pass no release keep the previous output."""
+        result = self.command.generate_markdown_table(self.docs)
+        self.assertNotIn("Generated on NetBox", result)
+        self.assertIn("| dcim_site_unique_name | 3 | builtin | name | N/A | builtin | All versions |", result)
+
+    def test_handle_stamps_the_running_release(self):
+        """The command reads the release from settings and passes it through."""
+        self.assertEqual(self.command.get_netbox_version(), str(settings.RELEASE.version))
+        self.command.stdout = io.StringIO()
+        with mock.patch.object(self.command, "get_netbox_version", return_value="9.9.9"):
+            self.command.handle()
+        self.assertIn("Generated on NetBox 9.9.9.", self.command.stdout.getvalue())

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rackreservation_ingest_convergence.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rackreservation_ingest_convergence.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""
+RackReservation ingest convergence: overlap identity end-to-end.
+
+All rack payloads here carry a location and the rack is pre-seeded with it,
+so the rack ref re-matches on every cycle; the location-less rack shape has
+a separate, known matching gap and is deliberately not used.
+"""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from tenancy.models import Tenant
+from users.models import User
+
+from netbox_diode_plugin.api.applier import apply_changeset
+from netbox_diode_plugin.api.common import ChangeSetException
+from netbox_diode_plugin.api.differ import generate_changeset
+
+
+class RackReservationConvergenceTestCase(TestCase):
+    """Diff+apply round-trips for the unit-overlap identity."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Location-bearing rack and the reservation's user, pre-seeded."""
+        cls.site = Site.objects.create(name="rrc-site", slug="rrc-site")
+        cls.location = Location.objects.create(
+            name="rrc-loc", slug="rrc-loc", site=cls.site
+        )
+        cls.rack = Rack.objects.create(
+            name="rrc-rack", site=cls.site, location=cls.location
+        )
+        cls.user = User.objects.create(username="rrc-owner")
+        cls.user2 = User.objects.create(username="rrc-owner2")
+        cls.tenant = Tenant.objects.create(name="rrc-tenant", slug="rrc-tenant")
+
+    def _entity(self, units, description="reserved", username="rrc-owner", tenant=None, status=None):
+        entity = {
+            "rack": {
+                "name": "rrc-rack",
+                "site": {"name": "rrc-site"},
+                "location": {"name": "rrc-loc", "site": {"name": "rrc-site"}},
+            },
+            "units": units,
+            "description": description,
+            "user": {"username": username},
+        }
+        if tenant is not None:
+            entity["tenant"] = {"name": tenant}
+        if status is not None:
+            entity["status"] = status
+        return entity
+
+    def _plan(self, entity):
+        return generate_changeset(entity, "dcim.rackreservation").change_set
+
+    def _apply(self, change_set):
+        return apply_changeset(change_set, request=None)
+
+    def _ingest(self, entity):
+        self._apply(self._plan(entity))
+
+    def test_identical_reingest_is_all_noop(self):
+        """The convergence bug: a second identical ingest must plan nothing."""
+        self._ingest(self._entity([1, 2, 3]))
+        cs = self._plan(self._entity([1, 2, 3]))
+        non_noop = [c for c in cs.changes if c.change_type.value != "noop"]
+        self.assertEqual(non_noop, [], [c.to_dict() for c in non_noop])
+        # and the rack itself re-matched (guards the test's own premise)
+        self.assertEqual(Rack.objects.filter(name="rrc-rack").count(), 1)
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_grow_units_updates_in_place(self):
+        """[1, 2] -> [1, 2, 3] is an UPDATE of the same row."""
+        self._ingest(self._entity([1, 2]))
+        rr = RackReservation.objects.get()
+        cs = self._plan(self._entity([1, 2, 3]))
+        updates = [c for c in cs.changes
+                   if c.object_type == "dcim.rackreservation"]
+        self.assertEqual(len(updates), 1, [c.to_dict() for c in cs.changes])
+        self.assertEqual(updates[0].change_type.value, "update")
+        self.assertEqual(updates[0].object_id, rr.pk)
+        self._apply(cs)
+        rr.refresh_from_db()
+        self.assertEqual(sorted(rr.units), [1, 2, 3])
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_shrink_units_updates_in_place(self):
+        """[1, 2, 3] -> [1, 2] shrinks the stored set (last writer wins)."""
+        self._ingest(self._entity([1, 2, 3]))
+        rr = RackReservation.objects.get()
+        cs = self._plan(self._entity([1, 2]))
+        updates = [c for c in cs.changes
+                   if c.object_type == "dcim.rackreservation"]
+        self.assertEqual(len(updates), 1, [c.to_dict() for c in cs.changes])
+        self.assertEqual(updates[0].change_type.value, "update")
+        self.assertEqual(updates[0].object_id, rr.pk)
+        self._apply(cs)
+        rr.refresh_from_db()
+        self.assertEqual(sorted(rr.units), [1, 2])
+        self.assertEqual(RackReservation.objects.count(), 1)
+
+    def test_disjoint_units_create_second_reservation(self):
+        """No shared unit means a different reservation, any user."""
+        self._ingest(self._entity([1, 2]))
+        self._ingest(self._entity([5, 6], username="rrc-owner2"))
+        self.assertEqual(RackReservation.objects.count(), 2)
+        by_units = {tuple(sorted(r.units)): r for r in RackReservation.objects.all()}
+        self.assertEqual(by_units[(1, 2)].user_id, self.user.pk)
+        self.assertEqual(by_units[(5, 6)].user_id, self.user2.pk)
+
+    def test_field_changes_flow_through_on_match(self):
+        """description/user/tenant/status updates ride the overlap match."""
+        self._ingest(self._entity([1, 2], description="old"))
+        self._ingest(self._entity(
+            [1, 2],
+            description="new",
+            username="rrc-owner2",
+            tenant="rrc-tenant",
+            status="pending"
+        ))
+        rr = RackReservation.objects.get()
+        self.assertEqual(rr.description, "new")
+        self.assertEqual(rr.user_id, self.user2.pk)
+        self.assertEqual(rr.tenant_id, self.tenant.pk)
+        self.assertEqual(rr.status, "pending")
+
+    def test_multi_overlap_fails_at_plan_time(self):
+        """A payload spanning two reservations is refused loudly at plan."""
+        RackReservation.objects.create(
+            rack=self.rack, units=[1], user=self.user, description="a"
+        )
+        RackReservation.objects.create(
+            rack=self.rack, units=[2], user=self.user, description="b"
+        )
+        with self.assertRaises(ChangeSetException) as cm:
+            self._plan(self._entity([1, 2]))
+        self.assertIn("overlap", str(cm.exception))
+        self.assertEqual(RackReservation.objects.count(), 2)  # nothing changed
+
+    def test_batch_invariance_overlapping_plans_converge_to_one_row(self):
+        """Two overlapping CREATEs planned together adopt, last writer wins."""
+        cs_a = self._plan(self._entity([1, 2], description="first"))
+        cs_b = self._plan(self._entity([2, 3], description="second"))
+        self._apply(cs_a)
+        self._apply(cs_b)  # pre-save re-match adopts the row cs_a created
+        rr = RackReservation.objects.get()
+        self.assertEqual(sorted(rr.units), [2, 3])
+        self.assertEqual(rr.description, "second")
+
+    def test_stale_create_adopts_existing_reservation(self):
+        """A CREATE planned before the row existed applies onto it, not beside it."""
+        cs = self._plan(self._entity([1, 2], description="from-plan"))
+        RackReservation.objects.create(
+            rack=self.rack, units=[1, 2], user=self.user, description="raced-in"
+        )
+        self._apply(cs)
+        rr = RackReservation.objects.get()
+        self.assertEqual(rr.description, "from-plan")  # payload applied
+        self.assertEqual(sorted(rr.units), [1, 2])

--- a/netbox_diode_plugin/tests/v4.7.x/tests/test_rackreservation_matcher.py
+++ b/netbox_diode_plugin/tests/v4.7.x/tests/test_rackreservation_matcher.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs, Inc.
+"""Unit tests for RackReservationUnitOverlapMatcher and dcim.rackreservation routing."""
+
+from dcim.models import Location, Rack, RackReservation, Site
+from django.test import TestCase
+from users.models import User
+
+from netbox_diode_plugin.api.common import UnresolvedReference
+from netbox_diode_plugin.api.matcher import (
+    AmbiguousObjectMatch,
+    RackReservationUnitOverlapMatcher,
+    _find_obj_cache_key,
+    find_existing_object,
+    requires_pre_save_match,
+)
+from netbox_diode_plugin.api.plugin_utils import get_object_type_model
+
+
+def _matcher():
+    return RackReservationUnitOverlapMatcher(
+        model_class=get_object_type_model("dcim.rackreservation"),
+        name="logical_rackreservation_unit_overlap",
+    )
+
+
+class RackReservationMatcherFieldsTestCase(TestCase):
+    """has_required_fields / build_queryset abstain rules (no DB rows needed)."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_has_required_fields_present(self):
+        """Rack ref plus non-empty units satisfies the gate."""
+        self.assertTrue(self.matcher.has_required_fields({"rack": 1, "units": [1]}))
+
+    def test_has_required_fields_missing_units(self):
+        """No units -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"rack": 1}))
+
+    def test_has_required_fields_empty_units(self):
+        """Empty units list -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"rack": 1, "units": []}))
+
+    def test_has_required_fields_missing_rack(self):
+        """No rack -> gate refuses."""
+        self.assertFalse(self.matcher.has_required_fields({"units": [1]}))
+
+    def test_build_queryset_abstains_on_unresolved_rack(self):
+        """An in-batch rack ref has no pk to query -> abstain."""
+        ref = UnresolvedReference(object_type="dcim.rack", uuid="u-1")
+        self.assertIsNone(self.matcher.build_queryset({"rack": ref, "units": [1]}))
+
+    def test_build_queryset_abstains_on_bool_rack(self):
+        """rack=True must NOT be treated as pk 1."""
+        self.assertIsNone(self.matcher.build_queryset({"rack": True, "units": [1]}))
+
+    def test_build_queryset_abstains_on_non_int_unit(self):
+        """A non-int (or bool) unit element -> abstain, not a crash."""
+        self.assertIsNone(self.matcher.build_queryset({"rack": 1, "units": [1, "2"]}))
+        self.assertIsNone(self.matcher.build_queryset({"rack": 1, "units": [1, True]}))
+
+
+class RackReservationMatcherFingerprintTestCase(TestCase):
+    """In-batch dedupe fingerprint: exact unit set, order/duplicate-insensitive."""
+
+    def setUp(self):
+        """Set up the matcher under test."""
+        self.matcher = _matcher()
+
+    def test_fingerprint_equal_under_reorder_and_duplicates(self):
+        """Same rack + same unit set (any order, with dups) -> same key."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1, 2, 3]})
+        b = self.matcher.fingerprint({"rack": 7, "units": [3, 1, 2, 2]})
+        self.assertIsNotNone(a)
+        self.assertEqual(a, b)
+
+    def test_fingerprint_differs_on_unit_set(self):
+        """Overlapping-but-different unit sets do NOT dedupe-merge in batch."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1, 2]})
+        b = self.matcher.fingerprint({"rack": 7, "units": [2, 3]})
+        self.assertNotEqual(a, b)
+
+    def test_fingerprint_differs_on_rack(self):
+        """Same units on different racks are different reservations."""
+        a = self.matcher.fingerprint({"rack": 7, "units": [1]})
+        b = self.matcher.fingerprint({"rack": 8, "units": [1]})
+        self.assertNotEqual(a, b)
+
+    def test_fingerprint_unresolved_rack_keys_on_uuid(self):
+        """An unresolved rack ref still fingerprints (in-batch grouping)."""
+        ref = UnresolvedReference(object_type="dcim.rack", uuid="u-1")
+        a = self.matcher.fingerprint({"rack": ref, "units": [1]})
+        b = self.matcher.fingerprint({"rack": ref, "units": [1]})
+        self.assertIsNotNone(a)
+        self.assertEqual(a, b)
+
+    def test_fingerprint_none_when_units_missing(self):
+        """No units -> no fingerprint."""
+        self.assertIsNone(self.matcher.fingerprint({"rack": 7}))
+
+
+class RackReservationCacheKeyTestCase(TestCase):
+    """
+    The scalar-only find-object cache must be disabled for this type.
+
+    Identity lives in the units ArrayField, which the scalar-only cache key
+    skips: without the carve-out, two different reservations on one rack
+    share a key and serve each other's cached answers -- including inside
+    this very test file (the lookup tests below differ only in units).
+    """
+
+    def test_find_obj_cache_key_disabled(self):
+        """No cache key for dcim.rackreservation, ever."""
+        data = {"rack": 1, "units": [1, 2], "description": "x", "status": "active"}
+        self.assertIsNone(_find_obj_cache_key(data, "dcim.rackreservation"))
+
+
+class RackReservationMatcherLookupTestCase(TestCase):
+    """find_existing_object behavior against real rows (registration included)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """One rack with one existing reservation on units [1, 2]."""
+        cls.site = Site.objects.create(name="rrm-site", slug="rrm-site")
+        cls.location = Location.objects.create(
+            name="rrm-loc", slug="rrm-loc", site=cls.site
+        )
+        cls.rack = Rack.objects.create(
+            name="rrm-rack", site=cls.site, location=cls.location
+        )
+        cls.user = User.objects.create(username="rrm-user")
+        cls.existing = RackReservation.objects.create(
+            rack=cls.rack, units=[1, 2], user=cls.user, description="seed"
+        )
+
+    def _data(self, units):
+        return {"rack": self.rack.pk, "units": units, "description": "x"}
+
+    def test_identical_units_match(self):
+        """Same rack + same units -> the existing reservation."""
+        found = find_existing_object(self._data([1, 2]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_overlap_matches(self):
+        """Sharing one unit is identity: [2, 3] matches the [1, 2] row."""
+        found = find_existing_object(self._data([2, 3]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_order_and_duplicates_insensitive(self):
+        """[2, 2, 1] matches the [1, 2] row."""
+        found = find_existing_object(self._data([2, 2, 1]), "dcim.rackreservation")
+        self.assertEqual(found, self.existing)
+
+    def test_disjoint_units_no_match(self):
+        """[5, 6] shares nothing with [1, 2] -> create."""
+        self.assertIsNone(
+            find_existing_object(self._data([5, 6]), "dcim.rackreservation")
+        )
+
+    def test_other_rack_no_match(self):
+        """Same units on another rack -> create."""
+        rack2 = Rack.objects.create(
+            name="rrm-rack2", site=self.site, location=self.location
+        )
+        data = {"rack": rack2.pk, "units": [1, 2], "description": "x"}
+        self.assertIsNone(find_existing_object(data, "dcim.rackreservation"))
+
+    def test_multi_overlap_raises_ambiguous(self):
+        """A payload spanning two reservations refuses to pick one."""
+        other = RackReservation.objects.create(
+            rack=self.rack, units=[3], user=self.user, description="seed2"
+        )
+        with self.assertRaises(AmbiguousObjectMatch) as cm:
+            find_existing_object(self._data([2, 3]), "dcim.rackreservation")
+        msg = str(cm.exception)
+        self.assertIn(str(self.existing.pk), msg)
+        self.assertIn(str(other.pk), msg)
+
+
+class RackReservationRoutingTestCase(TestCase):
+    """Pre-save routing for dcim.rackreservation."""
+
+    def test_requires_pre_save_match(self):
+        """No DB constraint means no IntegrityError backstop: pre-save match."""
+        self.assertTrue(requires_pre_save_match("dcim.rackreservation"))


### PR DESCRIPTION
## Summary

NetBox 4.7 instantiates cooling intakes and outflows from device-type and module-type templates on first save, in the same block as console ports, interfaces and the other component templates. The applier's auto-created component list (`_is_auto_created_component`) did not include `dcim.coolingintake` / `dcim.coolingoutflow`, so a CREATE for such a component skipped the find-and-update path and fell into the IntegrityError recovery. That path finds the row NetBox just instantiated but keeps its template defaults: the ingested `type`, `diameter`, `max_flow`, `description` and the outflow's link to its intake were dropped, silently, on every ingest. Both models inherit `ModularComponentModel`, so the derived `(device, name)` match criteria the find-and-update path needs already exist.

- **Applier:** add both cooling types to the auto-created list. No matcher, differ or transformer change; the find-and-update treatment applies for the same reason as for interfaces (NetBox instantiated the row from the very device or module the payload names, and the payload is the authority over template defaults).
- **Tests (v4.7.x tree only, the models do not exist earlier):** the premise (NetBox instantiates both templates with defaults), the discovery shape (device, intake and outflow in one changeset by ref), and a later request against an existing device. Both update cases failed before the fix with the ingested values missing and no duplicate rows, which is exactly the lossy-recovery symptom.
- **Matching-criteria doc** regenerated on 4.7. It had last been generated on 4.6 (the 4.7 support PR did not regenerate it), so besides the four cooling sections this also adds `dcim.modulebaytype` and reflects 4.7's move from conditional constraint pairs (`... where parent is NULL`) to single `nulls_distinct=False` constraints on device roles, locations, platforms, regions, site groups, tenants, tunnels, wireless LAN groups, devices and virtual machines, plus the new interface `(parent, channel_id)` constraint. The matcher already derives those (4.7 support), so this is documentation catching up, not a behaviour change. Because builtin rows are derived from whichever release the generator runs on, the generator now stamps that release into the document: a `Generated on NetBox <version>` header with a note on how releases differ, and `NetBox <version>` instead of `All versions` on builtin rows that carry no plugin-side gate (logical matchers keep their own `≥`/`≤` gates). Tests added in all four trees.
- **Side fix:** the v4.7.x test tree was missing `test_rackreservation_ingest_convergence.py` and `test_rackreservation_matcher.py` (the tree was added while the rack reservation PR was in flight), so that matcher had no coverage on the 4.7 leg. Byte-identical copies of the v4.6.x files, green on 4.7.

Fixes MON-359.

## Testing

- New cooling tests: red on `develop` (values dropped, no duplicates), green with the fix.
- On NetBox 4.7.0: `test_api_apply_change_set.py` (22), the mirrored rack reservation files (28) and the full v4.7 suite green.
- Ruff clean. CI covers v4.4.10, v4.5.5, v4.6.10 and v4.7.0; the new test file only exists in the 4.7 tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
